### PR TITLE
Snaxi Med Changes

### DIFF
--- a/_maps/map_files/Snaxi/Snaxi_Lumos.dmm
+++ b/_maps/map_files/Snaxi/Snaxi_Lumos.dmm
@@ -25760,13 +25760,6 @@
 	},
 /turf/open/floor/plating,
 /area/bridge)
-"mal" = (
-/obj/machinery/light,
-/obj/structure/sign/warning/securearea{
-	pixel_x = 32
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
 "mao" = (
 /obj/structure/tank_dispenser{
 	pixel_x = -1
@@ -68683,7 +68676,7 @@ keC
 vEr
 tNq
 xgq
-mal
+xAi
 aoX
 nVv
 nJJ

--- a/_maps/map_files/Snaxi/Snaxi_Lumos.dmm
+++ b/_maps/map_files/Snaxi/Snaxi_Lumos.dmm
@@ -1,7 +1,7 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "aaH" = (
-/obj/machinery/smartfridge/chemistry/preloaded,
-/turf/closed/wall,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/medical/chemistry)
 "aaO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -296,20 +296,11 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "adz" = (
 /obj/structure/sign/warning/nosmoking{
 	pixel_y = 30
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -318,12 +309,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -332,7 +317,7 @@
 	dir = 4
 	},
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -717,13 +702,19 @@
 /obj/machinery/airalarm{
 	pixel_y = 23
 	},
-/obj/structure/closet/secure_closet/chemical,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/structure/table/glass,
+/obj/item/clothing/glasses/science{
+	pixel_x = 2;
+	pixel_y = 4
+	},
+/obj/item/clothing/glasses/science,
+/obj/item/storage/box/syringes,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "alE" = (
@@ -855,16 +846,12 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "ann" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/eastright{
-	base_state = "left";
-	icon_state = "left";
-	name = "Chemistry Desk";
-	req_access_txt = "5; 33"
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
-/obj/machinery/door/firedoor/heavy,
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
+/turf/open/floor/plating,
+/area/medical/surgery)
 "anw" = (
 /obj/machinery/deepfryer,
 /turf/open/floor/plasteel/white,
@@ -907,17 +894,22 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "anK" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
+/obj/structure/table/reinforced,
+/obj/item/storage/backpack/duffelbag/med/surgery,
+/turf/open/floor/plasteel/freezer,
+/area/medical/surgery)
 "anL" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow,
+/obj/structure/chair/office/light{
+	dir = 4
+	},
+/obj/effect/landmark/start/chemist,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "anO" = (
@@ -965,16 +957,10 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/structure/closet/wardrobe/chemistry_white,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "aoo" = (
-/obj/structure/table/glass,
-/obj/machinery/reagentgrinder{
-	pixel_y = 8
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
@@ -982,13 +968,8 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow,
-/obj/item/reagent_containers/glass/beaker{
-	pixel_x = 5
-	},
-/obj/item/reagent_containers/glass/beaker{
-	pixel_x = 8;
-	pixel_y = 2
-	},
+/obj/machinery/chem_dispenser,
+/obj/machinery/light,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "aow" = (
@@ -1093,12 +1074,12 @@
 /turf/open/floor/wood,
 /area/library)
 "aqP" = (
-/obj/machinery/door/airlock/virology{
-	name = "Break Room";
-	req_access_txt = "39"
+/obj/machinery/vending/wallmed{
+	pixel_x = -28
 	},
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
+/obj/structure/closet/crate/freezer/blood,
+/turf/open/floor/plasteel/freezer,
+/area/medical/surgery)
 "arl" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -3058,10 +3039,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atm{
-	pixel_x = -28
-	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "aNg" = (
@@ -3248,11 +3225,6 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "aPp" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
-	},
 /obj/machinery/airalarm{
 	dir = 4;
 	pixel_x = -22
@@ -3877,6 +3849,10 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
+"bgz" = (
+/obj/machinery/smartfridge/chemistry/preloaded,
+/turf/closed/wall,
+/area/medical/chemistry)
 "bhe" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -6255,18 +6231,10 @@
 /turf/open/floor/plasteel/white,
 /area/security/prison)
 "bLM" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
+/obj/structure/chair{
 	dir = 8
 	},
-/obj/machinery/computer/cloning{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/effect/landmark/start/geneticist,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "bLO" = (
@@ -6296,9 +6264,6 @@
 /turf/closed/wall/r_wall,
 /area/quartermaster/miningdock)
 "bLW" = (
-/obj/structure/bodycontainer/morgue{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
@@ -6308,8 +6273,8 @@
 	dir = 8;
 	network = list("ss13","medbay")
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
@@ -8142,14 +8107,10 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "cwW" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
+/obj/structure/closet/crate/freezer/surplus_limbs,
+/obj/item/reagent_containers/glass/beaker/synthflesh,
+/turf/open/floor/plasteel/freezer,
+/area/medical/surgery)
 "cxX" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -8472,18 +8433,16 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/dorms)
 "cDS" = (
-/obj/structure/bodycontainer/morgue{
-	dir = 8
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/structure/bodycontainer/morgue{
+	dir = 2
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
@@ -8553,9 +8512,7 @@
 	network = list("ss13","medbay");
 	pixel_x = 22
 	},
-/obj/machinery/computer/operating{
-	dir = 4
-	},
+/obj/machinery/computer/operating,
 /turf/open/floor/plasteel/freezer,
 /area/medical/surgery)
 "cGz" = (
@@ -9501,9 +9458,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/mirror{
-	pixel_y = 28
-	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
@@ -9513,16 +9467,12 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/obj/machinery/shower{
-	pixel_x = 11;
-	pixel_y = 20
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/camera{
-	c_tag = "Genetics Cloning";
-	network = list("ss13","medbay")
+/obj/item/radio/intercom{
+	pixel_x = 1;
+	pixel_y = 23
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
@@ -9694,15 +9644,11 @@
 /turf/open/floor/plasteel/dark,
 /area/blueshield)
 "djL" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Genetics Maintenance";
-	req_access_txt = "5; 9; 68"
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/medical/genetics)
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "dks" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -10063,6 +10009,7 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "duB" = (
@@ -10344,24 +10291,11 @@
 /turf/open/floor/wood,
 /area/hallway/secondary/exit/departure_lounge)
 "dCI" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/machinery/light{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/white,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/medical/genetics)
 "dCM" = (
 /obj/machinery/status_display/supply{
@@ -10633,11 +10567,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
+	dir = 9
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -10864,22 +10796,15 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
 "dTL" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/clonepod,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "dTS" = (
@@ -11074,7 +10999,6 @@
 	name = "Genetics Requests Console";
 	pixel_y = 30
 	},
-/obj/machinery/dna_scannernew,
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -11082,6 +11006,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
+/obj/machinery/computer/scan_consolenew,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "dYl" = (
@@ -11797,7 +11722,9 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
 "eut" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/obj/structure/closet/secure_closet/medical2,
+/obj/item/tank/internals/anesthetic,
+/obj/item/tank/internals/anesthetic,
 /turf/open/floor/plasteel/freezer,
 /area/medical/surgery)
 "euz" = (
@@ -12211,7 +12138,18 @@
 /turf/open/floor/wood,
 /area/security/courtroom)
 "eFU" = (
-/turf/open/floor/plasteel/white,
+/obj/machinery/door/window/westleft{
+	dir = 2;
+	name = "Monkey Pen";
+	req_access_txt = "9"
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/mob/living/carbon/monkey,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/brflowers,
+/turf/open/floor/grass,
 /area/medical/genetics)
 "eGi" = (
 /obj/structure/cable{
@@ -12791,30 +12729,17 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
 "eSQ" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
 	},
-/obj/machinery/door/airlock/research/glass{
-	name = "Genetics Research";
-	req_access_txt = "5; 9; 68"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
+/obj/machinery/light/small{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/genetics)
+/turf/open/floor/plasteel/dark,
+/area/medical/morgue)
 "eTg" = (
 /obj/effect/landmark/start/roboticist,
 /obj/structure/disposalpipe/segment{
@@ -12921,6 +12846,21 @@
 /obj/item/key/security,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
+"eVY" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/eastright{
+	base_state = "left";
+	dir = 8;
+	icon_state = "left";
+	name = "Chemistry Desk";
+	req_access_txt = "5; 33"
+	},
+/obj/machinery/door/firedoor/heavy,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/medical/chemistry)
 "eWg" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -13268,9 +13208,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
 	},
-/obj/structure/closet/secure_closet/medical2,
-/obj/item/tank/internals/anesthetic,
-/obj/item/tank/internals/anesthetic,
 /turf/open/floor/plasteel/freezer,
 /area/medical/surgery)
 "fgM" = (
@@ -13281,7 +13218,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/mob/living/carbon/monkey,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "fhi" = (
@@ -14049,6 +13988,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "fBk" = (
@@ -14102,9 +14044,7 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/dorms)
 "fDi" = (
-/obj/machinery/computer/operating{
-	dir = 8
-	},
+/obj/machinery/computer/operating,
 /turf/open/floor/plasteel/freezer,
 /area/medical/surgery)
 "fDl" = (
@@ -14187,10 +14127,11 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "fGi" = (
-/obj/effect/landmark/start/medical_doctor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/structure/table/reinforced,
+/obj/item/storage/backpack/duffelbag/med/surgery,
 /turf/open/floor/plasteel/freezer,
 /area/medical/surgery)
 "fGl" = (
@@ -14481,19 +14422,16 @@
 /area/library)
 "fNO" = (
 /obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
@@ -14742,11 +14680,14 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
 "fUX" = (
-/obj/machinery/vending/medical{
-	pixel_x = -2
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/medical/morgue)
 "fVm" = (
 /turf/open/floor/wood{
 	icon_state = "wood-broken5"
@@ -14964,17 +14905,9 @@
 /area/storage/eva)
 "gbg" = (
 /obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple,
-/obj/machinery/dna_scannernew,
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "gbt" = (
@@ -15124,17 +15057,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"gev" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/machinery/disposal/bin,
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
 "geO" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -15270,6 +15192,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
+"gjf" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "gjA" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -15313,11 +15239,18 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "gkx" = (
-/obj/machinery/airalarm{
-	pixel_y = 23
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/machinery/dna_scannernew,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
+/area/medical/genetics)
 "gky" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -15493,16 +15426,14 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/light_switch{
-	pixel_y = -28
-	},
-/obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
@@ -15704,21 +15635,11 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
 "guR" = (
-/obj/structure/table/glass,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/reagent_containers/dropper,
-/obj/item/reagent_containers/dropper,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
+/obj/machinery/chem_heater,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "guV" = (
@@ -15733,6 +15654,9 @@
 	icon_state = "1-2"
 	},
 /obj/structure/bed/roller,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "gvA" = (
@@ -15919,12 +15843,14 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "gCS" = (
-/obj/structure/bodycontainer/morgue,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
+	},
+/obj/structure/bodycontainer/morgue{
+	dir = 2
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
@@ -15941,7 +15867,7 @@
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/structure/cable{
-	icon_state = "2-4"
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
@@ -16112,11 +16038,17 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/fitness)
 "gId" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
+/obj/machinery/door/airlock/medical/glass{
+	id_tag = "GeneticsDoor";
+	name = "Morgue";
+	req_access_txt = "5; 68"
 	},
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/plasteel/dark,
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plating,
 /area/medical/morgue)
 "gIm" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -16290,27 +16222,11 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "gNq" = (
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
 	},
-/obj/structure/sign/warning/securearea{
-	pixel_x = 32
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/genetics)
+/turf/open/floor/plasteel/dark,
+/area/medical/medbay/central)
 "gNy" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/machinery/atmospherics/components/binary/pump{
@@ -16592,16 +16508,12 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "gTb" = (
-/obj/structure/chair/office/light,
-/obj/effect/landmark/start/chemist,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/machinery/light,
+/obj/structure/closet/secure_closet/chemical,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "gTc" = (
@@ -16802,6 +16714,12 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
+"haL" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "haU" = (
 /obj/machinery/button/door{
 	id = "kitchen";
@@ -16896,14 +16814,14 @@
 /turf/open/floor/plating,
 /area/library)
 "heR" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
+/area/medical/genetics)
 "heS" = (
 /turf/open/openspace,
 /area/security/execution/education)
@@ -17015,19 +16933,16 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "hhI" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
+/obj/machinery/camera{
+	c_tag = "Genetics Research";
+	dir = 8;
+	network = list("ss13","medbay")
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
+/obj/structure/table/glass,
+/obj/item/storage/box/disks{
+	pixel_x = 2;
+	pixel_y = 2
 	},
-/obj/machinery/door/window/westleft{
-	dir = 1;
-	name = "Monkey Pen";
-	req_access_txt = "9"
-	},
-/mob/living/carbon/monkey,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "hik" = (
@@ -17190,12 +17105,10 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "hop" = (
@@ -17275,17 +17188,29 @@
 /turf/open/floor/carpet/black,
 /area/crew_quarters/heads/hos)
 "hpG" = (
-/obj/machinery/door/airlock/medical/glass{
-	id_tag = "GeneticsDoor";
-	name = "Morgue";
-	req_access_txt = "5; 68"
+/obj/structure/table,
+/obj/item/book/manual/wiki/medical_cloning{
+	pixel_y = 6
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/item/storage/box/rxglasses{
+	pixel_x = 3;
+	pixel_y = 3
 	},
-/turf/open/floor/plasteel/dark,
-/area/medical/morgue)
+/obj/item/storage/box/bodybags,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/item/pen,
+/obj/machinery/camera{
+	c_tag = "Genetics Cloning";
+	network = list("ss13","medbay")
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 "hpN" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -17475,9 +17400,6 @@
 	c_tag = "Northwestern Hall 9";
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
 /turf/open/floor/plasteel/white/corner{
 	dir = 4
 	},
@@ -17600,14 +17522,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "hxr" = (
-/obj/machinery/computer/scan_consolenew,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
+/mob/living/carbon/monkey,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/grass,
 /area/medical/genetics)
 "hxw" = (
 /obj/structure/cable{
@@ -17821,7 +17739,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
-/obj/structure/disposalpipe/segment,
+/obj/machinery/atm{
+	pixel_x = -28
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "hCz" = (
@@ -18038,9 +17958,10 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hop)
 "hIe" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
 	},
+/obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/plasteel/freezer,
 /area/medical/surgery)
 "hIl" = (
@@ -18921,6 +18842,9 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
+/obj/structure/chair/office/light{
+	dir = 1
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "iaO" = (
@@ -19336,9 +19260,9 @@
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/dorms)
 "inU" = (
-/obj/machinery/chem_dispenser,
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/dark,
+/area/medical/medbay/central)
 "iob" = (
 /obj/structure/window/plasma/reinforced{
 	dir = 1
@@ -19660,8 +19584,14 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
 "ivQ" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/firedoor/heavy,
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/eastright{
+	base_state = "left";
+	icon_state = "left";
+	name = "Chemistry Desk";
+	req_access_txt = "5; 33"
+	},
 /turf/open/floor/plating,
 /area/medical/chemistry)
 "iwc" = (
@@ -20068,17 +19998,15 @@
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "iGg" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
-/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
-/area/medical/medbay/central)
+/area/medical/morgue)
 "iGB" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -20182,6 +20110,12 @@
 "iIz" = (
 /obj/structure/cable{
 	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -20480,11 +20414,15 @@
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/quartermaster/storage)
 "iRy" = (
-/obj/machinery/firealarm{
-	pixel_y = 29
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
+/area/medical/genetics)
 "iRE" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -20567,14 +20505,10 @@
 /turf/open/floor/plating,
 /area/hallway/primary/aft)
 "iWu" = (
-/obj/machinery/chem_master,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "iWz" = (
@@ -20759,14 +20693,21 @@
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "jbE" = (
-/obj/machinery/vending/wardrobe/gene_wardrobe,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
+	},
+/obj/structure/disposalpipe/sorting/mail/flip{
+	sortType = 23
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
@@ -21106,7 +21047,6 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "jmd" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -21459,6 +21399,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "jyH" = (
@@ -21772,14 +21718,18 @@
 /turf/closed/wall,
 /area/security/prison)
 "jFY" = (
-/obj/structure/bodycontainer/morgue{
-	dir = 2
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
+	},
+/obj/structure/table,
+/obj/item/storage/box/bodybags,
+/obj/item/pen,
+/obj/item/paper/guides/jobs/medical/morgue{
+	pixel_x = 5;
+	pixel_y = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
@@ -21882,21 +21832,14 @@
 /turf/closed/wall/r_wall,
 /area/security/checkpoint/supply)
 "jIu" = (
-/obj/effect/turf_decal/tile/purple{
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/item/radio/intercom{
-	pixel_x = 28
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/genetics)
+/turf/open/floor/plasteel/dark,
+/area/medical/medbay/central)
 "jIK" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -21998,6 +21941,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "jNw" = (
@@ -22219,9 +22165,18 @@
 /turf/open/floor/grass,
 /area/hydroponics/garden)
 "jTh" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
 "jTl" = (
 /obj/effect/turf_decal/stripes,
@@ -22309,19 +22264,26 @@
 /turf/closed/wall/r_wall,
 /area/storage/tech)
 "jWx" = (
-/obj/structure/table/glass,
-/obj/item/stack/sheet/mineral/plasma,
-/obj/item/stack/sheet/mineral/plasma,
-/obj/item/reagent_containers/glass/bottle/epinephrine,
-/obj/item/stack/cable_coil/random,
-/obj/item/stack/cable_coil/random,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
+/obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/structure/table/glass,
+/obj/item/book/manual/wiki/chemistry{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/book/manual/wiki/chemistry,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
+/obj/machinery/firealarm{
+	pixel_x = 2;
+	pixel_y = 26
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "jWy" = (
@@ -22352,6 +22314,9 @@
 /obj/machinery/airalarm{
 	dir = 8;
 	pixel_x = 24
+	},
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -22589,10 +22554,10 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
 	},
-/mob/living/carbon/monkey,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "keI" = (
@@ -23110,7 +23075,18 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/closed/wall/r_wall,
+/obj/machinery/door/airlock/research/glass{
+	name = "Genetics Research";
+	req_access_txt = "5; 9; 68"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4;
+	name = "east facing firelock"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "kti" = (
 /obj/effect/turf_decal/bot,
@@ -23329,6 +23305,23 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/bridge)
+"kAt" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
 "kAO" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -23441,14 +23434,10 @@
 /area/ai_monitored/security/armory)
 "kEf" = (
 /obj/structure/disposalpipe/segment{
-	dir = 6
+	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
-	},
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/open/floor/plasteel/dark,
-/area/medical/medbay/central)
+/turf/closed/wall/r_wall,
+/area/medical/genetics)
 "kEz" = (
 /obj/vehicle/ridden/atv/snowmobile,
 /obj/item/key,
@@ -23639,8 +23628,20 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
 "kMc" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
+/obj/machinery/airalarm{
+	pixel_y = 23
+	},
+/obj/machinery/vending/medical{
+	pixel_x = -2
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -23659,9 +23660,6 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/port)
 "kMy" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
@@ -24028,9 +24026,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "kYE" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
 	},
+/obj/machinery/limbgrower,
 /turf/open/floor/plasteel/freezer,
 /area/medical/surgery)
 "kYF" = (
@@ -24130,6 +24129,21 @@
 /obj/machinery/disposal/bin,
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/bar)
+"laS" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/structure/sign/warning/nosmoking{
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
 "lba" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -24310,11 +24324,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "lgq" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/disposalpipe/segment,
 /turf/closed/wall,
 /area/medical/medbay/central)
 "lgJ" = (
@@ -24598,25 +24608,11 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "loT" = (
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc{
-	areastring = "/area/medical/genetics";
-	dir = 4;
-	name = "Genetics APC";
-	pixel_x = 24
-	},
-/obj/structure/table/glass,
-/obj/item/storage/pill_bottle/mannitol,
-/obj/item/storage/pill_bottle/mutadone{
-	pixel_x = 3
-	},
-/obj/item/radio/headset/headset_medsci,
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
+/obj/machinery/dna_scannernew,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "loV" = (
@@ -24660,7 +24656,9 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "lqt" = (
@@ -25274,16 +25272,29 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
 "lIn" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/backpack/duffelbag/med/surgery,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
 	},
-/turf/open/floor/plasteel/freezer,
-/area/medical/surgery)
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/power/apc{
+	areastring = "/area/medical/genetics";
+	dir = 4;
+	name = "Genetics APC";
+	pixel_x = -25
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 "lIJ" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -25353,21 +25364,20 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
 "lMx" = (
+/obj/structure/table/glass,
+/obj/item/radio/headset/headset_medsci,
+/obj/item/storage/pill_bottle/mannitol,
+/obj/item/storage/pill_bottle/mutadone{
+	pixel_x = 3
+	},
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/mob/living/carbon/monkey,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "lMF" = (
@@ -25868,10 +25878,9 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "mdq" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/closed/wall,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk,
+/turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
 "mdG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -26558,6 +26567,14 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/structure/table/glass,
+/obj/item/reagent_containers/glass/beaker/large{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/dropper,
+/obj/item/reagent_containers/dropper,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "mAK" = (
@@ -26677,18 +26694,11 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "mEI" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor/heavy,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/door/window/eastright{
-	base_state = "left";
-	dir = 1;
-	icon_state = "left";
-	name = "Chemistry Desk";
-	req_access_txt = "5; 33"
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 5
 	},
-/turf/open/floor/plating,
-/area/medical/chemistry)
+/turf/open/floor/plasteel/dark,
+/area/medical/medbay/central)
 "mET" = (
 /obj/structure/toilet/secret/prison,
 /obj/machinery/light/small{
@@ -26961,13 +26971,13 @@
 /turf/open/floor/wood,
 /area/medical/psych)
 "mLD" = (
-/obj/structure/closet/wardrobe/chemistry_white,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/machinery/vending/wardrobe/chem_wardrobe,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "mLK" = (
@@ -27154,23 +27164,6 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
-"mQJ" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/machinery/power/apc/auto_name/east,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/dark,
-/area/medical/morgue)
 "mQK" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -27316,11 +27309,13 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "mVh" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
 	},
-/turf/closed/wall,
-/area/medical/morgue)
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/dark,
+/area/medical/medbay/central)
 "mVi" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -27355,15 +27350,18 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "mVN" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/dark,
-/area/medical/medbay/central)
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 "mWc" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -27431,15 +27429,12 @@
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/bridge)
 "mYd" = (
-/obj/structure/bodycontainer/morgue{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/bodycontainer/morgue{
+	dir = 2
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
@@ -27544,14 +27539,17 @@
 /area/icemoon/surface/outdoors)
 "nbU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -27591,7 +27589,6 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "ndm" = (
-/obj/machinery/chem_dispenser,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
@@ -27819,6 +27816,9 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
 /turf/open/floor/plasteel/dark,
 /area/medical/surgery)
 "nhK" = (
@@ -27941,9 +27941,30 @@
 /turf/open/floor/carpet,
 /area/bridge)
 "nmR" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plating,
+/obj/machinery/door/airlock/research/glass{
+	name = "Genetics Research";
+	req_access_txt = "5; 9; 68"
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "nmY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -28252,10 +28273,12 @@
 	},
 /area/maintenance/aft/secondary)
 "nwq" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/closed/wall,
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
 "nwz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -28451,21 +28474,10 @@
 /turf/open/floor/plating,
 /area/medical/storage)
 "nBI" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/structure/table/glass,
-/obj/item/storage/box/syringes,
-/obj/item/clothing/glasses/science,
-/obj/item/clothing/glasses/science{
-	pixel_x = 2;
-	pixel_y = 4
-	},
+/obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "nBU" = (
@@ -28601,6 +28613,7 @@
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
 "nEa" = (
@@ -28933,7 +28946,12 @@
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "nOj" = (
-/obj/machinery/limbgrower,
+/obj/machinery/light_switch{
+	pixel_y = -23
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
 /turf/open/floor/plasteel/freezer,
 /area/medical/surgery)
 "nOk" = (
@@ -28982,11 +29000,14 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "nOR" = (
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/disposalpipe/segment{
+	dir = 9
 	},
-/turf/open/floor/plasteel/white,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
+/turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
 "nOY" = (
 /obj/machinery/camera{
@@ -29143,12 +29164,19 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "nRX" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/structure/closet/secure_closet/medical1,
+/obj/item/storage/box/rxglasses,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
@@ -29242,9 +29270,6 @@
 /turf/open/floor/plasteel,
 /area/storage/auxiliary)
 "nVv" = (
-/obj/structure/sign/warning/nosmoking{
-	pixel_y = 30
-	},
 /obj/structure/table/glass,
 /obj/item/grenade/chem_grenade,
 /obj/item/grenade/chem_grenade,
@@ -29263,6 +29288,11 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/item/stack/sheet/mineral/plasma,
+/obj/item/stack/cable_coil/random,
+/obj/item/stack/cable_coil/random,
+/obj/item/reagent_containers/glass/bottle/epinephrine,
+/obj/item/stack/sheet/mineral/plasma,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "nVI" = (
@@ -29307,13 +29337,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "nXs" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
+/mob/living/carbon/monkey,
+/obj/structure/window/reinforced,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/grass,
 /area/medical/genetics)
 "nXy" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -29594,9 +29622,6 @@
 "ofF" = (
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -30252,15 +30277,21 @@
 /turf/open/floor/plasteel/yellowsiding,
 /area/crew_quarters/fitness/pool)
 "ouB" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
-/obj/structure/disposalpipe/sorting/mail/flip{
-	sortType = 23
+/obj/machinery/light_switch{
+	pixel_y = -28
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
@@ -30980,8 +31011,18 @@
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
 "oTF" = (
-/turf/closed/wall/r_wall,
-/area/medical/morgue)
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 "oTT" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -31283,24 +31324,7 @@
 /turf/open/floor/plating,
 /area/medical/psych)
 "pbP" = (
-/obj/structure/table,
-/obj/item/storage/box/bodybags,
-/obj/item/pen,
-/obj/item/paper/guides/jobs/medical/morgue{
-	pixel_x = 5;
-	pixel_y = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
+/turf/closed/wall/r_wall,
 /area/medical/morgue)
 "pbS" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -32237,7 +32261,6 @@
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/miningdock)
 "pxE" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -32310,8 +32333,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "pyD" = (
-/obj/machinery/chem_heater,
-/obj/structure/disposalpipe/segment,
+/obj/machinery/chem_master,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "pyF" = (
@@ -33067,6 +33089,7 @@
 /obj/machinery/door/firedoor/border_only{
 	name = "south facing firelock"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
 /area/medical/surgery)
 "pRV" = (
@@ -33265,16 +33288,16 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple,
-/obj/structure/table,
-/obj/item/book/manual/wiki/medical_cloning{
-	pixel_y = 6
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
 	},
-/obj/item/storage/box/bodybags,
-/obj/item/storage/box/rxglasses{
-	pixel_x = 3;
-	pixel_y = 3
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
-/obj/item/pen,
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -22
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "pXp" = (
@@ -33321,10 +33344,17 @@
 /turf/closed/wall/r_wall,
 /area/medical/virology)
 "pZJ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
-/turf/closed/wall/r_wall,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "qal" = (
 /obj/structure/chair,
@@ -33522,9 +33552,16 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
 "qfd" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall,
-/area/medical/morgue)
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/machinery/dna_scannernew,
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 "qfJ" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -33996,8 +34033,6 @@
 	dir = 4;
 	pixel_x = -24
 	},
-/obj/structure/table/reinforced,
-/obj/item/storage/backpack/duffelbag/med/surgery,
 /turf/open/floor/plasteel/freezer,
 /area/medical/surgery)
 "qsD" = (
@@ -34106,6 +34141,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"qxz" = (
+/obj/machinery/light,
+/obj/structure/sign/warning/securearea{
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "qxM" = (
 /obj/machinery/door/airlock/public/glass{
 	id_tag = null;
@@ -34988,9 +35030,21 @@
 /turf/open/floor/circuit/off,
 /area/ai_monitored/turret_protected/ai)
 "qVD" = (
-/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
 /turf/open/floor/plasteel/white,
-/area/medical/chemistry)
+/area/medical/genetics)
 "qWa" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
@@ -35029,16 +35083,11 @@
 /turf/open/floor/plasteel/dark,
 /area/science/server)
 "qWL" = (
-/obj/structure/table/glass,
-/obj/item/book/manual/wiki/chemistry,
-/obj/item/book/manual/wiki/chemistry{
-	pixel_x = 3;
-	pixel_y = 3
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow,
+/obj/machinery/chem_master,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "qXm" = (
@@ -35130,11 +35179,18 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
 "qZP" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
 	},
-/turf/closed/wall,
-/area/medical/morgue)
+/obj/machinery/shower{
+	pixel_x = 11;
+	pixel_y = 20
+	},
+/obj/structure/mirror{
+	pixel_y = 28
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 "rac" = (
 /obj/structure/table,
 /obj/machinery/button/door{
@@ -35457,10 +35513,6 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "rjO" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/effect/landmark/start/geneticist,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
@@ -35509,8 +35561,7 @@
 /area/tcommsat/computer)
 "rkL" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "rkP" = (
 /obj/structure/window/reinforced{
@@ -35822,11 +35873,12 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "rqQ" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
 	},
-/turf/closed/wall,
-/area/medical/morgue)
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "rqS" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -35886,7 +35938,6 @@
 /area/hallway/secondary/entry)
 "rsy" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/disposalpipe/segment,
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/medbay/central)
@@ -36020,6 +36071,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
+"rwU" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "rwW" = (
 /obj/machinery/button/door{
 	id = "psyshu";
@@ -36361,7 +36418,6 @@
 /turf/open/floor/wood,
 /area/library)
 "rHS" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/airlock/medical{
 	name = "Morgue";
 	req_access_txt = "6;5"
@@ -36610,17 +36666,18 @@
 /turf/closed/wall,
 /area/maintenance/starboard)
 "rPD" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/door/airlock/medical/glass{
+	id_tag = "GeneticsDoor";
+	name = "Genetics";
+	req_access_txt = "5; 68"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/camera{
-	c_tag = "Northwestern Hall 8";
-	dir = 4
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
 	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
-/area/hallway/primary/port)
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 "rPU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -36664,7 +36721,6 @@
 /turf/closed/wall,
 /area/science/robotics/lab)
 "rQN" = (
-/obj/machinery/chem_master,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
@@ -36672,6 +36728,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow,
+/obj/machinery/chem_dispenser,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "rQU" = (
@@ -36727,6 +36784,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
 	icon_state = "1-4"
+	},
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/surgery)
@@ -36921,6 +36982,10 @@
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
 "rYD" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "rYN" = (
@@ -37138,11 +37203,12 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "seZ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/closed/wall,
-/area/medical/morgue)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/medical/genetics)
 "sfm" = (
 /obj/item/radio/intercom{
 	pixel_y = 25
@@ -37177,17 +37243,9 @@
 /obj/machinery/airalarm{
 	pixel_y = 23
 	},
-/obj/machinery/dna_scannernew,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
+/mob/living/carbon/monkey,
+/obj/structure/sink/puddle,
+/turf/open/floor/grass,
 /area/medical/genetics)
 "shN" = (
 /obj/structure/cable{
@@ -37276,9 +37334,6 @@
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "sjW" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
 	},
@@ -37288,10 +37343,23 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/purple,
 /obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/machinery/light{
 	dir = 4
 	},
-/obj/structure/closet/wardrobe/grey,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "skw" = (
@@ -37532,10 +37600,8 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "srB" = (
@@ -38607,21 +38673,15 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "sXl" = (
-/obj/structure/table/glass,
-/obj/item/storage/box/disks{
-	pixel_x = 2;
-	pixel_y = 2
-	},
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
+/mob/living/carbon/monkey,
+/obj/structure/window/reinforced{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/obj/structure/flora/ausbushes/grassybush,
+/turf/open/floor/grass,
 /area/medical/genetics)
 "sXs" = (
 /obj/effect/turf_decal/stripes/line,
@@ -38807,7 +38867,6 @@
 /obj/item/radio/intercom{
 	pixel_y = 20
 	},
-/obj/machinery/vending/wardrobe/chem_wardrobe,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
@@ -38816,6 +38875,18 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Chemistry"
+	},
+/obj/structure/table/glass,
+/obj/machinery/reagentgrinder{
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/glass/beaker{
+	pixel_x = 8;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/glass/beaker{
+	pixel_x = 8;
+	pixel_y = 2
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
@@ -39209,11 +39280,15 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
+/obj/machinery/clonepod,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
 	},
-/turf/closed/wall/r_wall,
-/area/medical/medbay/central)
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 "toa" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -39880,19 +39955,12 @@
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "tHr" = (
-/obj/structure/closet/secure_closet/medical1,
-/obj/item/storage/box/rxglasses,
 /obj/item/radio/intercom{
 	pixel_x = 25
 	},
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Genetics Research";
-	dir = 8;
-	network = list("ss13","medbay")
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
@@ -40092,6 +40160,9 @@
 /obj/item/reagent_containers/glass/beaker/cryoxadone{
 	pixel_x = 10
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
 "tML" = (
@@ -40120,9 +40191,15 @@
 /turf/open/floor/plasteel/dark,
 /area/science/server)
 "tNq" = (
-/obj/structure/disposalpipe/segment,
-/turf/closed/wall,
-/area/medical/medbay/central)
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor/heavy,
+/obj/machinery/door/window/westleft{
+	dir = 1;
+	name = "Monkey Pen";
+	req_access_txt = "9"
+	},
+/turf/open/floor/plating,
+/area/medical/genetics)
 "tNX" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -40901,9 +40978,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "ujD" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
 "ujE" = (
@@ -41247,9 +41322,6 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "uuD" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -41258,6 +41330,10 @@
 	},
 /obj/structure/bed/roller,
 /obj/machinery/iv_drip,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "uuU" = (
@@ -41763,11 +41839,11 @@
 /turf/open/floor/plating,
 /area/engine/atmospherics_engine)
 "uKI" = (
-/obj/structure/chair/office/light{
-	dir = 1
-	},
-/obj/effect/landmark/start/geneticist,
-/turf/open/floor/plasteel/white,
+/obj/structure/window/reinforced,
+/mob/living/carbon/monkey,
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/grass,
 /area/medical/genetics)
 "uKM" = (
 /obj/machinery/light{
@@ -42024,8 +42100,20 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "uUl" = (
-/turf/closed/wall/r_wall,
-/area/medical/medbay/central)
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/machinery/computer/cloning{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 "uUr" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -42037,6 +42125,7 @@
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
 "uUJ" = (
@@ -42186,8 +42275,8 @@
 /turf/open/floor/circuit/off,
 /area/ai_monitored/turret_protected/ai)
 "uXB" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
+/obj/structure/disposalpipe/junction{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -42332,15 +42421,11 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
+/obj/structure/chair/office/light{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "vaB" = (
@@ -42729,20 +42814,17 @@
 /turf/open/floor/wood,
 /area/library)
 "vkY" = (
-/obj/machinery/door/airlock/medical/glass{
-	id_tag = "GeneticsDoor";
-	name = "Genetics";
-	req_access_txt = "5; 68"
-	},
-/obj/machinery/door/firedoor/border_only,
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
-/area/medical/genetics)
+/area/medical/medbay/central)
 "vlv" = (
 /obj/effect/landmark/start/prisoner,
 /obj/effect/landmark/start/prisoner,
@@ -42922,15 +43004,12 @@
 /area/maintenance/aft/secondary)
 "vqF" = (
 /obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "vqP" = (
@@ -43121,6 +43200,7 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/medical_doctor,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
 "vvM" = (
@@ -43266,7 +43346,10 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
 "vyJ" = (
-/mob/living/carbon/monkey,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "vyM" = (
@@ -43328,7 +43411,14 @@
 /area/medical/surgery)
 "vAp" = (
 /obj/structure/disposalpipe/segment{
-	dir = 6
+	dir = 4
+	},
+/obj/machinery/vending/wardrobe/gene_wardrobe,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
@@ -43351,6 +43441,10 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/disposal/bin,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "vAF" = (
@@ -43533,9 +43627,13 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/chair/office/light,
+/obj/effect/landmark/start/geneticist,
+/obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/mob/living/carbon/monkey,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "vEA" = (
@@ -43649,8 +43747,11 @@
 /turf/open/floor/wood,
 /area/hallway/primary/central)
 "vIA" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+	dir = 6
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
@@ -43777,8 +43878,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/camera{
+	c_tag = "Northwestern Hall 8";
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
@@ -43859,9 +43961,6 @@
 /turf/open/floor/plasteel/white/side,
 /area/hallway/primary/port)
 "vNu" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
@@ -44836,8 +44935,8 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/computer/scan_consolenew{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
@@ -45270,8 +45369,11 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "wzH" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 5
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
@@ -45581,16 +45683,13 @@
 /turf/open/floor/plating,
 /area/science/robotics/lab)
 "wJN" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue,
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "0-8"
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
@@ -45607,6 +45706,7 @@
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
 "wKL" = (
@@ -45614,12 +45714,14 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "wKN" = (
-/obj/machinery/vending/wallmed{
-	pixel_y = -28
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/structure/closet/crate/freezer/blood,
-/turf/open/floor/plasteel/freezer,
-/area/medical/surgery)
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "wKU" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -46273,13 +46375,17 @@
 /turf/open/floor/plating,
 /area/engine/atmospherics_engine)
 "xgq" = (
-/obj/structure/closet/crate/freezer/surplus_limbs,
-/obj/item/reagent_containers/glass/beaker/synthflesh,
-/obj/machinery/light_switch{
-	pixel_y = -23
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/plasteel/freezer,
-/area/medical/surgery)
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "xgu" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
@@ -46650,7 +46756,9 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "xrW" = (
@@ -46783,7 +46891,9 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "xwO" = (
@@ -47114,18 +47224,14 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "xGj" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/port)
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "xGo" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -47228,8 +47334,10 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -27;
+	pixel_y = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -47736,6 +47844,18 @@
 	},
 /turf/open/floor/wood,
 /area/hallway/secondary/exit/departure_lounge)
+"xZh" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
 "xZp" = (
 /obj/structure/chair/stool/bar,
 /obj/machinery/camera{
@@ -63641,9 +63761,9 @@ pZD
 cGu
 qsz
 aPp
-wKN
-oto
-fUX
+oKr
+aqP
+ash
 ash
 ash
 hEQ
@@ -63897,12 +64017,12 @@ sVL
 pZD
 dfV
 oKr
+anK
 oKr
-xgq
-oto
-gkx
+cwW
+ash
 kMc
-anm
+djL
 nsi
 cEf
 eLX
@@ -64157,7 +64277,7 @@ hIe
 kYE
 nOj
 oto
-iRy
+ash
 anm
 anm
 anJ
@@ -64667,7 +64787,7 @@ puS
 iIg
 pZD
 fDi
-lIn
+pED
 fgp
 poT
 rFk
@@ -64675,7 +64795,7 @@ sTe
 jih
 jih
 wkM
-anm
+uUk
 alR
 anm
 anm
@@ -64924,7 +65044,7 @@ sXV
 laE
 pZD
 aaS
-aba
+ann
 aba
 aba
 oto
@@ -65192,10 +65312,10 @@ lgq
 rsy
 pxE
 jmd
-rkL
-tNq
-jTh
-mdq
+aoj
+ash
+aoj
+qWg
 aoj
 qWg
 anm
@@ -65445,7 +65565,7 @@ nhz
 pRf
 duu
 dJZ
-nwq
+ash
 hWn
 eSP
 uan
@@ -65453,10 +65573,10 @@ sMA
 uAe
 ykb
 tMt
-sMA
-xGP
-anm
-iEa
+mdq
+nwq
+rkL
+vkY
 lDj
 gzk
 eiR
@@ -65705,11 +65825,11 @@ ofF
 lCW
 fXH
 eSP
-uan
-sMA
+gNq
+inU
 uUC
-sMA
-sMA
+inU
+jIu
 sMA
 xGP
 anm
@@ -65960,14 +66080,14 @@ fKM
 adA
 hom
 lIm
-sMA
+ujD
 vvH
 ujD
-sMA
+ujD
 wKC
 nDC
 wzH
-sMA
+mEI
 xGP
 anm
 dSH
@@ -66207,14 +66327,14 @@ tlu
 wAW
 xhb
 uCi
-aqP
+uYa
 xFQ
 pZD
 eEy
 gzW
 ueK
 pZD
-ady
+anm
 ycQ
 ash
 tmy
@@ -66223,17 +66343,17 @@ tmy
 sMA
 vMf
 epK
-wKC
-wzH
-xGP
-anm
+jTh
+mVh
+nOR
+rqQ
 iEa
 anm
 sxa
 amD
+haL
 anm
 anm
-cwW
 jXh
 tUF
 tkr
@@ -66473,24 +66593,24 @@ pZD
 pZD
 pZD
 gZX
-seZ
-qfd
-qfd
-qfd
+gZX
+gZX
+gZX
+gZX
 rHS
-rqQ
-mVh
+gZX
+nYZ
 kEf
-iGg
-mVN
-nOR
+nnj
+nYZ
+nYZ
 wXj
 xAi
 aoX
 aoX
-ann
-ivQ
 aoX
+ivQ
+aaH
 aoX
 tUF
 gIG
@@ -66732,15 +66852,15 @@ pZD
 tyH
 vNu
 gCS
-gCS
+eSQ
 gCS
 ipu
 pbP
 qZP
 tnX
 uUl
-uUl
-uUl
+qfd
+nYZ
 wXj
 anm
 vmO
@@ -66748,7 +66868,7 @@ hik
 mAx
 ndm
 rQN
-aoX
+aaH
 soN
 ojv
 oTu
@@ -66989,15 +67109,15 @@ pZD
 jFY
 vIA
 rYD
+fUX
 rYD
-rYD
-rYD
+iGg
 gId
 oTF
 dTL
 bLM
 gbg
-nYZ
+nnj
 fJs
 jBr
 mYT
@@ -67249,17 +67369,17 @@ mYd
 bLW
 cDS
 wJN
-mQJ
+pbP
 hpG
 fNO
 rjO
 gXE
-nmR
+rPD
 nIR
 xhD
 xur
 lqg
-qVD
+yds
 pyD
 guR
 aaH
@@ -67511,17 +67631,17 @@ nYZ
 dcg
 fLL
 jNp
-nnj
+seZ
 adM
 anm
 aoX
 vAy
 yds
-anK
+yds
 gTb
-mEI
-xGj
-eDr
+aoX
+rJw
+xZh
 fYQ
 tXN
 tXN
@@ -67766,17 +67886,17 @@ nRX
 jbE
 nmR
 sjW
-eFU
+mVN
 pXl
-nnj
-adM
+nYZ
+uUk
 anm
 aoX
 tcP
 yds
-inU
+yds
 iWu
-aoX
+bgz
 rJw
 tkr
 fYQ
@@ -68021,12 +68141,12 @@ hxr
 uKI
 vAp
 ouB
-eSQ
-gNq
+nYZ
+nYZ
 dCI
-jIu
-vkY
-heR
+nnj
+nYZ
+uUk
 anm
 aoX
 ali
@@ -68034,7 +68154,7 @@ yds
 yds
 aon
 aoX
-rJw
+laS
 tkr
 fYQ
 oZE
@@ -68278,19 +68398,19 @@ sXl
 eFU
 jyA
 goK
-nYZ
-nYZ
+iRy
+lIn
 pZJ
-nYZ
-nYZ
-uUk
+qVD
+nnj
+wKN
 anm
 aoX
 mLD
 yds
 yds
-gev
-aoX
+guR
+aaH
 gsM
 tkr
 ayG
@@ -68531,21 +68651,21 @@ mbm
 mbm
 mbm
 nYZ
-hxr
-uKI
+gkx
+heR
 fBf
 vqF
 vax
 lMx
 keC
 vEr
-nnj
-uUk
-xAi
+tNq
+xgq
+qxz
 aoX
 nVv
-yds
-yds
+gjf
+rwU
 qWL
 aoX
 gsM
@@ -68797,14 +68917,14 @@ hhI
 vyJ
 fgM
 nnj
-uUk
+xGj
 anm
 aoX
 jWx
 nBI
 anL
 aoo
-aoX
+aaH
 gsM
 tkr
 wje
@@ -69049,7 +69169,7 @@ nYZ
 nYZ
 nYZ
 nYZ
-djL
+nYZ
 nYZ
 nYZ
 ktd
@@ -69058,9 +69178,9 @@ hxP
 uWY
 aoX
 aoX
-aoX
-aoX
-aoX
+aaH
+eVY
+aaH
 aoX
 gsM
 tkr
@@ -69313,9 +69433,9 @@ xrU
 yij
 iWY
 iTY
-yij
+kAt
 vLr
-rPD
+gKt
 srq
 cXi
 gKt

--- a/_maps/map_files/Snaxi/Snaxi_Lumos.dmm
+++ b/_maps/map_files/Snaxi/Snaxi_Lumos.dmm
@@ -308,7 +308,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -1062,15 +1061,6 @@
 "apJ" = (
 /turf/closed/wall/r_wall,
 /area/tcommsat/server)
-"apK" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/pod/dark,
-/area/medical/paramedic)
 "apN" = (
 /obj/machinery/telecomms/bus/preset_three,
 /turf/open/floor/plasteel/dark/telecomms,
@@ -3419,6 +3409,16 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
+"aRO" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/plasteel/dark,
+/area/medical/paramedic)
 "aSl" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -3630,8 +3630,15 @@
 	codes_txt = "patrol;next_patrol=QM";
 	location = "CHW"
 	},
+/obj/machinery/vending/wardrobe/medi_wardrobe,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"aYo" = (
+/obj/structure/rack,
+/obj/item/storage/box/masks,
+/obj/item/cartridge/medical,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "aYB" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
@@ -3743,23 +3750,14 @@
 /turf/open/floor/engine/plasma,
 /area/engine/atmos)
 "bcR" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/structure/disposaloutlet{
 	dir = 4
 	},
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = 28
+/obj/structure/disposalpipe/trunk{
+	dir = 8
 	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white/corner{
-	dir = 4
-	},
-/area/hallway/primary/port)
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/medical/virology)
 "bdd" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -3811,8 +3809,15 @@
 "beD" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
 /turf/open/floor/plating,
 /area/medical/virology)
+"bfa" = (
+/obj/structure/sign/poster/official/help_others,
+/turf/closed/wall,
+/area/medical/paramedic)
 "bff" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -4653,9 +4658,11 @@
 /turf/open/floor/plating,
 /area/icemoon/surface/outdoors)
 "byu" = (
-/obj/structure/disposalpipe/segment,
-/turf/closed/wall/r_wall,
-/area/medical/virology)
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 6
+	},
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors)
 "byz" = (
 /obj/machinery/door/morgue{
 	name = "Confession Booth (Chaplain)";
@@ -7238,6 +7245,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"cdV" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/dark,
+/area/medical/paramedic)
 "cep" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -8025,6 +8036,13 @@
 	},
 /turf/open/floor/plasteel/checker,
 /area/crew_quarters/heads/hor)
+"csa" = (
+/obj/machinery/door/airlock/atmos{
+	name = "Atmospherics Maintenance";
+	req_access_txt = "12;24;39"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "cso" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -8288,6 +8306,12 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
 	},
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/dropper,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/item/reagent_containers/syringe/antiviral,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "cAq" = (
@@ -8967,9 +8991,6 @@
 	pixel_x = -12;
 	pixel_y = 2
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
@@ -8978,6 +8999,9 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -10581,6 +10605,10 @@
 /obj/structure/mineral_door/woodrustic,
 /turf/open/floor/plating,
 /area/icemoon/surface/outdoors)
+"dII" = (
+/obj/structure/closet/l3closet/security,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "dJb" = (
 /obj/machinery/door/airlock{
 	id_tag = "Dorm3";
@@ -11074,14 +11102,10 @@
 	},
 /area/engine/break_room)
 "dYZ" = (
-/obj/docking_port/stationary{
-	dwidth = 1;
-	height = 4;
-	name = "escape pod loader";
-	roundstart_template = /datum/map_template/shuttle/escape_pod/default;
-	width = 3
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 8
 	},
-/turf/open/floor/plating/snowed/smoothed/icemoon,
+/turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors)
 "dZa" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -11421,12 +11445,12 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "eik" = (
-/obj/docking_port/stationary/random{
-	id = "pod_lavaland2";
-	name = "lavaland"
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 8
 	},
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/surface/outdoors)
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "eiz" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
@@ -12632,6 +12656,15 @@
 /obj/effect/landmark/start/station_engineer,
 /turf/open/floor/plating,
 /area/engine/atmospherics_engine)
+"eQR" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/machinery/airalarm{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/dark,
+/area/medical/paramedic)
 "eRt" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -12735,16 +12768,14 @@
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "eSJ" = (
-/obj/structure/table/glass,
-/obj/item/clothing/glasses/hud/health,
-/obj/item/healthanalyzer,
-/obj/item/clothing/gloves/color/latex,
 /obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
+/obj/machinery/smartfridge/chemistry/virology/preloaded,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "eSK" = (
@@ -12792,16 +12823,15 @@
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
 "eTu" = (
-/obj/machinery/door/airlock/medical/glass{
-	id_tag = "MedbayFoyer";
-	name = "Medbay";
-	req_access_txt = "5"
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
 	},
-/obj/structure/fans/tiny,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
-/turf/open/floor/pod/dark,
+/obj/machinery/space_heater,
+/turf/open/floor/plasteel/dark,
 /area/medical/paramedic)
 "eTv" = (
 /obj/machinery/airalarm{
@@ -12832,7 +12862,7 @@
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
 "eTX" = (
-/obj/machinery/vending/wardrobe/medi_wardrobe,
+/obj/structure/closet/secure_closet/medical1,
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
 "eUB" = (
@@ -12851,6 +12881,10 @@
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
+"eUK" = (
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "eVi" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Bridge";
@@ -14027,12 +14061,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
-"fBk" = (
-/obj/machinery/camera{
-	c_tag = "Northwestern Hall 10"
-	},
-/turf/open/floor/plasteel/dark,
-/area/hallway/primary/port)
 "fBs" = (
 /obj/machinery/light,
 /obj/machinery/camera{
@@ -14048,6 +14076,13 @@
 "fBS" = (
 /turf/open/floor/plating,
 /area/engine/storage)
+"fBV" = (
+/obj/machinery/door/airlock/external{
+	name = "Escape Pod Two"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/hallway/primary/port)
 "fCh" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
@@ -14087,6 +14122,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/security/brig)
+"fDn" = (
+/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
+/obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "fDo" = (
 /turf/closed/wall/r_wall,
 /area/hallway/primary/port)
@@ -14796,15 +14838,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "fXd" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 10
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/paramedic)
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "fXs" = (
 /obj/machinery/computer/nanite_chamber_control,
 /turf/open/floor/circuit,
@@ -15774,6 +15812,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"gzE" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
+/obj/structure/chair/office/light,
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "gzH" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -16232,18 +16275,13 @@
 /turf/open/floor/plasteel/checker,
 /area/crew_quarters/heads/hor)
 "gNb" = (
-/obj/structure/table/glass,
-/obj/item/storage/box/beakers{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/storage/box/syringes,
 /obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
+/obj/machinery/computer/pandemic,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "gNq" = (
@@ -16615,11 +16653,6 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
-"gVo" = (
-/obj/vehicle/ridden/atv/snowmobile,
-/obj/item/key,
-/turf/open/floor/pod/dark,
-/area/medical/paramedic)
 "gWc" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /obj/machinery/door/firedoor/border_only{
@@ -16650,6 +16683,12 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating,
 /area/hallway/primary/fore)
+"gWQ" = (
+/obj/machinery/camera{
+	c_tag = "Northwestern Hall 10"
+	},
+/turf/open/floor/plasteel/dark,
+/area/hallway/primary/port)
 "gWZ" = (
 /obj/machinery/computer/telecomms/monitor,
 /obj/effect/turf_decal/tile/green{
@@ -16713,13 +16752,6 @@
 "gZX" = (
 /turf/closed/wall,
 /area/medical/morgue)
-"hah" = (
-/obj/effect/landmark/event_spawn,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/pod/dark,
-/area/medical/paramedic)
 "haj" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -17043,9 +17075,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "hlT" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
+/mob/living/simple_animal/bot/medbot,
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
 "hlV" = (
@@ -17099,10 +17129,6 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"hnO" = (
-/obj/machinery/atmospherics/components/unary/cryo_cell,
-/turf/open/floor/plasteel/white,
-/area/medical/paramedic)
 "hnP" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -17121,9 +17147,6 @@
 "hom" = (
 /obj/structure/cable{
 	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
@@ -17345,6 +17368,19 @@
 	},
 /turf/open/floor/plasteel/airless/white/side,
 /area/medical/storage)
+"hss" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/visible{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/hallway/primary/port)
 "hsu" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -17411,19 +17447,11 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "hui" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/machinery/camera{
 	c_tag = "Northwestern Hall 9";
 	dir = 4
 	},
-/turf/open/floor/plasteel/white/corner{
-	dir = 4
-	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "huA" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/carbon_input{
@@ -17598,6 +17626,17 @@
 /obj/machinery/vending/autodrobe,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"hyJ" = (
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/machinery/disposal/bin,
+/turf/open/floor/plasteel/white,
+/area/medical/paramedic)
 "hyK" = (
 /obj/effect/turf_decal/trimline/yellow/filled,
 /obj/machinery/light{
@@ -17840,6 +17879,7 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
+/obj/item/reagent_containers/food/snacks/grown/strawberry,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "hDk" = (
@@ -17978,6 +18018,18 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hop)
+"hId" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/space_heater,
+/obj/structure/window/reinforced,
+/turf/open/floor/plasteel/dark,
+/area/medical/paramedic)
 "hIe" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -19311,10 +19363,17 @@
 /turf/open/floor/wood,
 /area/hallway/secondary/exit/departure_lounge)
 "iop" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible,
-/obj/effect/landmark/start/paramedic,
+/obj/machinery/computer/med_data{
+	dir = 1
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
+"iox" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "ioB" = (
 /obj/structure/frame/computer{
 	dir = 8
@@ -19769,14 +19828,11 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
 "iAO" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/light/small{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/hallway/primary/port)
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "iAR" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -19853,6 +19909,13 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/engine,
 /area/engine/supermatter)
+"iCE" = (
+/obj/docking_port/stationary/random{
+	id = "pod_lavaland2";
+	name = "lavaland"
+	},
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/surface/outdoors)
 "iCO" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -19987,7 +20050,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
@@ -20129,7 +20191,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "iIg" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -20610,6 +20672,24 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"iYh" = (
+/obj/machinery/door/airlock/medical/glass{
+	id_tag = "MedbayFoyer";
+	name = "Medbay";
+	req_access_txt = "5"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/structure/fans/tiny,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/medical/paramedic)
 "iYi" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/wood,
@@ -21091,6 +21171,14 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/storage/atmos)
+"jmg" = (
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plasteel/dark,
+/area/hallway/primary/port)
 "jmU" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -21285,6 +21373,16 @@
 /obj/item/reagent_containers/food/condiment/flour,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"jtV" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plasteel/dark,
+/area/medical/paramedic)
 "jur" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -21420,6 +21518,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"jym" = (
+/obj/machinery/door/airlock/external{
+	name = "Escape Pod One"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/hallway/primary/port)
 "jyA" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/disposalpipe/segment{
@@ -21575,10 +21680,15 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "jBP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
+/obj/structure/table/glass,
+/obj/item/book/manual/wiki/infections{
+	pixel_y = 7
+	},
+/obj/item/hand_labeler,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "jCw" = (
@@ -21695,7 +21805,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
-/obj/effect/landmark/start/paramedic,
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
 "jEE" = (
@@ -21903,12 +22012,9 @@
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "jKV" = (
-/obj/machinery/door/airlock/external{
-	name = "Escape Pod One"
-	},
-/obj/structure/fans/tiny,
+/obj/machinery/atmospherics/components/unary/tank/air,
 /turf/open/floor/plating,
-/area/hallway/primary/port)
+/area/maintenance/port/fore)
 "jLp" = (
 /obj/effect/turf_decal/arrows/red{
 	dir = 4
@@ -22135,6 +22241,11 @@
 	},
 /turf/open/floor/engine/o2,
 /area/engine/atmos)
+"jRd" = (
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "jRB" = (
 /obj/structure/table,
 /obj/item/storage/belt/utility,
@@ -22739,13 +22850,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "kkt" = (
-/obj/structure/table/glass,
-/obj/item/book/manual/wiki/infections{
-	pixel_y = 7
-	},
 /obj/item/reagent_containers/spray/cleaner,
-/obj/item/reagent_containers/dropper,
-/obj/item/reagent_containers/syringe/antiviral,
 /obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
@@ -22753,6 +22858,16 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/table/reinforced,
+/obj/item/storage/box/syringes,
+/obj/item/storage/box/beakers{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/item/stack/sheet/mineral/plasma,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "kkG" = (
@@ -22790,9 +22905,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/starboard)
 "klh" = (
-/obj/structure/table,
 /obj/item/radio/headset/headset_med,
-/obj/item/hand_labeler,
 /obj/structure/reagent_dispensers/virusfood{
 	pixel_x = 30
 	},
@@ -22800,6 +22913,11 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/green,
+/obj/machinery/door/window/westleft{
+	dir = 2;
+	name = "Lab Door";
+	req_access_txt = "39"
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "klo" = (
@@ -23306,6 +23424,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "kyc" = (
@@ -23497,7 +23616,13 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/surgery)
 "kHd" = (
-/turf/open/floor/pod/dark,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/bed/roller,
+/obj/machinery/iv_drip,
+/turf/open/floor/plasteel/dark,
 /area/medical/paramedic)
 "kHl" = (
 /obj/effect/turf_decal/tile/red{
@@ -23659,6 +23784,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
+"kLU" = (
+/obj/machinery/atmospherics/pipe/manifold4w/cyan/hidden,
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "kMc" = (
 /obj/machinery/airalarm{
 	pixel_y = 23
@@ -23681,14 +23810,18 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/external,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/public/glass{
+	name = "Snow Airlock"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/port)
 "kMy" = (
@@ -24146,8 +24279,8 @@
 	dir = 4;
 	name = "east facing firelock"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -24344,12 +24477,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
 /area/medical/medbay/central)
-"lgJ" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 9
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/paramedic)
 "lgX" = (
 /obj/machinery/camera{
 	c_tag = "Fore Starboard Solars";
@@ -24433,17 +24560,19 @@
 /turf/open/floor/wood,
 /area/hallway/secondary/exit/departure_lounge)
 "ljT" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/pod/dark,
+/obj/machinery/holopad,
+/turf/open/floor/plasteel/white,
 /area/medical/paramedic)
 "lki" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/public/glass{
+	name = "Snow Airlock"
+	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/structure/fans/tiny,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/port)
 "lkP" = (
@@ -24479,6 +24608,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"llI" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/medical/paramedic)
 "lmm" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -24664,6 +24797,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"lpw" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "lpR" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -24960,11 +25099,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/end,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "lzB" = (
@@ -25028,17 +25162,14 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "lBe" = (
-/obj/machinery/smartfridge/chemistry/virology/preloaded,
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/stripes/end,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/green,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "lBF" = (
@@ -25480,6 +25611,23 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/wood,
 /area/hallway/secondary/exit/departure_lounge)
+"lQv" = (
+/obj/machinery/door/airlock/medical/glass{
+	id_tag = "MedbayFoyer";
+	name = "Medbay";
+	req_access_txt = "5"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/medical/paramedic)
 "lQJ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel,
@@ -25680,11 +25828,11 @@
 /turf/open/floor/plating,
 /area/icemoon/surface/outdoors)
 "lXR" = (
-/obj/machinery/camera{
-	c_tag = "Northwest Paramedic Post Garage";
-	network = list("ss13","medbay")
+/obj/machinery/shower{
+	dir = 8
 	},
-/turf/open/floor/pod/dark,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/dark,
 /area/medical/paramedic)
 "lXT" = (
 /obj/structure/cable{
@@ -25994,6 +26142,13 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
+"mgd" = (
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/effect/landmark/start/paramedic,
+/turf/open/floor/plasteel/white,
+/area/medical/paramedic)
 "mgo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/firedoor/border_only{
@@ -26156,6 +26311,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/central)
+"mlq" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/suit_storage_unit/paramedic,
+/turf/open/floor/plasteel/dark,
+/area/medical/paramedic)
 "mlM" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -26648,12 +26813,6 @@
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
 "mDp" = (
-/obj/structure/table,
-/obj/item/paper_bin{
-	pixel_x = -2;
-	pixel_y = 5
-	},
-/obj/item/pen/red,
 /obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
@@ -27306,15 +27465,6 @@
 	},
 /turf/open/floor/carpet,
 /area/hallway/primary/central)
-"mTw" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer,
-/obj/item/radio/intercom{
-	frequency = 1485;
-	name = "Station Intercom (Medbay)";
-	pixel_y = 30
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/paramedic)
 "mVb" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -27688,7 +27838,11 @@
 	name = "Paramedic Post";
 	pixel_x = -26
 	},
-/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/item/radio/intercom{
+	frequency = 1485;
+	name = "Station Intercom (Medbay)";
+	pixel_y = 30
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
 "ndQ" = (
@@ -28503,6 +28657,18 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
+"nBc" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/vehicle/ridden/atv/snowmobile,
+/obj/item/key,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/dark,
+/area/medical/paramedic)
 "nBd" = (
 /obj/machinery/button/door{
 	id = "Dorm2";
@@ -28612,6 +28778,12 @@
 /obj/machinery/vending/cola/random,
 /turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
+"nCP" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "nCU" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -28705,8 +28877,12 @@
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors)
 "nEt" = (
-/obj/machinery/computer/crew{
-	dir = 1
+/obj/structure/table,
+/obj/item/storage/pill_bottle/epinephrine{
+	pixel_x = 3
+	},
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_x = -5
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
@@ -29112,6 +29288,11 @@
 	},
 /turf/open/floor/wood,
 /area/maintenance/bar)
+"nPv" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "nPF" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -29163,6 +29344,18 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
+"nQP" = (
+/obj/structure/table,
+/obj/machinery/newscaster{
+	pixel_y = 34
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/floor/plasteel/white,
+/area/medical/paramedic)
 "nRe" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -29687,8 +29880,8 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -30900,6 +31093,12 @@
 /obj/machinery/light/floor,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
+"oMU" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/hallway/primary/port)
 "oNv" = (
 /obj/structure/table/wood,
 /turf/open/floor/wood,
@@ -31594,7 +31793,7 @@
 "pfY" = (
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "pfZ" = (
@@ -31886,8 +32085,8 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "por" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 5
+/obj/machinery/computer/crew{
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
@@ -31998,26 +32197,11 @@
 /turf/closed/wall/r_wall,
 /area/engine/supermatter)
 "prl" = (
-/obj/structure/closet/l3closet/virology,
 /obj/machinery/light_switch{
 	pixel_x = 25
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"prD" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/airlock/medical/glass{
-	id_tag = "MedbayFoyer";
-	name = "Medbay";
-	req_access_txt = "5"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/paramedic)
 "prP" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -32364,15 +32548,8 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "pyw" = (
-/obj/structure/cable,
 /obj/structure/cable{
 	icon_state = "1-8"
-	},
-/obj/machinery/power/apc{
-	areastring = "/area/maintenance/port/fore";
-	dir = 4;
-	name = "Port Bow Maintenance APC";
-	pixel_x = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
@@ -32744,6 +32921,11 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/server)
+"pGS" = (
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/maintenance/port/fore)
 "pGW" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -33696,17 +33878,11 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "qip" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/structure/disposaloutlet{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/end{
-	dir = 4
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
 /turf/open/floor/plating/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors)
+/area/medical/virology)
 "qiF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/wood,
@@ -33781,6 +33957,10 @@
 "qlj" = (
 /turf/closed/wall,
 /area/crew_quarters/theatre)
+"qll" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "qlH" = (
 /obj/machinery/light{
 	dir = 4
@@ -34116,9 +34296,15 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
 "quh" = (
-/obj/machinery/space_heater,
-/obj/structure/window/reinforced,
-/turf/open/floor/pod/dark,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/bed/roller,
+/obj/machinery/iv_drip,
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel/dark,
 /area/medical/paramedic)
 "quj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -34648,16 +34834,12 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/solars/starboard/aft)
 "qJy" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Snow Airlock"
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+/turf/open/floor/plasteel/white/corner{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/hallway/primary/port)
 "qJM" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -34807,6 +34989,13 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hos)
+"qND" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Supply to Virology"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "qOb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/wood,
@@ -35327,6 +35516,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"rbS" = (
+/obj/docking_port/stationary{
+	dwidth = 1;
+	height = 4;
+	name = "escape pod loader";
+	roundstart_template = /datum/map_template/shuttle/escape_pod/default;
+	width = 3
+	},
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/surface/outdoors)
 "rbW" = (
 /obj/structure/closet/secure_closet/medical3,
 /obj/machinery/firealarm{
@@ -35614,6 +35813,22 @@
 "rkp" = (
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/computer)
+"rkz" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/power/apc{
+	areastring = "/area/maintenance/port/fore";
+	dir = 4;
+	name = "Port Bow Maintenance APC";
+	pixel_x = 24
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "rkL" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -36921,8 +37136,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
 	},
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/surface/outdoors)
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/port/fore)
 "rTQ" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -37221,8 +37438,9 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/landmark/blobstart,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	icon_state = "platingdmg2"
+	},
 /area/maintenance/port/fore)
 "sdN" = (
 /turf/open/floor/plating,
@@ -37759,6 +37977,11 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/crew_quarters/kitchen)
+"suC" = (
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/port/fore)
 "suK" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -37776,11 +37999,11 @@
 	dir = 1;
 	name = "north facing firelock"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "suL" = (
@@ -38264,24 +38487,39 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/engine,
 /area/engine/engineering)
-"sIn" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/door/airlock/external{
-	req_one_access_txt = "13;5"
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "sIT" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
 	},
-/turf/open/floor/pod/dark,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/table,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/item/storage/toolbox/mechanical{
+	pixel_y = 8
+	},
+/obj/item/storage/toolbox/emergency,
+/turf/open/floor/plasteel/dark,
 /area/medical/paramedic)
+"sIZ" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/item/paper_bin{
+	pixel_x = -2;
+	pixel_y = 5
+	},
+/obj/item/pen/red,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "sJs" = (
 /obj/machinery/light/small,
 /turf/open/floor/plasteel/dark,
@@ -38409,6 +38647,22 @@
 "sMA" = (
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
+"sMJ" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/light/floor,
+/obj/machinery/door/airlock/external{
+	req_one_access_txt = "13;5"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "sMX" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -38454,6 +38708,19 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
+"sNZ" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/vehicle/ridden/atv/snowmobile,
+/obj/item/key,
+/obj/effect/turf_decal/bot,
+/obj/structure/window/reinforced,
+/turf/open/floor/plasteel/dark,
+/area/medical/paramedic)
 "sOi" = (
 /obj/machinery/door/firedoor/border_only{
 	name = "south facing firelock"
@@ -38758,6 +39025,7 @@
 /obj/machinery/newscaster{
 	pixel_x = -30
 	},
+/obj/effect/landmark/start/virologist,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "sXl" = (
@@ -39018,11 +39286,12 @@
 /turf/open/floor/plating,
 /area/quartermaster/storage)
 "tdK" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/surface/outdoors)
+/turf/open/floor/plating,
+/area/medical/virology)
 "tdL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -40022,6 +40291,7 @@
 /area/maintenance/solars/starboard/aft)
 "tGK" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/medical/virology)
 "tGQ" = (
@@ -40088,6 +40358,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
+"tIC" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Morgue Maintenance";
+	req_access_txt = "6;5"
+	},
+/turf/open/floor/plating,
+/area/hallway/primary/port)
 "tJi" = (
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
@@ -40253,6 +40530,21 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
+"tMI" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external{
+	req_one_access_txt = "13;5"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "tML" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
@@ -40784,8 +41076,8 @@
 /turf/open/floor/plasteel,
 /area/medical/medbay/central)
 "ubd" = (
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/pod/dark,
+/obj/machinery/vending/wardrobe/medi_wardrobe,
+/turf/open/floor/plasteel/white,
 /area/medical/paramedic)
 "ubL" = (
 /obj/item/radio/intercom{
@@ -41184,6 +41476,11 @@
 	},
 /obj/machinery/vending/wallmed{
 	pixel_x = -28
+	},
+/obj/structure/table,
+/obj/item/storage/box/donkpockets{
+	pixel_x = 3;
+	pixel_y = 5
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
@@ -41651,6 +41948,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"uCd" = (
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/port/fore)
 "uCi" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plasteel/white,
@@ -41722,6 +42024,24 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
+"uEU" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = 28
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white/corner{
+	dir = 4
+	},
+/area/hallway/primary/port)
 "uFq" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -41770,7 +42090,12 @@
 /turf/open/floor/plating,
 /area/bridge)
 "uHM" = (
-/obj/structure/closet/secure_closet/medical3,
+/obj/structure/table,
+/obj/item/storage/box/gloves{
+	pixel_x = 3;
+	pixel_y = 4
+	},
+/obj/item/storage/box/masks,
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
 "uIs" = (
@@ -42048,8 +42373,11 @@
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
 "uPn" = (
-/obj/machinery/space_heater,
-/turf/open/floor/pod/dark,
+/obj/machinery/vending/wallmed{
+	pixel_y = 30
+	},
+/obj/effect/landmark/start/paramedic,
+/turf/open/floor/plasteel/dark,
 /area/medical/paramedic)
 "uPI" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -42433,13 +42761,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/external{
-	req_one_access_txt = "13;5"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "uYQ" = (
@@ -43129,7 +43451,12 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "vqQ" = (
-/obj/effect/landmark/start/virologist,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 9
+	},
+/obj/structure/table/reinforced,
+/obj/structure/window/reinforced,
+/obj/machinery/reagentgrinder,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "vqS" = (
@@ -43781,15 +44108,6 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "vFd" = (
-/obj/machinery/airalarm{
-	pixel_y = 32
-	},
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/machinery/camera{
-	c_tag = "Northwest Paramedic Post";
-	network = list("ss13","medbay")
-	},
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
 "vFe" = (
@@ -43805,22 +44123,18 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "vGn" = (
-/obj/machinery/light,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/floor/pod/dark,
+/obj/structure/closet/secure_closet/medical3,
+/obj/item/gun/syringe/dart,
+/obj/item/pickaxe,
+/turf/open/floor/plasteel/white,
 /area/medical/paramedic)
 "vHd" = (
 /obj/structure/table/wood,
@@ -44060,6 +44374,17 @@
 	},
 /turf/open/floor/plasteel/white/side,
 /area/hallway/primary/port)
+"vNj" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/item/clothing/gloves/color/latex,
+/obj/item/healthanalyzer,
+/obj/item/clothing/glasses/hud/health,
+/obj/structure/window/reinforced,
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "vNu" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -44075,12 +44400,20 @@
 /area/medical/morgue)
 "vNF" = (
 /obj/machinery/light,
+/obj/machinery/camera{
+	c_tag = "Northwest Paramedic Post Garage";
+	dir = 1;
+	network = list("ss13","medbay")
+	},
 /obj/structure/table,
-/obj/item/storage/toolbox/emergency,
-/obj/item/storage/firstaid/o2{
+/obj/item/storage/firstaid/fire{
 	pixel_x = 3;
 	pixel_y = 3
 	},
+/obj/structure/sign/poster/official/help_others{
+	pixel_y = -32
+	},
+/obj/item/storage/firstaid/brute,
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
 "vNY" = (
@@ -44258,8 +44591,8 @@
 /turf/open/floor/wood,
 /area/mine/living_quarters)
 "vST" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 10
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -44310,14 +44643,8 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
 "vTP" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/airlock/medical/glass{
-	id_tag = "MedbayFoyer";
-	name = "Medbay";
-	req_access_txt = "5"
-	},
+/obj/structure/table,
+/obj/item/folder/white,
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
 "vUj" = (
@@ -44360,7 +44687,6 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "vUB" = (
-/obj/machinery/computer/pandemic,
 /obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
@@ -44617,6 +44943,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"waG" = (
+/obj/structure/closet/crate/medical,
+/obj/item/stack/medical/bruise_pack,
+/obj/item/stack/medical/ointment,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "waP" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -44957,6 +45289,15 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"wjX" = (
+/obj/machinery/atmospherics/pipe/simple/supply/visible{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/hallway/primary/port)
 "wkg" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -45019,19 +45360,20 @@
 /area/lawoffice)
 "wlD" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
+/turf/open/floor/plating,
+/area/medical/virology)
+"wlG" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plating,
 /area/medical/virology)
-"wlG" = (
-/obj/machinery/door/airlock/external{
-	name = "Escape Pod Two"
-	},
-/obj/structure/fans/tiny,
-/turf/open/floor/plating,
-/area/hallway/primary/port)
 "wlV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/old,
@@ -45253,6 +45595,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmospherics_engine)
+"wsz" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "wtp" = (
 /obj/structure/closet/wardrobe/grey,
 /turf/open/floor/plasteel,
@@ -45892,9 +46241,24 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
+"wOb" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/landmark/start/paramedic,
+/turf/open/floor/plasteel/dark,
+/area/medical/paramedic)
 "wOn" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/pod/dark,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/medical/paramedic)
 "wPD" = (
 /obj/structure/cable{
@@ -46364,13 +46728,13 @@
 	dir = 4;
 	pixel_x = -22
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 5
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "xdc" = (
@@ -46829,6 +47193,16 @@
 /obj/structure/closet/wardrobe/miner,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
+"xpn" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/tank_dispenser/oxygen,
+/turf/open/floor/plasteel/dark,
+/area/medical/paramedic)
 "xpU" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -47013,15 +47387,13 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/manifold/cyan/hidden,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "xwO" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
+/obj/structure/table/glass,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
+/obj/item/storage/box/monkeycubes,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "xxi" = (
@@ -47628,6 +48000,10 @@
 	},
 /turf/open/floor/plating,
 /area/icemoon/surface/outdoors)
+"xNM" = (
+/obj/structure/closet/l3closet/virology,
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "xNX" = (
 /obj/machinery/computer/secure_data{
 	dir = 4
@@ -47774,6 +48150,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/effect/landmark/start/paramedic,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "xSP" = (
@@ -47809,23 +48186,12 @@
 /turf/open/floor/wood,
 /area/security/courtroom)
 "xUe" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/disposalpipe/segment{
+	dir = 10
 	},
-/obj/machinery/door/airlock/public/glass{
-	name = "Snow Airlock"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/hallway/primary/port)
+/turf/open/floor/plating,
+/area/medical/virology)
 "xUm" = (
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
@@ -47888,11 +48254,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "xVn" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
+/obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
+	dir = 8
 	},
-/turf/closed/wall/r_wall,
-/area/medical/virology)
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "xVC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
@@ -48367,6 +48733,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
+"ylO" = (
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "ylW" = (
 /obj/structure/window{
 	dir = 4
@@ -65415,7 +65787,7 @@ cni
 qbY
 fYU
 vST
-uYa
+iIg
 aaS
 joT
 kGS
@@ -65929,7 +66301,7 @@ mpj
 mpj
 gIE
 hBH
-vST
+nCP
 pZD
 pZD
 pZD
@@ -66186,7 +66558,7 @@ hDj
 pfY
 wlD
 jBP
-xwO
+kLU
 cRX
 suK
 vGi
@@ -66443,7 +66815,7 @@ tlu
 wAW
 xhb
 uCi
-uYa
+nCP
 xFQ
 pZD
 eEy
@@ -66695,12 +67067,12 @@ ydp
 ydp
 ydp
 pZD
-xVn
-byu
-byu
-byu
+pZD
+pZD
+pZD
+pZD
 lzw
-uYa
+nCP
 lMF
 pZD
 pZD
@@ -66957,7 +67329,7 @@ tGK
 beD
 kkt
 cAo
-uYa
+sIZ
 kWC
 itU
 sWT
@@ -67209,12 +67581,12 @@ ydp
 ydp
 ydp
 ydp
+bcR
 avT
-avT
-mpj
+tdK
 gNb
 uYa
-uYa
+vNj
 mgC
 fjS
 uUr
@@ -67467,14 +67839,14 @@ ydp
 ydp
 ydp
 avT
-avT
-mpj
+byu
+wlG
 eSJ
-uYa
+gzE
 vqQ
 uYa
 uYa
-uYa
+xNM
 mpj
 xgB
 xgB
@@ -67724,8 +68096,8 @@ ydp
 ydp
 ydp
 ydp
-avT
-mpj
+dYZ
+xUe
 lBe
 mDp
 klh
@@ -67980,8 +68352,8 @@ ydp
 ydp
 ydp
 ydp
-ydp
-ydp
+mbm
+eik
 pZD
 pZD
 pZD
@@ -68237,20 +68609,20 @@ ydp
 ydp
 ydp
 ydp
-ydp
-ydp
-ydp
-ydp
-avT
-avT
-avT
-xUL
-vBe
 mbm
+fXd
+xVn
+qll
+iox
+csa
+uCd
 iJl
 iJl
-mbm
+nPv
 iJl
+waG
+aYo
+pGS
 eJu
 nYZ
 hxr
@@ -68494,20 +68866,20 @@ ydp
 ydp
 ydp
 ydp
-ydp
-ydp
-ydp
-avT
-avT
-avT
-avT
-xUL
+mbm
+iAO
+ylO
+iJl
+qND
+mbm
+iJl
+lpw
 rTG
-sIn
+uYp
 kxU
 sdH
 uYp
-kxU
+rkz
 pyw
 nYZ
 sXl
@@ -68751,21 +69123,21 @@ ydp
 ydp
 ydp
 avT
-avT
-avT
-avT
-avT
-avT
-avT
-avT
-xUL
-ace
+mbm
+jKV
+fDn
+jKV
+wsz
+mbm
+dII
+mbm
+tMI
 mbm
 mvQ
 mvQ
 mbm
 mbm
-mbm
+iJl
 nYZ
 gkx
 gNq
@@ -69008,21 +69380,21 @@ ydp
 ydp
 ydp
 avT
-avT
-ydp
-ydp
-ydp
-avT
-avT
-avT
-avT
-ace
+mbm
+mbm
+mbm
+mbm
+mbm
+mbm
+mbm
+mbm
+eJu
 mbm
 qIm
 qIm
 mbm
-avT
-avT
+eUK
+pGS
 nYZ
 dYa
 iaM
@@ -69264,7 +69636,7 @@ ydp
 ydp
 ydp
 ydp
-bmX
+avT
 ydp
 ydp
 ydp
@@ -69272,14 +69644,14 @@ ydp
 avT
 avT
 avT
-avT
-bGt
-avT
-avT
-avT
+mbm
+sMJ
+mbm
 avT
 avT
-avT
+mbm
+eUK
+iJl
 nYZ
 nYZ
 nYZ
@@ -69534,14 +69906,14 @@ ace
 avT
 avT
 avT
-avT
-avT
-xUL
-xUL
-xUL
-xUL
-tdK
-tmO
+mbm
+jRd
+lpw
+iJl
+iJl
+suC
+iJl
+tIC
 hui
 hBQ
 aNf
@@ -69791,15 +70163,15 @@ ace
 avT
 avT
 avT
-avT
-avT
-eik
-xUL
-xUL
-xUL
-dYZ
-jKV
-fYx
+mbm
+mbm
+mbm
+qIm
+qIm
+mbm
+mbm
+tmO
+wje
 aYf
 xSN
 wje
@@ -70054,11 +70426,11 @@ xUL
 xUL
 xUL
 xUL
-xUL
+oMU
 tmO
 fYx
 oDm
-tmO
+rhX
 rhX
 rhX
 eLm
@@ -70307,15 +70679,15 @@ avT
 avT
 avT
 avT
-avT
-avT
-tmO
-tmO
-tmO
-tmO
-bcR
+iCE
+xUL
+xUL
+xUL
+rbS
+jym
+fYx
 oDm
-tmO
+rhX
 ndM
 umX
 fbb
@@ -70568,12 +70940,12 @@ xUL
 xUL
 xUL
 xUL
-tdK
+xUL
 tmO
 fYx
 oDm
-tmO
-hnO
+llI
+vFd
 por
 jEb
 tvF
@@ -70821,15 +71193,15 @@ avT
 avT
 avT
 avT
-eik
-xUL
-xUL
-xUL
-dYZ
-wlG
-fYx
-oDm
+avT
+avT
+wdv
+wdv
+wdv
 tmO
+uEU
+oDm
+llI
 vFd
 iop
 cSC
@@ -71082,15 +71454,15 @@ xUL
 xUL
 xUL
 xUL
-xUL
+oMU
 tmO
 fYx
 oDm
-tmO
-mTw
-lgJ
+llI
+vFd
+vFd
 hlT
-fXd
+xQF
 eTX
 rhX
 ujE
@@ -71335,20 +71707,20 @@ avT
 avT
 avT
 avT
-avT
-avT
-tmO
-tmO
-tmO
-tmO
+iCE
+xUL
+xUL
+xUL
+rbS
+fBV
 qJy
-xUe
-tmO
+oDm
 rhX
+nQP
 vTP
-prD
-rhX
-rhX
+vFd
+mgd
+hyJ
 rhX
 xWq
 xWq
@@ -71592,21 +71964,21 @@ avT
 avT
 avT
 avT
-avT
-avT
-avT
-avT
-avT
+xUL
+xUL
+xUL
+xUL
+xUL
 tmO
-fBk
-iAO
-tmO
+qJy
+oDm
+rhX
 quh
 kHd
 ljT
-kHd
+vFd
 ubd
-rhX
+llI
 xUL
 xUL
 xUL
@@ -71851,19 +72223,19 @@ avT
 avT
 avT
 avT
-avT
-avT
-avT
+wdv
+wdv
+wdv
 tmO
 lki
 kMt
-tmO
-uPn
-kHd
-ljT
-kHd
-gVo
 rhX
+uPn
+cdV
+vFd
+vFd
+vGn
+llI
 xUL
 xUL
 xUL
@@ -72111,16 +72483,16 @@ avT
 avT
 avT
 avT
-avT
-vBe
-xnm
-wdv
+tmO
+gWQ
+wjX
 rhX
+eQR
 lXR
-hah
-kHd
+vFd
+vFd
 vGn
-rhX
+llI
 xUL
 xUL
 xUL
@@ -72368,15 +72740,15 @@ avT
 avT
 avT
 avT
-avT
-xUL
-xnm
-xUL
-eTu
-kHd
-ljT
-kHd
-gVo
+tmO
+jmg
+hss
+rhX
+rhX
+rhX
+lQv
+lQv
+bfa
 rhX
 xUL
 xUL
@@ -72628,13 +73000,13 @@ avT
 avT
 xUL
 xnm
-xUL
+rhX
 eTu
-kHd
-apK
+hId
+wOn
 wOn
 sIT
-rhX
+llI
 xUL
 xUL
 xUL
@@ -72885,13 +73257,13 @@ avT
 avT
 vBe
 xnm
-xUL
-rhX
-rhX
-rhX
-rhX
-rhX
-rhX
+iYh
+wOn
+aRO
+wOb
+wOn
+wOn
+llI
 xUL
 xUL
 xUL
@@ -73142,17 +73514,17 @@ avT
 avT
 xUL
 xnm
+iYh
+wOn
+wOn
+jtV
+wOn
+wOn
+llI
 avT
-hmM
-hmM
-ydp
-ydp
-ydp
-wdv
-ydp
-ydp
-ydp
-ydp
+avT
+avT
+avT
 wdv
 avT
 avT
@@ -73399,17 +73771,17 @@ avT
 avT
 xUL
 xnm
+rhX
+nBc
+sNZ
+mlq
+xpn
+mlq
+llI
 avT
 avT
 avT
-ydp
-ydp
-ydp
-ydp
-ydp
-ydp
-ydp
-ydp
+avT
 ydp
 avT
 avT
@@ -73656,13 +74028,13 @@ xUL
 vBe
 xUL
 xnm
-avT
-avT
-avT
-avT
-ydp
-ydp
-ydp
+rhX
+rhX
+rhX
+rhX
+rhX
+rhX
+rhX
 ydp
 ydp
 ydp
@@ -73917,8 +74289,8 @@ avT
 avT
 avT
 avT
-ydp
-ydp
+avT
+avT
 ydp
 ydp
 ydp
@@ -74173,8 +74545,8 @@ avT
 avT
 avT
 avT
-ydp
-ydp
+avT
+avT
 ydp
 ydp
 ydp
@@ -74943,7 +75315,7 @@ avT
 avT
 avT
 avT
-avT
+ydp
 ydp
 ydp
 ydp
@@ -75200,7 +75572,7 @@ avT
 avT
 avT
 avT
-avT
+ydp
 ydp
 ydp
 ydp
@@ -75457,7 +75829,7 @@ avT
 avT
 avT
 avT
-avT
+ydp
 ydp
 ydp
 ydp

--- a/_maps/map_files/Snaxi/Snaxi_Lumos.dmm
+++ b/_maps/map_files/Snaxi/Snaxi_Lumos.dmm
@@ -599,6 +599,23 @@
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plating,
 /area/engine/engineering)
+"aja" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
 "ajg" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/northleft{
@@ -969,7 +986,6 @@
 	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/machinery/chem_dispenser,
-/obj/machinery/light,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "aow" = (
@@ -3849,10 +3865,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
-"bgz" = (
-/obj/machinery/smartfridge/chemistry/preloaded,
-/turf/closed/wall,
-/area/medical/chemistry)
 "bhe" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -9162,6 +9174,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/junction/flip,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "cXr" = (
@@ -12846,21 +12861,6 @@
 /obj/item/key/security,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
-"eVY" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/eastright{
-	base_state = "left";
-	dir = 8;
-	icon_state = "left";
-	name = "Chemistry Desk";
-	req_access_txt = "5; 33"
-	},
-/obj/machinery/door/firedoor/heavy,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/medical/chemistry)
 "eWg" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -15192,10 +15192,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
-"gjf" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
 "gjA" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -15541,14 +15537,11 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "gsM" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/port)
+/turf/open/floor/plasteel/dark,
+/area/medical/medbay/central)
 "gsQ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel,
@@ -16222,11 +16215,14 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "gNq" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
-/area/medical/medbay/central)
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 "gNy" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/machinery/atmospherics/components/binary/pump{
@@ -16714,12 +16710,6 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
-"haL" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
 "haU" = (
 /obj/machinery/button/door{
 	id = "kitchen";
@@ -16814,14 +16804,9 @@
 /turf/open/floor/plating,
 /area/library)
 "heR" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/genetics)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/dark,
+/area/medical/medbay/central)
 "heS" = (
 /turf/open/openspace,
 /area/security/execution/education)
@@ -19260,9 +19245,15 @@
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/dorms)
 "inU" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
-/area/medical/medbay/central)
+/area/medical/morgue)
 "iob" = (
 /obj/structure/window/plasma/reinforced{
 	dir = 1
@@ -19998,15 +19989,15 @@
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "iGg" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "2-4"
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/dark,
-/area/medical/morgue)
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 "iGB" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -20414,15 +20405,14 @@
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/quartermaster/storage)
 "iRy" = (
-/obj/effect/turf_decal/tile/purple{
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/white,
-/area/medical/genetics)
+/turf/open/floor/plasteel/dark,
+/area/medical/medbay/central)
 "iRE" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -21832,11 +21822,16 @@
 /turf/closed/wall/r_wall,
 /area/security/checkpoint/supply)
 "jIu" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
 	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 6
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
@@ -22165,19 +22160,25 @@
 /turf/open/floor/grass,
 /area/hydroponics/garden)
 "jTh" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/structure/disposalpipe/segment{
-	dir = 6
+/obj/structure/disposalpipe/segment,
+/obj/machinery/power/apc{
+	areastring = "/area/medical/genetics";
+	dir = 4;
+	name = "Genetics APC";
+	pixel_x = -25
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
+/obj/structure/cable{
+	icon_state = "0-4"
 	},
-/turf/open/floor/plasteel/dark,
-/area/medical/medbay/central)
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 "jTl" = (
 /obj/effect/turf_decal/stripes,
 /obj/machinery/computer/cargo{
@@ -23305,23 +23306,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/bridge)
-"kAt" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/port)
 "kAO" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -24129,21 +24113,6 @@
 /obj/machinery/disposal/bin,
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/bar)
-"laS" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/structure/sign/warning/nosmoking{
-	pixel_y = 30
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/port)
 "lba" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -25276,25 +25245,10 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
 "lIn" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/power/apc{
-	areastring = "/area/medical/genetics";
-	dir = 4;
-	name = "Genetics APC";
-	pixel_x = -25
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/genetics)
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk,
+/turf/open/floor/plasteel/dark,
+/area/medical/medbay/central)
 "lIJ" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -25321,6 +25275,18 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/primary/central)
+"lKv" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
 "lKT" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -25794,6 +25760,13 @@
 	},
 /turf/open/floor/plating,
 /area/bridge)
+"mal" = (
+/obj/machinery/light,
+/obj/structure/sign/warning/securearea{
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "mao" = (
 /obj/structure/tank_dispenser{
 	pixel_x = -1
@@ -25878,8 +25851,9 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "mdq" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk,
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 5
+	},
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
 "mdG" = (
@@ -26694,9 +26668,11 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "mEI" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 5
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
 	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
 "mET" = (
@@ -27309,13 +27285,18 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "mVh" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
 	},
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/dark,
-/area/medical/medbay/central)
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 "mVi" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -27350,18 +27331,13 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "mVN" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/genetics)
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/dark,
+/area/medical/medbay/central)
 "mWc" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -28273,11 +28249,13 @@
 	},
 /area/maintenance/aft/secondary)
 "nwq" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line,
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
 "nwz" = (
@@ -28863,6 +28841,10 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
+"nJJ" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "nKO" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -29000,15 +28982,16 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "nOR" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/disposalpipe/segment{
-	dir = 9
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
-/area/medical/medbay/central)
+/obj/effect/turf_decal/tile/purple,
+/obj/machinery/dna_scannernew,
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 "nOY" = (
 /obj/machinery/camera{
 	c_tag = "Dorms West";
@@ -32981,6 +32964,10 @@
 	},
 /turf/open/floor/plasteel/chapel,
 /area/chapel/main)
+"pNR" = (
+/obj/machinery/smartfridge/chemistry/preloaded,
+/turf/closed/wall,
+/area/medical/chemistry)
 "pNU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
@@ -33552,14 +33539,19 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
 "qfd" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/machinery/dna_scannernew,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "qfJ" = (
@@ -34141,13 +34133,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"qxz" = (
-/obj/machinery/light,
-/obj/structure/sign/warning/securearea{
-	pixel_x = 32
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
 "qxM" = (
 /obj/machinery/door/airlock/public/glass{
 	id_tag = null;
@@ -34724,6 +34709,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"qNk" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
 "qNz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment{
@@ -35030,21 +35024,9 @@
 /turf/open/floor/circuit/off,
 /area/ai_monitored/turret_protected/ai)
 "qVD" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
-/area/medical/genetics)
+/area/medical/medbay/central)
 "qWa" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
@@ -35088,6 +35070,9 @@
 	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/machinery/chem_master,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "qXm" = (
@@ -35560,7 +35545,10 @@
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/computer)
 "rkL" = (
-/obj/structure/disposalpipe/segment,
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "rkP" = (
@@ -35873,12 +35861,18 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "rqQ" = (
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/door/airlock/medical/glass{
+	id_tag = "GeneticsDoor";
+	name = "Genetics";
+	req_access_txt = "5; 68"
 	},
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
+/area/medical/genetics)
 "rqS" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -36071,12 +36065,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
-"rwU" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
 "rwW" = (
 /obj/machinery/button/door{
 	id = "psyshu";
@@ -36666,18 +36654,16 @@
 /turf/closed/wall,
 /area/maintenance/starboard)
 "rPD" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/door/airlock/medical/glass{
-	id_tag = "GeneticsDoor";
-	name = "Genetics";
-	req_access_txt = "5; 68"
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
 	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plasteel/white,
-/area/medical/genetics)
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
 "rPU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -37602,6 +37588,12 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "srB" = (
@@ -37667,6 +37659,12 @@
 	},
 /turf/open/floor/engine/n2o,
 /area/engine/atmos)
+"stk" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "stW" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -38237,6 +38235,21 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/entry)
+"sKn" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/eastright{
+	base_state = "left";
+	dir = 8;
+	icon_state = "left";
+	name = "Chemistry Desk";
+	req_access_txt = "5; 33"
+	},
+/obj/machinery/door/firedoor/heavy,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/medical/chemistry)
 "sKN" = (
 /obj/structure/window/plasma/reinforced{
 	dir = 8
@@ -42555,6 +42568,21 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
+"veD" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/structure/sign/warning/nosmoking{
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
 "veF" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/drinkingglass{
@@ -47771,6 +47799,12 @@
 	},
 /turf/closed/wall/r_wall,
 /area/medical/virology)
+"xVC" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "xWi" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -47844,18 +47878,6 @@
 	},
 /turf/open/floor/wood,
 /area/hallway/secondary/exit/departure_lounge)
-"xZh" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/port)
 "xZp" = (
 /obj/structure/chair/stool/bar,
 /obj/machinery/camera{
@@ -65573,9 +65595,9 @@ sMA
 uAe
 ykb
 tMt
-mdq
-nwq
-rkL
+lIn
+mVN
+qVD
 vkY
 lDj
 gzk
@@ -65825,11 +65847,11 @@ ofF
 lCW
 fXH
 eSP
-gNq
-inU
+gsM
+heR
 uUC
-inU
-jIu
+heR
+iRy
 sMA
 xGP
 anm
@@ -66087,7 +66109,7 @@ ujD
 wKC
 nDC
 wzH
-mEI
+mdq
 xGP
 anm
 dSH
@@ -66343,15 +66365,15 @@ tmy
 sMA
 vMf
 epK
-jTh
-mVh
-nOR
-rqQ
+jIu
+mEI
+nwq
+rkL
 iEa
 anm
 sxa
 amD
-haL
+stk
 anm
 anm
 jXh
@@ -66859,7 +66881,7 @@ pbP
 qZP
 tnX
 uUl
-qfd
+nOR
 nYZ
 wXj
 anm
@@ -67111,7 +67133,7 @@ vIA
 rYD
 fUX
 rYD
-iGg
+inU
 gId
 oTF
 dTL
@@ -67374,7 +67396,7 @@ hpG
 fNO
 rjO
 gXE
-rPD
+rqQ
 nIR
 xhD
 xur
@@ -67383,7 +67405,7 @@ yds
 pyD
 guR
 aaH
-rJw
+qNk
 tqa
 wje
 wWL
@@ -67641,7 +67663,7 @@ yds
 gTb
 aoX
 rJw
-xZh
+lKv
 fYQ
 tXN
 tXN
@@ -67886,7 +67908,7 @@ nRX
 jbE
 nmR
 sjW
-mVN
+mVh
 pXl
 nYZ
 uUk
@@ -67896,7 +67918,7 @@ tcP
 yds
 yds
 iWu
-bgz
+pNR
 rJw
 tkr
 fYQ
@@ -68154,7 +68176,7 @@ yds
 yds
 aon
 aoX
-laS
+veD
 tkr
 fYQ
 oZE
@@ -68398,10 +68420,10 @@ sXl
 eFU
 jyA
 goK
-iRy
-lIn
+iGg
+jTh
 pZJ
-qVD
+qfd
 nnj
 wKN
 anm
@@ -68411,7 +68433,7 @@ yds
 yds
 guR
 aaH
-gsM
+aAL
 tkr
 ayG
 tXN
@@ -68652,7 +68674,7 @@ mbm
 mbm
 nYZ
 gkx
-heR
+gNq
 fBf
 vqF
 vax
@@ -68661,14 +68683,14 @@ keC
 vEr
 tNq
 xgq
-qxz
+mal
 aoX
 nVv
-gjf
-rwU
+nJJ
+xVC
 qWL
 aoX
-gsM
+aAL
 tkr
 wje
 pjg
@@ -68925,7 +68947,7 @@ nBI
 anL
 aoo
 aaH
-gsM
+aAL
 tkr
 wje
 wEP
@@ -69179,10 +69201,10 @@ uWY
 aoX
 aoX
 aaH
-eVY
+sKn
 aaH
 aoX
-gsM
+aAL
 tkr
 wje
 xOY
@@ -69433,9 +69455,9 @@ xrU
 yij
 iWY
 iTY
-kAt
+aja
 vLr
-gKt
+rPD
 srq
 cXi
 gKt

--- a/_maps/map_files/Snaxi/Snaxi_Lumos.dmm
+++ b/_maps/map_files/Snaxi/Snaxi_Lumos.dmm
@@ -477,6 +477,19 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /turf/open/floor/plasteel/dark,
 /area/engine/supermatter)
+"agi" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "agy" = (
 /turf/open/floor/wood,
 /area/library)
@@ -691,6 +704,10 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "akQ" = (
@@ -732,7 +749,7 @@
 	},
 /obj/item/clothing/glasses/science,
 /obj/item/storage/box/syringes,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/medical/chemistry)
 "alE" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
@@ -740,11 +757,8 @@
 /area/icemoon/surface/outdoors)
 "alF" = (
 /obj/structure/table/reinforced,
-/obj/item/reagent_containers/food/drinks/britcup{
-	desc = "Kingston's personal cup."
-	},
 /obj/machinery/door/window/eastright{
-	dir = 2;
+	dir = 1;
 	name = "Medbay";
 	req_access_txt = "5"
 	},
@@ -825,7 +839,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/medical/chemistry)
 "anh" = (
 /obj/structure/cable{
@@ -927,7 +941,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/medical/chemistry)
 "anO" = (
 /obj/machinery/airalarm{
@@ -967,6 +981,10 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "aon" = (
@@ -975,7 +993,7 @@
 	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/structure/closet/wardrobe/chemistry_white,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/medical/chemistry)
 "aoo" = (
 /obj/effect/turf_decal/tile/yellow{
@@ -986,7 +1004,7 @@
 	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/machinery/chem_dispenser,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/medical/chemistry)
 "aow" = (
 /obj/machinery/suit_storage_unit/captain,
@@ -1001,7 +1019,6 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
 	},
-/obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
@@ -1012,10 +1029,6 @@
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
 "aoT" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/effect/turf_decal/loading_area{
 	dir = 1
 	},
@@ -1025,6 +1038,10 @@
 /obj/structure/chair{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "aoV" = (
@@ -2504,9 +2521,6 @@
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
@@ -6247,7 +6261,7 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/geneticist,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/medical/genetics)
 "bLO" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -8686,6 +8700,16 @@
 "cLO" = (
 /turf/open/floor/engine,
 /area/engine/engineering)
+"cLS" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "cLX" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -9121,7 +9145,7 @@
 "cVu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/landmark/start/medical_doctor,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/medical/medbay/central)
 "cVG" = (
 /obj/structure/cable{
@@ -9489,7 +9513,7 @@
 	pixel_x = 1;
 	pixel_y = 23
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/medical/genetics)
 "dcH" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -10820,7 +10844,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/medical/genetics)
 "dTS" = (
 /obj/effect/turf_decal/tile/yellow{
@@ -10981,12 +11005,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "dXR" = (
@@ -11141,7 +11159,15 @@
 	name = "south facing firelock"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 1
+	},
 /area/medical/medbay/central)
 "ecI" = (
 /obj/structure/cable{
@@ -11423,7 +11449,7 @@
 "eiR" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/westleft{
-	dir = 2;
+	dir = 1;
 	name = "Medbay";
 	req_access_txt = "5"
 	},
@@ -11663,9 +11689,6 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "esE" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
@@ -13652,7 +13675,7 @@
 	dir = 8;
 	pixel_x = -14
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/medical/medbay/central)
 "frh" = (
 /obj/structure/cable{
@@ -13669,7 +13692,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/medical/chemistry)
 "frB" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -13915,7 +13938,18 @@
 /obj/machinery/door/firedoor/border_only{
 	name = "south facing firelock"
 	},
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 9
+	},
 /area/medical/medbay/central)
 "fze" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -14376,7 +14410,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/medical/genetics)
 "fLW" = (
 /obj/structure/cable{
@@ -14433,7 +14467,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/medical/genetics)
 "fNR" = (
 /obj/machinery/camera{
@@ -14908,7 +14942,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/medical/genetics)
 "gbt" = (
 /obj/structure/chair,
@@ -15633,7 +15667,7 @@
 	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/machinery/chem_heater,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/medical/chemistry)
 "guV" = (
 /obj/structure/chair/sofa/right{
@@ -15728,9 +15762,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "gzk" = (
-/obj/machinery/computer/crew{
-	dir = 8
-	},
+/obj/structure/chair/office/light,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "gzt" = (
@@ -16510,7 +16542,7 @@
 /obj/effect/turf_decal/tile/yellow,
 /obj/machinery/light,
 /obj/structure/closet/secure_closet/chemical,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/medical/chemistry)
 "gTc" = (
 /obj/machinery/door/window/eastright{
@@ -16631,7 +16663,7 @@
 	},
 /obj/effect/turf_decal/tile/purple,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/medical/genetics)
 "gXM" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -16827,14 +16859,14 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "hfX" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
+/obj/item/radio/intercom{
+	frequency = 1485;
+	name = "Station Intercom (Medbay)";
+	pixel_x = 2;
+	pixel_y = 22
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/port)
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "hfZ" = (
 /obj/machinery/porta_turret/ai{
 	dir = 4
@@ -16944,7 +16976,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/medical/chemistry)
 "hiO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -17194,7 +17226,7 @@
 	c_tag = "Genetics Cloning";
 	network = list("ss13","medbay")
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/medical/genetics)
 "hpN" = (
 /obj/structure/cable{
@@ -17307,7 +17339,11 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/airless/white/side,
 /area/medical/storage)
 "hsu" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -18047,7 +18083,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/medical/medbay/central)
 "hLo" = (
 /obj/structure/reagent_dispensers/peppertank{
@@ -20499,7 +20535,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/medical/chemistry)
 "iWz" = (
 /obj/structure/window/reinforced,
@@ -20637,7 +20673,7 @@
 /area/crew_quarters/heads/hos)
 "jap" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/medical/chemistry)
 "jar" = (
 /obj/structure/chair/office/light{
@@ -21939,7 +21975,7 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/medical/genetics)
 "jNw" = (
 /obj/structure/cable{
@@ -22285,7 +22321,7 @@
 	pixel_x = 2;
 	pixel_y = 26
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/medical/chemistry)
 "jWy" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
@@ -22319,7 +22355,15 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 1
+	},
 /area/medical/medbay/central)
 "jXt" = (
 /obj/effect/turf_decal/stripes/line{
@@ -23277,6 +23321,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "kyo" = (
@@ -24574,7 +24622,16 @@
 /obj/machinery/door/firedoor/border_only{
 	name = "south facing firelock"
 	},
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel/white/side{
+	dir = 5
+	},
 /area/medical/medbay/central)
 "loT" = (
 /obj/effect/turf_decal/tile/purple,
@@ -24628,7 +24685,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/medical/chemistry)
 "lqt" = (
 /obj/structure/cable{
@@ -24699,7 +24756,7 @@
 	dir = 8
 	},
 /obj/structure/closet/secure_closet,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/medical/medbay/central)
 "ltk" = (
 /obj/structure/cable{
@@ -25045,9 +25102,16 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "lDj" = (
-/obj/machinery/computer/med_data{
-	dir = 8
+/obj/item/storage/firstaid/regular{
+	pixel_x = -6;
+	pixel_y = 5
 	},
+/obj/item/reagent_containers/food/drinks/britcup{
+	desc = "Kingston's personal cup.";
+	pixel_x = 9;
+	pixel_y = 4
+	},
+/obj/structure/table/reinforced,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "lDD" = (
@@ -25760,6 +25824,15 @@
 	},
 /turf/open/floor/plating,
 /area/bridge)
+"mal" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "mao" = (
 /obj/structure/tank_dispenser{
 	pixel_x = -1
@@ -25966,9 +26039,10 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "mhv" = (
-/obj/structure/table/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/cell_charger,
+/obj/machinery/computer/crew{
+	dir = 4
+	},
 /obj/structure/window/reinforced{
 	dir = 8
 	},
@@ -26542,7 +26616,14 @@
 /obj/item/reagent_containers/glass/beaker/large,
 /obj/item/reagent_containers/dropper,
 /obj/item/reagent_containers/dropper,
-/turf/open/floor/plasteel/white,
+/obj/machinery/button/door{
+	id = "robotics2";
+	name = "Shutters Control Button";
+	pixel_x = -23;
+	pixel_y = -6;
+	req_access_txt = "29"
+	},
+/turf/open/floor/plasteel,
 /area/medical/chemistry)
 "mAK" = (
 /obj/effect/landmark/event_spawn,
@@ -26797,6 +26878,7 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "mIz" = (
@@ -26947,7 +27029,7 @@
 	dir = 4
 	},
 /obj/machinery/vending/wardrobe/chem_wardrobe,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/medical/chemistry)
 "mLK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -27288,7 +27370,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/medical/genetics)
 "mVi" = (
 /obj/effect/turf_decal/tile/red{
@@ -27564,7 +27646,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/medical/chemistry)
 "ndn" = (
 /obj/machinery/camera{
@@ -27933,7 +28015,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/airless/white/side{
+	dir = 1
+	},
 /area/medical/genetics)
 "nmY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -28308,6 +28392,10 @@
 	dir = 1;
 	network = list("ss13","medbay")
 	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "nyd" = (
@@ -28449,7 +28537,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/medical/chemistry)
 "nBU" = (
 /obj/structure/window/reinforced{
@@ -28836,7 +28924,7 @@
 /area/security/brig)
 "nJJ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/medical/chemistry)
 "nKO" = (
 /obj/structure/cable{
@@ -28983,7 +29071,7 @@
 	},
 /obj/effect/turf_decal/tile/purple,
 /obj/machinery/dna_scannernew,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/medical/genetics)
 "nOY" = (
 /obj/machinery/camera{
@@ -29269,7 +29357,7 @@
 /obj/item/stack/cable_coil/random,
 /obj/item/reagent_containers/glass/bottle/epinephrine,
 /obj/item/stack/sheet/mineral/plasma,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/medical/chemistry)
 "nVI" = (
 /obj/structure/sign/poster/contraband/random{
@@ -29617,17 +29705,9 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "oge" = (
-/obj/structure/table/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/obj/item/radio/intercom{
-	frequency = 1485;
-	name = "Station Intercom (Medbay)"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/white,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/medical/medbay/central)
 "ogM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -29814,9 +29894,6 @@
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -30551,17 +30628,12 @@
 /turf/open/floor/plasteel,
 /area/engine/atmospherics_engine)
 "oDw" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/port)
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "oEa" = (
 /obj/machinery/airalarm{
 	dir = 1;
@@ -30997,7 +31069,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/medical/genetics)
 "oTT" = (
 /obj/structure/cable{
@@ -31431,11 +31503,10 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
 "pdL" = (
-/obj/structure/table/reinforced,
-/obj/structure/window/reinforced{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/structure/window/reinforced,
+/obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "pdW" = (
@@ -32310,7 +32381,7 @@
 /area/maintenance/port/fore)
 "pyD" = (
 /obj/machinery/chem_master,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/medical/chemistry)
 "pyF" = (
 /obj/structure/cable{
@@ -32764,7 +32835,6 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hop)
 "pKr" = (
-/obj/structure/table/reinforced,
 /obj/machinery/button/door{
 	desc = "A remote control switch for the medbay foyer.";
 	id = "MedbayFoyer";
@@ -32774,6 +32844,13 @@
 	req_access_txt = "5"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/table/reinforced,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "pKF" = (
@@ -32998,7 +33075,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/medical/medbay/central)
 "pPz" = (
 /obj/machinery/hydroponics/constructable,
@@ -33070,7 +33147,13 @@
 	name = "south facing firelock"
 	},
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
 /area/medical/surgery)
 "pRV" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -33235,12 +33318,6 @@
 "pWz" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -33278,7 +33355,7 @@
 	dir = 1;
 	pixel_y = -22
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/medical/genetics)
 "pXp" = (
 /obj/structure/window/reinforced,
@@ -34589,7 +34666,7 @@
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
 /obj/machinery/iv_drip,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/medical/medbay/central)
 "qJU" = (
 /obj/structure/toilet/secret/prison{
@@ -35066,7 +35143,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/medical/chemistry)
 "qXm" = (
 /obj/effect/turf_decal/tile/blue,
@@ -35492,7 +35569,7 @@
 /area/ai_monitored/turret_protected/ai_upload)
 "rjO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/medical/genetics)
 "rjP" = (
 /obj/structure/table/wood,
@@ -35802,12 +35879,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/machinery/camera{
 	c_tag = "Outer Medbay Lobby"
 	},
@@ -35864,7 +35935,13 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel/airless/white/side,
 /area/medical/genetics)
 "rqS" = (
 /obj/effect/turf_decal/tile/blue{
@@ -36317,7 +36394,11 @@
 /obj/machinery/door/firedoor/border_only{
 	name = "south facing firelock"
 	},
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel/freezer,
 /area/medical/surgery)
 "rFB" = (
 /obj/effect/turf_decal/tile/yellow,
@@ -36708,7 +36789,7 @@
 	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/machinery/chem_dispenser,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/medical/chemistry)
 "rQU" = (
 /obj/structure/cable{
@@ -37339,7 +37420,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/medical/genetics)
 "skw" = (
 /obj/structure/cable{
@@ -37656,6 +37737,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
 	},
+/obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "stW" = (
@@ -38894,7 +38976,7 @@
 	pixel_x = 8;
 	pixel_y = 2
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/medical/chemistry)
 "tcU" = (
 /obj/structure/cable{
@@ -39293,7 +39375,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/medical/genetics)
 "toa" = (
 /obj/structure/cable{
@@ -40446,16 +40528,18 @@
 "tUi" = (
 /obj/structure/table,
 /obj/structure/bedsheetbin/color,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/medical/medbay/central)
 "tUF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 4
+	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/white/corner{
+	dir = 1
+	},
 /area/hallway/primary/port)
 "tVh" = (
 /obj/structure/cable{
@@ -40483,9 +40567,6 @@
 /obj/machinery/vending/wardrobe/medi_wardrobe,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay Storage";
@@ -40700,7 +40781,7 @@
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
 /obj/machinery/iv_drip,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/medical/medbay/central)
 "ubd" = (
 /obj/structure/reagent_dispensers/fueltank,
@@ -42118,7 +42199,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/medical/genetics)
 "uUr" = (
 /obj/structure/disposalpipe/trunk{
@@ -42844,6 +42925,9 @@
 /obj/structure/disposalpipe/junction{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "vlv" = (
@@ -43193,19 +43277,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
 /obj/structure/table,
 /obj/item/folder/white,
 /obj/item/clothing/neck/stethoscope,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/medical/medbay/central)
 "vuO" = (
 /obj/machinery/light{
@@ -43374,8 +43452,9 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "vyM" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/firstaid/regular,
+/obj/machinery/computer/med_data{
+	dir = 8
+	},
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -43466,7 +43545,7 @@
 	dir = 8
 	},
 /obj/machinery/disposal/bin,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/medical/chemistry)
 "vAF" = (
 /obj/structure/cable{
@@ -44394,7 +44473,13 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel/airless/white/side{
+	dir = 4
+	},
 /area/medical/medbay/central)
 "vYc" = (
 /obj/effect/landmark/blobstart,
@@ -44717,15 +44802,16 @@
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "wen" = (
-/obj/structure/table/reinforced,
-/obj/machinery/button/door{
-	desc = "A remote control switch for the medbay foyer.";
-	id = "MedbayFoyer";
-	name = "Medbay Doors Control";
-	normaldoorcontrol = 1;
-	plane = -4;
-	req_access_txt = "5"
+/obj/structure/window/reinforced{
+	dir = 4
 	},
+/obj/machinery/cell_charger{
+	pixel_x = -2
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/table/reinforced,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "weS" = (
@@ -46335,6 +46421,13 @@
 /obj/structure/reagent_dispensers/foamtank,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"xeY" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "xfs" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -46565,13 +46658,15 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "xlg" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/corner{
+	dir = 4
+	},
 /area/hallway/primary/port)
 "xlm" = (
 /obj/machinery/vending/wardrobe/atmos_wardrobe,
@@ -46845,7 +46940,13 @@
 	},
 /obj/machinery/door/firedoor/heavy,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/plasteel/airless/white/side{
+	dir = 1
+	},
 /area/medical/chemistry)
 "xuB" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -47349,7 +47450,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/medical/medbay/central)
 "xHU" = (
 /obj/effect/turf_decal/tile/blue{
@@ -47382,7 +47483,7 @@
 /obj/item/soap,
 /obj/item/clothing/suit/straight_jacket,
 /obj/item/clothing/mask/muzzle,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/medical/medbay/central)
 "xJn" = (
 /obj/machinery/computer/card/minor/ce,
@@ -47796,7 +47897,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/medical/chemistry)
 "xWi" = (
 /obj/structure/cable{
@@ -47975,7 +48076,7 @@
 /turf/closed/mineral/random/snow/no_caves,
 /area/icemoon/surface/outdoors)
 "yds" = (
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/medical/chemistry)
 "ydQ" = (
 /obj/machinery/power/apc{
@@ -64826,7 +64927,7 @@ anH
 anh
 anH
 rQz
-aok
+agi
 loO
 aFJ
 arK
@@ -65081,7 +65182,7 @@ mIu
 pKr
 mhv
 oge
-jih
+oDw
 pig
 aom
 wLs
@@ -65333,16 +65434,16 @@ aoj
 qWg
 aoj
 qWg
-anm
+hfX
 kyf
-anm
+mal
 alU
 alF
-anm
+mal
 anJ
 aoU
 aoj
-oDw
+aAL
 oDm
 wje
 axi
@@ -65595,11 +65696,11 @@ vkY
 lDj
 gzk
 eiR
-anm
+mal
 anJ
 aoU
 aoj
-oDw
+aAL
 uAj
 xJr
 mfi
@@ -65851,8 +65952,8 @@ anm
 iEa
 wen
 vyM
-pdL
-anm
+aoj
+ady
 fQx
 nya
 apP
@@ -66111,9 +66212,9 @@ anm
 amD
 anm
 anm
-anm
+xeY
 fyV
-hfX
+aAV
 aBI
 asO
 uGY
@@ -66367,10 +66468,10 @@ anm
 sxa
 amD
 stk
-anm
-anm
+pdL
+cLS
 jXh
-tUF
+aAL
 tkr
 wje
 uGY

--- a/_maps/map_files/Snaxi/Snaxi_Lumos.dmm
+++ b/_maps/map_files/Snaxi/Snaxi_Lumos.dmm
@@ -1111,6 +1111,15 @@
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/hallway/primary/port)
+"arr" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/machinery/airalarm{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/dark,
+/area/medical/paramedic)
 "arE" = (
 /obj/structure/table,
 /obj/structure/extinguisher_cabinet{
@@ -2387,6 +2396,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
+"aDO" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/power/apc{
+	areastring = "/area/maintenance/port/fore";
+	dir = 4;
+	name = "Port Bow Maintenance APC";
+	pixel_x = 24
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "aDQ" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/visible,
 /obj/structure/disposalpipe/segment{
@@ -2416,6 +2441,10 @@
 /obj/effect/landmark/start/depsec/medical,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
+"aEo" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/medical/paramedic)
 "aEC" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -3755,24 +3784,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"bdf" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = 28
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white/corner{
-	dir = 4
-	},
-/area/hallway/primary/port)
 "bdm" = (
 /obj/machinery/light{
 	dir = 1
@@ -3882,11 +3893,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
-"bge" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "bhe" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -4179,12 +4185,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
-"brc" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "bri" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -6174,10 +6174,6 @@
 /obj/machinery/disposal/bin,
 /turf/open/floor/plasteel/cult,
 /area/lawoffice)
-"bJL" = (
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "bJQ" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -6668,17 +6664,6 @@
 	dir = 1
 	},
 /area/chapel/main)
-"bQX" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/machinery/disposal/bin,
-/turf/open/floor/plasteel/white,
-/area/medical/paramedic)
 "bRy" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
@@ -7002,18 +6987,6 @@
 	},
 /turf/open/floor/carpet/black,
 /area/crew_quarters/heads/hos)
-"bWX" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/vehicle/ridden/atv/snowmobile,
-/obj/item/key,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel/dark,
-/area/medical/paramedic)
 "bXe" = (
 /obj/machinery/airalarm{
 	pixel_y = 24
@@ -8077,14 +8050,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/bridge)
-"cuc" = (
-/obj/machinery/door/airlock/external,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/structure/fans/tiny,
-/turf/open/floor/plasteel/dark,
-/area/hallway/primary/port)
 "cux" = (
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
@@ -8703,6 +8668,10 @@
 	},
 /turf/open/floor/carpet/orange,
 /area/engine/secure_construction)
+"cKE" = (
+/obj/structure/closet/l3closet/security,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "cKK" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -8955,6 +8924,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/starboard)
+"cQF" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/vehicle/ridden/atv/snowmobile,
+/obj/item/key,
+/obj/effect/turf_decal/bot,
+/obj/structure/window/reinforced,
+/turf/open/floor/plasteel/dark,
+/area/medical/paramedic)
 "cQU" = (
 /obj/structure/sink{
 	pixel_y = 20
@@ -9337,12 +9319,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
-"cYl" = (
-/obj/machinery/camera{
-	c_tag = "Northwestern Hall 10"
-	},
-/turf/open/floor/plasteel/dark,
-/area/hallway/primary/port)
 "cYq" = (
 /obj/machinery/suit_storage_unit/atmos,
 /turf/open/floor/plasteel,
@@ -9745,13 +9721,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/blueshield)
-"djy" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Morgue Maintenance";
-	req_access_txt = "6;5"
-	},
-/turf/open/floor/plating,
-/area/hallway/primary/port)
 "djL" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
@@ -10022,6 +9991,16 @@
 	},
 /turf/open/floor/wood,
 /area/security/courtroom)
+"drQ" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/tank_dispenser/oxygen,
+/turf/open/floor/plasteel/dark,
+/area/medical/paramedic)
 "dsk" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -10033,10 +10012,6 @@
 /obj/machinery/disposal/bin,
 /turf/open/floor/wood,
 /area/hallway/primary/port)
-"dsm" = (
-/obj/machinery/atmospherics/pipe/manifold4w/cyan/hidden,
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
 "dsn" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -10213,13 +10188,6 @@
 /obj/effect/turf_decal/tile/brown,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"dvy" = (
-/obj/machinery/door/airlock/atmos{
-	name = "Atmospherics Maintenance";
-	req_access_txt = "12;24;39"
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "dvz" = (
 /obj/machinery/newscaster{
 	pixel_x = 32
@@ -10748,6 +10716,13 @@
 "dMj" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/nuke_storage)
+"dMp" = (
+/obj/machinery/door/airlock/external{
+	name = "Escape Pod Two"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/hallway/primary/port)
 "dMI" = (
 /obj/structure/chair/office/dark{
 	dir = 4
@@ -10860,6 +10835,18 @@
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
+"dQZ" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/vehicle/ridden/atv/snowmobile,
+/obj/item/key,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/dark,
+/area/medical/paramedic)
 "dRI" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall/r_wall,
@@ -11070,6 +11057,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"dXf" = (
+/obj/structure/rack,
+/obj/item/storage/box/masks,
+/obj/item/cartridge/medical,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "dXs" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -11107,6 +11100,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"dXU" = (
+/obj/structure/sign/poster/official/help_others,
+/turf/closed/wall,
+/area/medical/paramedic)
 "dYa" = (
 /obj/machinery/requests_console{
 	department = "Genetics";
@@ -11198,6 +11195,10 @@
 	},
 /turf/open/floor/wood,
 /area/bridge/meeting_room)
+"ebz" = (
+/obj/machinery/atmospherics/pipe/manifold4w/cyan/hidden,
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "ebF" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -11275,6 +11276,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
+"edf" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/light/floor,
+/obj/machinery/door/airlock/external{
+	req_one_access_txt = "13;5"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "edH" = (
 /obj/machinery/holopad,
 /turf/open/floor/wood,
@@ -11694,11 +11711,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
-"ero" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
-/obj/structure/chair/office/light,
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
 "erx" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/dark,
@@ -12271,12 +12283,6 @@
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/floor/grass,
 /area/medical/genetics)
-"eGg" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "eGi" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -12622,16 +12628,6 @@
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
-"eNw" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/oil,
-/turf/open/floor/plasteel/dark,
-/area/medical/paramedic)
 "eNG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -13080,6 +13076,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
+"eZc" = (
+/obj/structure/table,
+/obj/machinery/newscaster{
+	pixel_y = 34
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/floor/plasteel/white,
+/area/medical/paramedic)
 "eZe" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
@@ -13123,12 +13131,6 @@
 	},
 /turf/open/floor/wood,
 /area/bridge/meeting_room)
-"eZC" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/hallway/primary/port)
 "eZD" = (
 /obj/structure/chair/comfy/black{
 	dir = 8
@@ -13674,6 +13676,13 @@
 /obj/structure/table/wood/fancy,
 /turf/open/floor/plasteel/cult,
 /area/library)
+"foW" = (
+/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
+/obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "fpa" = (
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
@@ -14136,6 +14145,16 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/dorms)
+"fBC" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/landmark/start/paramedic,
+/turf/open/floor/plasteel/dark,
+/area/medical/paramedic)
 "fBG" = (
 /obj/structure/grille/broken,
 /turf/open/floor/plating/asteroid/snow/icemoon,
@@ -14276,6 +14295,13 @@
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"fGX" = (
+/obj/machinery/door/airlock/external{
+	name = "Escape Pod One"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/hallway/primary/port)
 "fHa" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -14773,6 +14799,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/server)
+"fSV" = (
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "fTn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -15925,12 +15957,6 @@
 /obj/effect/spawner/lootdrop/wall/fifty_percent_falsewall,
 /turf/open/floor/plating,
 /area/security/prison)
-"gBL" = (
-/obj/structure/closet/crate/medical,
-/obj/item/stack/medical/bruise_pack,
-/obj/item/stack/medical/ointment,
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "gCd" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -16756,16 +16782,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
-"gXZ" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/landmark/start/paramedic,
-/turf/open/floor/plasteel/dark,
-/area/medical/paramedic)
 "gYC" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -16810,16 +16826,6 @@
 "gZX" = (
 /turf/closed/wall,
 /area/medical/morgue)
-"gZY" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/plasteel/dark,
-/area/medical/paramedic)
 "haj" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -17136,13 +17142,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"hkI" = (
-/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
-/obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "hlh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
@@ -17454,6 +17453,16 @@
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/floor/plating,
 /area/engine/engineering)
+"hsy" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plasteel/dark,
+/area/medical/paramedic)
 "hsC" = (
 /obj/docking_port/stationary{
 	dwidth = 3;
@@ -18467,12 +18476,6 @@
 	},
 /turf/open/floor/wood,
 /area/security/courtroom)
-"hRp" = (
-/obj/structure/rack,
-/obj/item/storage/box/masks,
-/obj/item/cartridge/medical,
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "hRt" = (
 /turf/closed/wall,
 /area/quartermaster/qm)
@@ -20223,9 +20226,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "iIg" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 5
-	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "iIz" = (
@@ -21790,6 +21791,16 @@
 	},
 /turf/open/floor/carpet,
 /area/medical/psych)
+"jDX" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/suit_storage_unit/paramedic,
+/turf/open/floor/plasteel/dark,
+/area/medical/paramedic)
 "jEb" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -21980,6 +21991,12 @@
 	dir = 8
 	},
 /area/crew_quarters/fitness/pool)
+"jIL" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "jJb" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible,
 /turf/closed/wall/r_wall,
@@ -22038,6 +22055,11 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/construction/storage)
+"jMX" = (
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/port/fore)
 "jNd" = (
 /obj/structure/closet/secure_closet/genpop,
 /obj/item/radio/headset{
@@ -23441,10 +23463,6 @@
 	},
 /turf/open/floor/plasteel/white/side,
 /area/hallway/primary/port)
-"kzA" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/medical/paramedic)
 "kzS" = (
 /obj/machinery/computer/upload/borg,
 /turf/open/floor/circuit,
@@ -23497,6 +23515,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"kBl" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Morgue Maintenance";
+	req_access_txt = "6;5"
+	},
+/turf/open/floor/plating,
+/area/hallway/primary/port)
 "kBK" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -23518,23 +23543,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"kCp" = (
-/obj/machinery/door/airlock/medical/glass{
-	id_tag = "MedbayFoyer";
-	name = "Medbay";
-	req_access_txt = "5"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/medical/paramedic)
 "kCv" = (
 /obj/machinery/door/window/eastleft{
 	name = "Coffin Pyre";
@@ -23892,18 +23900,11 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
-"kNG" = (
-/obj/structure/table,
-/obj/machinery/newscaster{
-	pixel_y = 34
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/item/paper_bin,
-/obj/item/pen,
-/turf/open/floor/plasteel/white,
-/area/medical/paramedic)
+"kMV" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "kNQ" = (
 /obj/machinery/computer/security/hos{
 	dir = 4
@@ -24292,9 +24293,6 @@
 	dir = 4;
 	name = "east facing firelock"
 	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 8
-	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "laL" = (
@@ -24551,6 +24549,13 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
+"liJ" = (
+/obj/docking_port/stationary/random{
+	id = "pod_lavaland2";
+	name = "lavaland"
+	},
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/surface/outdoors)
 "liL" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -25175,10 +25180,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"lBm" = (
-/obj/structure/closet/l3closet/security,
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "lBF" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -25368,6 +25369,16 @@
 	},
 /turf/open/floor/wood,
 /area/hallway/primary/central)
+"lGu" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/plasteel/dark,
+/area/medical/paramedic)
 "lGy" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -25601,6 +25612,12 @@
 	},
 /turf/open/floor/carpet,
 /area/medical/psych)
+"lPw" = (
+/obj/structure/closet/crate/medical,
+/obj/item/stack/medical/bruise_pack,
+/obj/item/stack/medical/ointment,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "lPB" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/floor/plasteel,
@@ -26305,16 +26322,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/checkpoint/supply)
-"mlY" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/suit_storage_unit/paramedic,
-/turf/open/floor/plasteel/dark,
-/area/medical/paramedic)
 "mmJ" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -26582,6 +26589,17 @@
 	dir = 1
 	},
 /area/crew_quarters/fitness/pool)
+"mvb" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/item/clothing/gloves/color/latex,
+/obj/item/healthanalyzer,
+/obj/item/clothing/glasses/hud/health,
+/obj/structure/window/reinforced,
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "mvA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
@@ -26979,6 +26997,10 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
+"mHM" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/dark,
+/area/medical/paramedic)
 "mHU" = (
 /obj/machinery/light{
 	dir = 8
@@ -27671,6 +27693,11 @@
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plating,
 /area/medical/chemistry)
+"mZf" = (
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/maintenance/port/fore)
 "mZk" = (
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
@@ -28077,6 +28104,21 @@
 	},
 /turf/open/floor/plasteel/cult,
 /area/library)
+"nld" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external{
+	req_one_access_txt = "13;5"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "nlk" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -28173,6 +28215,13 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/genetics)
+"nnk" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "nnV" = (
 /obj/machinery/light{
 	dir = 1
@@ -28575,15 +28624,6 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/maintenance/central)
-"nzr" = (
-/obj/machinery/atmospherics/pipe/simple/supply/visible{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/hallway/primary/port)
 "nzD" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -28635,6 +28675,12 @@
 	},
 /turf/open/pool,
 /area/crew_quarters/fitness/pool)
+"nAp" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 8
+	},
+/turf/closed/wall/r_wall,
+/area/medical/virology)
 "nAx" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -28866,13 +28912,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/port)
-"nED" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Supply to Virology"
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "nEI" = (
 /obj/structure/dresser,
 /obj/machinery/camera{
@@ -30677,17 +30716,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
-"ozV" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 8
-	},
-/obj/structure/table/reinforced,
-/obj/item/clothing/gloves/color/latex,
-/obj/item/healthanalyzer,
-/obj/item/clothing/glasses/hud/health,
-/obj/structure/window/reinforced,
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
 "oAX" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -30772,6 +30800,13 @@
 /obj/structure/chair/stool,
 /turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
+"oCf" = (
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/effect/landmark/start/paramedic,
+/turf/open/floor/plasteel/white,
+/area/medical/paramedic)
 "oDm" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -30872,13 +30907,6 @@
 /obj/item/stack/cable_coil,
 /turf/open/floor/plating,
 /area/engine/storage)
-"oHq" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/effect/landmark/start/paramedic,
-/turf/open/floor/plasteel/white,
-/area/medical/paramedic)
 "oHU" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 10
@@ -31298,10 +31326,6 @@
 	},
 /turf/open/floor/wood,
 /area/maintenance/bar)
-"oVv" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "oVW" = (
 /obj/structure/bed,
 /obj/item/bedsheet/mime,
@@ -31866,10 +31890,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"pii" = (
-/obj/structure/closet/l3closet/virology,
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
 "piu" = (
 /turf/open/floor/plating,
 /area/maintenance/disposal)
@@ -32338,7 +32358,6 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -32420,6 +32439,17 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
+"pwu" = (
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/machinery/disposal/bin,
+/turf/open/floor/plasteel/white,
+/area/medical/paramedic)
 "pwC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
@@ -32705,11 +32735,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
-"pCZ" = (
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
-/area/maintenance/port/fore)
 "pDh" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -33694,11 +33719,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"qdn" = (
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/maintenance/port/fore)
 "qdZ" = (
 /obj/machinery/door/airlock/public{
 	name = "Permabrig Dorm 2"
@@ -33943,13 +33963,6 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
-"qlc" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "qlj" = (
 /turf/closed/wall,
 /area/crew_quarters/theatre)
@@ -34119,6 +34132,18 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
+"qpN" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
+"qpQ" = (
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plasteel/dark,
+/area/hallway/primary/port)
 "qpW" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/effect/turf_decal/tile/brown{
@@ -34245,11 +34270,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/janitor)
-"qrV" = (
-/obj/structure/closet/crate,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "qsm" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -35361,18 +35381,6 @@
 	dir = 4
 	},
 /area/hallway/secondary/exit/departure_lounge)
-"qXQ" = (
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/space_heater,
-/obj/structure/window/reinforced,
-/turf/open/floor/plasteel/dark,
-/area/medical/paramedic)
 "qYD" = (
 /obj/machinery/vending/security,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -35880,6 +35888,13 @@
 /obj/machinery/photocopier/faxmachine,
 /turf/open/floor/plasteel/checker,
 /area/crew_quarters/heads/hor)
+"rmc" = (
+/obj/machinery/door/airlock/atmos{
+	name = "Atmospherics Maintenance";
+	req_access_txt = "12;24;39"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "rmo" = (
 /obj/effect/turf_decal/vg_decals/atmos/carbon_dioxide,
 /obj/machinery/light/small{
@@ -35982,6 +35997,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"rnN" = (
+/obj/machinery/door/airlock/medical/glass{
+	id_tag = "MedbayFoyer";
+	name = "Medbay";
+	req_access_txt = "5"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/structure/fans/tiny,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/medical/paramedic)
 "rom" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -36356,6 +36389,11 @@
 	},
 /turf/open/floor/wood,
 /area/medical/psych)
+"rwY" = (
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "rxc" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -36370,6 +36408,11 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"rxo" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
+/obj/structure/chair/office/light,
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "rxt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -36475,22 +36518,6 @@
 /obj/machinery/vending/cola/pwr_game,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"rAp" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/light/floor,
-/obj/machinery/door/airlock/external{
-	req_one_access_txt = "13;5"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "rAw" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -36646,13 +36673,6 @@
 "rGc" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 6
-	},
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/surface/outdoors)
-"rGq" = (
-/obj/docking_port/stationary/random{
-	id = "pod_lavaland2";
-	name = "lavaland"
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
@@ -36904,10 +36924,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"rNV" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/dark,
-/area/medical/paramedic)
 "rOd" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -37313,13 +37329,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"saI" = (
-/obj/machinery/door/airlock/external{
-	name = "Escape Pod One"
-	},
-/obj/structure/fans/tiny,
-/turf/open/floor/plating,
-/area/hallway/primary/port)
 "saN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/item/kirbyplants/random,
@@ -37739,15 +37748,6 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hop)
-"slS" = (
-/obj/machinery/shower{
-	dir = 8
-	},
-/obj/machinery/airalarm{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/dark,
-/area/medical/paramedic)
 "sma" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/closet/cabinet,
@@ -37952,6 +37952,16 @@
 /obj/item/pickaxe,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"ssi" = (
+/obj/docking_port/stationary{
+	dwidth = 1;
+	height = 4;
+	name = "escape pod loader";
+	roundstart_template = /datum/map_template/shuttle/escape_pod/default;
+	width = 3
+	},
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/surface/outdoors)
 "ssF" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -40034,6 +40044,19 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
+"tyN" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/visible{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/hallway/primary/port)
 "tzB" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 6
@@ -40527,6 +40550,24 @@
 	},
 /turf/open/floor/plating,
 /area/medical/genetics)
+"tNv" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = 28
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white/corner{
+	dir = 4
+	},
+/area/hallway/primary/port)
 "tNX" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -40797,6 +40838,12 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
+"tVq" = (
+/obj/machinery/camera{
+	c_tag = "Northwestern Hall 10"
+	},
+/turf/open/floor/plasteel/dark,
+/area/hallway/primary/port)
 "tVS" = (
 /obj/item/radio/intercom{
 	frequency = 1485;
@@ -41002,6 +41049,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
+"uaS" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 5
+	},
+/turf/closed/wall/r_wall,
+/area/medical/virology)
 "uaU" = (
 /obj/structure/bed/dogbed{
 	desc = "A comfy-looking pet bed. You can even strap your pet in, in case the gravity turns off.";
@@ -41040,6 +41093,15 @@
 	},
 /turf/open/floor/plating,
 /area/engine/storage)
+"uch" = (
+/obj/machinery/atmospherics/pipe/simple/supply/visible{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/hallway/primary/port)
 "ucC" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating,
@@ -41652,6 +41714,22 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
+"uuv" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/item/paper_bin{
+	pixel_x = -2;
+	pixel_y = 5
+	},
+/obj/item/pen/red,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "uuD" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -42056,12 +42134,6 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/bar)
-"uIT" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
 "uIU" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -42701,24 +42773,6 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
-"uZc" = (
-/obj/machinery/door/airlock/medical/glass{
-	id_tag = "MedbayFoyer";
-	name = "Medbay";
-	req_access_txt = "5"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/structure/fans/tiny,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/medical/paramedic)
 "uZd" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -42807,19 +42861,6 @@
 /obj/machinery/vending/cigarette,
 /turf/open/floor/plating,
 /area/maintenance/bar)
-"vbi" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/vehicle/ridden/atv/snowmobile,
-/obj/item/key,
-/obj/effect/turf_decal/bot,
-/obj/structure/window/reinforced,
-/turf/open/floor/plasteel/dark,
-/area/medical/paramedic)
 "vbn" = (
 /obj/structure/toilet/secret/prison{
 	dir = 1
@@ -43299,6 +43340,11 @@
 /obj/machinery/smartfridge/chemistry/preloaded,
 /turf/closed/wall/r_wall,
 /area/medical/chemistry)
+"vmP" = (
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/port/fore)
 "vnn" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -43348,11 +43394,6 @@
 	},
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors)
-"voI" = (
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
-	},
-/area/maintenance/port/fore)
 "vpz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/airlock/public/glass{
@@ -43378,22 +43419,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
-"vqn" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/power/apc{
-	areastring = "/area/maintenance/port/fore";
-	dir = 4;
-	name = "Port Bow Maintenance APC";
-	pixel_x = 24
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "vqv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/airlock{
@@ -44151,6 +44176,23 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
+"vJj" = (
+/obj/machinery/door/airlock/medical/glass{
+	id_tag = "MedbayFoyer";
+	name = "Medbay";
+	req_access_txt = "5"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/medical/paramedic)
 "vJs" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -44341,6 +44383,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"vMk" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "vMl" = (
 /obj/structure/window/reinforced,
 /obj/structure/flora/ausbushes/brflowers,
@@ -44563,7 +44611,7 @@
 /area/mine/living_quarters)
 "vST" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 10
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -44591,6 +44639,13 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel/dark,
 /area/engine/secure_construction)
+"vTr" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Supply to Virology"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "vTs" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -44613,6 +44668,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/visible,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
+"vTO" = (
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "vTP" = (
 /obj/structure/table,
 /obj/item/folder/white,
@@ -44687,22 +44746,6 @@
 /obj/machinery/iv_drip,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"vVt" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 8
-	},
-/obj/structure/table/reinforced,
-/obj/item/paper_bin{
-	pixel_x = -2;
-	pixel_y = 5
-	},
-/obj/item/pen/red,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
 "vVz" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -45491,16 +45534,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
 /area/security/prison)
-"wpW" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/structure/tank_dispenser/oxygen,
-/turf/open/floor/plasteel/dark,
-/area/medical/paramedic)
 "wqd" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -45770,21 +45803,6 @@
 "wyg" = (
 /turf/closed/wall/mineral/wood,
 /area/maintenance/bar)
-"wyS" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/door/airlock/external{
-	req_one_access_txt = "13;5"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "wzf" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -45808,6 +45826,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
+"wzy" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/hallway/primary/port)
 "wzF" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 5
@@ -45826,6 +45850,18 @@
 "wAx" = (
 /turf/closed/wall,
 /area/hydroponics)
+"wAC" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/space_heater,
+/obj/structure/window/reinforced,
+/turf/open/floor/plasteel/dark,
+/area/medical/paramedic)
 "wAM" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -46091,13 +46127,6 @@
 "wIA" = (
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"wIQ" = (
-/obj/machinery/door/airlock/external{
-	name = "Escape Pod Two"
-	},
-/obj/structure/fans/tiny,
-/turf/open/floor/plating,
-/area/hallway/primary/port)
 "wIT" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -46247,19 +46276,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/paramedic)
-"wPq" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/visible{
-	dir = 4
-	},
-/obj/machinery/door/airlock/external,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/hallway/primary/port)
 "wPD" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -46592,6 +46608,10 @@
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
+"wZz" = (
+/obj/structure/closet/l3closet/virology,
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "wZJ" = (
 /obj/structure/chair/sofa{
 	dir = 4
@@ -47044,12 +47064,6 @@
 	icon_state = "wood-broken5"
 	},
 /area/maintenance/bar)
-"xlD" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "xlX" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/visible{
 	dir = 1
@@ -47656,10 +47670,6 @@
 /obj/effect/turf_decal/tile/brown,
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
-"xEr" = (
-/obj/structure/sign/poster/official/help_others,
-/turf/closed/wall,
-/area/medical/paramedic)
 "xEt" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
@@ -48287,16 +48297,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"xXE" = (
-/obj/docking_port/stationary{
-	dwidth = 1;
-	height = 4;
-	name = "escape pod loader";
-	roundstart_template = /datum/map_template/shuttle/escape_pod/default;
-	width = 3
-	},
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/surface/outdoors)
 "xXS" = (
 /obj/machinery/rnd/server,
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
@@ -65273,7 +65273,7 @@ pZD
 adx
 puS
 iIg
-pZD
+uaS
 fDi
 pED
 fgp
@@ -65530,7 +65530,7 @@ pZD
 pZD
 sXV
 laE
-pZD
+nAp
 aaS
 ann
 aba
@@ -65786,8 +65786,8 @@ nnV
 cni
 qbY
 fYU
+uYa
 vST
-iIg
 aaS
 joT
 kGS
@@ -66301,7 +66301,7 @@ mpj
 mpj
 gIE
 hBH
-uIT
+vST
 pZD
 pZD
 pZD
@@ -66558,7 +66558,7 @@ hDj
 pfY
 wlD
 jBP
-dsm
+ebz
 cRX
 suK
 vGi
@@ -66815,7 +66815,7 @@ tlu
 wAW
 xhb
 uCi
-uIT
+vST
 xFQ
 pZD
 eEy
@@ -67072,7 +67072,7 @@ pZD
 pZD
 pZD
 lzw
-uIT
+vST
 lMF
 pZD
 pZD
@@ -67329,7 +67329,7 @@ tGK
 beD
 kkt
 cAo
-vVt
+uuv
 kWC
 itU
 sWT
@@ -67586,7 +67586,7 @@ avT
 tdK
 gNb
 uYa
-ozV
+mvb
 mgC
 fjS
 uUr
@@ -67842,11 +67842,11 @@ avT
 byu
 wlG
 eSJ
-ero
+rxo
 vqQ
 uYa
 uYa
-pii
+wZz
 mpj
 xgB
 xgB
@@ -68612,17 +68612,17 @@ ydp
 mbm
 fXd
 xVn
-oVv
-eGg
-dvy
-qdn
+qpN
+jIL
+rmc
+vmP
 iJl
 iJl
-bge
+kMV
 iJl
-gBL
-hRp
-pCZ
+lPw
+dXf
+mZf
 eJu
 nYZ
 hxr
@@ -68868,18 +68868,18 @@ ydp
 ydp
 mbm
 iAO
-brc
+fSV
 iJl
-nED
+vTr
 mbm
 iJl
-xlD
+vMk
 rTG
 uYp
 kxU
 sdH
 uYp
-vqn
+aDO
 pyw
 nYZ
 sXl
@@ -69125,13 +69125,13 @@ ydp
 ydp
 mbm
 jKV
-hkI
+foW
 jKV
-qlc
+nnk
 mbm
-lBm
+cKE
 mbm
-wyS
+nld
 mbm
 mvQ
 mvQ
@@ -69393,8 +69393,8 @@ mbm
 qIm
 qIm
 mbm
-bJL
-pCZ
+vTO
+mZf
 nYZ
 dYa
 iaM
@@ -69645,12 +69645,12 @@ ydp
 ydp
 avT
 mbm
-rAp
+edf
 mbm
 avT
 avT
 mbm
-bJL
+vTO
 iJl
 nYZ
 nYZ
@@ -69907,13 +69907,13 @@ avT
 avT
 avT
 mbm
-qrV
-xlD
+rwY
+vMk
 iJl
 iJl
-voI
+jMX
 iJl
-djy
+kBl
 hui
 hBQ
 aNf
@@ -70426,7 +70426,7 @@ xUL
 xUL
 xUL
 xUL
-eZC
+wzy
 tmO
 fYx
 oDm
@@ -70679,12 +70679,12 @@ avT
 avT
 avT
 avT
-rGq
+liJ
 xUL
 xUL
 xUL
-xXE
-saI
+ssi
+fGX
 fYx
 oDm
 rhX
@@ -70944,7 +70944,7 @@ xUL
 tmO
 fYx
 oDm
-kzA
+aEo
 vFd
 por
 jEb
@@ -71199,9 +71199,9 @@ wdv
 wdv
 wdv
 tmO
-bdf
+tNv
 oDm
-kzA
+aEo
 vFd
 iop
 cSC
@@ -71454,11 +71454,11 @@ xUL
 xUL
 xUL
 xUL
-eZC
+wzy
 tmO
 fYx
 oDm
-kzA
+aEo
 vFd
 vFd
 hlT
@@ -71707,20 +71707,20 @@ avT
 avT
 avT
 avT
-rGq
+liJ
 xUL
 xUL
 xUL
-xXE
-wIQ
+ssi
+dMp
 qJy
 oDm
 rhX
-kNG
+eZc
 vTP
 vFd
-oHq
-bQX
+oCf
+pwu
 rhX
 xWq
 xWq
@@ -71978,7 +71978,7 @@ kHd
 ljT
 vFd
 ubd
-kzA
+aEo
 xUL
 xUL
 xUL
@@ -72231,11 +72231,11 @@ lki
 kMt
 rhX
 uPn
-rNV
+mHM
 vFd
 vFd
 vGn
-kzA
+aEo
 xUL
 xUL
 xUL
@@ -72484,15 +72484,15 @@ avT
 avT
 avT
 tmO
-cYl
-nzr
+tVq
+uch
 rhX
-slS
+arr
 lXR
 vFd
 vFd
 vGn
-kzA
+aEo
 xUL
 xUL
 xUL
@@ -72741,14 +72741,14 @@ avT
 avT
 avT
 tmO
-cuc
-wPq
+qpQ
+tyN
 rhX
 rhX
 rhX
-kCp
-kCp
-xEr
+vJj
+vJj
+dXU
 rhX
 xUL
 xUL
@@ -73002,11 +73002,11 @@ xUL
 xnm
 rhX
 eTu
-qXQ
+wAC
 wOn
 wOn
 sIT
-kzA
+aEo
 xUL
 xUL
 xUL
@@ -73257,13 +73257,13 @@ avT
 avT
 vBe
 xnm
-uZc
+rnN
 wOn
-eNw
-gXZ
+lGu
+fBC
 wOn
 wOn
-kzA
+aEo
 xUL
 xUL
 xUL
@@ -73514,13 +73514,13 @@ avT
 avT
 xUL
 xnm
-uZc
+rnN
 wOn
 wOn
-gZY
+hsy
 wOn
 wOn
-kzA
+aEo
 avT
 avT
 avT
@@ -73772,12 +73772,12 @@ avT
 xUL
 xnm
 rhX
-bWX
-vbi
-mlY
-wpW
-mlY
-kzA
+dQZ
+cQF
+jDX
+drQ
+jDX
+aEo
 avT
 avT
 avT

--- a/_maps/map_files/Snaxi/Snaxi_Lumos.dmm
+++ b/_maps/map_files/Snaxi/Snaxi_Lumos.dmm
@@ -65,11 +65,22 @@
 /turf/open/floor/plasteel/white,
 /area/security/prison)
 "abs" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
+/obj/machinery/vending/wardrobe/viro_wardrobe,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
 	},
-/turf/open/floor/carpet,
-/area/medical/psych)
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/machinery/camera{
+	c_tag = "Virology Break Room";
+	network = list("ss13","medbay")
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "abG" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -102,13 +113,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"abZ" = (
-/obj/effect/landmark/start/medical_doctor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/freezer,
-/area/medical/surgery)
 "ace" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -244,29 +248,50 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "adu" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "psyshu";
-	name = "psy shutters"
+/obj/machinery/iv_drip,
+/obj/item/radio/intercom{
+	pixel_y = 25
 	},
-/turf/open/floor/plating,
-/area/medical/psych)
-"adw" = (
-/obj/machinery/firealarm{
-	pixel_y = 29
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
-"adx" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
 /turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
+/area/medical/virology)
+"adw" = (
+/obj/item/storage/secure/safe{
+	pixel_x = 5;
+	pixel_y = 29
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
+"adx" = (
+/obj/structure/bed,
+/obj/item/bedsheet/medical,
+/obj/machinery/requests_console{
+	department = "Virology";
+	name = "Virology Requests Console";
+	pixel_x = 32
+	},
+/obj/machinery/light_switch{
+	pixel_y = 26
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "ady" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -394,16 +419,20 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "adZ" = (
-/obj/machinery/light{
+/obj/structure/table,
+/obj/machinery/microwave{
+	pixel_y = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "aet" = (
@@ -1064,17 +1093,12 @@
 /turf/open/floor/wood,
 /area/library)
 "aqP" = (
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/door/airlock/virology{
+	name = "Break Room";
+	req_access_txt = "39"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/port)
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "arl" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -1096,6 +1120,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
+	},
+/obj/machinery/airalarm{
+	pixel_y = 32
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
@@ -3221,15 +3248,15 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "aPp" = (
-/obj/machinery/firealarm{
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/machinery/airalarm{
 	dir = 4;
-	pixel_x = -24
+	pixel_x = -22
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
-/obj/structure/table/reinforced,
-/obj/item/storage/backpack/duffelbag/med/surgery,
 /turf/open/floor/plasteel/freezer,
 /area/medical/surgery)
 "aPw" = (
@@ -6673,15 +6700,17 @@
 /turf/open/floor/carpet,
 /area/chapel/office)
 "bSb" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 12
+/obj/item/radio/intercom{
+	frequency = 1485;
+	name = "Station Intercom (Medbay)";
+	pixel_y = 30
 	},
-/obj/structure/mirror{
-	pixel_x = 25
+/obj/machinery/light{
+	dir = 4
 	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
+/obj/structure/closet/secure_closet/psychologist,
+/turf/open/floor/wood,
+/area/medical/psych)
 "bSd" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -8519,9 +8548,16 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "cGu" = (
-/obj/structure/filingcabinet,
-/turf/open/floor/wood,
-/area/medical/psych)
+/obj/machinery/camera{
+	c_tag = "Surgery A";
+	network = list("ss13","medbay");
+	pixel_x = 22
+	},
+/obj/machinery/computer/operating{
+	dir = 4
+	},
+/turf/open/floor/plasteel/freezer,
+/area/medical/surgery)
 "cGz" = (
 /obj/structure/table,
 /obj/item/storage/backpack/duffelbag/med/surgery,
@@ -9115,16 +9151,7 @@
 /area/hydroponics/garden)
 "cVu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "cVG" = (
@@ -9605,12 +9632,12 @@
 /turf/open/floor/circuit/off,
 /area/ai_monitored/turret_protected/ai)
 "dfV" = (
-/obj/structure/table,
-/obj/machinery/microwave{
-	pixel_y = 4
+/obj/item/radio/intercom{
+	pixel_y = 25
 	},
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
+/obj/structure/table/optable,
+/turf/open/floor/plasteel/freezer,
+/area/medical/surgery)
 "dhg" = (
 /turf/closed/wall,
 /area/construction/storage)
@@ -10464,6 +10491,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/bed/roller,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "dFp" = (
@@ -10674,13 +10702,6 @@
 	},
 /turf/open/floor/wood,
 /area/security/vacantoffice/a)
-"dML" = (
-/obj/item/radio/intercom{
-	pixel_y = 25
-	},
-/obj/structure/table/optable,
-/turf/open/floor/plasteel/freezer,
-/area/medical/surgery)
 "dMR" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -11305,15 +11326,9 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "efp" = (
-/obj/machinery/iv_drip,
-/obj/item/radio/intercom{
-	pixel_y = 25
-	},
-/obj/effect/turf_decal/tile/green{
+/obj/structure/chair/stool,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -11356,8 +11371,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/bed/roller,
-/obj/machinery/iv_drip,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "egk" = (
@@ -11566,9 +11579,11 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
 "eoW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -11581,7 +11596,9 @@
 /turf/open/floor/plating,
 /area/crew_quarters/fitness)
 "epK" = (
-/obj/machinery/atmospherics/components/unary/cryo_cell,
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
 "epU" = (
@@ -11706,32 +11723,26 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "esE" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"esK" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
 "esY" = (
 /turf/open/openspace/icemoon,
 /area/engine/atmos)
 "ets" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
 /obj/machinery/camera{
 	c_tag = "Medbay Treatment Center";
 	dir = 8;
 	network = list("ss13","medbay")
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/machinery/computer/med_data{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
 "etz" = (
@@ -11786,11 +11797,9 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
 "eut" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/medical/psych)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/turf/open/floor/plasteel/freezer,
+/area/medical/surgery)
 "euz" = (
 /obj/structure/closet/wardrobe/mixed,
 /turf/open/floor/plating,
@@ -11887,10 +11896,20 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/obj/structure/closet/crate/bin,
-/obj/machinery/light{
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/structure/chair/comfy/black{
+	dir = 8
+	},
+/obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "exE" = (
@@ -12037,11 +12056,12 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
 "eDm" = (
-/obj/structure/chair/sofa/right{
-	dir = 4
+/obj/machinery/light{
+	dir = 1
 	},
-/turf/open/floor/carpet,
-/area/medical/psych)
+/obj/structure/table/optable,
+/turf/open/floor/plasteel/freezer,
+/area/medical/surgery)
 "eDr" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -12768,7 +12788,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
 "eSQ" = (
@@ -13246,11 +13265,12 @@
 /turf/open/floor/plating,
 /area/engine/atmos)
 "fgp" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/backpack/duffelbag/med/surgery,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
 	},
+/obj/structure/closet/secure_closet/medical2,
+/obj/item/tank/internals/anesthetic,
+/obj/item/tank/internals/anesthetic,
 /turf/open/floor/plasteel/freezer,
 /area/medical/surgery)
 "fgM" = (
@@ -13407,9 +13427,6 @@
 /turf/closed/wall/r_wall,
 /area/engine/engineering)
 "fkF" = (
-/obj/machinery/door/airlock/medical{
-	name = "Psychologist Lobby"
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -13419,6 +13436,10 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8;
 	name = "west facing firelock"
+	},
+/obj/machinery/door/airlock/medical{
+	name = "Medbay Break Room";
+	req_access_txt = "5"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -13676,27 +13697,21 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "fqM" = (
-/obj/structure/table,
 /obj/machinery/newscaster{
 	pixel_x = -30
 	},
-/obj/item/storage/box/donkpockets{
-	pixel_x = 3;
-	pixel_y = 5
-	},
-/obj/item/reagent_containers/spray/cleaner,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 6
+	},
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -14
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -13854,12 +13869,26 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "fva" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/structure/table,
+/obj/item/storage/box/donkpockets{
+	pixel_x = -6;
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/spray/cleaner,
+/obj/machinery/camera{
+	c_tag = "Medbay Break Room";
+	network = list("ss13","medbay")
+	},
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/item/kirbyplants{
-	icon_state = "plant-04"
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
 	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "fve" = (
@@ -14073,9 +14102,11 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/dorms)
 "fDi" = (
-/obj/machinery/light/small,
-/turf/open/floor/plating/asteroid/snow/icemoon,
-/area/medical/psych)
+/obj/machinery/computer/operating{
+	dir = 8
+	},
+/turf/open/floor/plasteel/freezer,
+/area/medical/surgery)
 "fDl" = (
 /obj/structure/bodycontainer/morgue{
 	dir = 8
@@ -14156,13 +14187,12 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "fGi" = (
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp/green{
-	pixel_x = 1;
-	pixel_y = 5
+/obj/effect/landmark/start/medical_doctor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
-/turf/open/floor/carpet,
-/area/medical/psych)
+/turf/open/floor/plasteel/freezer,
+/area/medical/surgery)
 "fGl" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
@@ -14651,8 +14681,9 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "fRS" = (
+/obj/machinery/smartfridge/organ/preloaded,
 /turf/closed/wall,
-/area/medical/psych)
+/area/medical/surgery)
 "fSs" = (
 /obj/structure/bookcase/random/fiction,
 /turf/open/floor/wood,
@@ -14711,11 +14742,11 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
 "fUX" = (
-/obj/structure/cable{
-	icon_state = "2-8"
+/obj/machinery/vending/medical{
+	pixel_x = -2
 	},
-/turf/open/floor/wood,
-/area/medical/psych)
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "fVm" = (
 /turf/open/floor/wood{
 	icon_state = "wood-broken5"
@@ -14745,14 +14776,25 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/zone3)
 "fWo" = (
-/obj/machinery/door/airlock/medical{
-	name = "Patient Room"
-	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
+/obj/machinery/door/airlock/medical{
+	id_tag = "psy1";
+	name = "Psychology Office";
+	req_access_txt = "71"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/wood,
+/area/medical/psych)
 "fWB" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -14799,9 +14841,8 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "fXH" = (
-/obj/structure/closet/secure_closet/medical1{
-	anchored = 1;
-	pixel_x = -3
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
@@ -15272,9 +15313,11 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "gkx" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/airalarm{
+	pixel_y = 23
+	},
 /turf/open/floor/plasteel/white,
-/area/medical/virology)
+/area/medical/medbay/central)
 "gky" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -15599,11 +15642,9 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "gtO" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
+/obj/structure/bookcase/random,
+/turf/open/floor/wood,
+/area/medical/psych)
 "gtR" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/engine_waste{
 	dir = 8
@@ -15692,7 +15733,6 @@
 	icon_state = "1-2"
 	},
 /obj/structure/bed/roller,
-/obj/machinery/iv_drip,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "gvA" = (
@@ -17150,8 +17190,10 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -17996,7 +18038,9 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hop)
 "hIe" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
 /turf/open/floor/plasteel/freezer,
 /area/medical/surgery)
 "hIl" = (
@@ -18096,16 +18140,6 @@
 "hKt" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -18341,13 +18375,26 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "hQb" = (
-/obj/structure/table,
-/obj/item/soap/nanotrasen,
-/obj/item/clothing/mask/muzzle,
-/obj/item/clothing/suit/straight_jacket,
-/obj/machinery/vending/wallmed{
-	pixel_x = -28
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
 	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/chair/comfy/black{
+	dir = 4
+	},
+/obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "hQl" = (
@@ -18563,19 +18610,14 @@
 /turf/open/floor/wood,
 /area/hallway/primary/fore)
 "hVm" = (
-/obj/machinery/vending/wardrobe/viro_wardrobe,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
+/obj/machinery/light/small{
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/green{
 	dir = 8
-	},
-/obj/machinery/camera{
-	c_tag = "Virology Break Room";
-	network = list("ss13","medbay")
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -18650,11 +18692,16 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "hWn" = (
-/obj/machinery/sleeper,
 /obj/structure/mirror{
 	pixel_y = 28
 	},
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/machinery/shower{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "hWQ" = (
 /obj/structure/chair/sofa/corp/left{
@@ -19693,21 +19740,11 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
 "iyW" = (
-/obj/item/radio/intercom{
-	frequency = 1485;
-	name = "Station Intercom (Medbay)";
-	pixel_x = -30
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
 	},
-/obj/machinery/camera{
-	c_tag = "Medbay Patient Room";
-	dir = 4;
-	network = list("ss13","medbay")
-	},
-/obj/structure/bed,
-/obj/item/bedsheet/medical,
-/obj/machinery/iv_drip,
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
+/turf/open/floor/wood,
+/area/medical/psych)
 "iza" = (
 /obj/structure/chair{
 	dir = 1
@@ -20032,13 +20069,14 @@
 /area/security/prison)
 "iGg" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
-	dir = 8
-	},
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = 24
 	},
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
 "iGB" = (
@@ -20136,12 +20174,8 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "iIg" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -20446,12 +20480,11 @@
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/quartermaster/storage)
 "iRy" = (
-/obj/structure/chair/comfy/brown,
 /obj/machinery/firealarm{
 	pixel_y = 29
 	},
-/turf/open/floor/carpet,
-/area/medical/psych)
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "iRE" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -20664,7 +20697,7 @@
 	},
 /area/security/execution/education)
 "iZH" = (
-/turf/closed/wall/r_wall,
+/turf/closed/wall,
 /area/medical/psych)
 "iZZ" = (
 /obj/structure/cable{
@@ -20956,18 +20989,11 @@
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "jiV" = (
-/obj/structure/table,
-/obj/item/storage/firstaid/brute,
-/obj/item/storage/firstaid/brute{
-	pixel_x = 3;
-	pixel_y = 3
+/obj/machinery/light/small{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/plasteel/white,
-/area/medical/storage)
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/medical/psych)
 "jiY" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -21081,7 +21107,13 @@
 /area/maintenance/disposal)
 "jmd" = (
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/white,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
 "jmf" = (
 /obj/structure/cable{
@@ -21142,6 +21174,9 @@
 	},
 /obj/structure/chair{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/surgery)
@@ -21362,15 +21397,15 @@
 /area/hallway/primary/port)
 "jxr" = (
 /obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "jxw" = (
@@ -21673,13 +21708,16 @@
 /turf/open/floor/plating,
 /area/maintenance/aft/secondary)
 "jDK" = (
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp/green{
+	pixel_x = 1;
+	pixel_y = 5
+	},
+/obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "0-4"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/wood,
+/turf/open/floor/carpet,
 /area/medical/psych)
 "jEb" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -22599,13 +22637,12 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "kgx" = (
-/obj/structure/table,
-/obj/machinery/reagentgrinder{
-	desc = "Used to grind things up into raw materials and liquids.";
-	pixel_y = 5
+/obj/structure/chair/comfy/brown,
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
+/turf/open/floor/carpet,
+/area/medical/psych)
 "kgM" = (
 /obj/machinery/telecomms/server/presets/engineering,
 /turf/open/floor/plasteel/dark/telecomms,
@@ -22775,8 +22812,12 @@
 /turf/open/floor/plating,
 /area/security/courtroom)
 "kmj" = (
-/obj/structure/reagent_dispensers/water_cooler,
-/turf/open/floor/wood,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "psyshu";
+	name = "psy shutters"
+	},
+/turf/open/floor/plating,
 /area/medical/psych)
 "kms" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -23137,11 +23178,18 @@
 /area/medical/storage)
 "kuy" = (
 /obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "kuU" = (
@@ -23421,12 +23469,10 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
 /obj/structure/chair{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
 /area/medical/surgery)
 "kHd" = (
@@ -23473,12 +23519,10 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "kHX" = (
-/obj/machinery/holopad,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/chair/sofa/left{
+	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/wood,
+/turf/open/floor/carpet,
 /area/medical/psych)
 "kIp" = (
 /obj/structure/cable{
@@ -23513,6 +23557,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -23592,9 +23639,6 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
 "kMc" = (
-/obj/machinery/airalarm{
-	pixel_y = 23
-	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
 	},
@@ -23880,19 +23924,12 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "kUo" = (
-/obj/machinery/door/airlock/virology{
-	name = "Break Room";
-	req_access_txt = "39"
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	name = "east facing firelock"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
+/obj/effect/landmark/start/psychologist,
+/turf/open/floor/carpet,
+/area/medical/psych)
 "kUy" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -23991,7 +24028,9 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "kYE" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
 /turf/open/floor/plasteel/freezer,
 /area/medical/surgery)
 "kYF" = (
@@ -24068,11 +24107,18 @@
 /turf/open/floor/plasteel/dark,
 /area/teleporter)
 "laE" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
+/obj/machinery/door/airlock/virology{
+	name = "Break Room";
+	req_access_txt = "39"
 	},
-/turf/open/floor/plating,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4;
+	name = "east facing firelock"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/virology)
 "laL" = (
 /obj/structure/window/reinforced{
@@ -24630,14 +24676,19 @@
 /turf/open/floor/plasteel,
 /area/storage/atmos)
 "lqR" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/light,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "lqW" = (
@@ -24677,17 +24728,10 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/camera{
-	c_tag = "Medbay Break Room";
-	network = list("ss13","medbay")
-	},
+/obj/structure/closet/secure_closet,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "ltk" = (
@@ -24954,15 +24998,8 @@
 	},
 /area/engine/break_room)
 "lAS" = (
-/obj/item/storage/secure/safe{
-	pixel_x = 5;
-	pixel_y = 29
-	},
-/obj/effect/turf_decal/tile/green{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -25028,11 +25065,12 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
 "lCW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
+/turf/open/floor/plasteel/dark,
+/area/medical/medbay/central)
 "lDi" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -25233,20 +25271,16 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "lIm" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
 "lIn" = (
-/obj/machinery/computer/operating{
-	dir = 8
+/obj/structure/table/reinforced,
+/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel/freezer,
 /area/medical/surgery)
@@ -25384,15 +25418,10 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
 "lOX" = (
-/obj/structure/chair/office/dark,
-/obj/effect/landmark/start/psychologist,
-/obj/structure/cable{
-	icon_state = "1-4"
+/obj/structure/chair/sofa/right{
+	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/wood,
+/turf/open/floor/carpet,
 /area/medical/psych)
 "lPB" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
@@ -25632,45 +25661,17 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/atmospherics_engine)
 "lYk" = (
-/obj/structure/table,
-/obj/item/storage/firstaid/regular{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/storage/firstaid/regular,
-/obj/item/storage/firstaid/regular{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/storage/firstaid/regular{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/machinery/power/apc/auto_name/south{
-	pixel_y = -27
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel/white,
-/area/medical/storage)
-"lYq" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/door/airlock/medical{
-	id_tag = "psy1";
-	name = "Psychology Office";
-	req_access_txt = "71"
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor/border_only{
-	name = "south facing firelock"
+/turf/open/floor/plasteel/white,
+/area/medical/storage)
+"lYq" = (
+/obj/machinery/holopad,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/open/floor/wood,
+/turf/open/floor/carpet,
 /area/medical/psych)
 "lYJ" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -26433,6 +26434,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "mwW" = (
@@ -26525,11 +26529,20 @@
 /turf/open/floor/plasteel/white,
 /area/security/prison)
 "mAk" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
+/obj/machinery/computer/arcade/tetris,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
 	},
-/obj/structure/disposalpipe/trunk,
-/obj/machinery/disposal/bin,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "mAn" = (
@@ -26826,9 +26839,16 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "mIS" = (
-/obj/structure/closet/wardrobe/pjs,
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/table/wood,
+/obj/machinery/computer/med_data/laptop{
+	dir = 1;
+	pixel_y = 4
+	},
+/turf/open/floor/wood,
+/area/medical/psych)
 "mJd" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -26929,14 +26949,14 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "mLB" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
+	dir = 4
 	},
 /obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
+	icon_state = "2-4"
 	},
 /turf/open/floor/wood,
 /area/medical/psych)
@@ -27042,10 +27062,10 @@
 /turf/open/floor/plasteel,
 /area/janitor)
 "mNP" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
-/turf/open/floor/plating/asteroid/snow/icemoon,
+/turf/open/floor/wood,
 /area/medical/psych)
 "mNS" = (
 /obj/machinery/door/airlock/security/glass{
@@ -27342,7 +27362,6 @@
 	dir = 9
 	},
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
 "mWc" = (
@@ -28142,25 +28161,23 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/pool)
 "ntd" = (
-/obj/machinery/door/airlock/medical{
-	name = "Medbay Break Room";
-	req_access_txt = "5"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/closed/wall,
 /area/medical/medbay/central)
 "ntO" = (
-/obj/machinery/limbgrower,
-/turf/open/floor/plasteel/freezer,
-/area/medical/surgery)
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/medical/psych)
 "ntV" = (
 /obj/machinery/camera{
 	c_tag = "AI Chamber - Port";
@@ -28581,17 +28598,8 @@
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors)
 "nDC" = (
-/obj/structure/table/glass,
-/obj/item/reagent_containers/glass/beaker/cryoxadone{
-	pixel_x = 10
-	},
-/obj/item/reagent_containers/glass/beaker/cryoxadone{
-	pixel_x = 10
-	},
-/obj/item/wrench/medical,
-/obj/machinery/camera{
-	c_tag = "Medbay Cryogenics";
-	network = list("ss13","medbay")
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
@@ -28852,6 +28860,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "nKU" = (
@@ -28919,9 +28933,7 @@
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "nOj" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
+/obj/machinery/limbgrower,
 /turf/open/floor/plasteel/freezer,
 /area/medical/surgery)
 "nOk" = (
@@ -29377,9 +29389,15 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "oaC" = (
-/obj/machinery/computer/med_data,
-/turf/open/floor/plasteel/dark,
-/area/medical/medbay/central)
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/medical/psych)
 "oaF" = (
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/white/corner{
@@ -29577,11 +29595,11 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -29641,9 +29659,12 @@
 /turf/open/floor/plasteel/dark,
 /area/teleporter)
 "ohi" = (
-/obj/effect/landmark/start/medical_doctor,
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
+/obj/structure/bookcase/random,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/medical/psych)
 "ohk" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -29781,9 +29802,25 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/junction/flip{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "ojs" = (
@@ -29849,11 +29886,8 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "okY" = (
-/obj/structure/bed,
-/obj/item/bedsheet/medical,
-/obj/machinery/iv_drip,
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
+/turf/open/floor/wood,
+/area/medical/psych)
 "old" = (
 /obj/item/kirbyplants{
 	icon_state = "applebush"
@@ -30694,9 +30728,6 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "oKr" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /turf/open/floor/plasteel/freezer,
 /area/medical/surgery)
 "oKD" = (
@@ -31225,10 +31256,10 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "pbk" = (
+/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
 	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "pbs" = (
@@ -31241,15 +31272,15 @@
 /turf/open/floor/plasteel/dark,
 /area/blueshield)
 "pbw" = (
-/obj/structure/closet/secure_closet/psychologist,
-/obj/machinery/light{
-	dir = 8
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "psyshu";
+	name = "psy shutters"
 	},
-/obj/machinery/power/apc/auto_name/north,
-/obj/structure/cable{
-	icon_state = "0-4"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
-/turf/open/floor/wood,
+/turf/open/floor/plating,
 /area/medical/psych)
 "pbP" = (
 /obj/structure/table,
@@ -31482,8 +31513,10 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/pool)
 "pfN" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/structure/table,
+/obj/machinery/reagentgrinder{
+	desc = "Used to grind things up into raw materials and liquids.";
+	pixel_y = 5
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -31798,12 +31831,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "poT" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
-/obj/structure/closet/secure_closet/medical2,
-/obj/item/tank/internals/anesthetic,
-/obj/item/tank/internals/anesthetic,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/freezer,
 /area/medical/surgery)
 "poU" = (
@@ -32068,21 +32096,12 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
 "puS" = (
-/obj/structure/bed,
-/obj/item/bedsheet/medical,
-/obj/machinery/requests_console{
-	department = "Virology";
-	name = "Virology Requests Console";
-	pixel_x = 32
-	},
-/obj/machinery/light_switch{
-	pixel_y = 26
-	},
-/obj/effect/turf_decal/tile/green{
+/obj/machinery/light/small{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -32220,8 +32239,10 @@
 "pxE" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
 "pxS" = (
 /obj/structure/cable{
@@ -32257,8 +32278,19 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "pxZ" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "pyw" = (
@@ -32528,10 +32560,9 @@
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "pED" = (
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
-/obj/structure/table/optable,
 /turf/open/floor/plasteel/freezer,
 /area/medical/surgery)
 "pEF" = (
@@ -32600,17 +32631,20 @@
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "pFM" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
 	},
-/turf/open/floor/wood,
-/area/medical/psych)
+/obj/effect/turf_decal/tile/blue,
+/obj/structure/chair/comfy/black,
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "pFR" = (
 /turf/closed/wall,
 /area/hallway/primary/fore)
@@ -32958,16 +32992,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -33904,26 +33928,15 @@
 /turf/open/floor/plasteel/dark,
 /area/teleporter)
 "qrA" = (
-/obj/structure/chair/comfy/black{
-	dir = 4
-	},
 /obj/machinery/airalarm{
 	dir = 4;
 	pixel_x = -22
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 30
+/obj/machinery/shower{
+	pixel_y = 20
 	},
-/obj/effect/landmark/start/medical_doctor,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -33979,14 +33992,12 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "qsz" = (
-/obj/machinery/camera{
-	c_tag = "Surgery A";
-	network = list("ss13","medbay");
-	pixel_x = 22
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -24
 	},
-/obj/machinery/computer/operating{
-	dir = 4
-	},
+/obj/structure/table/reinforced,
+/obj/item/storage/backpack/duffelbag/med/surgery,
 /turf/open/floor/plasteel/freezer,
 /area/medical/surgery)
 "qsD" = (
@@ -34555,16 +34566,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/structure/bed,
+/obj/item/bedsheet/medical,
+/obj/machinery/iv_drip,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "qJU" = (
@@ -34708,11 +34712,18 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "qOA" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/turf/closed/wall,
-/area/medical/psych)
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "qOJ" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -35498,10 +35509,8 @@
 /area/tcommsat/computer)
 "rkL" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/medical/medbay/central)
 "rkP" = (
 /obj/structure/window/reinforced{
@@ -35878,7 +35887,8 @@
 "rsy" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
-/turf/closed/wall,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/medical/medbay/central)
 "rsD" = (
 /obj/structure/table/wood,
@@ -36011,9 +36021,35 @@
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
 "rwW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/closed/wall,
-/area/medical/medbay/central)
+/obj/machinery/button/door{
+	id = "psyshu";
+	name = "Shutter button";
+	pixel_x = -25;
+	pixel_y = 6;
+	req_access_txt = "71"
+	},
+/obj/machinery/button/door{
+	id = "psy1";
+	name = "Bolt Control";
+	normaldoorcontrol = 1;
+	pixel_x = -25;
+	pixel_y = -6;
+	req_access_txt = "71";
+	specialfunctions = 4
+	},
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8;
+	pixel_x = 4
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/medical/psych)
 "rxc" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -36235,8 +36271,15 @@
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
 "rFk" = (
+/obj/machinery/door/airlock/medical{
+	name = "Operating Theatre";
+	req_access_txt = "45"
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/freezer,
+/obj/machinery/door/firedoor/border_only{
+	name = "south facing firelock"
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "rFB" = (
 /obj/effect/turf_decal/tile/yellow,
@@ -36385,23 +36428,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "rJl" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/structure/table/wood,
-/obj/machinery/button/door{
-	id = "psyshu";
-	name = "Shutter button";
-	pixel_x = -25;
-	pixel_y = 6;
-	req_access_txt = "71"
-	},
-/obj/machinery/button/door{
-	id = "psy1";
-	name = "Bolt Control";
-	normaldoorcontrol = 1;
-	pixel_x = -25;
-	pixel_y = -6;
-	req_access_txt = "71";
-	specialfunctions = 4
-	},
 /turf/open/floor/wood,
 /area/medical/psych)
 "rJw" = (
@@ -36651,6 +36681,19 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "rRk" = (
@@ -36682,9 +36725,6 @@
 /area/medical/storage)
 "rSn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/chair{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
@@ -38382,11 +38422,16 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "sSs" = (
-/obj/machinery/shower{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 9
 	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/structure/reagent_dispensers/water_cooler,
+/turf/open/floor/wood,
+/area/medical/psych)
 "sSy" = (
 /obj/effect/turf_decal/stripes,
 /turf/open/floor/plasteel,
@@ -38422,16 +38467,15 @@
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "sTe" = (
-/obj/machinery/door/airlock/medical{
-	name = "Operating Theatre";
-	req_access_txt = "45"
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/door/firedoor/border_only{
-	name = "south facing firelock"
-	},
 /turf/open/floor/plasteel/white,
-/area/medical/surgery)
+/area/medical/medbay/central)
 "sTq" = (
 /turf/open/openspace/icemoon,
 /area/engine/atmospherics_engine)
@@ -38516,14 +38560,9 @@
 /turf/open/floor/plasteel,
 /area/engine/atmospherics_engine)
 "sVL" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
+/obj/structure/table,
+/obj/machinery/microwave{
+	pixel_y = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -38600,7 +38639,7 @@
 /area/crew_quarters/heads/cmo)
 "sXV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
+	dir = 4
 	},
 /turf/closed/wall/r_wall,
 /area/medical/virology)
@@ -38868,14 +38907,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"tfm" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/sleeper,
-/obj/structure/mirror{
-	pixel_y = 28
-	},
-/turf/open/floor/plasteel/dark,
-/area/medical/medbay/central)
 "tfq" = (
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=2";
@@ -39135,13 +39166,10 @@
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "tmy" = (
-/obj/machinery/shower{
+/obj/machinery/sleeper{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/end{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
 "tmI" = (
 /obj/structure/cable{
@@ -39386,18 +39414,18 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "tsq" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
 /obj/structure/table,
-/obj/structure/bedsheetbin{
-	pixel_x = 2
-	},
-/obj/machinery/camera{
-	c_tag = "Medbay Psychologist Lobby";
-	dir = 1;
-	network = list("ss13","medbay")
-	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "tsK" = (
@@ -40056,6 +40084,14 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/structure/table/glass,
+/obj/item/wrench/medical,
+/obj/item/reagent_containers/glass/beaker/cryoxadone{
+	pixel_x = 10
+	},
+/obj/item/reagent_containers/glass/beaker/cryoxadone{
+	pixel_x = 10
+	},
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
 "tML" = (
@@ -40099,13 +40135,21 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "tOs" = (
-/obj/structure/closet/crate/freezer/surplus_limbs,
-/obj/item/reagent_containers/glass/beaker/synthflesh,
-/obj/machinery/light_switch{
-	pixel_y = -23
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_y = -28
 	},
-/turf/open/floor/plasteel/freezer,
-/area/medical/surgery)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/filingcabinet,
+/obj/machinery/camera{
+	c_tag = "Psychologist's Office";
+	dir = 1;
+	network = list("ss13","medbay")
+	},
+/turf/open/floor/wood,
+/area/medical/psych)
 "tOz" = (
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/pool)
@@ -40317,19 +40361,8 @@
 /turf/open/floor/plating,
 /area/security/detectives_office)
 "tUi" = (
-/obj/machinery/computer/arcade/orion_trail{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/structure/table,
+/obj/structure/bedsheetbin/color,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "tUF" = (
@@ -40511,18 +40544,11 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "uan" = (
-/obj/structure/table/wood,
-/obj/machinery/computer/med_data/laptop{
-	dir = 1;
-	pixel_y = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
-/obj/machinery/camera{
-	c_tag = "Psychologist Office";
-	dir = 1;
-	network = list("ss13","medbay")
-	},
-/turf/open/floor/wood,
-/area/medical/psych)
+/turf/open/floor/plasteel/dark,
+/area/medical/medbay/central)
 "uap" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -40585,23 +40611,12 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
 "uba" = (
-/obj/structure/table,
-/obj/machinery/microwave{
-	pixel_y = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/structure/bed,
+/obj/item/bedsheet/medical,
+/obj/machinery/iv_drip,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "ubd" = (
@@ -40886,14 +40901,11 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "ujD" = (
-/obj/machinery/airalarm{
-	pixel_y = 32
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/port)
+/turf/open/floor/plasteel/dark,
+/area/medical/medbay/central)
 "ujE" = (
 /obj/machinery/light{
 	dir = 4
@@ -41212,11 +41224,10 @@
 /turf/open/floor/plating,
 /area/storage/atmos)
 "utS" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
+/obj/machinery/light/small{
+	dir = 1
 	},
-/turf/open/floor/wood,
+/turf/open/floor/plating/asteroid/snow/icemoon,
 /area/medical/psych)
 "uup" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -41402,12 +41413,11 @@
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "uAe" = (
-/obj/machinery/vending/wallmed{
-	pixel_y = -28
+/obj/machinery/atmospherics/components/unary/cryo_cell{
+	dir = 4
 	},
-/obj/structure/closet/crate/freezer/blood,
-/turf/open/floor/plasteel/freezer,
-/area/medical/surgery)
+/turf/open/floor/plasteel/dark,
+/area/medical/medbay/central)
 "uAj" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -42024,13 +42034,11 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "uUC" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 8
 	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/wood,
-/area/medical/psych)
+/turf/open/floor/plasteel/dark,
+/area/medical/medbay/central)
 "uUJ" = (
 /obj/structure/bed,
 /obj/item/bedsheet/syndie,
@@ -43088,16 +43096,15 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/structure/table,
+/obj/item/folder/white,
+/obj/item/clothing/neck/stethoscope,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "vuO" = (
@@ -43113,7 +43120,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
 "vvM" = (
@@ -43796,8 +43803,11 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "vMf" = (
-/turf/open/floor/carpet,
-/area/medical/psych)
+/obj/machinery/atmospherics/components/unary/cryo_cell{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/medical/medbay/central)
 "vMg" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -43967,9 +43977,18 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
 "vRa" = (
-/obj/structure/bookcase/random,
-/turf/open/floor/wood,
-/area/medical/psych)
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/structure/table,
+/obj/item/storage/firstaid/brute{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/firstaid/brute,
+/turf/open/floor/plasteel/white,
+/area/medical/storage)
 "vRc" = (
 /obj/structure/bookcase{
 	name = "Forbidden Knowledge"
@@ -44214,9 +44233,16 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "vWt" = (
-/obj/structure/chair/stool,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
+/obj/structure/table,
+/obj/item/stack/sheet/mineral/plasma,
+/obj/item/stack/sheet/mineral/plasma,
+/obj/item/storage/box/donkpockets{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -22
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -44393,7 +44419,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
@@ -44410,8 +44435,26 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
 "wbg" = (
-/turf/open/floor/wood,
-/area/medical/psych)
+/obj/machinery/power/apc/auto_name/south{
+	pixel_y = -27
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/structure/table,
+/obj/item/storage/firstaid/regular{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/storage/firstaid/regular,
+/obj/item/storage/firstaid/regular{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel/white,
+/area/medical/storage)
 "wbE" = (
 /turf/open/floor/carpet,
 /area/hallway/secondary/exit/departure_lounge)
@@ -44574,11 +44617,11 @@
 /turf/open/floor/plating,
 /area/hallway/primary/aft)
 "wfK" = (
-/obj/structure/table,
-/obj/item/clothing/neck/stethoscope,
-/obj/item/folder/white,
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
+/obj/item/kirbyplants{
+	icon_state = "plant-08"
+	},
+/turf/open/floor/wood,
+/area/medical/psych)
 "wfN" = (
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
@@ -45047,18 +45090,21 @@
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
 "wut" = (
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
 	},
-/obj/item/kirbyplants{
-	icon_state = "plant-08"
+/obj/effect/turf_decal/tile/blue,
+/obj/structure/table,
+/obj/item/storage/firstaid/fire{
+	pixel_x = 3;
+	pixel_y = 3
 	},
-/obj/machinery/light{
+/obj/item/storage/firstaid/fire,
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/turf/open/floor/wood,
-/area/medical/psych)
+/turf/open/floor/plasteel/white,
+/area/medical/storage)
 "wuC" = (
 /obj/structure/cable,
 /obj/machinery/power/solar{
@@ -45415,17 +45461,8 @@
 /turf/open/floor/plating,
 /area/engine/storage)
 "wFR" = (
-/obj/structure/table,
-/obj/item/storage/firstaid/fire,
-/obj/item/storage/firstaid/fire{
-	pixel_x = 3;
-	pixel_y = 3
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/white,
@@ -45567,7 +45604,9 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
 "wKC" = (
-/obj/machinery/atmospherics/pipe/manifold4w/general/visible,
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
 "wKL" = (
@@ -45575,18 +45614,10 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "wKN" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
+/obj/machinery/vending/wallmed{
+	pixel_y = -28
 	},
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -22
-	},
+/obj/structure/closet/crate/freezer/blood,
 /turf/open/floor/plasteel/freezer,
 /area/medical/surgery)
 "wKU" = (
@@ -46242,6 +46273,11 @@
 /turf/open/floor/plating,
 /area/engine/atmospherics_engine)
 "xgq" = (
+/obj/structure/closet/crate/freezer/surplus_limbs,
+/obj/item/reagent_containers/glass/beaker/synthflesh,
+/obj/machinery/light_switch{
+	pixel_y = -23
+	},
 /turf/open/floor/plasteel/freezer,
 /area/medical/surgery)
 "xgu" = (
@@ -46402,11 +46438,14 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "xlg" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
-/area/medical/medbay/central)
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
 "xlm" = (
 /obj/machinery/vending/wardrobe/atmos_wardrobe,
 /turf/open/floor/plasteel,
@@ -46822,17 +46861,24 @@
 /area/hallway/primary/aft)
 "xAa" = (
 /obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
 /obj/structure/disposalpipe/segment{
-	dir = 5
+	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "xAi" = (
@@ -47036,15 +47082,11 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "xFy" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/structure/bed,
-/obj/item/bedsheet/medical,
-/obj/machinery/iv_drip,
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
+/turf/open/floor/wood,
+/area/medical/psych)
 "xFQ" = (
 /obj/machinery/doorButtons/airlock_controller{
 	idExterior = "virology_airlock_exterior";
@@ -47174,25 +47216,23 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "xHU" = (
-/obj/machinery/smartfridge/organ/preloaded,
-/turf/closed/wall,
-/area/medical/surgery)
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "xIJ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -47200,29 +47240,19 @@
 /turf/open/floor/circuit/off,
 /area/ai_monitored/turret_protected/ai)
 "xIT" = (
-/obj/structure/chair/comfy/black{
-	dir = 4
-	},
 /obj/item/radio/intercom{
 	frequency = 1485;
 	name = "Station Intercom (Medbay)";
 	pixel_x = -30
 	},
-/obj/effect/landmark/start/medical_doctor,
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/table,
+/obj/item/soap,
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/clothing/mask/muzzle,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "xJn" = (
@@ -47282,19 +47312,11 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "xKu" = (
-/obj/structure/table,
-/obj/item/stack/sheet/mineral/plasma,
-/obj/item/stack/sheet/mineral/plasma,
-/obj/item/storage/box/donkpockets{
-	pixel_x = 3;
-	pixel_y = 3
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
 	},
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
 "xKv" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/effect/turf_decal/tile/neutral{
@@ -47484,11 +47506,14 @@
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
 "xQH" = (
-/obj/structure/chair/sofa/left{
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/carpet,
-/area/medical/psych)
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
 "xRq" = (
 /turf/closed/wall/r_wall,
 /area/blueshield)
@@ -47702,13 +47727,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/quartermaster/sorting)
-"xYN" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/medical/surgery)
 "xZg" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -47743,12 +47761,12 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
 "xZX" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/bed/roller,
+/obj/machinery/iv_drip,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "yae" = (
@@ -47802,15 +47820,10 @@
 /turf/open/floor/pod/dark,
 /area/maintenance/starboard)
 "ycQ" = (
-/obj/machinery/vending/medical{
-	pixel_x = -2
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "ydl" = (
@@ -57983,7 +57996,7 @@ ydp
 ydp
 ydp
 ydp
-avT
+ydp
 avT
 bBh
 apJ
@@ -58497,7 +58510,7 @@ ydp
 ydp
 ydp
 ydp
-ydp
+avT
 avT
 bBh
 apJ
@@ -58753,8 +58766,8 @@ ydp
 ydp
 ydp
 ydp
-ydp
-ydp
+avT
+avT
 avT
 bBh
 apJ
@@ -59009,9 +59022,9 @@ ydp
 ydp
 ydp
 ydp
-ydp
-ydp
-ydp
+avT
+avT
+avT
 avT
 bBh
 apJ
@@ -59262,13 +59275,13 @@ ydp
 ydp
 ydp
 ydp
-cUC
-cUC
-cUC
-cUC
-cUC
 ydp
 ydp
+ydp
+avT
+avT
+avT
+avT
 avT
 bBh
 apJ
@@ -59519,13 +59532,13 @@ ydp
 ydp
 ydp
 ydp
-cUC
-kRI
-fdJ
-hGU
-cUC
 ydp
-ydp
+avT
+avT
+avT
+avT
+avT
+avT
 avT
 bBh
 apJ
@@ -59776,13 +59789,13 @@ ydp
 ydp
 ydp
 ydp
-cUC
-vSJ
-kZL
-kZL
-maR
 ydp
-ydp
+avT
+avT
+avT
+avT
+avT
+avT
 avT
 bBh
 apJ
@@ -60033,14 +60046,14 @@ ydp
 ydp
 ydp
 ydp
-cUC
-ehh
-kZL
-hap
-cUC
-ydp
-ydp
-ydp
+avT
+avT
+avT
+avT
+avT
+avT
+avT
+avT
 bBh
 avT
 apJ
@@ -60290,14 +60303,14 @@ ydp
 ydp
 ydp
 ydp
-cUC
-cUC
-cUC
-cUC
-cUC
-ydp
-ydp
-ydp
+avT
+avT
+avT
+avT
+avT
+avT
+avT
+avT
 bBh
 avT
 avT
@@ -60546,14 +60559,14 @@ ydp
 ydp
 ydp
 ydp
-ydp
-ydp
-ydp
-ydp
-ydp
-ydp
-ydp
-ydp
+avT
+avT
+avT
+avT
+avT
+avT
+avT
+avT
 avT
 bBh
 avT
@@ -60801,16 +60814,16 @@ ydp
 ydp
 ydp
 ydp
+ydp
+ydp
 avT
 avT
-ydp
-ydp
-ydp
-ydp
-ydp
-ydp
-ydp
-ydp
+jiV
+avT
+avT
+avT
+jiV
+avT
 avT
 bBh
 avT
@@ -61056,19 +61069,19 @@ ydp
 ydp
 ydp
 ydp
-avT
-avT
-avT
-avT
-ydp
-ydp
-ydp
-ydp
 ydp
 ydp
 ydp
 ydp
 avT
+iZH
+iZH
+kmj
+kmj
+kmj
+iZH
+iZH
+utS
 bBh
 avT
 avT
@@ -61311,20 +61324,20 @@ ydp
 ydp
 ydp
 ydp
-avT
-avT
-avT
-avT
-avT
-avT
-avT
 ydp
 ydp
 ydp
 ydp
 ydp
 ydp
-ydp
+avT
+iZH
+jDK
+kHX
+lOX
+okY
+rwW
+kmj
 avT
 bBh
 fDo
@@ -61568,20 +61581,20 @@ ydp
 ydp
 ydp
 ydp
+ydp
+ydp
+ydp
+ydp
+ydp
+ydp
 avT
-avT
+iZH
+kgx
+kUo
+lYq
 mNP
-avT
-avT
-avT
-mNP
-ash
-ash
-ash
-ash
-ash
-ash
-ash
+rJl
+kmj
 avT
 bBh
 wSc
@@ -61824,21 +61837,21 @@ ydp
 ydp
 ydp
 ydp
+ydp
+ydp
+ydp
+ydp
+ydp
+ydp
+ydp
 avT
-avT
-fRS
-fRS
-adu
-adu
-adu
-fRS
-ash
+iZH
 wfK
 okY
 iyW
 xFy
 mIS
-ash
+kmj
 avT
 rUq
 tGQ
@@ -62080,23 +62093,23 @@ ydp
 ydp
 ydp
 ydp
+ydp
+ydp
+ydp
+ydp
+ydp
+ydp
+ydp
+ydp
 avT
-avT
-fDi
-fRS
-pbw
-utS
-kmj
-wbg
-rJl
-ash
+iZH
 gtO
-anm
+gtO
 ohi
-anm
-xAi
-ash
-avT
+ntO
+tOs
+iZH
+utS
 avT
 fDo
 iOd
@@ -62336,21 +62349,21 @@ ydp
 ydp
 ydp
 ydp
+ydp
+avT
+ydp
+ydp
+ydp
+ydp
+ydp
+ydp
 avT
 avT
-avT
-avT
-adu
-fUX
-jDK
-kHX
-lOX
-uan
-ash
+iZH
 bSb
-esK
-esK
-esK
+okY
+mLB
+oaC
 sSs
 sXJ
 sXJ
@@ -62592,23 +62605,23 @@ ydp
 ydp
 ydp
 ydp
+ydp
 avT
 avT
 avT
+ydp
+ydp
+ydp
+ydp
 avT
 avT
-adu
-vRa
-vRa
-vRa
-pFM
-cGu
-ash
-ash
-aoj
+avT
+iZH
+iZH
+kmj
 fWo
-aoj
-ash
+pbw
+iZH
 sXJ
 tyI
 kmM
@@ -62848,19 +62861,19 @@ ydp
 ydp
 ydp
 ydp
+ydp
 avT
 avT
 avT
 avT
 avT
+ydp
+ydp
 avT
-adu
-fGi
-xQH
-eDm
-mLB
-uUC
-lYq
+avT
+avT
+avT
+ash
 adZ
 jxr
 xAa
@@ -63104,24 +63117,24 @@ ydp
 ydp
 ydp
 ydp
+ydp
+ydp
 avT
 avT
 avT
 avT
 avT
 avT
-fDi
-fRS
-iRy
-vMf
-abs
-eut
-wut
-adu
+avT
+avT
+avT
+avT
+avT
+ash
 fva
-pIE
+lqR
 rQU
-anm
+pFM
 tsq
 gIm
 vTh
@@ -63136,8 +63149,8 @@ tUi
 lmF
 tVS
 fpa
-jiV
-lmF
+fpa
+vRa
 ash
 aoj
 ash
@@ -63367,18 +63380,18 @@ avT
 avT
 avT
 avT
-avT
-iZH
-fRS
-fRS
-qOA
-fRS
-fRS
-fRS
+aaS
+oto
+oto
+oto
+oto
+oto
+ash
+ash
 mAk
 pxZ
 ojp
-anm
+qOA
 exq
 gIm
 pNO
@@ -63389,13 +63402,13 @@ sXJ
 hEQ
 vXs
 gZQ
-aoj
+ash
 lmF
 lSN
 rrD
 lYk
-lmF
-wje
+wbg
+tmO
 arI
 syN
 atr
@@ -63620,17 +63633,17 @@ ydp
 ydp
 ydp
 ydp
-ydp
 pZD
 mpj
 mpj
 mpj
-aaS
+pZD
+cGu
 qsz
 aPp
 wKN
-uAe
 oto
+fUX
 ash
 ash
 hEQ
@@ -63651,8 +63664,8 @@ lUd
 kqV
 jPh
 wFR
-lmF
-ujD
+wut
+tmO
 arH
 auV
 auV
@@ -63877,19 +63890,19 @@ ydp
 ydp
 ydp
 ydp
-ydp
 pZD
+abs
 hVm
 sVL
+pZD
 dfV
-aaS
-dML
+oKr
 oKr
 xgq
-tOs
 oto
+gkx
 kMc
-eLX
+anm
 nsi
 cEf
 eLX
@@ -63909,9 +63922,9 @@ olz
 wuj
 bwm
 lmF
-aqP
+tmO
 waP
-aDh
+xKu
 aDh
 lmu
 mNo
@@ -64133,19 +64146,19 @@ ydp
 ydp
 ydp
 ydp
-ydp
-ydp
+avT
 pZD
+adu
 efp
 vWt
-xKu
-aaS
+pZD
+eut
 hIe
 kYE
 nOj
-ntO
 oto
-adw
+iRy
+anm
 anm
 anJ
 lUb
@@ -64166,9 +64179,9 @@ lmF
 hIP
 nBx
 oUC
-tUF
+xlg
 jGF
-uBi
+xQH
 iKM
 bNb
 bNb
@@ -64390,19 +64403,19 @@ ydp
 ydp
 ydp
 ydp
-ydp
-ydp
+avT
 pZD
+adw
 lAS
 pfN
-kgx
-aaS
+pZD
+eDm
 pED
+fGi
 oKr
-abZ
-xgq
+fRS
 xHU
-ady
+anm
 anm
 anJ
 uXB
@@ -64424,8 +64437,8 @@ aol
 akB
 ecD
 esE
-oDm
-wje
+nDl
+lZs
 avU
 avX
 avX
@@ -64647,19 +64660,19 @@ ydp
 ydp
 ydp
 ydp
-ydp
-ydp
+avT
 pZD
+adx
 puS
 iIg
-lCW
-aaS
+pZD
+fDi
 lIn
 fgp
 poT
 rFk
 sTe
-adx
+jih
 jih
 wkM
 anm
@@ -64909,12 +64922,12 @@ pZD
 pZD
 sXV
 laE
-kUo
+pZD
 aaS
 aba
-xYN
 aba
 aba
+oto
 oto
 adz
 iIz
@@ -65165,8 +65178,8 @@ nnV
 cni
 qbY
 fYU
-uYa
 vST
+uYa
 aaS
 joT
 kGS
@@ -65422,7 +65435,7 @@ tAa
 xkR
 pfY
 wlD
-gkx
+xwO
 xwh
 aaS
 gWj
@@ -65435,9 +65448,9 @@ dJZ
 nwq
 hWn
 eSP
-anm
-anJ
-ash
+uan
+sMA
+uAe
 ykb
 tMt
 sMA
@@ -65689,14 +65702,14 @@ pZD
 pZD
 ady
 ofF
-ash
+lCW
 fXH
 eSP
-anm
-anJ
-aoj
-epK
-wzH
+uan
+sMA
+uUC
+sMA
+sMA
 sMA
 xGP
 anm
@@ -65946,14 +65959,14 @@ iFK
 fKM
 adA
 hom
-aoj
-oaC
+lIm
+sMA
 vvH
-anm
-lqR
-ash
+ujD
+sMA
+wKC
 nDC
-xlg
+wzH
 sMA
 xGP
 anm
@@ -66194,21 +66207,21 @@ tlu
 wAW
 xhb
 uCi
-uYa
+aqP
 xFQ
 pZD
 eEy
 gzW
 ueK
 pZD
-lIm
+ady
 ycQ
-rwW
-tfm
+ash
+tmy
 ets
 tmy
-anm
-aoj
+sMA
+vMf
 epK
 wKC
 wzH

--- a/_maps/map_files/Snaxi/Snaxi_Lumos.dmm
+++ b/_maps/map_files/Snaxi/Snaxi_Lumos.dmm
@@ -3409,16 +3409,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
-"aRO" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/oil,
-/turf/open/floor/plasteel/dark,
-/area/medical/paramedic)
 "aSl" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -3633,12 +3623,6 @@
 /obj/machinery/vending/wardrobe/medi_wardrobe,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"aYo" = (
-/obj/structure/rack,
-/obj/item/storage/box/masks,
-/obj/item/cartridge/medical,
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "aYB" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
@@ -3771,6 +3755,24 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"bdf" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = 28
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white/corner{
+	dir = 4
+	},
+/area/hallway/primary/port)
 "bdm" = (
 /obj/machinery/light{
 	dir = 1
@@ -3814,10 +3816,6 @@
 	},
 /turf/open/floor/plating,
 /area/medical/virology)
-"bfa" = (
-/obj/structure/sign/poster/official/help_others,
-/turf/closed/wall,
-/area/medical/paramedic)
 "bff" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -3884,6 +3882,11 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
+"bge" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "bhe" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -4176,6 +4179,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
+"brc" = (
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "bri" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -6165,6 +6174,10 @@
 /obj/machinery/disposal/bin,
 /turf/open/floor/plasteel/cult,
 /area/lawoffice)
+"bJL" = (
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "bJQ" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -6655,6 +6668,17 @@
 	dir = 1
 	},
 /area/chapel/main)
+"bQX" = (
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/machinery/disposal/bin,
+/turf/open/floor/plasteel/white,
+/area/medical/paramedic)
 "bRy" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
@@ -6978,6 +7002,18 @@
 	},
 /turf/open/floor/carpet/black,
 /area/crew_quarters/heads/hos)
+"bWX" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/vehicle/ridden/atv/snowmobile,
+/obj/item/key,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/dark,
+/area/medical/paramedic)
 "bXe" = (
 /obj/machinery/airalarm{
 	pixel_y = 24
@@ -7245,10 +7281,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"cdV" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/dark,
-/area/medical/paramedic)
 "cep" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -8036,13 +8068,6 @@
 	},
 /turf/open/floor/plasteel/checker,
 /area/crew_quarters/heads/hor)
-"csa" = (
-/obj/machinery/door/airlock/atmos{
-	name = "Atmospherics Maintenance";
-	req_access_txt = "12;24;39"
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "cso" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -8052,6 +8077,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/bridge)
+"cuc" = (
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plasteel/dark,
+/area/hallway/primary/port)
 "cux" = (
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
@@ -9304,6 +9337,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
+"cYl" = (
+/obj/machinery/camera{
+	c_tag = "Northwestern Hall 10"
+	},
+/turf/open/floor/plasteel/dark,
+/area/hallway/primary/port)
 "cYq" = (
 /obj/machinery/suit_storage_unit/atmos,
 /turf/open/floor/plasteel,
@@ -9706,6 +9745,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/blueshield)
+"djy" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Morgue Maintenance";
+	req_access_txt = "6;5"
+	},
+/turf/open/floor/plating,
+/area/hallway/primary/port)
 "djL" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
@@ -9987,6 +10033,10 @@
 /obj/machinery/disposal/bin,
 /turf/open/floor/wood,
 /area/hallway/primary/port)
+"dsm" = (
+/obj/machinery/atmospherics/pipe/manifold4w/cyan/hidden,
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "dsn" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -10163,6 +10213,13 @@
 /obj/effect/turf_decal/tile/brown,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"dvy" = (
+/obj/machinery/door/airlock/atmos{
+	name = "Atmospherics Maintenance";
+	req_access_txt = "12;24;39"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "dvz" = (
 /obj/machinery/newscaster{
 	pixel_x = 32
@@ -10605,10 +10662,6 @@
 /obj/structure/mineral_door/woodrustic,
 /turf/open/floor/plating,
 /area/icemoon/surface/outdoors)
-"dII" = (
-/obj/structure/closet/l3closet/security,
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "dJb" = (
 /obj/machinery/door/airlock{
 	id_tag = "Dorm3";
@@ -11641,6 +11694,11 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
+"ero" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
+/obj/structure/chair/office/light,
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "erx" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/dark,
@@ -12213,6 +12271,12 @@
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/floor/grass,
 /area/medical/genetics)
+"eGg" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "eGi" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -12558,6 +12622,16 @@
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
+"eNw" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/plasteel/dark,
+/area/medical/paramedic)
 "eNG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -12656,15 +12730,6 @@
 /obj/effect/landmark/start/station_engineer,
 /turf/open/floor/plating,
 /area/engine/atmospherics_engine)
-"eQR" = (
-/obj/machinery/shower{
-	dir = 8
-	},
-/obj/machinery/airalarm{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/dark,
-/area/medical/paramedic)
 "eRt" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -12881,10 +12946,6 @@
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
-"eUK" = (
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "eVi" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Bridge";
@@ -13062,6 +13123,12 @@
 	},
 /turf/open/floor/wood,
 /area/bridge/meeting_room)
+"eZC" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/hallway/primary/port)
 "eZD" = (
 /obj/structure/chair/comfy/black{
 	dir = 8
@@ -14076,13 +14143,6 @@
 "fBS" = (
 /turf/open/floor/plating,
 /area/engine/storage)
-"fBV" = (
-/obj/machinery/door/airlock/external{
-	name = "Escape Pod Two"
-	},
-/obj/structure/fans/tiny,
-/turf/open/floor/plating,
-/area/hallway/primary/port)
 "fCh" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
@@ -14122,13 +14182,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/security/brig)
-"fDn" = (
-/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
-/obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "fDo" = (
 /turf/closed/wall/r_wall,
 /area/hallway/primary/port)
@@ -15812,11 +15865,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"gzE" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
-/obj/structure/chair/office/light,
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
 "gzH" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -15877,6 +15925,12 @@
 /obj/effect/spawner/lootdrop/wall/fifty_percent_falsewall,
 /turf/open/floor/plating,
 /area/security/prison)
+"gBL" = (
+/obj/structure/closet/crate/medical,
+/obj/item/stack/medical/bruise_pack,
+/obj/item/stack/medical/ointment,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "gCd" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -16683,12 +16737,6 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating,
 /area/hallway/primary/fore)
-"gWQ" = (
-/obj/machinery/camera{
-	c_tag = "Northwestern Hall 10"
-	},
-/turf/open/floor/plasteel/dark,
-/area/hallway/primary/port)
 "gWZ" = (
 /obj/machinery/computer/telecomms/monitor,
 /obj/effect/turf_decal/tile/green{
@@ -16708,6 +16756,16 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
+"gXZ" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/landmark/start/paramedic,
+/turf/open/floor/plasteel/dark,
+/area/medical/paramedic)
 "gYC" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -16752,6 +16810,16 @@
 "gZX" = (
 /turf/closed/wall,
 /area/medical/morgue)
+"gZY" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plasteel/dark,
+/area/medical/paramedic)
 "haj" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -17068,6 +17136,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"hkI" = (
+/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
+/obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "hlh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
@@ -17368,19 +17443,6 @@
 	},
 /turf/open/floor/plasteel/airless/white/side,
 /area/medical/storage)
-"hss" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/visible{
-	dir = 4
-	},
-/obj/machinery/door/airlock/external,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/hallway/primary/port)
 "hsu" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -17626,17 +17688,6 @@
 /obj/machinery/vending/autodrobe,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"hyJ" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/machinery/disposal/bin,
-/turf/open/floor/plasteel/white,
-/area/medical/paramedic)
 "hyK" = (
 /obj/effect/turf_decal/trimline/yellow/filled,
 /obj/machinery/light{
@@ -18018,18 +18069,6 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hop)
-"hId" = (
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/space_heater,
-/obj/structure/window/reinforced,
-/turf/open/floor/plasteel/dark,
-/area/medical/paramedic)
 "hIe" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -18428,6 +18467,12 @@
 	},
 /turf/open/floor/wood,
 /area/security/courtroom)
+"hRp" = (
+/obj/structure/rack,
+/obj/item/storage/box/masks,
+/obj/item/cartridge/medical,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "hRt" = (
 /turf/closed/wall,
 /area/quartermaster/qm)
@@ -19368,12 +19413,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
-"iox" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "ioB" = (
 /obj/structure/frame/computer{
 	dir = 8
@@ -19909,13 +19948,6 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/engine,
 /area/engine/supermatter)
-"iCE" = (
-/obj/docking_port/stationary/random{
-	id = "pod_lavaland2";
-	name = "lavaland"
-	},
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/surface/outdoors)
 "iCO" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -20672,24 +20704,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"iYh" = (
-/obj/machinery/door/airlock/medical/glass{
-	id_tag = "MedbayFoyer";
-	name = "Medbay";
-	req_access_txt = "5"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/structure/fans/tiny,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/medical/paramedic)
 "iYi" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/wood,
@@ -21171,14 +21185,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/storage/atmos)
-"jmg" = (
-/obj/machinery/door/airlock/external,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/structure/fans/tiny,
-/turf/open/floor/plasteel/dark,
-/area/hallway/primary/port)
 "jmU" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -21373,16 +21379,6 @@
 /obj/item/reagent_containers/food/condiment/flour,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
-"jtV" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/plasteel/dark,
-/area/medical/paramedic)
 "jur" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -21518,13 +21514,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"jym" = (
-/obj/machinery/door/airlock/external{
-	name = "Escape Pod One"
-	},
-/obj/structure/fans/tiny,
-/turf/open/floor/plating,
-/area/hallway/primary/port)
 "jyA" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/disposalpipe/segment{
@@ -22241,11 +22230,6 @@
 	},
 /turf/open/floor/engine/o2,
 /area/engine/atmos)
-"jRd" = (
-/obj/structure/closet/crate,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "jRB" = (
 /obj/structure/table,
 /obj/item/storage/belt/utility,
@@ -23457,6 +23441,10 @@
 	},
 /turf/open/floor/plasteel/white/side,
 /area/hallway/primary/port)
+"kzA" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/medical/paramedic)
 "kzS" = (
 /obj/machinery/computer/upload/borg,
 /turf/open/floor/circuit,
@@ -23530,6 +23518,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"kCp" = (
+/obj/machinery/door/airlock/medical/glass{
+	id_tag = "MedbayFoyer";
+	name = "Medbay";
+	req_access_txt = "5"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/medical/paramedic)
 "kCv" = (
 /obj/machinery/door/window/eastleft{
 	name = "Coffin Pyre";
@@ -23784,10 +23789,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
-"kLU" = (
-/obj/machinery/atmospherics/pipe/manifold4w/cyan/hidden,
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
 "kMc" = (
 /obj/machinery/airalarm{
 	pixel_y = 23
@@ -23891,6 +23892,18 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
+"kNG" = (
+/obj/structure/table,
+/obj/machinery/newscaster{
+	pixel_y = 34
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/floor/plasteel/white,
+/area/medical/paramedic)
 "kNQ" = (
 /obj/machinery/computer/security/hos{
 	dir = 4
@@ -24608,10 +24621,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"llI" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/medical/paramedic)
 "lmm" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -24797,12 +24806,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"lpw" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "lpR" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -25172,6 +25175,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"lBm" = (
+/obj/structure/closet/l3closet/security,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "lBF" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -25611,23 +25618,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/wood,
 /area/hallway/secondary/exit/departure_lounge)
-"lQv" = (
-/obj/machinery/door/airlock/medical/glass{
-	id_tag = "MedbayFoyer";
-	name = "Medbay";
-	req_access_txt = "5"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/medical/paramedic)
 "lQJ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel,
@@ -26142,13 +26132,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
-"mgd" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/effect/landmark/start/paramedic,
-/turf/open/floor/plasteel/white,
-/area/medical/paramedic)
 "mgo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/firedoor/border_only{
@@ -26311,16 +26294,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/central)
-"mlq" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/suit_storage_unit/paramedic,
-/turf/open/floor/plasteel/dark,
-/area/medical/paramedic)
 "mlM" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -26332,6 +26305,16 @@
 	},
 /turf/open/floor/plating,
 /area/security/checkpoint/supply)
+"mlY" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/suit_storage_unit/paramedic,
+/turf/open/floor/plasteel/dark,
+/area/medical/paramedic)
 "mmJ" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -28592,6 +28575,15 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/maintenance/central)
+"nzr" = (
+/obj/machinery/atmospherics/pipe/simple/supply/visible{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/hallway/primary/port)
 "nzD" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -28657,18 +28649,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
-"nBc" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/vehicle/ridden/atv/snowmobile,
-/obj/item/key,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel/dark,
-/area/medical/paramedic)
 "nBd" = (
 /obj/machinery/button/door{
 	id = "Dorm2";
@@ -28778,12 +28758,6 @@
 /obj/machinery/vending/cola/random,
 /turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
-"nCP" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
 "nCU" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -28892,6 +28866,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/port)
+"nED" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Supply to Virology"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "nEI" = (
 /obj/structure/dresser,
 /obj/machinery/camera{
@@ -29288,11 +29269,6 @@
 	},
 /turf/open/floor/wood,
 /area/maintenance/bar)
-"nPv" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "nPF" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -29344,18 +29320,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
-"nQP" = (
-/obj/structure/table,
-/obj/machinery/newscaster{
-	pixel_y = 34
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/item/paper_bin,
-/obj/item/pen,
-/turf/open/floor/plasteel/white,
-/area/medical/paramedic)
 "nRe" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -30713,6 +30677,17 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
+"ozV" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/item/clothing/gloves/color/latex,
+/obj/item/healthanalyzer,
+/obj/item/clothing/glasses/hud/health,
+/obj/structure/window/reinforced,
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "oAX" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -30897,6 +30872,13 @@
 /obj/item/stack/cable_coil,
 /turf/open/floor/plating,
 /area/engine/storage)
+"oHq" = (
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/effect/landmark/start/paramedic,
+/turf/open/floor/plasteel/white,
+/area/medical/paramedic)
 "oHU" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 10
@@ -31093,12 +31075,6 @@
 /obj/machinery/light/floor,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
-"oMU" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/hallway/primary/port)
 "oNv" = (
 /obj/structure/table/wood,
 /turf/open/floor/wood,
@@ -31322,6 +31298,10 @@
 	},
 /turf/open/floor/wood,
 /area/maintenance/bar)
+"oVv" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "oVW" = (
 /obj/structure/bed,
 /obj/item/bedsheet/mime,
@@ -31886,6 +31866,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"pii" = (
+/obj/structure/closet/l3closet/virology,
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "piu" = (
 /turf/open/floor/plating,
 /area/maintenance/disposal)
@@ -32721,6 +32705,11 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
+"pCZ" = (
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/maintenance/port/fore)
 "pDh" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -32921,11 +32910,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/server)
-"pGS" = (
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
-/area/maintenance/port/fore)
 "pGW" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -33710,6 +33694,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"qdn" = (
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/port/fore)
 "qdZ" = (
 /obj/machinery/door/airlock/public{
 	name = "Permabrig Dorm 2"
@@ -33954,13 +33943,16 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
+"qlc" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "qlj" = (
 /turf/closed/wall,
 /area/crew_quarters/theatre)
-"qll" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "qlH" = (
 /obj/machinery/light{
 	dir = 4
@@ -34253,6 +34245,11 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/janitor)
+"qrV" = (
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "qsm" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -34989,13 +34986,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hos)
-"qND" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Supply to Virology"
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "qOb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/wood,
@@ -35371,6 +35361,18 @@
 	dir = 4
 	},
 /area/hallway/secondary/exit/departure_lounge)
+"qXQ" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/space_heater,
+/obj/structure/window/reinforced,
+/turf/open/floor/plasteel/dark,
+/area/medical/paramedic)
 "qYD" = (
 /obj/machinery/vending/security,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -35516,16 +35518,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"rbS" = (
-/obj/docking_port/stationary{
-	dwidth = 1;
-	height = 4;
-	name = "escape pod loader";
-	roundstart_template = /datum/map_template/shuttle/escape_pod/default;
-	width = 3
-	},
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/surface/outdoors)
 "rbW" = (
 /obj/structure/closet/secure_closet/medical3,
 /obj/machinery/firealarm{
@@ -35813,22 +35805,6 @@
 "rkp" = (
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/computer)
-"rkz" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/power/apc{
-	areastring = "/area/maintenance/port/fore";
-	dir = 4;
-	name = "Port Bow Maintenance APC";
-	pixel_x = 24
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "rkL" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -36499,6 +36475,22 @@
 /obj/machinery/vending/cola/pwr_game,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"rAp" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/light/floor,
+/obj/machinery/door/airlock/external{
+	req_one_access_txt = "13;5"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "rAw" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -36654,6 +36646,13 @@
 "rGc" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 6
+	},
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/surface/outdoors)
+"rGq" = (
+/obj/docking_port/stationary/random{
+	id = "pod_lavaland2";
+	name = "lavaland"
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
@@ -36905,6 +36904,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"rNV" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/dark,
+/area/medical/paramedic)
 "rOd" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -37310,6 +37313,13 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"saI" = (
+/obj/machinery/door/airlock/external{
+	name = "Escape Pod One"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/hallway/primary/port)
 "saN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/item/kirbyplants/random,
@@ -37729,6 +37739,15 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hop)
+"slS" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/machinery/airalarm{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/dark,
+/area/medical/paramedic)
 "sma" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/closet/cabinet,
@@ -37977,11 +37996,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/crew_quarters/kitchen)
-"suC" = (
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
-	},
-/area/maintenance/port/fore)
 "suK" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -38504,22 +38518,6 @@
 /obj/item/storage/toolbox/emergency,
 /turf/open/floor/plasteel/dark,
 /area/medical/paramedic)
-"sIZ" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 8
-	},
-/obj/structure/table/reinforced,
-/obj/item/paper_bin{
-	pixel_x = -2;
-	pixel_y = 5
-	},
-/obj/item/pen/red,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
 "sJs" = (
 /obj/machinery/light/small,
 /turf/open/floor/plasteel/dark,
@@ -38647,22 +38645,6 @@
 "sMA" = (
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
-"sMJ" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/light/floor,
-/obj/machinery/door/airlock/external{
-	req_one_access_txt = "13;5"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "sMX" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -38708,19 +38690,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
-"sNZ" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/vehicle/ridden/atv/snowmobile,
-/obj/item/key,
-/obj/effect/turf_decal/bot,
-/obj/structure/window/reinforced,
-/turf/open/floor/plasteel/dark,
-/area/medical/paramedic)
 "sOi" = (
 /obj/machinery/door/firedoor/border_only{
 	name = "south facing firelock"
@@ -40358,13 +40327,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
-"tIC" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Morgue Maintenance";
-	req_access_txt = "6;5"
-	},
-/turf/open/floor/plating,
-/area/hallway/primary/port)
 "tJi" = (
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
@@ -40530,21 +40492,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
-"tMI" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/door/airlock/external{
-	req_one_access_txt = "13;5"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "tML" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
@@ -41948,11 +41895,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
-"uCd" = (
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/maintenance/port/fore)
 "uCi" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plasteel/white,
@@ -42024,24 +41966,6 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
-"uEU" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = 28
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white/corner{
-	dir = 4
-	},
-/area/hallway/primary/port)
 "uFq" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -42132,6 +42056,12 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/bar)
+"uIT" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "uIU" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -42771,6 +42701,24 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
+"uZc" = (
+/obj/machinery/door/airlock/medical/glass{
+	id_tag = "MedbayFoyer";
+	name = "Medbay";
+	req_access_txt = "5"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/structure/fans/tiny,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/medical/paramedic)
 "uZd" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -42859,6 +42807,19 @@
 /obj/machinery/vending/cigarette,
 /turf/open/floor/plating,
 /area/maintenance/bar)
+"vbi" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/vehicle/ridden/atv/snowmobile,
+/obj/item/key,
+/obj/effect/turf_decal/bot,
+/obj/structure/window/reinforced,
+/turf/open/floor/plasteel/dark,
+/area/medical/paramedic)
 "vbn" = (
 /obj/structure/toilet/secret/prison{
 	dir = 1
@@ -43387,6 +43348,11 @@
 	},
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors)
+"voI" = (
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/port/fore)
 "vpz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/airlock/public/glass{
@@ -43412,6 +43378,22 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
+"vqn" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/power/apc{
+	areastring = "/area/maintenance/port/fore";
+	dir = 4;
+	name = "Port Bow Maintenance APC";
+	pixel_x = 24
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "vqv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/airlock{
@@ -44374,17 +44356,6 @@
 	},
 /turf/open/floor/plasteel/white/side,
 /area/hallway/primary/port)
-"vNj" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 8
-	},
-/obj/structure/table/reinforced,
-/obj/item/clothing/gloves/color/latex,
-/obj/item/healthanalyzer,
-/obj/item/clothing/glasses/hud/health,
-/obj/structure/window/reinforced,
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
 "vNu" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -44716,6 +44687,22 @@
 /obj/machinery/iv_drip,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"vVt" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/item/paper_bin{
+	pixel_x = -2;
+	pixel_y = 5
+	},
+/obj/item/pen/red,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "vVz" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -44943,12 +44930,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"waG" = (
-/obj/structure/closet/crate/medical,
-/obj/item/stack/medical/bruise_pack,
-/obj/item/stack/medical/ointment,
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "waP" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -45289,15 +45270,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"wjX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/visible{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/hallway/primary/port)
 "wkg" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -45519,6 +45491,16 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
 /area/security/prison)
+"wpW" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/tank_dispenser/oxygen,
+/turf/open/floor/plasteel/dark,
+/area/medical/paramedic)
 "wqd" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -45595,13 +45577,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmospherics_engine)
-"wsz" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "wtp" = (
 /obj/structure/closet/wardrobe/grey,
 /turf/open/floor/plasteel,
@@ -45795,6 +45770,21 @@
 "wyg" = (
 /turf/closed/wall/mineral/wood,
 /area/maintenance/bar)
+"wyS" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external{
+	req_one_access_txt = "13;5"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "wzf" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -46101,6 +46091,13 @@
 "wIA" = (
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"wIQ" = (
+/obj/machinery/door/airlock/external{
+	name = "Escape Pod Two"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/hallway/primary/port)
 "wIT" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -46241,16 +46238,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
-"wOb" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/landmark/start/paramedic,
-/turf/open/floor/plasteel/dark,
-/area/medical/paramedic)
 "wOn" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -46260,6 +46247,19 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/paramedic)
+"wPq" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/visible{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/hallway/primary/port)
 "wPD" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -47044,6 +47044,12 @@
 	icon_state = "wood-broken5"
 	},
 /area/maintenance/bar)
+"xlD" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "xlX" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/visible{
 	dir = 1
@@ -47193,16 +47199,6 @@
 /obj/structure/closet/wardrobe/miner,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
-"xpn" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/structure/tank_dispenser/oxygen,
-/turf/open/floor/plasteel/dark,
-/area/medical/paramedic)
 "xpU" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -47660,6 +47656,10 @@
 /obj/effect/turf_decal/tile/brown,
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
+"xEr" = (
+/obj/structure/sign/poster/official/help_others,
+/turf/closed/wall,
+/area/medical/paramedic)
 "xEt" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
@@ -48000,10 +48000,6 @@
 	},
 /turf/open/floor/plating,
 /area/icemoon/surface/outdoors)
-"xNM" = (
-/obj/structure/closet/l3closet/virology,
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
 "xNX" = (
 /obj/machinery/computer/secure_data{
 	dir = 4
@@ -48291,6 +48287,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"xXE" = (
+/obj/docking_port/stationary{
+	dwidth = 1;
+	height = 4;
+	name = "escape pod loader";
+	roundstart_template = /datum/map_template/shuttle/escape_pod/default;
+	width = 3
+	},
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/surface/outdoors)
 "xXS" = (
 /obj/machinery/rnd/server,
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
@@ -48733,12 +48739,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
-"ylO" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "ylW" = (
 /obj/structure/window{
 	dir = 4
@@ -66301,7 +66301,7 @@ mpj
 mpj
 gIE
 hBH
-nCP
+uIT
 pZD
 pZD
 pZD
@@ -66558,7 +66558,7 @@ hDj
 pfY
 wlD
 jBP
-kLU
+dsm
 cRX
 suK
 vGi
@@ -66815,7 +66815,7 @@ tlu
 wAW
 xhb
 uCi
-nCP
+uIT
 xFQ
 pZD
 eEy
@@ -67072,7 +67072,7 @@ pZD
 pZD
 pZD
 lzw
-nCP
+uIT
 lMF
 pZD
 pZD
@@ -67329,7 +67329,7 @@ tGK
 beD
 kkt
 cAo
-sIZ
+vVt
 kWC
 itU
 sWT
@@ -67586,7 +67586,7 @@ avT
 tdK
 gNb
 uYa
-vNj
+ozV
 mgC
 fjS
 uUr
@@ -67842,11 +67842,11 @@ avT
 byu
 wlG
 eSJ
-gzE
+ero
 vqQ
 uYa
 uYa
-xNM
+pii
 mpj
 xgB
 xgB
@@ -68612,17 +68612,17 @@ ydp
 mbm
 fXd
 xVn
-qll
-iox
-csa
-uCd
+oVv
+eGg
+dvy
+qdn
 iJl
 iJl
-nPv
+bge
 iJl
-waG
-aYo
-pGS
+gBL
+hRp
+pCZ
 eJu
 nYZ
 hxr
@@ -68868,18 +68868,18 @@ ydp
 ydp
 mbm
 iAO
-ylO
+brc
 iJl
-qND
+nED
 mbm
 iJl
-lpw
+xlD
 rTG
 uYp
 kxU
 sdH
 uYp
-rkz
+vqn
 pyw
 nYZ
 sXl
@@ -69122,16 +69122,16 @@ ydp
 ydp
 ydp
 ydp
-avT
+ydp
 mbm
 jKV
-fDn
+hkI
 jKV
-wsz
+qlc
 mbm
-dII
+lBm
 mbm
-tMI
+wyS
 mbm
 mvQ
 mvQ
@@ -69379,7 +69379,7 @@ ydp
 ydp
 ydp
 ydp
-avT
+ydp
 mbm
 mbm
 mbm
@@ -69393,8 +69393,8 @@ mbm
 qIm
 qIm
 mbm
-eUK
-pGS
+bJL
+pCZ
 nYZ
 dYa
 iaM
@@ -69636,21 +69636,21 @@ ydp
 ydp
 ydp
 ydp
+ydp
+ydp
+ydp
+ydp
+ydp
+ydp
+ydp
 avT
-ydp
-ydp
-ydp
-ydp
-avT
+mbm
+rAp
+mbm
 avT
 avT
 mbm
-sMJ
-mbm
-avT
-avT
-mbm
-eUK
+bJL
 iJl
 nYZ
 nYZ
@@ -69907,13 +69907,13 @@ avT
 avT
 avT
 mbm
-jRd
-lpw
+qrV
+xlD
 iJl
 iJl
-suC
+voI
 iJl
-tIC
+djy
 hui
 hBQ
 aNf
@@ -70411,8 +70411,8 @@ ydp
 ydp
 ydp
 ydp
-ydp
-ydp
+avT
+avT
 avT
 avT
 avT
@@ -70426,7 +70426,7 @@ xUL
 xUL
 xUL
 xUL
-oMU
+eZC
 tmO
 fYx
 oDm
@@ -70665,10 +70665,10 @@ ydp
 ydp
 ydp
 ydp
-ydp
-ydp
-ydp
-ydp
+avT
+avT
+avT
+avT
 ydp
 avT
 avT
@@ -70679,12 +70679,12 @@ avT
 avT
 avT
 avT
-iCE
+rGq
 xUL
 xUL
 xUL
-rbS
-jym
+xXE
+saI
 fYx
 oDm
 rhX
@@ -70922,7 +70922,7 @@ ydp
 ydp
 ydp
 ydp
-ydp
+avT
 ydp
 ydp
 ydp
@@ -70944,7 +70944,7 @@ xUL
 tmO
 fYx
 oDm
-llI
+kzA
 vFd
 por
 jEb
@@ -71178,8 +71178,8 @@ ydp
 ydp
 ydp
 ydp
-ydp
-ydp
+bmX
+avT
 ydp
 ydp
 ydp
@@ -71199,9 +71199,9 @@ wdv
 wdv
 wdv
 tmO
-uEU
+bdf
 oDm
-llI
+kzA
 vFd
 iop
 cSC
@@ -71454,11 +71454,11 @@ xUL
 xUL
 xUL
 xUL
-oMU
+eZC
 tmO
 fYx
 oDm
-llI
+kzA
 vFd
 vFd
 hlT
@@ -71707,20 +71707,20 @@ avT
 avT
 avT
 avT
-iCE
+rGq
 xUL
 xUL
 xUL
-rbS
-fBV
+xXE
+wIQ
 qJy
 oDm
 rhX
-nQP
+kNG
 vTP
 vFd
-mgd
-hyJ
+oHq
+bQX
 rhX
 xWq
 xWq
@@ -71978,7 +71978,7 @@ kHd
 ljT
 vFd
 ubd
-llI
+kzA
 xUL
 xUL
 xUL
@@ -72231,11 +72231,11 @@ lki
 kMt
 rhX
 uPn
-cdV
+rNV
 vFd
 vFd
 vGn
-llI
+kzA
 xUL
 xUL
 xUL
@@ -72484,15 +72484,15 @@ avT
 avT
 avT
 tmO
-gWQ
-wjX
+cYl
+nzr
 rhX
-eQR
+slS
 lXR
 vFd
 vFd
 vGn
-llI
+kzA
 xUL
 xUL
 xUL
@@ -72741,14 +72741,14 @@ avT
 avT
 avT
 tmO
-jmg
-hss
+cuc
+wPq
 rhX
 rhX
 rhX
-lQv
-lQv
-bfa
+kCp
+kCp
+xEr
 rhX
 xUL
 xUL
@@ -73002,11 +73002,11 @@ xUL
 xnm
 rhX
 eTu
-hId
+qXQ
 wOn
 wOn
 sIT
-llI
+kzA
 xUL
 xUL
 xUL
@@ -73257,13 +73257,13 @@ avT
 avT
 vBe
 xnm
-iYh
+uZc
 wOn
-aRO
-wOb
+eNw
+gXZ
 wOn
 wOn
-llI
+kzA
 xUL
 xUL
 xUL
@@ -73514,13 +73514,13 @@ avT
 avT
 xUL
 xnm
-iYh
+uZc
 wOn
 wOn
-jtV
+gZY
 wOn
 wOn
-llI
+kzA
 avT
 avT
 avT
@@ -73772,12 +73772,12 @@ avT
 xUL
 xnm
 rhX
-nBc
-sNZ
-mlq
-xpn
-mlq
-llI
+bWX
+vbi
+mlY
+wpW
+mlY
+kzA
 avT
 avT
 avT


### PR DESCRIPTION
## About The Pull Request

Virology and Surgery were pushed up a bit. Psych, break room, and patient room were all moved. Med storage was made a little larger. Cryo/Sleeper area, genetics, and chemistry were almost completely redone as well.

## Why It's Good For The Game

The Cryo/Sleeper area was the main focus of this change. I have changed the area to open it up more to every angle of medical besides the morgue, fixed pipes accordingly, and made sure it wasn't going to be crowded to avoid destroying the purpose of the change. Virology and Surgery being pushed back was a byproduct of switching the break room with the Psychologist's lobby. The Psychologist's office is now where the Patient Room was and the Break Room took the area of Psychologist's lobby. The Patient Room is now placed beside the expanded medical storage. Chemistry was opened up to let natural lighting in and to allow for two desks instead of both chemists crowding in the same area. This also opened up the room some to allow more fluid movement and efficiency. As for genetics, the room was rearranged and slightly expanded to give it a new "customer" window and to let it be a bit more spacious and less cramped. Some piping was also redone to get most of it out of the walls. Morgue is also a tad smaller now.

I have sent screenshots of the changed parts of medical in the #snaxiiiii channel on Discord.

## Changelog
:cl:
add: Added renovated and spacious cryo/sleeper area.
add: Added slightly more space to medical storage.
del: Removed Psychologist's lobby and door besides old Break Room
tweak: Patient Room, Break Room, and Psychologist's Office is now all moved
/:cl:

