### PR TITLE
pickaxes can actually mine one tile again

### DIFF
--- a/code/game/turfs/simulated/minerals.dm
+++ b/code/game/turfs/simulated/minerals.dm
@@ -64,8 +64,6 @@
 		to_chat(user, "<span class='notice'>You start picking...</span>")
 
 		if(I.use_tool(src, user, 40, volume=50))
-			if(!I.digrange)
-				return
 			var/range = I.digrange //Store the current digrange so people don't cheese digspeed swapping for faster mining
 			var/list/dug_tiles = list()
 			if(ismineralturf(src))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
for some reason, someone added a return to make something not work in the pickaxes, what a dumbass.
![image](https://user-images.githubusercontent.com/55967837/96509412-fa771780-1229-11eb-8fbf-e206ad06585c.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
fix the pickaxe 2020
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: pickaxes can mine single turfs again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
