### PR TITLE
Icemoon Ruin Fixes + Two New Icemoon Surface Ruins

### DIFF
--- a/_maps/RandomRuins/IceRuins/icemoon_outhouse.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_outhouse.dmm
@@ -1,0 +1,146 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/turf/template_noop,
+/area/template_noop)
+"h" = (
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors)
+"B" = (
+/turf/closed/mineral/random/snow/more_caves,
+/area/icemoon/surface/outdoors)
+"J" = (
+/obj/structure/flora/grass/brown,
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors)
+"K" = (
+/obj/structure/mineral_door/woodrustic,
+/turf/open/floor/wood,
+/area/ruin/unpowered)
+"N" = (
+/turf/closed/wall/mineral/wood,
+/area/ruin/unpowered)
+"S" = (
+/obj/structure/toilet,
+/turf/open/floor/wood,
+/area/ruin/unpowered)
+
+(1,1,1) = {"
+a
+a
+a
+a
+a
+a
+a
+a
+a
+a
+"}
+(2,1,1) = {"
+a
+B
+B
+J
+h
+h
+B
+a
+a
+a
+"}
+(3,1,1) = {"
+B
+B
+h
+h
+h
+h
+h
+h
+B
+a
+"}
+(4,1,1) = {"
+B
+h
+h
+N
+N
+N
+h
+h
+h
+a
+"}
+(5,1,1) = {"
+B
+h
+h
+N
+S
+K
+h
+h
+B
+a
+"}
+(6,1,1) = {"
+B
+h
+h
+N
+N
+N
+h
+h
+B
+B
+"}
+(7,1,1) = {"
+a
+a
+h
+h
+h
+h
+J
+h
+B
+B
+"}
+(8,1,1) = {"
+a
+a
+J
+h
+h
+h
+h
+h
+B
+B
+"}
+(9,1,1) = {"
+a
+a
+a
+h
+a
+a
+B
+B
+B
+a
+"}
+(10,1,1) = {"
+a
+a
+a
+a
+a
+a
+a
+a
+a
+a
+"}

--- a/_maps/RandomRuins/IceRuins/icemoon_store.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_store.dmm
@@ -1,7 +1,7 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "ay" = (
 /turf/closed/mineral/random/snow/more_caves,
-/area/icemoon/underground/explored)
+/area/icemoon/surface/outdoors)
 "az" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -223,6 +223,9 @@
 	},
 /turf/open/floor/plating,
 /area/ruin/powered)
+"oL" = (
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/ruin/powered)
 "oS" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/food/condiment/mayonnaise,
@@ -261,14 +264,16 @@
 /turf/open/floor/plasteel/yellowsiding{
 	dir = 4
 	},
-/area/icemoon/surface/outdoors)
+/area/ruin/powered)
 "rc" = (
 /turf/open/floor/plasteel/yellowsiding/corner{
 	dir = 4
 	},
-/area/icemoon/surface/outdoors)
+/area/ruin/powered)
 "rn" = (
-/obj/machinery/atmospherics/components/unary/tank/air,
+/obj/machinery/atmospherics/components/unary/tank/air{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/ruin/powered)
 "rs" = (
@@ -324,14 +329,14 @@
 "sm" = (
 /obj/structure/rack,
 /obj/item/storage/fancy/cracker_pack{
+	pixel_x = -5;
+	pixel_y = 3
+	},
+/obj/item/storage/fancy/cracker_pack{
 	pixel_y = -5
 	},
 /obj/item/storage/fancy/cracker_pack{
 	pixel_x = 7
-	},
-/obj/item/storage/fancy/cracker_pack{
-	pixel_x = -5;
-	pixel_y = 3
 	},
 /turf/open/floor/plasteel,
 /area/ruin/powered)
@@ -343,7 +348,7 @@
 /turf/open/floor/plasteel/yellowsiding{
 	dir = 1
 	},
-/area/icemoon/surface/outdoors)
+/area/ruin/powered)
 "tF" = (
 /turf/open/floor/plasteel/showroomfloor,
 /area/ruin/powered)
@@ -389,7 +394,7 @@
 /turf/open/floor/plasteel/yellowsiding{
 	dir = 9
 	},
-/area/icemoon/surface/outdoors)
+/area/ruin/powered)
 "zb" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/fancy/cigarettes/cigars,
@@ -459,6 +464,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/ruin/powered)
+"Dm" = (
+/obj/structure/flora/grass/green,
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors)
 "DA" = (
 /obj/machinery/door/window/northleft{
 	name = "Cooler Door"
@@ -661,6 +670,10 @@
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/open/floor/plasteel/showroomfloor,
 /area/ruin/powered)
+"IO" = (
+/obj/structure/flora/grass/brown,
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors)
 "IW" = (
 /turf/open/floor/plating,
 /area/ruin/powered)
@@ -678,7 +691,7 @@
 /turf/open/floor/plasteel/yellowsiding{
 	dir = 5
 	},
-/area/icemoon/surface/outdoors)
+/area/ruin/powered)
 "Lp" = (
 /obj/structure/rack,
 /obj/item/storage/firstaid/regular{
@@ -823,13 +836,13 @@
 	dir = 4
 	},
 /turf/open/floor/plating/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors)
+/area/ruin/powered)
 "Up" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 4
 	},
 /turf/open/floor/plating/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors)
+/area/ruin/powered)
 "Ux" = (
 /obj/machinery/light/small,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
@@ -864,7 +877,6 @@
 	dir = 1
 	},
 /obj/machinery/microwave{
-	pixel_x = -3;
 	pixel_y = 6
 	},
 /obj/machinery/light{
@@ -914,7 +926,7 @@
 /turf/open/floor/plasteel/yellowsiding{
 	dir = 1
 	},
-/area/icemoon/surface/outdoors)
+/area/ruin/powered)
 "ZE" = (
 /obj/machinery/door/airlock{
 	name = "Checkout Counter"
@@ -962,7 +974,7 @@ Ud
 Ud
 ay
 ND
-ND
+Dm
 ND
 ND
 ND
@@ -1032,7 +1044,7 @@ fD
 az
 IE
 TL
-ND
+Dm
 ND
 Ud
 Ud
@@ -1061,7 +1073,7 @@ IE
 TL
 ND
 ND
-ND
+IO
 Ud
 "}
 (6,1,1) = {"
@@ -1086,7 +1098,7 @@ GX
 tF
 tF
 TL
-ND
+IO
 ND
 ND
 Ud
@@ -1115,14 +1127,14 @@ XZ
 TL
 Up
 ND
-ND
+Dm
 Ud
 "}
 (8,1,1) = {"
 Ud
 ND
 ND
-ND
+IO
 yt
 yt
 yt
@@ -1178,7 +1190,7 @@ ND
 ND
 ND
 ND
-ND
+IO
 ND
 YT
 TL
@@ -1229,7 +1241,7 @@ ay
 (12,1,1) = {"
 Ud
 ay
-ND
+Dm
 ND
 yt
 yt
@@ -1281,7 +1293,7 @@ ay
 Ud
 "}
 (14,1,1) = {"
-Ud
+ay
 ay
 ay
 ND
@@ -1305,18 +1317,18 @@ in
 DJ
 TL
 ay
-Ud
+ay
 "}
 (15,1,1) = {"
-Ud
 ay
 ay
+ay
 ND
 yt
 yt
 yt
-ND
-ND
+oL
+oL
 YT
 TL
 IW
@@ -1332,18 +1344,18 @@ Ba
 Ux
 TL
 ay
-Ud
+ay
 "}
 (16,1,1) = {"
-Ud
 ay
 ay
+ay
 ND
 yt
 yt
 yt
-ND
-ND
+oL
+oL
 YT
 TL
 ZN
@@ -1359,7 +1371,7 @@ rs
 ZZ
 TL
 ay
-Ud
+ay
 "}
 (17,1,1) = {"
 Ud
@@ -1369,8 +1381,8 @@ ND
 ND
 ND
 ND
-ND
-ND
+oL
+oL
 KL
 TL
 TL
@@ -1386,18 +1398,18 @@ TL
 TL
 TL
 ay
-Ud
+ay
 "}
 (18,1,1) = {"
 Ud
 Ud
 ay
 ay
+IO
 ND
 ND
 ND
-ND
-ND
+Dm
 ND
 ND
 ND
@@ -1437,8 +1449,8 @@ ay
 ay
 ay
 ay
-Ud
-Ud
+ay
+ay
 Ud
 Ud
 "}

--- a/_maps/RandomRuins/IceRuins/icemoon_tartucube.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_tartucube.dmm
@@ -1,0 +1,92 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/turf/template_noop,
+/area/template_noop)
+"k" = (
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors)
+"t" = (
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/surface/outdoors)
+"B" = (
+/obj/effect/decal/remains/human,
+/obj/item/clothing/head/beanie/cyan{
+	desc = "A once stylish beanie. The perfect winter accessory for one who was with a keen atmos sense, and  who just couldn't handle a safe shift on their station.";
+	name = "tattered old cyan beanie";
+	pixel_x = 8;
+	pixel_y = 6
+	},
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors)
+"M" = (
+/obj/structure/flora/grass/brown,
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors)
+"W" = (
+/obj/structure/girder/reinforced,
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors)
+
+(1,1,1) = {"
+a
+a
+a
+a
+a
+a
+a
+"}
+(2,1,1) = {"
+a
+a
+k
+k
+k
+M
+a
+"}
+(3,1,1) = {"
+a
+a
+t
+W
+t
+k
+a
+"}
+(4,1,1) = {"
+a
+k
+W
+B
+W
+k
+a
+"}
+(5,1,1) = {"
+a
+M
+t
+W
+t
+a
+a
+"}
+(6,1,1) = {"
+a
+a
+k
+k
+k
+a
+a
+"}
+(7,1,1) = {"
+a
+a
+a
+a
+a
+a
+a
+"}

--- a/code/datums/ruins/icemoon.dm
+++ b/code/datums/ruins/icemoon.dm
@@ -50,6 +50,18 @@
 	description = "What remains of a Nanotrasen Navy ship and its uncomfortable landing."
 	suffix = "icemoon_wreckship.dmm"
 
+/datum/map_template/ruin/icemoon/outhouse
+	name = "Outhouse"
+	id = "shitter"
+	description = "A completely ordinary outhouse, although who put it here?"
+	suffix = "icemoon_outhouse.dmm"
+
+/datum/map_template/ruin/icemoon/tartucube
+	name = "Shitter Containment Cube"
+	id = "tartucube"
+	description = "Sometimes, people just cannot avoid making and handle explosives..."
+	suffix = "icemoon_tartucube.dmm"
+
 // above and below ground together
 
 /datum/map_template/ruin/icemoon/mining_site


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/26664829/101978635-0674c980-3c1c-11eb-82ad-30a87a8116f9.png)

![image](https://user-images.githubusercontent.com/26664829/101978647-15f41280-3c1c-11eb-86d0-5aab0594c635.png)

![image](https://user-images.githubusercontent.com/26664829/101978652-23a99800-3c1c-11eb-9bcf-df5fb0bd3392.png)

## About The Pull Request

Fixes a small atmos issue in the Icemoon Store ruin as well as a few area errors I made. Two new ruins added, one being just a literally outhouse, the other being a very old (by now) inside joke for Lumos.

## Why It's Good For The Game

Makes ruins I made not cry pls more cool ruins, mostly focused on being small and polite on space.

## Changelog
:cl:
add: outhouse ruin
add: tartu cube ruin
tweak: fixes issue with atmos in the Icemoon_Store ruin, plus some area fixes and alittle grass here and there.
/:cl:
