### PR TITLE
Cloning Auto-Scanning

### DIFF
--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -64,6 +64,9 @@
 	if(!(scanner && LAZYLEN(pods) && autoprocess))
 		return
 
+	if(scanner.occupant && scanner.scan_level > 2) //Lumos change - Auto-scans patients at level 2 scanning modules
+		scan_occupant(scanner.occupant)
+
 	for(var/datum/data/record/R in records)
 		var/obj/machinery/clonepod/pod = GetAvailableEfficientPod(R.fields["mind"])
 


### PR DESCRIPTION
Enables auto-scanning for cloning.

## About The Pull Request

Enables the cloning pod computer to auto-scan occupants in the attached DNA scanner when auto-processing. The scanning modules must be level 2 or above.

## Why It's Good For The Game

Auto-scanning is a quality of life improvement that allows the process of getting scanned a lot smoother and simpler as well as able to be done solo. Something people usually have to resort to when there's no medical staff.

## Changelog
:cl:
add: Cloner auto-scanning during auto-processing when upgraded to tier 2 scanning modules.
/:cl: