### PR TITLE
Crew Transfer Vote Changes

### DIFF
--- a/config/config.txt
+++ b/config/config.txt
@@ -188,10 +188,10 @@ VOTE_PERIOD 600
 
 ## autovote initial delay (deciseconds) before first automatic transfer vote call (default 120 minutes)
 ## Set to 0 to disable the subsystem altogether.
-VOTE_AUTOTRANSFER_INITIAL 72000
+VOTE_AUTOTRANSFER_INITIAL 216000
 
 ## autovote delay (deciseconds) before sequential automatic transfer votes are called (default 30 minutes)
-VOTE_AUTOTRANSFER_INTERVAL 18000
+VOTE_AUTOTRANSFER_INTERVAL 36000
 
 ## autovote maximum votes until automatic transfer call. (default 4)
 ## Set to 0 to force automatic crew transfer after the 'vote_autotransfer_initial' elapsed.


### PR DESCRIPTION

## About The Pull Request

Changes the time until automatic transfer vote to six hours into the round from the previous two hours. The delay between each consecutive transfer vote has been set to one hour rather than every thirty minutes.

## Why It's Good For The Game

Longer rounds encourage players to pursue station objectives and discourages people from voting for shuttle transfer in order to roll for antagonist roles on the station. Overall, most players agreed that a four hour or a six hour round were the best options for Lumos station.

## Changelog
:cl:
config: changed time until crew transfer vote
/:cl:

