### PR TITLE
Removes most Quantum Pads from Snaxi

### DIFF
--- a/_maps/map_files/Snaxi/IcemoonUnderground_Above_Lumos.dmm
+++ b/_maps/map_files/Snaxi/IcemoonUnderground_Above_Lumos.dmm
@@ -216,22 +216,6 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/primary/port)
-"de" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/quantumpad{
-	map_pad_id = "miningbase";
-	map_pad_link_id = "xenoarch"
-	},
-/turf/open/floor/carpet,
-/area/hallway/primary/port)
 "df" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
@@ -3601,13 +3585,6 @@
 "Gs" = (
 /turf/closed/wall/r_wall,
 /area/science/circuit)
-"Gt" = (
-/obj/machinery/quantumpad{
-	map_pad_id = "xenoarch";
-	map_pad_link_id = "miningbase"
-	},
-/turf/open/floor/plasteel,
-/area/mine/living_quarters)
 "Gu" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible,
 /obj/machinery/meter,
@@ -20762,7 +20739,7 @@ sq
 zw
 sR
 wO
-de
+cw
 wO
 TS
 gb
@@ -36237,7 +36214,7 @@ Jv
 Jv
 nN
 sa
-Gt
+sa
 sa
 sa
 GN

--- a/_maps/map_files/Snaxi/IcemoonUnderground_Above_Lumos.dmm
+++ b/_maps/map_files/Snaxi/IcemoonUnderground_Above_Lumos.dmm
@@ -103,6 +103,22 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"ci" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/quantumpad{
+	map_pad_id = "xenoarch";
+	map_pad_link_id = "miningbase"
+	},
+/turf/open/floor/carpet,
+/area/hallway/primary/port)
 "cj" = (
 /obj/effect/decal/cleanable/blood/gibs/human/body,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
@@ -694,6 +710,13 @@
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"fz" = (
+/obj/machinery/quantumpad{
+	map_pad_id = "miningbase";
+	map_pad_link_id = "xenoarch"
+	},
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
 "fA" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "testlab";
@@ -20739,7 +20762,7 @@ sq
 zw
 sR
 wO
-cw
+ci
 wO
 TS
 gb
@@ -36214,7 +36237,7 @@ Jv
 Jv
 nN
 sa
-sa
+fz
 sa
 sa
 GN

--- a/_maps/map_files/Snaxi/Snaxi_Lumos.dmm
+++ b/_maps/map_files/Snaxi/Snaxi_Lumos.dmm
@@ -4342,12 +4342,6 @@
 	},
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors)
-"buO" = (
-/obj/machinery/computer/shuttle/snow_taxi{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/port)
 "buX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/wood,
@@ -4609,9 +4603,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/turf_decal/arrows/red{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -6549,13 +6540,6 @@
 /obj/machinery/holopad,
 /turf/open/floor/carpet,
 /area/hallway/secondary/exit/departure_lounge)
-"bQf" = (
-/obj/machinery/quantumpad{
-	map_pad_id = "4";
-	map_pad_link_id = "3"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "bQg" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -7823,10 +7807,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"cpC" = (
-/obj/effect/turf_decal/arrows/red,
-/turf/open/floor/plasteel,
-/area/hallway/primary/port)
 "cqa" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/structure/chair/comfy/brown{
@@ -8820,13 +8800,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"cQa" = (
-/obj/machinery/quantumpad{
-	map_pad_id = "6";
-	map_pad_link_id = "5"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "cQp" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/open/floor/plasteel,
@@ -13531,14 +13504,6 @@
 /obj/structure/closet/crate/bin,
 /turf/open/floor/plasteel/white,
 /area/security/prison)
-"fnu" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/machinery/quantumpad{
-	map_pad_id = "1";
-	map_pad_link_id = "2"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "fnx" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -20405,9 +20370,8 @@
 /area/chapel/main)
 "iPX" = (
 /obj/machinery/light,
-/obj/machinery/quantumpad{
-	map_pad_id = "2";
-	map_pad_link_id = "1"
+/obj/machinery/computer/shuttle/snow_taxi{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
@@ -21896,12 +21860,6 @@
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/hallway/primary/port)
-"jLp" = (
-/obj/effect/turf_decal/arrows/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "jLF" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -24306,9 +24264,6 @@
 /obj/machinery/camera{
 	c_tag = "Northwestern Hall 7";
 	dir = 8
-	},
-/obj/effect/turf_decal/arrows/red{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
@@ -34878,13 +34833,6 @@
 "qTb" = (
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
-"qTo" = (
-/obj/machinery/quantumpad{
-	map_pad_id = "5";
-	map_pad_link_id = "6"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "qTG" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -42035,13 +41983,6 @@
 /obj/item/bedsheet/syndie,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
-"uUZ" = (
-/obj/machinery/quantumpad{
-	map_pad_id = "3";
-	map_pad_link_id = "4"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/port)
 "uVe" = (
 /obj/structure/table/wood,
 /obj/item/screwdriver{
@@ -43774,12 +43715,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"vLt" = (
-/obj/effect/turf_decal/arrows/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "vLE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 5
@@ -46816,7 +46751,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
 	},
-/obj/effect/turf_decal/arrows/red,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "xAa" = (
@@ -71620,7 +71554,7 @@ xUL
 xUL
 tmO
 wje
-cpC
+wje
 iPX
 tmO
 ydp
@@ -71876,7 +71810,7 @@ xUL
 xUL
 xUL
 usE
-buO
+wje
 wje
 wje
 tmO
@@ -72135,7 +72069,7 @@ eNu
 arl
 wje
 lhB
-uUZ
+wje
 tmO
 ydp
 avT
@@ -84512,7 +84446,7 @@ vAs
 vAs
 vAs
 xhH
-fnu
+yae
 bxR
 mPM
 ohK
@@ -85026,8 +84960,8 @@ vAs
 vAs
 vAs
 lbp
-cQa
-jLp
+lhQ
+lhQ
 bDT
 bAt
 mmO
@@ -88789,8 +88723,8 @@ xUL
 xUL
 xUL
 kVO
-bQf
-vLt
+qgm
+qgm
 qgm
 qgm
 iLA
@@ -89303,7 +89237,7 @@ xUL
 xUL
 xUL
 qaO
-qTo
+qgm
 xzM
 pFu
 mGp


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR removes all quantum pads from Snaxi.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Snaxi was made specifically to have a map that wouldn't take place in space and allow people to move around a colony that was built on an arctic planet, quantum pads nullify about 40% of the map and it makes people never see it unless they go out of their way to _not_ use them.
I personally feel that removing these, even if just for a test merge, would be a good opportunity to see if this is a viable option, it would certainly make it a lot more fun for RP cause you would actually have to wear a winter jacket and oxygen mask to travel between each building which I personally enjoy a lot.

I tried to keep balance in mind and was told to make medical resources available to make up for the difficulty that comes with not being able to move crit people to medbay, however, all mini-medbay rooms in the other 2 buildings already are all-access and have 2 stretchers in them each and the necessary materials to take care of 2-3 crit people

Also:
![meme](https://user-images.githubusercontent.com/69254487/95119264-fd630a00-074b-11eb-8f4b-dc30704681d1.jpg)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: Removed most quantum pads from Snaxi
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
