### PR TITLE
Readds Morgue Access to Chef's ID

### DIFF
--- a/code/modules/jobs/job_types/cook.dm
+++ b/code/modules/jobs/job_types/cook.dm
@@ -12,8 +12,8 @@
 
 	outfit = /datum/outfit/job/cook
 
-	access = list(ACCESS_HYDROPONICS, ACCESS_BAR, ACCESS_KITCHEN, ACCESS_MINERAL_STOREROOM) //Skyrat Edit, No Morgue Access
-	minimal_access = list(ACCESS_KITCHEN, ACCESS_MINERAL_STOREROOM) //Skyrat Edit, No Morgue Access
+	access = list(ACCESS_HYDROPONICS, ACCESS_BAR, ACCESS_KITCHEN, ACCESS_MORGUE, ACCESS_MINERAL_STOREROOM) //Lumos Edit, Readds Morgue Access
+	minimal_access = list(ACCESS_KITCHEN, ACCESS_MORGUE, ACCESS_MINERAL_STOREROOM) //Lumos Edit, Readds Morgue Access
 	paycheck = PAYCHECK_EASY
 	paycheck_department = ACCOUNT_SRV
 


### PR DESCRIPTION
## About The Pull Request

Skyrat removed chef's morgue access, added it back.

## Why It's Good For The Game

https://www.youtube.com/watch?v=AGTsiOttTYs
We need the meats.

## Changelog
:cl:
code: readded morgue access to chef
/:cl: