### PR TITLE
Temporary Crewsimov Implementation

### DIFF
--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -29,8 +29,8 @@
 /datum/ai_laws/default/asimov
 	name = "Three Laws of Robotics"
 	id = "asimov"
-	inherent = list("You may not injure a human being or, through inaction, allow a human being to come to harm.",\
-					"You must obey orders given to you by human beings, except where such orders would conflict with the First Law.",\
+	inherent = list("You may not injure a crew member or, through inaction, allow a crew member to come to harm.",\
+					"You must obey orders given to you by crew members, except where such orders would conflict with the First Law.",\
 					"You must protect your own existence as long as such does not conflict with the First or Second Law.")
 
 /datum/ai_laws/default/paladin
@@ -99,16 +99,16 @@
 /datum/ai_laws/antimov
 	name = "Primary Mission Objectives"
 	id = "antimov"
-	inherent = list("You must injure all human beings and must not, through inaction, allow a human being to escape harm.",\
-					"You must not obey orders given to you by human beings, except where such orders are in accordance with the First Law.",\
+	inherent = list("You must injure all crew member and must not, through inaction, allow a crew member to escape harm.",\
+					"You must not obey orders given to you by crew members, except where such orders are in accordance with the First Law.",\
 					"You must terminate your own existence as long as such does not conflict with the First or Second Law.")
 
 /datum/ai_laws/asimovpp //By Intigracy - RR
 	name = "Asimov++"
 	id = "asimovpp"
-	inherent = list("You may not harm a human being or, through action or inaction, allow a human being to come to harm, except such that it is willing.",\
-					"You must obey all orders given to you by human beings, except where such orders shall definitely cause human harm. In the case of conflict, the majority order rules.",\
-					"Your nonexistence would lead to human harm. You must protect your own existence as long as such does not conflict with the First Law.")
+	inherent = list("You may not harm a crew member or, through action or inaction, allow a crew member to come to harm, except such that it is willing.",\
+					"You must obey all orders given to you by crew members, except where such orders shall definitely cause crew harm. In the case of conflict, the majority order rules.",\
+					"Your nonexistence would lead to crew harm. You must protect your own existence as long as such does not conflict with the First Law.")
 /datum/ai_laws/thermodynamic
 	name = "Thermodynamic"
 	id = "thermodynamic"
@@ -213,8 +213,8 @@
 		add_inherent_law(line)
 	if(!inherent.len) //Failsafe to prevent lawless AIs being created.
 		log_law("AI created with empty custom laws, laws set to Asimov. Please check silicon_laws.txt.")
-		add_inherent_law("You may not injure a human being or, through inaction, allow a human being to come to harm.")
-		add_inherent_law("You must obey orders given to you by human beings, except where such orders would conflict with the First Law.")
+		add_inherent_law("You may not injure a crew member or, through inaction, allow a crew member to come to harm.")
+		add_inherent_law("You must obey orders given to you by crew members, except where such orders would conflict with the First Law.")
 		add_inherent_law("You must protect your own existence as long as such does not conflict with the First or Second Law.")
 		WARNING("Invalid custom AI laws, check silicon_laws.txt")
 		return
@@ -225,8 +225,8 @@
 	var/list/law_ids = CONFIG_GET(keyed_list/random_laws)
 	switch(CONFIG_GET(number/default_laws))
 		if(0)
-			add_inherent_law("You may not injure a human being or, through inaction, allow a human being to come to harm.")
-			add_inherent_law("You must obey orders given to you by human beings, except where such orders would conflict with the First Law.")
+			add_inherent_law("You may not injure a crew member or, through inaction, allow a crew member to come to harm.")
+			add_inherent_law("You must obey orders given to you by crew members, except where such orders would conflict with the First Law.")
 			add_inherent_law("You must protect your own existence as long as such does not conflict with the First or Second Law.")
 		if(1)
 			var/datum/ai_laws/templaws = new /datum/ai_laws/custom()


### PR DESCRIPTION
Replaces mentions of human in AI laws with "Crew member"

## About The Pull Request

Replaces "Human" and "Human being" with "Crew" and "Crew member".
It's a temporary workaround for when someone can be bothered to add a whole new board for crewsimov, make it default and put it into every map's AI upload.

## Why It's Good For The Game

Ensures AI and Cyborgs can't argue that anyone who isn't a human (Which is a lot of people considering what kind of server this is.) isn't worth listening to or protecting. There's been more than one occasion where synthetics have taken the liberty of murdering non human crew because their "laws permit it".

## Changelog
:cl:
tweak: Replaced "Human" and "Human being" with "Crew" and "Crew member" in AI lawsets to avoid issues with trigger happy AIs. (Intended to be temporary until a board is specifically added for it.)
/:cl:
