### PR TITLE
Keeps dogs (and drakes) but makes them less cringe

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -149,6 +149,7 @@
 	has_snowflake_deadsprite = TRUE
 	cyborg_pixel_offset = -16
 	hat_offset = INFINITY
+	/* Lumos Change - Removes cringe dogborg modules like tongue, SLEEPER, and nose
 	basic_modules += new /obj/item/dogborg_nose(src)
 	basic_modules += new /obj/item/dogborg_tongue(src)
 	var/obj/item/dogborg/sleeper/K9/flavour/I = new(src)
@@ -163,6 +164,7 @@
 		if(cyborg_base_icon == "scrubpup")
 			I.icon_state = "compactor"
 	basic_modules += I
+	*/ //Lumos Change End
 	rebuild_modules()
 
 /obj/item/robot_module/proc/remove_module(obj/item/I, delete_after)

--- a/code/modules/mob/living/silicon/robot/update_icons.dm
+++ b/code/modules/mob/living/silicon/robot/update_icons.dm
@@ -9,10 +9,12 @@
 	if(disabler)
 		add_overlay("disabler")//ditto
 
+	/* LUMOS CHANGE - Should remove gross dogborg sleeper pixels from ever being used. Shouldn't be too necessary considering I took away the sleeper module
 	if(sleeper_g && module.sleeper_overlay)
 		add_overlay("[module.sleeper_overlay]_g[sleeper_nv ? "_nv" : ""]")
 	if(sleeper_r && module.sleeper_overlay)
 		add_overlay("[module.sleeper_overlay]_r[sleeper_nv ? "_nv" : ""]")
+	*/ //LUMOS CHANGE END
 	if(stat == DEAD && module.has_snowflake_deadsprite)
 		icon_state = "[module.cyborg_base_icon]-wreck"
 

--- a/modular_skyrat/code/datums/interactions/lewd/lewd_datums.dm
+++ b/modular_skyrat/code/datums/interactions/lewd/lewd_datums.dm
@@ -11,7 +11,8 @@
 									/mob/living/simple_animal/parrot,
 									/mob/living/simple_animal/sloth,
 									/mob/living/simple_animal/pickle,
-									/mob/living/simple_animal/hostile/retaliate/goat)
+									/mob/living/simple_animal/hostile/retaliate/goat,
+									/mob/living/silicon/robot) //Lumos Change to blacklist cyborgs from lewd verbs. I hope this is a decent compromise for everyone
 
 /datum/interaction/lewd/kiss
 	command = "deepkiss"


### PR DESCRIPTION
## About The Pull Request

Removes the cringe from dogborgs and keeps the cool looking drakes. This PR would delete the sleeper, nose, and tongue module from the cyborgs. 

Also, this should add cyborgs to the lewd verb blacklist. No more foot-licking dogs running around.

## Why It's Good For The Game

Keeps the robot dogs for the people who like them in a platonic manner. Yes, such people exist.

~~If you're gonna remove dogborgs, then you should at least remove all taurs from character setup as well.~~

## Changelog
:cl:
del: Removed dogborg sleeper, nose, and tongue modules
/:cl:
