### PR TITLE
All ridable things can't block projectiles

### DIFF
--- a/code/modules/vehicles/ridden.dm
+++ b/code/modules/vehicles/ridden.dm
@@ -6,7 +6,6 @@
 	default_driver_move = FALSE
 	var/legs_required = 1
 	var/arms_required = 0	//why not?
-	density = 0 //bullet go through haha
 
 /obj/vehicle/ridden/Initialize()
 	. = ..()
@@ -82,3 +81,9 @@
 /obj/vehicle/ridden/zap_act(zap_str, zap_flags, shocked_targets)
 	zap_buckle_check(zap_str)
 	. = ..()
+
+/obj/vehicle/ridden/CanPass(atom/movable/mover, turf/target)
+    if(isprojectile(mover))
+        return TRUE
+    else
+        return ..()

--- a/code/modules/vehicles/ridden.dm
+++ b/code/modules/vehicles/ridden.dm
@@ -6,6 +6,7 @@
 	default_driver_move = FALSE
 	var/legs_required = 1
 	var/arms_required = 0	//why not?
+	density = 0 //bullet go through haha
 
 /obj/vehicle/ridden/Initialize()
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Things such as the janniecart and secway can no longer block projectiles.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fighting someone on a secway is incredibly inconsistent and pretty much removes all ranged options to use against someone, meaning you either have to rely on luck to beat them from range or go melee and get beaten by a stunbaton.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Ridables can't block projectiles.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
