### PR TITLE
gives engineers pickaxes on snaxi

### DIFF
--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -163,6 +163,13 @@
 
 	new /obj/item/tank/internals/emergency_oxygen/engi(src)
 
+// LUMOS EDIT START - SNAXIPICKS
+	if(SSmapping.stat_map_name == "Snow Taxi")
+		if(!ishuman(loc))
+			return
+		new /obj/item/pickaxe/mini(src)
+// LUMOS EDIT END - SNAXIPICKS
+
 /obj/item/storage/box/engineer/radio/PopulateContents()
 	..() // we want the regular items too.
 	new /obj/item/radio/off(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Everyone else has pickaxes, just forgot that engineers get their own box oops.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Engineers now get pickaxes as well on snaxi
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
