### PR TITLE
Synthetics know more languages

### DIFF
--- a/code/modules/language/language_holder.dm
+++ b/code/modules/language/language_holder.dm
@@ -320,7 +320,7 @@ Key procs
 								/datum/language/technorussian = list(LANGUAGE_ATOM),
 								/datum/language/neokanji = list(LANGUAGE_ATOM),
 								/datum/language/dunmeri = list(LANGUAGE_ATOM),
-								/datum/language/dwarf = list(LANGUAGE_ATOM)),
+								/datum/language/dwarf = list(LANGUAGE_ATOM),
 								// LUMOS EDIT - MOAR LANGUAGES
 								/datum/language/vox = list(LANGUAGE_ATOM),
 								/datum/language/calcic = list(LANGUAGE_ATOM),
@@ -336,7 +336,7 @@ Key procs
 							/datum/language/neokanji = list(LANGUAGE_ATOM),
 							/datum/language/dunmeri = list(LANGUAGE_ATOM),
 							/datum/language/slime = list(LANGUAGE_ATOM),
-							/datum/language/dwarf = list(LANGUAGE_ATOM)),
+							/datum/language/dwarf = list(LANGUAGE_ATOM),
 							// LUMOS EDIT - MOAR LANGUAGES
 							/datum/language/vox = list(LANGUAGE_ATOM),
 							/datum/language/calcic = list(LANGUAGE_ATOM),

--- a/code/modules/language/language_holder.dm
+++ b/code/modules/language/language_holder.dm
@@ -320,7 +320,13 @@ Key procs
 								/datum/language/technorussian = list(LANGUAGE_ATOM),
 								/datum/language/neokanji = list(LANGUAGE_ATOM),
 								/datum/language/dunmeri = list(LANGUAGE_ATOM),
-								/datum/language/dwarf = list(LANGUAGE_ATOM))
+								/datum/language/dwarf = list(LANGUAGE_ATOM)),
+								// LUMOS EDIT - MOAR LANGUAGES
+								/datum/language/vox = list(LANGUAGE_ATOM),
+								/datum/language/calcic = list(LANGUAGE_ATOM),
+								/datum/language/moffic = list(LANGUAGE_ATOM),
+								/datum/language/sylvan = list(LANGUAGE_ATOM),
+								/datum/language/shadowtongue = list(LANGUAGE_ATOM))
 	spoken_languages = list(/datum/language/common = list(LANGUAGE_ATOM),
 							/datum/language/machine = list(LANGUAGE_ATOM),
 							/datum/language/draconic = list(LANGUAGE_ATOM),
@@ -330,7 +336,13 @@ Key procs
 							/datum/language/neokanji = list(LANGUAGE_ATOM),
 							/datum/language/dunmeri = list(LANGUAGE_ATOM),
 							/datum/language/slime = list(LANGUAGE_ATOM),
-							/datum/language/dwarf = list(LANGUAGE_ATOM))
+							/datum/language/dwarf = list(LANGUAGE_ATOM)),
+							// LUMOS EDIT - MOAR LANGUAGES
+							/datum/language/vox = list(LANGUAGE_ATOM),
+							/datum/language/calcic = list(LANGUAGE_ATOM),
+							/datum/language/moffic = list(LANGUAGE_ATOM),
+							/datum/language/sylvan = list(LANGUAGE_ATOM),
+							/datum/language/shadowtongue = list(LANGUAGE_ATOM))
 
 /datum/language_holder/venus
 	understood_languages = list(/datum/language/common = list(LANGUAGE_ATOM),


### PR DESCRIPTION
## About The Pull Request

Adds more languages to the synthetic (AI/Cyborg) language holder so they can speak and understand more languages.

## Why It's Good For The Game

Allows for efficient communication between synthetics (AI/Cyborg) and crew members who speak different languages.

## Changelog
:cl:
add: Added commonly spoken crew languages to what synthetics (AI/Cyborg) can speak and understand
/:cl:
