### PR TITLE
Bluespace beakers buff

### DIFF
--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -247,11 +247,8 @@
 	volume = 300
 	amount_per_transfer_from_this = 10
 	possible_transfer_amounts = list(5,10,15,20,25,30,50,100,300)
+	container_flags = APTFT_ALTCLICK|APTFT_VERB //LUMOS CHANGE - Because who wants to waste diamonds and bluespace crystals on something that can be melted?
 	container_HP = 5
-
-/obj/item/reagent_containers/glass/beaker/bluespace/Initialize() // Lumos change
-	beaker_weakness_bitflag &= ~PH_WEAK
-	. = ..()
 
 /obj/item/reagent_containers/glass/beaker/cryoxadone
 	list_reagents = list(/datum/reagent/medicine/cryoxadone = 30)

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -241,13 +241,17 @@
 	name = "bluespace beaker"
 	desc = "A bluespace beaker, powered by experimental bluespace technology \
 		and Element Cuban combined with the Compound Pete. Can hold up to \
-		300 units. Unable to withstand reagents of an extreme pH."
+		300 units. Able to withstand reagents of an extreme pH."
 	icon_state = "beakerbluespace"
 	custom_materials = list(/datum/material/glass = 5000, /datum/material/plasma = 3000, /datum/material/diamond = 1000, /datum/material/bluespace = 1000)
 	volume = 300
 	amount_per_transfer_from_this = 10
 	possible_transfer_amounts = list(5,10,15,20,25,30,50,100,300)
 	container_HP = 5
+
+/obj/item/reagent_containers/glass/beaker/bluespace/Initialize() // Lumos change
+	beaker_weakness_bitflag &= ~PH_WEAK
+	. = ..()
 
 /obj/item/reagent_containers/glass/beaker/cryoxadone
 	list_reagents = list(/datum/reagent/medicine/cryoxadone = 30)


### PR DESCRIPTION
## About The Pull Request

Changes it so the bluespace beaker has the same flags as the metamaterial beaker.

## Why It's Good For The Game

Because why not? Expensive beakers should be PH proof. Nobody uses metamaterial beakers anyways they just use bluespace ones until they melt and print more.

## Changelog
:cl:
tweak: buffed bluespace beakers to be PH resistant
/:cl:
