### PR TITLE
moff antennae show up on hardsuits

### DIFF
--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -181,7 +181,7 @@
 		"legs"				= pick("Plantigrade","Digitigrade"),
 		"caps"				= pick(GLOB.caps_list),
 		"insect_wings"		= pick(GLOB.insect_wings_list),
-		"insect_fluff"		= "None",
+		"insect_fluff"		= pick(GLOB.insect_fluffs_list),
 		"insect_markings"	= pick(GLOB.insect_markings_list),
 		"taur"				= "None",
 		"mam_body_markings" = snowflake_markings_list.len ? pick(snowflake_markings_list) : "None",

--- a/code/modules/mob/dead/new_player/sprite_accessories/body_markings.dm
+++ b/code/modules/mob/dead/new_player/sprite_accessories/body_markings.dm
@@ -222,6 +222,7 @@
 /datum/sprite_accessory/insect_fluff
 	icon = 'icons/mob/wings.dmi'
 	color_src = 0
+	mutant_part_string = "insect_fluff"
 	relevant_layers = list(BODY_FRONT_LAYER)
 
 /datum/sprite_accessory/insect_fluff/none

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -722,7 +722,7 @@ GLOBAL_LIST_EMPTY(roundstart_race_datums)
 
 	if(mutant_bodyparts["insect_fluff"])
 		if(!H.dna.features["insect_fluff"] || H.dna.features["insect_fluff"] == "None" || H.wear_suit && (H.wear_suit.flags_inv & HIDEJUMPSUIT))
-			bodyparts_to_add -= "insect_fluff"
+			bodyparts_to_add -= "insect_fluffs"
 
 //CITADEL EDIT
 	//Race specific bodyparts:


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

so moths look like moths in hardsuits
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: moth antennae shows up on hardsuits
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
