### PR TITLE
Fuckmy

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation_Lumos.dmm
+++ b/_maps/map_files/MetaStation/MetaStation_Lumos.dmm
@@ -62113,12 +62113,13 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "cxy" = (
-/obj/structure/sign/warning/nosmoking{
-	pixel_x = 28
-	},
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 8
+	},
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics)
@@ -63219,10 +63220,6 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics/cloning)
 "cAb" = (
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics/cloning)
 "cAc" = (
@@ -79721,6 +79718,9 @@
 /obj/structure/flora/ausbushes/fernybush{
 	pixel_x = -3;
 	pixel_y = 3
+	},
+/obj/structure/sign/warning/nosmoking{
+	pixel_x = 28
 	},
 /turf/open/floor/grass,
 /area/medical/genetics)

--- a/_maps/map_files/Snaxi/Snaxi_Lumos.dmm
+++ b/_maps/map_files/Snaxi/Snaxi_Lumos.dmm
@@ -1,7 +1,7 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "aaH" = (
-/obj/machinery/smartfridge/chemistry/preloaded,
-/turf/closed/wall,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/medical/chemistry)
 "aaO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -296,20 +296,11 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "adz" = (
 /obj/structure/sign/warning/nosmoking{
 	pixel_y = 30
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -318,12 +309,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -332,7 +317,7 @@
 	dir = 4
 	},
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -717,13 +702,19 @@
 /obj/machinery/airalarm{
 	pixel_y = 23
 	},
-/obj/structure/closet/secure_closet/chemical,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/structure/table/glass,
+/obj/item/clothing/glasses/science{
+	pixel_x = 2;
+	pixel_y = 4
+	},
+/obj/item/clothing/glasses/science,
+/obj/item/storage/box/syringes,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "alE" = (
@@ -855,16 +846,12 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "ann" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/eastright{
-	base_state = "left";
-	icon_state = "left";
-	name = "Chemistry Desk";
-	req_access_txt = "5; 33"
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
-/obj/machinery/door/firedoor/heavy,
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
+/turf/open/floor/plating,
+/area/medical/surgery)
 "anw" = (
 /obj/machinery/deepfryer,
 /turf/open/floor/plasteel/white,
@@ -907,17 +894,22 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "anK" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
+/obj/structure/table/reinforced,
+/obj/item/storage/backpack/duffelbag/med/surgery,
+/turf/open/floor/plasteel/freezer,
+/area/medical/surgery)
 "anL" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow,
+/obj/structure/chair/office/light{
+	dir = 4
+	},
+/obj/effect/landmark/start/chemist,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "anO" = (
@@ -965,16 +957,10 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/structure/closet/wardrobe/chemistry_white,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "aoo" = (
-/obj/structure/table/glass,
-/obj/machinery/reagentgrinder{
-	pixel_y = 8
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
@@ -982,13 +968,8 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow,
-/obj/item/reagent_containers/glass/beaker{
-	pixel_x = 5
-	},
-/obj/item/reagent_containers/glass/beaker{
-	pixel_x = 8;
-	pixel_y = 2
-	},
+/obj/machinery/chem_dispenser,
+/obj/machinery/light,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "aow" = (
@@ -1093,12 +1074,12 @@
 /turf/open/floor/wood,
 /area/library)
 "aqP" = (
-/obj/machinery/door/airlock/virology{
-	name = "Break Room";
-	req_access_txt = "39"
+/obj/machinery/vending/wallmed{
+	pixel_x = -28
 	},
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
+/obj/structure/closet/crate/freezer/blood,
+/turf/open/floor/plasteel/freezer,
+/area/medical/surgery)
 "arl" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -3058,10 +3039,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atm{
-	pixel_x = -28
-	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "aNg" = (
@@ -3248,11 +3225,6 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "aPp" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
-	},
 /obj/machinery/airalarm{
 	dir = 4;
 	pixel_x = -22
@@ -3877,6 +3849,10 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
+"bgz" = (
+/obj/machinery/smartfridge/chemistry/preloaded,
+/turf/closed/wall,
+/area/medical/chemistry)
 "bhe" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -6255,18 +6231,10 @@
 /turf/open/floor/plasteel/white,
 /area/security/prison)
 "bLM" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
+/obj/structure/chair{
 	dir = 8
 	},
-/obj/machinery/computer/cloning{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/effect/landmark/start/geneticist,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "bLO" = (
@@ -6296,9 +6264,6 @@
 /turf/closed/wall/r_wall,
 /area/quartermaster/miningdock)
 "bLW" = (
-/obj/structure/bodycontainer/morgue{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
@@ -6308,8 +6273,8 @@
 	dir = 8;
 	network = list("ss13","medbay")
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
@@ -8142,14 +8107,10 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "cwW" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
+/obj/structure/closet/crate/freezer/surplus_limbs,
+/obj/item/reagent_containers/glass/beaker/synthflesh,
+/turf/open/floor/plasteel/freezer,
+/area/medical/surgery)
 "cxX" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -8472,18 +8433,16 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/dorms)
 "cDS" = (
-/obj/structure/bodycontainer/morgue{
-	dir = 8
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/structure/bodycontainer/morgue{
+	dir = 2
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
@@ -8553,9 +8512,7 @@
 	network = list("ss13","medbay");
 	pixel_x = 22
 	},
-/obj/machinery/computer/operating{
-	dir = 4
-	},
+/obj/machinery/computer/operating,
 /turf/open/floor/plasteel/freezer,
 /area/medical/surgery)
 "cGz" = (
@@ -9501,9 +9458,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/mirror{
-	pixel_y = 28
-	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
@@ -9513,16 +9467,12 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/obj/machinery/shower{
-	pixel_x = 11;
-	pixel_y = 20
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/camera{
-	c_tag = "Genetics Cloning";
-	network = list("ss13","medbay")
+/obj/item/radio/intercom{
+	pixel_x = 1;
+	pixel_y = 23
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
@@ -9694,15 +9644,11 @@
 /turf/open/floor/plasteel/dark,
 /area/blueshield)
 "djL" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Genetics Maintenance";
-	req_access_txt = "5; 9; 68"
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/medical/genetics)
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "dks" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -10063,6 +10009,7 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "duB" = (
@@ -10344,24 +10291,11 @@
 /turf/open/floor/wood,
 /area/hallway/secondary/exit/departure_lounge)
 "dCI" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/machinery/light{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/white,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/medical/genetics)
 "dCM" = (
 /obj/machinery/status_display/supply{
@@ -10633,11 +10567,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
+	dir = 9
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -10864,22 +10796,15 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
 "dTL" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/clonepod,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "dTS" = (
@@ -11074,7 +10999,6 @@
 	name = "Genetics Requests Console";
 	pixel_y = 30
 	},
-/obj/machinery/dna_scannernew,
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -11082,6 +11006,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
+/obj/machinery/computer/scan_consolenew,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "dYl" = (
@@ -11797,7 +11722,9 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
 "eut" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/obj/structure/closet/secure_closet/medical2,
+/obj/item/tank/internals/anesthetic,
+/obj/item/tank/internals/anesthetic,
 /turf/open/floor/plasteel/freezer,
 /area/medical/surgery)
 "euz" = (
@@ -12211,7 +12138,18 @@
 /turf/open/floor/wood,
 /area/security/courtroom)
 "eFU" = (
-/turf/open/floor/plasteel/white,
+/obj/machinery/door/window/westleft{
+	dir = 2;
+	name = "Monkey Pen";
+	req_access_txt = "9"
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/mob/living/carbon/monkey,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/brflowers,
+/turf/open/floor/grass,
 /area/medical/genetics)
 "eGi" = (
 /obj/structure/cable{
@@ -12791,30 +12729,17 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
 "eSQ" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
 	},
-/obj/machinery/door/airlock/research/glass{
-	name = "Genetics Research";
-	req_access_txt = "5; 9; 68"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
+/obj/machinery/light/small{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/genetics)
+/turf/open/floor/plasteel/dark,
+/area/medical/morgue)
 "eTg" = (
 /obj/effect/landmark/start/roboticist,
 /obj/structure/disposalpipe/segment{
@@ -12921,6 +12846,21 @@
 /obj/item/key/security,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
+"eVY" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/eastright{
+	base_state = "left";
+	dir = 8;
+	icon_state = "left";
+	name = "Chemistry Desk";
+	req_access_txt = "5; 33"
+	},
+/obj/machinery/door/firedoor/heavy,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/medical/chemistry)
 "eWg" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -13268,9 +13208,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
 	},
-/obj/structure/closet/secure_closet/medical2,
-/obj/item/tank/internals/anesthetic,
-/obj/item/tank/internals/anesthetic,
 /turf/open/floor/plasteel/freezer,
 /area/medical/surgery)
 "fgM" = (
@@ -13281,7 +13218,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/mob/living/carbon/monkey,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "fhi" = (
@@ -14049,6 +13988,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "fBk" = (
@@ -14102,9 +14044,7 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/dorms)
 "fDi" = (
-/obj/machinery/computer/operating{
-	dir = 8
-	},
+/obj/machinery/computer/operating,
 /turf/open/floor/plasteel/freezer,
 /area/medical/surgery)
 "fDl" = (
@@ -14187,10 +14127,11 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "fGi" = (
-/obj/effect/landmark/start/medical_doctor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/structure/table/reinforced,
+/obj/item/storage/backpack/duffelbag/med/surgery,
 /turf/open/floor/plasteel/freezer,
 /area/medical/surgery)
 "fGl" = (
@@ -14481,19 +14422,16 @@
 /area/library)
 "fNO" = (
 /obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
@@ -14742,11 +14680,14 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
 "fUX" = (
-/obj/machinery/vending/medical{
-	pixel_x = -2
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/medical/morgue)
 "fVm" = (
 /turf/open/floor/wood{
 	icon_state = "wood-broken5"
@@ -14964,17 +14905,9 @@
 /area/storage/eva)
 "gbg" = (
 /obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple,
-/obj/machinery/dna_scannernew,
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "gbt" = (
@@ -15124,17 +15057,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"gev" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/machinery/disposal/bin,
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
 "geO" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -15270,6 +15192,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
+"gjf" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "gjA" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -15313,11 +15239,18 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "gkx" = (
-/obj/machinery/airalarm{
-	pixel_y = 23
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/machinery/dna_scannernew,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
+/area/medical/genetics)
 "gky" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -15493,16 +15426,14 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/light_switch{
-	pixel_y = -28
-	},
-/obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
@@ -15704,21 +15635,11 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
 "guR" = (
-/obj/structure/table/glass,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/reagent_containers/dropper,
-/obj/item/reagent_containers/dropper,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
+/obj/machinery/chem_heater,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "guV" = (
@@ -15733,6 +15654,9 @@
 	icon_state = "1-2"
 	},
 /obj/structure/bed/roller,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "gvA" = (
@@ -15919,12 +15843,14 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "gCS" = (
-/obj/structure/bodycontainer/morgue,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
+	},
+/obj/structure/bodycontainer/morgue{
+	dir = 2
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
@@ -15941,7 +15867,7 @@
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/structure/cable{
-	icon_state = "2-4"
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
@@ -16112,11 +16038,17 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/fitness)
 "gId" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
+/obj/machinery/door/airlock/medical/glass{
+	id_tag = "GeneticsDoor";
+	name = "Morgue";
+	req_access_txt = "5; 68"
 	},
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/plasteel/dark,
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plating,
 /area/medical/morgue)
 "gIm" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -16290,27 +16222,11 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "gNq" = (
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
 	},
-/obj/structure/sign/warning/securearea{
-	pixel_x = 32
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/genetics)
+/turf/open/floor/plasteel/dark,
+/area/medical/medbay/central)
 "gNy" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/machinery/atmospherics/components/binary/pump{
@@ -16592,16 +16508,12 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "gTb" = (
-/obj/structure/chair/office/light,
-/obj/effect/landmark/start/chemist,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/machinery/light,
+/obj/structure/closet/secure_closet/chemical,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "gTc" = (
@@ -16802,6 +16714,12 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
+"haL" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "haU" = (
 /obj/machinery/button/door{
 	id = "kitchen";
@@ -16896,14 +16814,14 @@
 /turf/open/floor/plating,
 /area/library)
 "heR" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
+/area/medical/genetics)
 "heS" = (
 /turf/open/openspace,
 /area/security/execution/education)
@@ -17015,19 +16933,16 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "hhI" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
+/obj/machinery/camera{
+	c_tag = "Genetics Research";
+	dir = 8;
+	network = list("ss13","medbay")
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
+/obj/structure/table/glass,
+/obj/item/storage/box/disks{
+	pixel_x = 2;
+	pixel_y = 2
 	},
-/obj/machinery/door/window/westleft{
-	dir = 1;
-	name = "Monkey Pen";
-	req_access_txt = "9"
-	},
-/mob/living/carbon/monkey,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "hik" = (
@@ -17190,12 +17105,10 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "hop" = (
@@ -17275,17 +17188,29 @@
 /turf/open/floor/carpet/black,
 /area/crew_quarters/heads/hos)
 "hpG" = (
-/obj/machinery/door/airlock/medical/glass{
-	id_tag = "GeneticsDoor";
-	name = "Morgue";
-	req_access_txt = "5; 68"
+/obj/structure/table,
+/obj/item/book/manual/wiki/medical_cloning{
+	pixel_y = 6
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/item/storage/box/rxglasses{
+	pixel_x = 3;
+	pixel_y = 3
 	},
-/turf/open/floor/plasteel/dark,
-/area/medical/morgue)
+/obj/item/storage/box/bodybags,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/item/pen,
+/obj/machinery/camera{
+	c_tag = "Genetics Cloning";
+	network = list("ss13","medbay")
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 "hpN" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -17475,9 +17400,6 @@
 	c_tag = "Northwestern Hall 9";
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
 /turf/open/floor/plasteel/white/corner{
 	dir = 4
 	},
@@ -17600,14 +17522,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "hxr" = (
-/obj/machinery/computer/scan_consolenew,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
+/mob/living/carbon/monkey,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/grass,
 /area/medical/genetics)
 "hxw" = (
 /obj/structure/cable{
@@ -17821,7 +17739,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
-/obj/structure/disposalpipe/segment,
+/obj/machinery/atm{
+	pixel_x = -28
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "hCz" = (
@@ -18038,9 +17958,10 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hop)
 "hIe" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
 	},
+/obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/plasteel/freezer,
 /area/medical/surgery)
 "hIl" = (
@@ -18921,6 +18842,9 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
+/obj/structure/chair/office/light{
+	dir = 1
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "iaO" = (
@@ -19336,9 +19260,9 @@
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/dorms)
 "inU" = (
-/obj/machinery/chem_dispenser,
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/dark,
+/area/medical/medbay/central)
 "iob" = (
 /obj/structure/window/plasma/reinforced{
 	dir = 1
@@ -19660,8 +19584,14 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
 "ivQ" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/firedoor/heavy,
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/eastright{
+	base_state = "left";
+	icon_state = "left";
+	name = "Chemistry Desk";
+	req_access_txt = "5; 33"
+	},
 /turf/open/floor/plating,
 /area/medical/chemistry)
 "iwc" = (
@@ -20068,17 +19998,15 @@
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "iGg" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
-/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
-/area/medical/medbay/central)
+/area/medical/morgue)
 "iGB" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -20182,6 +20110,12 @@
 "iIz" = (
 /obj/structure/cable{
 	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -20480,11 +20414,15 @@
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/quartermaster/storage)
 "iRy" = (
-/obj/machinery/firealarm{
-	pixel_y = 29
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
+/area/medical/genetics)
 "iRE" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -20567,14 +20505,10 @@
 /turf/open/floor/plating,
 /area/hallway/primary/aft)
 "iWu" = (
-/obj/machinery/chem_master,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "iWz" = (
@@ -20759,14 +20693,21 @@
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "jbE" = (
-/obj/machinery/vending/wardrobe/gene_wardrobe,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
+	},
+/obj/structure/disposalpipe/sorting/mail/flip{
+	sortType = 23
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
@@ -21106,7 +21047,6 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "jmd" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -21459,6 +21399,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "jyH" = (
@@ -21772,14 +21718,18 @@
 /turf/closed/wall,
 /area/security/prison)
 "jFY" = (
-/obj/structure/bodycontainer/morgue{
-	dir = 2
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
+	},
+/obj/structure/table,
+/obj/item/storage/box/bodybags,
+/obj/item/pen,
+/obj/item/paper/guides/jobs/medical/morgue{
+	pixel_x = 5;
+	pixel_y = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
@@ -21882,21 +21832,14 @@
 /turf/closed/wall/r_wall,
 /area/security/checkpoint/supply)
 "jIu" = (
-/obj/effect/turf_decal/tile/purple{
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/item/radio/intercom{
-	pixel_x = 28
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/genetics)
+/turf/open/floor/plasteel/dark,
+/area/medical/medbay/central)
 "jIK" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -21998,6 +21941,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "jNw" = (
@@ -22219,9 +22165,18 @@
 /turf/open/floor/grass,
 /area/hydroponics/garden)
 "jTh" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
 "jTl" = (
 /obj/effect/turf_decal/stripes,
@@ -22309,19 +22264,26 @@
 /turf/closed/wall/r_wall,
 /area/storage/tech)
 "jWx" = (
-/obj/structure/table/glass,
-/obj/item/stack/sheet/mineral/plasma,
-/obj/item/stack/sheet/mineral/plasma,
-/obj/item/reagent_containers/glass/bottle/epinephrine,
-/obj/item/stack/cable_coil/random,
-/obj/item/stack/cable_coil/random,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
+/obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/structure/table/glass,
+/obj/item/book/manual/wiki/chemistry{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/book/manual/wiki/chemistry,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
+/obj/machinery/firealarm{
+	pixel_x = 2;
+	pixel_y = 26
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "jWy" = (
@@ -22352,6 +22314,9 @@
 /obj/machinery/airalarm{
 	dir = 8;
 	pixel_x = 24
+	},
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -22589,10 +22554,10 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
 	},
-/mob/living/carbon/monkey,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "keI" = (
@@ -23110,7 +23075,18 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/closed/wall/r_wall,
+/obj/machinery/door/airlock/research/glass{
+	name = "Genetics Research";
+	req_access_txt = "5; 9; 68"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4;
+	name = "east facing firelock"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "kti" = (
 /obj/effect/turf_decal/bot,
@@ -23329,6 +23305,23 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/bridge)
+"kAt" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
 "kAO" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -23441,14 +23434,10 @@
 /area/ai_monitored/security/armory)
 "kEf" = (
 /obj/structure/disposalpipe/segment{
-	dir = 6
+	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
-	},
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/open/floor/plasteel/dark,
-/area/medical/medbay/central)
+/turf/closed/wall/r_wall,
+/area/medical/genetics)
 "kEz" = (
 /obj/vehicle/ridden/atv/snowmobile,
 /obj/item/key,
@@ -23639,8 +23628,20 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
 "kMc" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
+/obj/machinery/airalarm{
+	pixel_y = 23
+	},
+/obj/machinery/vending/medical{
+	pixel_x = -2
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -23659,9 +23660,6 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/port)
 "kMy" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
@@ -24028,9 +24026,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "kYE" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
 	},
+/obj/machinery/limbgrower,
 /turf/open/floor/plasteel/freezer,
 /area/medical/surgery)
 "kYF" = (
@@ -24130,6 +24129,21 @@
 /obj/machinery/disposal/bin,
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/bar)
+"laS" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/structure/sign/warning/nosmoking{
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
 "lba" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -24310,11 +24324,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "lgq" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/disposalpipe/segment,
 /turf/closed/wall,
 /area/medical/medbay/central)
 "lgJ" = (
@@ -24598,25 +24608,11 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "loT" = (
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc{
-	areastring = "/area/medical/genetics";
-	dir = 4;
-	name = "Genetics APC";
-	pixel_x = 24
-	},
-/obj/structure/table/glass,
-/obj/item/storage/pill_bottle/mannitol,
-/obj/item/storage/pill_bottle/mutadone{
-	pixel_x = 3
-	},
-/obj/item/radio/headset/headset_medsci,
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
+/obj/machinery/dna_scannernew,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "loV" = (
@@ -24660,7 +24656,9 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "lqt" = (
@@ -25274,16 +25272,29 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
 "lIn" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/backpack/duffelbag/med/surgery,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
 	},
-/turf/open/floor/plasteel/freezer,
-/area/medical/surgery)
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/power/apc{
+	areastring = "/area/medical/genetics";
+	dir = 4;
+	name = "Genetics APC";
+	pixel_x = -25
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 "lIJ" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -25353,21 +25364,20 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
 "lMx" = (
+/obj/structure/table/glass,
+/obj/item/radio/headset/headset_medsci,
+/obj/item/storage/pill_bottle/mannitol,
+/obj/item/storage/pill_bottle/mutadone{
+	pixel_x = 3
+	},
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/mob/living/carbon/monkey,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "lMF" = (
@@ -25868,10 +25878,9 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "mdq" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/closed/wall,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk,
+/turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
 "mdG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -26558,6 +26567,14 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/structure/table/glass,
+/obj/item/reagent_containers/glass/beaker/large{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/dropper,
+/obj/item/reagent_containers/dropper,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "mAK" = (
@@ -26677,18 +26694,11 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "mEI" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor/heavy,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/door/window/eastright{
-	base_state = "left";
-	dir = 1;
-	icon_state = "left";
-	name = "Chemistry Desk";
-	req_access_txt = "5; 33"
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 5
 	},
-/turf/open/floor/plating,
-/area/medical/chemistry)
+/turf/open/floor/plasteel/dark,
+/area/medical/medbay/central)
 "mET" = (
 /obj/structure/toilet/secret/prison,
 /obj/machinery/light/small{
@@ -26961,13 +26971,13 @@
 /turf/open/floor/wood,
 /area/medical/psych)
 "mLD" = (
-/obj/structure/closet/wardrobe/chemistry_white,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/machinery/vending/wardrobe/chem_wardrobe,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "mLK" = (
@@ -27154,23 +27164,6 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
-"mQJ" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/machinery/power/apc/auto_name/east,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/dark,
-/area/medical/morgue)
 "mQK" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -27316,11 +27309,13 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "mVh" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
 	},
-/turf/closed/wall,
-/area/medical/morgue)
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/dark,
+/area/medical/medbay/central)
 "mVi" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -27355,15 +27350,18 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "mVN" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/dark,
-/area/medical/medbay/central)
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 "mWc" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -27431,15 +27429,12 @@
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/bridge)
 "mYd" = (
-/obj/structure/bodycontainer/morgue{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/bodycontainer/morgue{
+	dir = 2
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
@@ -27544,14 +27539,17 @@
 /area/icemoon/surface/outdoors)
 "nbU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -27591,7 +27589,6 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "ndm" = (
-/obj/machinery/chem_dispenser,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
@@ -27819,6 +27816,9 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
 /turf/open/floor/plasteel/dark,
 /area/medical/surgery)
 "nhK" = (
@@ -27941,9 +27941,30 @@
 /turf/open/floor/carpet,
 /area/bridge)
 "nmR" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plating,
+/obj/machinery/door/airlock/research/glass{
+	name = "Genetics Research";
+	req_access_txt = "5; 9; 68"
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "nmY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -28252,10 +28273,12 @@
 	},
 /area/maintenance/aft/secondary)
 "nwq" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/closed/wall,
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
 "nwz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -28451,21 +28474,10 @@
 /turf/open/floor/plating,
 /area/medical/storage)
 "nBI" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/structure/table/glass,
-/obj/item/storage/box/syringes,
-/obj/item/clothing/glasses/science,
-/obj/item/clothing/glasses/science{
-	pixel_x = 2;
-	pixel_y = 4
-	},
+/obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "nBU" = (
@@ -28601,6 +28613,7 @@
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
 "nEa" = (
@@ -28933,7 +28946,12 @@
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "nOj" = (
-/obj/machinery/limbgrower,
+/obj/machinery/light_switch{
+	pixel_y = -23
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
 /turf/open/floor/plasteel/freezer,
 /area/medical/surgery)
 "nOk" = (
@@ -28982,11 +29000,14 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "nOR" = (
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/disposalpipe/segment{
+	dir = 9
 	},
-/turf/open/floor/plasteel/white,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
+/turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
 "nOY" = (
 /obj/machinery/camera{
@@ -29143,12 +29164,19 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "nRX" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/structure/closet/secure_closet/medical1,
+/obj/item/storage/box/rxglasses,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
@@ -29242,9 +29270,6 @@
 /turf/open/floor/plasteel,
 /area/storage/auxiliary)
 "nVv" = (
-/obj/structure/sign/warning/nosmoking{
-	pixel_y = 30
-	},
 /obj/structure/table/glass,
 /obj/item/grenade/chem_grenade,
 /obj/item/grenade/chem_grenade,
@@ -29263,6 +29288,11 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/item/stack/sheet/mineral/plasma,
+/obj/item/stack/cable_coil/random,
+/obj/item/stack/cable_coil/random,
+/obj/item/reagent_containers/glass/bottle/epinephrine,
+/obj/item/stack/sheet/mineral/plasma,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "nVI" = (
@@ -29307,13 +29337,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "nXs" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
+/mob/living/carbon/monkey,
+/obj/structure/window/reinforced,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/grass,
 /area/medical/genetics)
 "nXy" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -29594,9 +29622,6 @@
 "ofF" = (
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -30252,15 +30277,21 @@
 /turf/open/floor/plasteel/yellowsiding,
 /area/crew_quarters/fitness/pool)
 "ouB" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
-/obj/structure/disposalpipe/sorting/mail/flip{
-	sortType = 23
+/obj/machinery/light_switch{
+	pixel_y = -28
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
@@ -30980,8 +31011,18 @@
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
 "oTF" = (
-/turf/closed/wall/r_wall,
-/area/medical/morgue)
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 "oTT" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -31283,24 +31324,7 @@
 /turf/open/floor/plating,
 /area/medical/psych)
 "pbP" = (
-/obj/structure/table,
-/obj/item/storage/box/bodybags,
-/obj/item/pen,
-/obj/item/paper/guides/jobs/medical/morgue{
-	pixel_x = 5;
-	pixel_y = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
+/turf/closed/wall/r_wall,
 /area/medical/morgue)
 "pbS" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -32237,7 +32261,6 @@
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/miningdock)
 "pxE" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -32310,8 +32333,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "pyD" = (
-/obj/machinery/chem_heater,
-/obj/structure/disposalpipe/segment,
+/obj/machinery/chem_master,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "pyF" = (
@@ -33067,6 +33089,7 @@
 /obj/machinery/door/firedoor/border_only{
 	name = "south facing firelock"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
 /area/medical/surgery)
 "pRV" = (
@@ -33265,16 +33288,16 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple,
-/obj/structure/table,
-/obj/item/book/manual/wiki/medical_cloning{
-	pixel_y = 6
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
 	},
-/obj/item/storage/box/bodybags,
-/obj/item/storage/box/rxglasses{
-	pixel_x = 3;
-	pixel_y = 3
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
-/obj/item/pen,
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -22
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "pXp" = (
@@ -33321,10 +33344,17 @@
 /turf/closed/wall/r_wall,
 /area/medical/virology)
 "pZJ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
-/turf/closed/wall/r_wall,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "qal" = (
 /obj/structure/chair,
@@ -33522,9 +33552,16 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
 "qfd" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall,
-/area/medical/morgue)
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/machinery/dna_scannernew,
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 "qfJ" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -33996,8 +34033,6 @@
 	dir = 4;
 	pixel_x = -24
 	},
-/obj/structure/table/reinforced,
-/obj/item/storage/backpack/duffelbag/med/surgery,
 /turf/open/floor/plasteel/freezer,
 /area/medical/surgery)
 "qsD" = (
@@ -34106,6 +34141,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"qxz" = (
+/obj/machinery/light,
+/obj/structure/sign/warning/securearea{
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "qxM" = (
 /obj/machinery/door/airlock/public/glass{
 	id_tag = null;
@@ -34988,9 +35030,21 @@
 /turf/open/floor/circuit/off,
 /area/ai_monitored/turret_protected/ai)
 "qVD" = (
-/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
 /turf/open/floor/plasteel/white,
-/area/medical/chemistry)
+/area/medical/genetics)
 "qWa" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
@@ -35029,16 +35083,11 @@
 /turf/open/floor/plasteel/dark,
 /area/science/server)
 "qWL" = (
-/obj/structure/table/glass,
-/obj/item/book/manual/wiki/chemistry,
-/obj/item/book/manual/wiki/chemistry{
-	pixel_x = 3;
-	pixel_y = 3
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow,
+/obj/machinery/chem_master,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "qXm" = (
@@ -35130,11 +35179,18 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
 "qZP" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
 	},
-/turf/closed/wall,
-/area/medical/morgue)
+/obj/machinery/shower{
+	pixel_x = 11;
+	pixel_y = 20
+	},
+/obj/structure/mirror{
+	pixel_y = 28
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 "rac" = (
 /obj/structure/table,
 /obj/machinery/button/door{
@@ -35457,10 +35513,6 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "rjO" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/effect/landmark/start/geneticist,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
@@ -35509,8 +35561,7 @@
 /area/tcommsat/computer)
 "rkL" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "rkP" = (
 /obj/structure/window/reinforced{
@@ -35822,11 +35873,12 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "rqQ" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
 	},
-/turf/closed/wall,
-/area/medical/morgue)
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "rqS" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -35886,7 +35938,6 @@
 /area/hallway/secondary/entry)
 "rsy" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/disposalpipe/segment,
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/medbay/central)
@@ -36020,6 +36071,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
+"rwU" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "rwW" = (
 /obj/machinery/button/door{
 	id = "psyshu";
@@ -36361,7 +36418,6 @@
 /turf/open/floor/wood,
 /area/library)
 "rHS" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/airlock/medical{
 	name = "Morgue";
 	req_access_txt = "6;5"
@@ -36610,17 +36666,18 @@
 /turf/closed/wall,
 /area/maintenance/starboard)
 "rPD" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/door/airlock/medical/glass{
+	id_tag = "GeneticsDoor";
+	name = "Genetics";
+	req_access_txt = "5; 68"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/camera{
-	c_tag = "Northwestern Hall 8";
-	dir = 4
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
 	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
-/area/hallway/primary/port)
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 "rPU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -36664,7 +36721,6 @@
 /turf/closed/wall,
 /area/science/robotics/lab)
 "rQN" = (
-/obj/machinery/chem_master,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
@@ -36672,6 +36728,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow,
+/obj/machinery/chem_dispenser,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "rQU" = (
@@ -36727,6 +36784,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
 	icon_state = "1-4"
+	},
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/surgery)
@@ -36921,6 +36982,10 @@
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
 "rYD" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "rYN" = (
@@ -37138,11 +37203,12 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "seZ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/closed/wall,
-/area/medical/morgue)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/medical/genetics)
 "sfm" = (
 /obj/item/radio/intercom{
 	pixel_y = 25
@@ -37177,17 +37243,9 @@
 /obj/machinery/airalarm{
 	pixel_y = 23
 	},
-/obj/machinery/dna_scannernew,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
+/mob/living/carbon/monkey,
+/obj/structure/sink/puddle,
+/turf/open/floor/grass,
 /area/medical/genetics)
 "shN" = (
 /obj/structure/cable{
@@ -37276,9 +37334,6 @@
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "sjW" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
 	},
@@ -37288,10 +37343,23 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/purple,
 /obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/machinery/light{
 	dir = 4
 	},
-/obj/structure/closet/wardrobe/grey,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "skw" = (
@@ -37532,10 +37600,8 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "srB" = (
@@ -38607,21 +38673,15 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "sXl" = (
-/obj/structure/table/glass,
-/obj/item/storage/box/disks{
-	pixel_x = 2;
-	pixel_y = 2
-	},
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
+/mob/living/carbon/monkey,
+/obj/structure/window/reinforced{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/obj/structure/flora/ausbushes/grassybush,
+/turf/open/floor/grass,
 /area/medical/genetics)
 "sXs" = (
 /obj/effect/turf_decal/stripes/line,
@@ -38807,7 +38867,6 @@
 /obj/item/radio/intercom{
 	pixel_y = 20
 	},
-/obj/machinery/vending/wardrobe/chem_wardrobe,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
@@ -38816,6 +38875,18 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Chemistry"
+	},
+/obj/structure/table/glass,
+/obj/machinery/reagentgrinder{
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/glass/beaker{
+	pixel_x = 8;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/glass/beaker{
+	pixel_x = 8;
+	pixel_y = 2
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
@@ -39209,11 +39280,15 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
+/obj/machinery/clonepod,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
 	},
-/turf/closed/wall/r_wall,
-/area/medical/medbay/central)
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 "toa" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -39880,19 +39955,12 @@
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "tHr" = (
-/obj/structure/closet/secure_closet/medical1,
-/obj/item/storage/box/rxglasses,
 /obj/item/radio/intercom{
 	pixel_x = 25
 	},
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Genetics Research";
-	dir = 8;
-	network = list("ss13","medbay")
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
@@ -40092,6 +40160,9 @@
 /obj/item/reagent_containers/glass/beaker/cryoxadone{
 	pixel_x = 10
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
 "tML" = (
@@ -40120,9 +40191,15 @@
 /turf/open/floor/plasteel/dark,
 /area/science/server)
 "tNq" = (
-/obj/structure/disposalpipe/segment,
-/turf/closed/wall,
-/area/medical/medbay/central)
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor/heavy,
+/obj/machinery/door/window/westleft{
+	dir = 1;
+	name = "Monkey Pen";
+	req_access_txt = "9"
+	},
+/turf/open/floor/plating,
+/area/medical/genetics)
 "tNX" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -40901,9 +40978,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "ujD" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
 "ujE" = (
@@ -41247,9 +41322,6 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "uuD" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -41258,6 +41330,10 @@
 	},
 /obj/structure/bed/roller,
 /obj/machinery/iv_drip,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "uuU" = (
@@ -41763,11 +41839,11 @@
 /turf/open/floor/plating,
 /area/engine/atmospherics_engine)
 "uKI" = (
-/obj/structure/chair/office/light{
-	dir = 1
-	},
-/obj/effect/landmark/start/geneticist,
-/turf/open/floor/plasteel/white,
+/obj/structure/window/reinforced,
+/mob/living/carbon/monkey,
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/grass,
 /area/medical/genetics)
 "uKM" = (
 /obj/machinery/light{
@@ -42024,8 +42100,20 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "uUl" = (
-/turf/closed/wall/r_wall,
-/area/medical/medbay/central)
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/machinery/computer/cloning{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 "uUr" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -42037,6 +42125,7 @@
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
 "uUJ" = (
@@ -42186,8 +42275,8 @@
 /turf/open/floor/circuit/off,
 /area/ai_monitored/turret_protected/ai)
 "uXB" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
+/obj/structure/disposalpipe/junction{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -42332,15 +42421,11 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
+/obj/structure/chair/office/light{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "vaB" = (
@@ -42729,20 +42814,17 @@
 /turf/open/floor/wood,
 /area/library)
 "vkY" = (
-/obj/machinery/door/airlock/medical/glass{
-	id_tag = "GeneticsDoor";
-	name = "Genetics";
-	req_access_txt = "5; 68"
-	},
-/obj/machinery/door/firedoor/border_only,
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
-/area/medical/genetics)
+/area/medical/medbay/central)
 "vlv" = (
 /obj/effect/landmark/start/prisoner,
 /obj/effect/landmark/start/prisoner,
@@ -42922,15 +43004,12 @@
 /area/maintenance/aft/secondary)
 "vqF" = (
 /obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "vqP" = (
@@ -43121,6 +43200,7 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/medical_doctor,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
 "vvM" = (
@@ -43266,7 +43346,10 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
 "vyJ" = (
-/mob/living/carbon/monkey,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "vyM" = (
@@ -43328,7 +43411,14 @@
 /area/medical/surgery)
 "vAp" = (
 /obj/structure/disposalpipe/segment{
-	dir = 6
+	dir = 4
+	},
+/obj/machinery/vending/wardrobe/gene_wardrobe,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
@@ -43351,6 +43441,10 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/disposal/bin,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "vAF" = (
@@ -43533,9 +43627,13 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/chair/office/light,
+/obj/effect/landmark/start/geneticist,
+/obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/mob/living/carbon/monkey,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "vEA" = (
@@ -43649,8 +43747,11 @@
 /turf/open/floor/wood,
 /area/hallway/primary/central)
 "vIA" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+	dir = 6
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
@@ -43777,8 +43878,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/camera{
+	c_tag = "Northwestern Hall 8";
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
@@ -43859,9 +43961,6 @@
 /turf/open/floor/plasteel/white/side,
 /area/hallway/primary/port)
 "vNu" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
@@ -44836,8 +44935,8 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/computer/scan_consolenew{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
@@ -45270,8 +45369,11 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "wzH" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 5
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
@@ -45581,16 +45683,13 @@
 /turf/open/floor/plating,
 /area/science/robotics/lab)
 "wJN" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue,
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "0-8"
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
@@ -45607,6 +45706,7 @@
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
 "wKL" = (
@@ -45614,12 +45714,14 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "wKN" = (
-/obj/machinery/vending/wallmed{
-	pixel_y = -28
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/structure/closet/crate/freezer/blood,
-/turf/open/floor/plasteel/freezer,
-/area/medical/surgery)
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "wKU" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -46273,13 +46375,17 @@
 /turf/open/floor/plating,
 /area/engine/atmospherics_engine)
 "xgq" = (
-/obj/structure/closet/crate/freezer/surplus_limbs,
-/obj/item/reagent_containers/glass/beaker/synthflesh,
-/obj/machinery/light_switch{
-	pixel_y = -23
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/plasteel/freezer,
-/area/medical/surgery)
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "xgu" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
@@ -46650,7 +46756,9 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "xrW" = (
@@ -46783,7 +46891,9 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "xwO" = (
@@ -47114,18 +47224,14 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "xGj" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/port)
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "xGo" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -47228,8 +47334,10 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -27;
+	pixel_y = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -47736,6 +47844,18 @@
 	},
 /turf/open/floor/wood,
 /area/hallway/secondary/exit/departure_lounge)
+"xZh" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
 "xZp" = (
 /obj/structure/chair/stool/bar,
 /obj/machinery/camera{
@@ -63641,9 +63761,9 @@ pZD
 cGu
 qsz
 aPp
-wKN
-oto
-fUX
+oKr
+aqP
+ash
 ash
 ash
 hEQ
@@ -63897,12 +64017,12 @@ sVL
 pZD
 dfV
 oKr
+anK
 oKr
-xgq
-oto
-gkx
+cwW
+ash
 kMc
-anm
+djL
 nsi
 cEf
 eLX
@@ -64157,7 +64277,7 @@ hIe
 kYE
 nOj
 oto
-iRy
+ash
 anm
 anm
 anJ
@@ -64667,7 +64787,7 @@ puS
 iIg
 pZD
 fDi
-lIn
+pED
 fgp
 poT
 rFk
@@ -64675,7 +64795,7 @@ sTe
 jih
 jih
 wkM
-anm
+uUk
 alR
 anm
 anm
@@ -64924,7 +65044,7 @@ sXV
 laE
 pZD
 aaS
-aba
+ann
 aba
 aba
 oto
@@ -65192,10 +65312,10 @@ lgq
 rsy
 pxE
 jmd
-rkL
-tNq
-jTh
-mdq
+aoj
+ash
+aoj
+qWg
 aoj
 qWg
 anm
@@ -65445,7 +65565,7 @@ nhz
 pRf
 duu
 dJZ
-nwq
+ash
 hWn
 eSP
 uan
@@ -65453,10 +65573,10 @@ sMA
 uAe
 ykb
 tMt
-sMA
-xGP
-anm
-iEa
+mdq
+nwq
+rkL
+vkY
 lDj
 gzk
 eiR
@@ -65705,11 +65825,11 @@ ofF
 lCW
 fXH
 eSP
-uan
-sMA
+gNq
+inU
 uUC
-sMA
-sMA
+inU
+jIu
 sMA
 xGP
 anm
@@ -65960,14 +66080,14 @@ fKM
 adA
 hom
 lIm
-sMA
+ujD
 vvH
 ujD
-sMA
+ujD
 wKC
 nDC
 wzH
-sMA
+mEI
 xGP
 anm
 dSH
@@ -66207,14 +66327,14 @@ tlu
 wAW
 xhb
 uCi
-aqP
+uYa
 xFQ
 pZD
 eEy
 gzW
 ueK
 pZD
-ady
+anm
 ycQ
 ash
 tmy
@@ -66223,17 +66343,17 @@ tmy
 sMA
 vMf
 epK
-wKC
-wzH
-xGP
-anm
+jTh
+mVh
+nOR
+rqQ
 iEa
 anm
 sxa
 amD
+haL
 anm
 anm
-cwW
 jXh
 tUF
 tkr
@@ -66473,24 +66593,24 @@ pZD
 pZD
 pZD
 gZX
-seZ
-qfd
-qfd
-qfd
+gZX
+gZX
+gZX
+gZX
 rHS
-rqQ
-mVh
+gZX
+nYZ
 kEf
-iGg
-mVN
-nOR
+nnj
+nYZ
+nYZ
 wXj
 xAi
 aoX
 aoX
-ann
-ivQ
 aoX
+ivQ
+aaH
 aoX
 tUF
 gIG
@@ -66732,15 +66852,15 @@ pZD
 tyH
 vNu
 gCS
-gCS
+eSQ
 gCS
 ipu
 pbP
 qZP
 tnX
 uUl
-uUl
-uUl
+qfd
+nYZ
 wXj
 anm
 vmO
@@ -66748,7 +66868,7 @@ hik
 mAx
 ndm
 rQN
-aoX
+aaH
 soN
 ojv
 oTu
@@ -66989,15 +67109,15 @@ pZD
 jFY
 vIA
 rYD
+fUX
 rYD
-rYD
-rYD
+iGg
 gId
 oTF
 dTL
 bLM
 gbg
-nYZ
+nnj
 fJs
 jBr
 mYT
@@ -67249,17 +67369,17 @@ mYd
 bLW
 cDS
 wJN
-mQJ
+pbP
 hpG
 fNO
 rjO
 gXE
-nmR
+rPD
 nIR
 xhD
 xur
 lqg
-qVD
+yds
 pyD
 guR
 aaH
@@ -67511,17 +67631,17 @@ nYZ
 dcg
 fLL
 jNp
-nnj
+seZ
 adM
 anm
 aoX
 vAy
 yds
-anK
+yds
 gTb
-mEI
-xGj
-eDr
+aoX
+rJw
+xZh
 fYQ
 tXN
 tXN
@@ -67766,17 +67886,17 @@ nRX
 jbE
 nmR
 sjW
-eFU
+mVN
 pXl
-nnj
-adM
+nYZ
+uUk
 anm
 aoX
 tcP
 yds
-inU
+yds
 iWu
-aoX
+bgz
 rJw
 tkr
 fYQ
@@ -68021,12 +68141,12 @@ hxr
 uKI
 vAp
 ouB
-eSQ
-gNq
+nYZ
+nYZ
 dCI
-jIu
-vkY
-heR
+nnj
+nYZ
+uUk
 anm
 aoX
 ali
@@ -68034,7 +68154,7 @@ yds
 yds
 aon
 aoX
-rJw
+laS
 tkr
 fYQ
 oZE
@@ -68278,19 +68398,19 @@ sXl
 eFU
 jyA
 goK
-nYZ
-nYZ
+iRy
+lIn
 pZJ
-nYZ
-nYZ
-uUk
+qVD
+nnj
+wKN
 anm
 aoX
 mLD
 yds
 yds
-gev
-aoX
+guR
+aaH
 gsM
 tkr
 ayG
@@ -68531,21 +68651,21 @@ mbm
 mbm
 mbm
 nYZ
-hxr
-uKI
+gkx
+heR
 fBf
 vqF
 vax
 lMx
 keC
 vEr
-nnj
-uUk
-xAi
+tNq
+xgq
+qxz
 aoX
 nVv
-yds
-yds
+gjf
+rwU
 qWL
 aoX
 gsM
@@ -68797,14 +68917,14 @@ hhI
 vyJ
 fgM
 nnj
-uUk
+xGj
 anm
 aoX
 jWx
 nBI
 anL
 aoo
-aoX
+aaH
 gsM
 tkr
 wje
@@ -69049,7 +69169,7 @@ nYZ
 nYZ
 nYZ
 nYZ
-djL
+nYZ
 nYZ
 nYZ
 ktd
@@ -69058,9 +69178,9 @@ hxP
 uWY
 aoX
 aoX
-aoX
-aoX
-aoX
+aaH
+eVY
+aaH
 aoX
 gsM
 tkr
@@ -69313,9 +69433,9 @@ xrU
 yij
 iWY
 iTY
-yij
+kAt
 vLr
-rPD
+gKt
 srq
 cXi
 gKt

--- a/_maps/map_files/Snaxi/Snaxi_Lumos.dmm
+++ b/_maps/map_files/Snaxi/Snaxi_Lumos.dmm
@@ -1,7 +1,7 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "aaH" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/obj/machinery/smartfridge/chemistry/preloaded,
+/turf/closed/wall,
 /area/medical/chemistry)
 "aaO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -296,11 +296,20 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "adz" = (
 /obj/structure/sign/warning/nosmoking{
 	pixel_y = 30
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -309,6 +318,12 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -317,7 +332,7 @@
 	dir = 4
 	},
 /obj/structure/cable{
-	icon_state = "1-8"
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -702,19 +717,13 @@
 /obj/machinery/airalarm{
 	pixel_y = 23
 	},
+/obj/structure/closet/secure_closet/chemical,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/structure/table/glass,
-/obj/item/clothing/glasses/science{
-	pixel_x = 2;
-	pixel_y = 4
-	},
-/obj/item/clothing/glasses/science,
-/obj/item/storage/box/syringes,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "alE" = (
@@ -846,12 +855,16 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "ann" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/eastright{
+	base_state = "left";
+	icon_state = "left";
+	name = "Chemistry Desk";
+	req_access_txt = "5; 33"
 	},
-/turf/open/floor/plating,
-/area/medical/surgery)
+/obj/machinery/door/firedoor/heavy,
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "anw" = (
 /obj/machinery/deepfryer,
 /turf/open/floor/plasteel/white,
@@ -894,22 +907,17 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "anK" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/backpack/duffelbag/med/surgery,
-/turf/open/floor/plasteel/freezer,
-/area/medical/surgery)
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "anL" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow,
-/obj/structure/chair/office/light{
-	dir = 4
-	},
-/obj/effect/landmark/start/chemist,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "anO" = (
@@ -957,10 +965,16 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow,
-/obj/structure/closet/wardrobe/chemistry_white,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "aoo" = (
+/obj/structure/table/glass,
+/obj/machinery/reagentgrinder{
+	pixel_y = 8
+	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
@@ -968,8 +982,13 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow,
-/obj/machinery/chem_dispenser,
-/obj/machinery/light,
+/obj/item/reagent_containers/glass/beaker{
+	pixel_x = 5
+	},
+/obj/item/reagent_containers/glass/beaker{
+	pixel_x = 8;
+	pixel_y = 2
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "aow" = (
@@ -1074,12 +1093,12 @@
 /turf/open/floor/wood,
 /area/library)
 "aqP" = (
-/obj/machinery/vending/wallmed{
-	pixel_x = -28
+/obj/machinery/door/airlock/virology{
+	name = "Break Room";
+	req_access_txt = "39"
 	},
-/obj/structure/closet/crate/freezer/blood,
-/turf/open/floor/plasteel/freezer,
-/area/medical/surgery)
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "arl" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -3039,6 +3058,10 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atm{
+	pixel_x = -28
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "aNg" = (
@@ -3225,6 +3248,11 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "aPp" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
 /obj/machinery/airalarm{
 	dir = 4;
 	pixel_x = -22
@@ -3849,10 +3877,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
-"bgz" = (
-/obj/machinery/smartfridge/chemistry/preloaded,
-/turf/closed/wall,
-/area/medical/chemistry)
 "bhe" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -6231,10 +6255,18 @@
 /turf/open/floor/plasteel/white,
 /area/security/prison)
 "bLM" = (
-/obj/structure/chair{
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
-/obj/effect/landmark/start/geneticist,
+/obj/machinery/computer/cloning{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "bLO" = (
@@ -6264,6 +6296,9 @@
 /turf/closed/wall/r_wall,
 /area/quartermaster/miningdock)
 "bLW" = (
+/obj/structure/bodycontainer/morgue{
+	dir = 8
+	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
@@ -6273,8 +6308,8 @@
 	dir = 8;
 	network = list("ss13","medbay")
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
@@ -8107,10 +8142,14 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "cwW" = (
-/obj/structure/closet/crate/freezer/surplus_limbs,
-/obj/item/reagent_containers/glass/beaker/synthflesh,
-/turf/open/floor/plasteel/freezer,
-/area/medical/surgery)
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "cxX" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -8433,16 +8472,18 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/dorms)
 "cDS" = (
+/obj/structure/bodycontainer/morgue{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/structure/bodycontainer/morgue{
-	dir = 2
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
@@ -8512,7 +8553,9 @@
 	network = list("ss13","medbay");
 	pixel_x = 22
 	},
-/obj/machinery/computer/operating,
+/obj/machinery/computer/operating{
+	dir = 4
+	},
 /turf/open/floor/plasteel/freezer,
 /area/medical/surgery)
 "cGz" = (
@@ -9458,6 +9501,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/structure/mirror{
+	pixel_y = 28
+	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
@@ -9467,12 +9513,16 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
+/obj/machinery/shower{
+	pixel_x = 11;
+	pixel_y = 20
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/item/radio/intercom{
-	pixel_x = 1;
-	pixel_y = 23
+/obj/machinery/camera{
+	c_tag = "Genetics Cloning";
+	network = list("ss13","medbay")
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
@@ -9644,11 +9694,15 @@
 /turf/open/floor/plasteel/dark,
 /area/blueshield)
 "djL" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
+/obj/machinery/door/airlock/maintenance{
+	name = "Genetics Maintenance";
+	req_access_txt = "5; 9; 68"
 	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/medical/genetics)
 "dks" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -10009,7 +10063,6 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "duB" = (
@@ -10291,11 +10344,24 @@
 /turf/open/floor/wood,
 /area/hallway/secondary/exit/departure_lounge)
 "dCI" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "dCM" = (
 /obj/machinery/status_display/supply{
@@ -10567,9 +10633,11 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/structure/disposalpipe/segment{
-	dir = 9
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -10796,15 +10864,22 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
 "dTL" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
+/obj/machinery/clonepod,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "dTS" = (
@@ -10999,6 +11074,7 @@
 	name = "Genetics Requests Console";
 	pixel_y = 30
 	},
+/obj/machinery/dna_scannernew,
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -11006,7 +11082,6 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/obj/machinery/computer/scan_consolenew,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "dYl" = (
@@ -11722,9 +11797,7 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
 "eut" = (
-/obj/structure/closet/secure_closet/medical2,
-/obj/item/tank/internals/anesthetic,
-/obj/item/tank/internals/anesthetic,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/plasteel/freezer,
 /area/medical/surgery)
 "euz" = (
@@ -12138,18 +12211,7 @@
 /turf/open/floor/wood,
 /area/security/courtroom)
 "eFU" = (
-/obj/machinery/door/window/westleft{
-	dir = 2;
-	name = "Monkey Pen";
-	req_access_txt = "9"
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/mob/living/carbon/monkey,
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/ausbushes/brflowers,
-/turf/open/floor/grass,
+/turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "eGi" = (
 /obj/structure/cable{
@@ -12729,17 +12791,30 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
 "eSQ" = (
-/obj/effect/turf_decal/tile/blue{
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/research/glass{
+	name = "Genetics Research";
+	req_access_txt = "5; 9; 68"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
 	},
-/obj/machinery/light/small{
-	dir = 8
+/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
-/area/medical/morgue)
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 "eTg" = (
 /obj/effect/landmark/start/roboticist,
 /obj/structure/disposalpipe/segment{
@@ -12846,21 +12921,6 @@
 /obj/item/key/security,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
-"eVY" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/eastright{
-	base_state = "left";
-	dir = 8;
-	icon_state = "left";
-	name = "Chemistry Desk";
-	req_access_txt = "5; 33"
-	},
-/obj/machinery/door/firedoor/heavy,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/medical/chemistry)
 "eWg" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -13208,6 +13268,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
 	},
+/obj/structure/closet/secure_closet/medical2,
+/obj/item/tank/internals/anesthetic,
+/obj/item/tank/internals/anesthetic,
 /turf/open/floor/plasteel/freezer,
 /area/medical/surgery)
 "fgM" = (
@@ -13218,9 +13281,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/mob/living/carbon/monkey,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "fhi" = (
@@ -13988,9 +14049,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "fBk" = (
@@ -14044,7 +14102,9 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/dorms)
 "fDi" = (
-/obj/machinery/computer/operating,
+/obj/machinery/computer/operating{
+	dir = 8
+	},
 /turf/open/floor/plasteel/freezer,
 /area/medical/surgery)
 "fDl" = (
@@ -14127,11 +14187,10 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "fGi" = (
+/obj/effect/landmark/start/medical_doctor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/table/reinforced,
-/obj/item/storage/backpack/duffelbag/med/surgery,
 /turf/open/floor/plasteel/freezer,
 /area/medical/surgery)
 "fGl" = (
@@ -14422,16 +14481,19 @@
 /area/library)
 "fNO" = (
 /obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
@@ -14680,14 +14742,11 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
 "fUX" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/vending/medical{
+	pixel_x = -2
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/medical/morgue)
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "fVm" = (
 /turf/open/floor/wood{
 	icon_state = "wood-broken5"
@@ -14905,9 +14964,17 @@
 /area/storage/eva)
 "gbg" = (
 /obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple,
+/obj/machinery/dna_scannernew,
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -22
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "gbt" = (
@@ -15057,6 +15124,17 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"gev" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/disposal/bin,
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "geO" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -15192,10 +15270,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
-"gjf" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
 "gjA" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -15239,18 +15313,11 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "gkx" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/machinery/dna_scannernew,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
+/obj/machinery/airalarm{
+	pixel_y = 23
 	},
 /turf/open/floor/plasteel/white,
-/area/medical/genetics)
+/area/medical/medbay/central)
 "gky" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -15426,14 +15493,16 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/light_switch{
+	pixel_y = -28
+	},
+/obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
@@ -15635,11 +15704,21 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
 "guR" = (
+/obj/structure/table/glass,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow,
-/obj/machinery/chem_heater,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/dropper,
+/obj/item/reagent_containers/dropper,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "guV" = (
@@ -15654,9 +15733,6 @@
 	icon_state = "1-2"
 	},
 /obj/structure/bed/roller,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "gvA" = (
@@ -15843,14 +15919,12 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "gCS" = (
+/obj/structure/bodycontainer/morgue,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
-	},
-/obj/structure/bodycontainer/morgue{
-	dir = 2
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
@@ -15867,7 +15941,7 @@
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
@@ -16038,17 +16112,11 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/fitness)
 "gId" = (
-/obj/machinery/door/airlock/medical/glass{
-	id_tag = "GeneticsDoor";
-	name = "Morgue";
-	req_access_txt = "5; 68"
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "gIm" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -16222,11 +16290,27 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "gNq" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
-/turf/open/floor/plasteel/dark,
-/area/medical/medbay/central)
+/obj/structure/sign/warning/securearea{
+	pixel_x = 32
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 "gNy" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/machinery/atmospherics/components/binary/pump{
@@ -16508,12 +16592,16 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "gTb" = (
+/obj/structure/chair/office/light,
+/obj/effect/landmark/start/chemist,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow,
-/obj/machinery/light,
-/obj/structure/closet/secure_closet/chemical,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "gTc" = (
@@ -16714,12 +16802,6 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
-"haL" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
 "haU" = (
 /obj/machinery/button/door{
 	id = "kitchen";
@@ -16814,14 +16896,14 @@
 /turf/open/floor/plating,
 /area/library)
 "heR" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/white,
-/area/medical/genetics)
+/area/medical/medbay/central)
 "heS" = (
 /turf/open/openspace,
 /area/security/execution/education)
@@ -16933,16 +17015,19 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "hhI" = (
-/obj/machinery/camera{
-	c_tag = "Genetics Research";
-	dir = 8;
-	network = list("ss13","medbay")
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
 	},
-/obj/structure/table/glass,
-/obj/item/storage/box/disks{
-	pixel_x = 2;
-	pixel_y = 2
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
 	},
+/obj/machinery/door/window/westleft{
+	dir = 1;
+	name = "Monkey Pen";
+	req_access_txt = "9"
+	},
+/mob/living/carbon/monkey,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "hik" = (
@@ -17105,10 +17190,12 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "hop" = (
@@ -17188,29 +17275,17 @@
 /turf/open/floor/carpet/black,
 /area/crew_quarters/heads/hos)
 "hpG" = (
-/obj/structure/table,
-/obj/item/book/manual/wiki/medical_cloning{
-	pixel_y = 6
+/obj/machinery/door/airlock/medical/glass{
+	id_tag = "GeneticsDoor";
+	name = "Morgue";
+	req_access_txt = "5; 68"
 	},
-/obj/item/storage/box/rxglasses{
-	pixel_x = 3;
-	pixel_y = 3
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/item/storage/box/bodybags,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/item/pen,
-/obj/machinery/camera{
-	c_tag = "Genetics Cloning";
-	network = list("ss13","medbay")
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/genetics)
+/turf/open/floor/plasteel/dark,
+/area/medical/morgue)
 "hpN" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -17400,6 +17475,9 @@
 	c_tag = "Northwestern Hall 9";
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
 /turf/open/floor/plasteel/white/corner{
 	dir = 4
 	},
@@ -17522,10 +17600,14 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "hxr" = (
-/mob/living/carbon/monkey,
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/open/floor/grass,
+/obj/machinery/computer/scan_consolenew,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "hxw" = (
 /obj/structure/cable{
@@ -17739,9 +17821,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
-/obj/machinery/atm{
-	pixel_x = -28
-	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "hCz" = (
@@ -17958,10 +18038,9 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hop)
 "hIe" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
 	},
-/obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/plasteel/freezer,
 /area/medical/surgery)
 "hIl" = (
@@ -18842,9 +18921,6 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/obj/structure/chair/office/light{
-	dir = 1
-	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "iaO" = (
@@ -19260,9 +19336,9 @@
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/dorms)
 "inU" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/dark,
-/area/medical/medbay/central)
+/obj/machinery/chem_dispenser,
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "iob" = (
 /obj/structure/window/plasma/reinforced{
 	dir = 1
@@ -19584,14 +19660,8 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
 "ivQ" = (
+/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/firedoor/heavy,
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/eastright{
-	base_state = "left";
-	icon_state = "left";
-	name = "Chemistry Desk";
-	req_access_txt = "5; 33"
-	},
 /turf/open/floor/plating,
 /area/medical/chemistry)
 "iwc" = (
@@ -19998,15 +20068,17 @@
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "iGg" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/disposalpipe/segment,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
 	},
-/obj/structure/cable{
-	icon_state = "2-4"
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/plasteel/dark,
-/area/medical/morgue)
+/area/medical/medbay/central)
 "iGB" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -20110,12 +20182,6 @@
 "iIz" = (
 /obj/structure/cable{
 	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -20414,15 +20480,11 @@
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/quartermaster/storage)
 "iRy" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
+/obj/machinery/firealarm{
+	pixel_y = 29
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
-/area/medical/genetics)
+/area/medical/medbay/central)
 "iRE" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -20505,10 +20567,14 @@
 /turf/open/floor/plating,
 /area/hallway/primary/aft)
 "iWu" = (
+/obj/machinery/chem_master,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "iWz" = (
@@ -20693,21 +20759,14 @@
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "jbE" = (
+/obj/machinery/vending/wardrobe/gene_wardrobe,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
-	},
-/obj/structure/disposalpipe/sorting/mail/flip{
-	sortType = 23
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
@@ -21047,6 +21106,7 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "jmd" = (
+/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -21399,12 +21459,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "jyH" = (
@@ -21718,18 +21772,14 @@
 /turf/closed/wall,
 /area/security/prison)
 "jFY" = (
+/obj/structure/bodycontainer/morgue{
+	dir = 2
+	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
-	},
-/obj/structure/table,
-/obj/item/storage/box/bodybags,
-/obj/item/pen,
-/obj/item/paper/guides/jobs/medical/morgue{
-	pixel_x = 5;
-	pixel_y = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
@@ -21832,14 +21882,21 @@
 /turf/closed/wall/r_wall,
 /area/security/checkpoint/supply)
 "jIu" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
+/obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
-/area/medical/medbay/central)
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/item/radio/intercom{
+	pixel_x = 28
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 "jIK" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -21941,9 +21998,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple,
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "jNw" = (
@@ -22165,18 +22219,9 @@
 /turf/open/floor/grass,
 /area/hydroponics/garden)
 "jTh" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
-	},
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel/dark,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
 /area/medical/medbay/central)
 "jTl" = (
 /obj/effect/turf_decal/stripes,
@@ -22264,26 +22309,19 @@
 /turf/closed/wall/r_wall,
 /area/storage/tech)
 "jWx" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
+/obj/structure/table/glass,
+/obj/item/stack/sheet/mineral/plasma,
+/obj/item/stack/sheet/mineral/plasma,
+/obj/item/reagent_containers/glass/bottle/epinephrine,
+/obj/item/stack/cable_coil/random,
+/obj/item/stack/cable_coil/random,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
-/obj/structure/table/glass,
-/obj/item/book/manual/wiki/chemistry{
-	pixel_x = 3;
-	pixel_y = 3
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
 	},
-/obj/item/book/manual/wiki/chemistry,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
-/obj/machinery/firealarm{
-	pixel_x = 2;
-	pixel_y = 26
-	},
+/obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "jWy" = (
@@ -22314,9 +22352,6 @@
 /obj/machinery/airalarm{
 	dir = 8;
 	pixel_x = 24
-	},
-/obj/machinery/light{
-	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -22554,10 +22589,10 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
+/mob/living/carbon/monkey,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "keI" = (
@@ -23075,18 +23110,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/research/glass{
-	name = "Genetics Research";
-	req_access_txt = "5; 9; 68"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	name = "east facing firelock"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
+/turf/closed/wall/r_wall,
 /area/medical/genetics)
 "kti" = (
 /obj/effect/turf_decal/bot,
@@ -23305,23 +23329,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/bridge)
-"kAt" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/port)
 "kAO" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -23434,10 +23441,14 @@
 /area/ai_monitored/security/armory)
 "kEf" = (
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 6
 	},
-/turf/closed/wall/r_wall,
-/area/medical/genetics)
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/plasteel/dark,
+/area/medical/medbay/central)
 "kEz" = (
 /obj/vehicle/ridden/atv/snowmobile,
 /obj/item/key,
@@ -23628,20 +23639,8 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
 "kMc" = (
-/obj/machinery/airalarm{
-	pixel_y = 23
-	},
-/obj/machinery/vending/medical{
-	pixel_x = -2
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -23660,6 +23659,9 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/port)
 "kMy" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
@@ -24026,10 +24028,9 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "kYE" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
 	},
-/obj/machinery/limbgrower,
 /turf/open/floor/plasteel/freezer,
 /area/medical/surgery)
 "kYF" = (
@@ -24129,21 +24130,6 @@
 /obj/machinery/disposal/bin,
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/bar)
-"laS" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/structure/sign/warning/nosmoking{
-	pixel_y = 30
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/port)
 "lba" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -24324,7 +24310,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "lgq" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/disposalpipe/segment,
 /turf/closed/wall,
 /area/medical/medbay/central)
 "lgJ" = (
@@ -24608,11 +24598,25 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "loT" = (
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	areastring = "/area/medical/genetics";
+	dir = 4;
+	name = "Genetics APC";
+	pixel_x = 24
+	},
+/obj/structure/table/glass,
+/obj/item/storage/pill_bottle/mannitol,
+/obj/item/storage/pill_bottle/mutadone{
+	pixel_x = 3
+	},
+/obj/item/radio/headset/headset_medsci,
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/obj/machinery/dna_scannernew,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "loV" = (
@@ -24656,9 +24660,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "lqt" = (
@@ -25272,29 +25274,16 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
 "lIn" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
+/obj/structure/table/reinforced,
+/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/power/apc{
-	areastring = "/area/medical/genetics";
-	dir = 4;
-	name = "Genetics APC";
-	pixel_x = -25
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/genetics)
+/turf/open/floor/plasteel/freezer,
+/area/medical/surgery)
 "lIJ" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -25364,20 +25353,21 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
 "lMx" = (
-/obj/structure/table/glass,
-/obj/item/radio/headset/headset_medsci,
-/obj/item/storage/pill_bottle/mannitol,
-/obj/item/storage/pill_bottle/mutadone{
-	pixel_x = 3
-	},
 /obj/structure/cable{
-	icon_state = "2-8"
+	icon_state = "1-2"
 	},
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/mob/living/carbon/monkey,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "lMF" = (
@@ -25878,9 +25868,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "mdq" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk,
-/turf/open/floor/plasteel/dark,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/closed/wall,
 /area/medical/medbay/central)
 "mdG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -26567,14 +26558,6 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/structure/table/glass,
-/obj/item/reagent_containers/glass/beaker/large{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/dropper,
-/obj/item/reagent_containers/dropper,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "mAK" = (
@@ -26694,11 +26677,18 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "mEI" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 5
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor/heavy,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/door/window/eastright{
+	base_state = "left";
+	dir = 1;
+	icon_state = "left";
+	name = "Chemistry Desk";
+	req_access_txt = "5; 33"
 	},
-/turf/open/floor/plasteel/dark,
-/area/medical/medbay/central)
+/turf/open/floor/plating,
+/area/medical/chemistry)
 "mET" = (
 /obj/structure/toilet/secret/prison,
 /obj/machinery/light/small{
@@ -26971,13 +26961,13 @@
 /turf/open/floor/wood,
 /area/medical/psych)
 "mLD" = (
+/obj/structure/closet/wardrobe/chemistry_white,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/vending/wardrobe/chem_wardrobe,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "mLK" = (
@@ -27164,6 +27154,23 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"mQJ" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/medical/morgue)
 "mQK" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -27309,13 +27316,11 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "mVh" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
 	},
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/dark,
-/area/medical/medbay/central)
+/turf/closed/wall,
+/area/medical/morgue)
 "mVi" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -27350,18 +27355,15 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "mVN" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
+/obj/structure/disposalpipe/segment{
+	dir = 9
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/genetics)
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/dark,
+/area/medical/medbay/central)
 "mWc" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -27429,12 +27431,15 @@
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/bridge)
 "mYd" = (
+/obj/structure/bodycontainer/morgue{
+	dir = 8
+	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue,
-/obj/structure/bodycontainer/morgue{
-	dir = 2
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
@@ -27539,17 +27544,14 @@
 /area/icemoon/surface/outdoors)
 "nbU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -27589,6 +27591,7 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "ndm" = (
+/obj/machinery/chem_dispenser,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
@@ -27816,9 +27819,6 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
 /turf/open/floor/plasteel/dark,
 /area/medical/surgery)
 "nhK" = (
@@ -27941,30 +27941,9 @@
 /turf/open/floor/carpet,
 /area/bridge)
 "nmR" = (
+/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/door/airlock/research/glass{
-	name = "Genetics Research";
-	req_access_txt = "5; 9; 68"
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plating,
 /area/medical/genetics)
 "nmY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -28273,12 +28252,10 @@
 	},
 /area/maintenance/aft/secondary)
 "nwq" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
 	},
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/dark,
+/turf/closed/wall,
 /area/medical/medbay/central)
 "nwz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -28474,10 +28451,21 @@
 /turf/open/floor/plating,
 /area/medical/storage)
 "nBI" = (
-/obj/effect/turf_decal/tile/yellow,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/structure/table/glass,
+/obj/item/storage/box/syringes,
+/obj/item/clothing/glasses/science,
+/obj/item/clothing/glasses/science{
+	pixel_x = 2;
+	pixel_y = 4
+	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "nBU" = (
@@ -28613,7 +28601,6 @@
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
 "nEa" = (
@@ -28946,12 +28933,7 @@
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "nOj" = (
-/obj/machinery/light_switch{
-	pixel_y = -23
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
+/obj/machinery/limbgrower,
 /turf/open/floor/plasteel/freezer,
 /area/medical/surgery)
 "nOk" = (
@@ -29000,14 +28982,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "nOR" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/disposalpipe/segment{
-	dir = 9
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "nOY" = (
 /obj/machinery/camera{
@@ -29164,19 +29143,12 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "nRX" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/structure/closet/secure_closet/medical1,
-/obj/item/storage/box/rxglasses,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
@@ -29270,6 +29242,9 @@
 /turf/open/floor/plasteel,
 /area/storage/auxiliary)
 "nVv" = (
+/obj/structure/sign/warning/nosmoking{
+	pixel_y = 30
+	},
 /obj/structure/table/glass,
 /obj/item/grenade/chem_grenade,
 /obj/item/grenade/chem_grenade,
@@ -29288,11 +29263,6 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/item/stack/sheet/mineral/plasma,
-/obj/item/stack/cable_coil/random,
-/obj/item/stack/cable_coil/random,
-/obj/item/reagent_containers/glass/bottle/epinephrine,
-/obj/item/stack/sheet/mineral/plasma,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "nVI" = (
@@ -29337,11 +29307,13 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "nXs" = (
-/mob/living/carbon/monkey,
-/obj/structure/window/reinforced,
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/open/floor/grass,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "nXy" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -29622,6 +29594,9 @@
 "ofF" = (
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -30277,21 +30252,15 @@
 /turf/open/floor/plasteel/yellowsiding,
 /area/crew_quarters/fitness/pool)
 "ouB" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
-/obj/machinery/light_switch{
-	pixel_y = -28
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/structure/disposalpipe/sorting/mail/flip{
+	sortType = 23
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
@@ -31011,18 +30980,8 @@
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
 "oTF" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/white,
-/area/medical/genetics)
+/turf/closed/wall/r_wall,
+/area/medical/morgue)
 "oTT" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -31324,7 +31283,24 @@
 /turf/open/floor/plating,
 /area/medical/psych)
 "pbP" = (
-/turf/closed/wall/r_wall,
+/obj/structure/table,
+/obj/item/storage/box/bodybags,
+/obj/item/pen,
+/obj/item/paper/guides/jobs/medical/morgue{
+	pixel_x = 5;
+	pixel_y = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "pbS" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -32261,6 +32237,7 @@
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/miningdock)
 "pxE" = (
+/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -32333,7 +32310,8 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "pyD" = (
-/obj/machinery/chem_master,
+/obj/machinery/chem_heater,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "pyF" = (
@@ -33089,7 +33067,6 @@
 /obj/machinery/door/firedoor/border_only{
 	name = "south facing firelock"
 	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
 /area/medical/surgery)
 "pRV" = (
@@ -33288,16 +33265,16 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
+/obj/structure/table,
+/obj/item/book/manual/wiki/medical_cloning{
+	pixel_y = 6
 	},
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/item/storage/box/bodybags,
+/obj/item/storage/box/rxglasses{
+	pixel_x = 3;
+	pixel_y = 3
 	},
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
+/obj/item/pen,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "pXp" = (
@@ -33344,17 +33321,10 @@
 /turf/closed/wall/r_wall,
 /area/medical/virology)
 "pZJ" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/white,
+/turf/closed/wall/r_wall,
 /area/medical/genetics)
 "qal" = (
 /obj/structure/chair,
@@ -33552,16 +33522,9 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
 "qfd" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/machinery/dna_scannernew,
-/turf/open/floor/plasteel/white,
-/area/medical/genetics)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/closed/wall,
+/area/medical/morgue)
 "qfJ" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -34033,6 +33996,8 @@
 	dir = 4;
 	pixel_x = -24
 	},
+/obj/structure/table/reinforced,
+/obj/item/storage/backpack/duffelbag/med/surgery,
 /turf/open/floor/plasteel/freezer,
 /area/medical/surgery)
 "qsD" = (
@@ -34141,13 +34106,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"qxz" = (
-/obj/machinery/light,
-/obj/structure/sign/warning/securearea{
-	pixel_x = 32
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
 "qxM" = (
 /obj/machinery/door/airlock/public/glass{
 	id_tag = null;
@@ -35030,21 +34988,9 @@
 /turf/open/floor/circuit/off,
 /area/ai_monitored/turret_protected/ai)
 "qVD" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
-/area/medical/genetics)
+/area/medical/chemistry)
 "qWa" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
@@ -35083,11 +35029,16 @@
 /turf/open/floor/plasteel/dark,
 /area/science/server)
 "qWL" = (
+/obj/structure/table/glass,
+/obj/item/book/manual/wiki/chemistry,
+/obj/item/book/manual/wiki/chemistry{
+	pixel_x = 3;
+	pixel_y = 3
+	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow,
-/obj/machinery/chem_master,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "qXm" = (
@@ -35179,18 +35130,11 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
 "qZP" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
 	},
-/obj/machinery/shower{
-	pixel_x = 11;
-	pixel_y = 20
-	},
-/obj/structure/mirror{
-	pixel_y = 28
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/genetics)
+/turf/closed/wall,
+/area/medical/morgue)
 "rac" = (
 /obj/structure/table,
 /obj/machinery/button/door{
@@ -35513,6 +35457,10 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "rjO" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/landmark/start/geneticist,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
@@ -35561,7 +35509,8 @@
 /area/tcommsat/computer)
 "rkL" = (
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/white,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/medical/medbay/central)
 "rkP" = (
 /obj/structure/window/reinforced{
@@ -35873,12 +35822,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "rqQ" = (
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
 	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
+/turf/closed/wall,
+/area/medical/morgue)
 "rqS" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -35938,6 +35886,7 @@
 /area/hallway/secondary/entry)
 "rsy" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/disposalpipe/segment,
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/medbay/central)
@@ -36071,12 +36020,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
-"rwU" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
 "rwW" = (
 /obj/machinery/button/door{
 	id = "psyshu";
@@ -36418,6 +36361,7 @@
 /turf/open/floor/wood,
 /area/library)
 "rHS" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/airlock/medical{
 	name = "Morgue";
 	req_access_txt = "6;5"
@@ -36666,18 +36610,17 @@
 /turf/closed/wall,
 /area/maintenance/starboard)
 "rPD" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/door/airlock/medical/glass{
-	id_tag = "GeneticsDoor";
-	name = "Genetics";
-	req_access_txt = "5; 68"
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/camera{
+	c_tag = "Northwestern Hall 8";
+	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plasteel/white,
-/area/medical/genetics)
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
 "rPU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -36721,6 +36664,7 @@
 /turf/closed/wall,
 /area/science/robotics/lab)
 "rQN" = (
+/obj/machinery/chem_master,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
@@ -36728,7 +36672,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow,
-/obj/machinery/chem_dispenser,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "rQU" = (
@@ -36784,10 +36727,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
 	icon_state = "1-4"
-	},
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/surgery)
@@ -36982,10 +36921,6 @@
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
 "rYD" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "rYN" = (
@@ -37203,12 +37138,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "seZ" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
 	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/medical/genetics)
+/turf/closed/wall,
+/area/medical/morgue)
 "sfm" = (
 /obj/item/radio/intercom{
 	pixel_y = 25
@@ -37243,9 +37177,17 @@
 /obj/machinery/airalarm{
 	pixel_y = 23
 	},
-/mob/living/carbon/monkey,
-/obj/structure/sink/puddle,
-/turf/open/floor/grass,
+/obj/machinery/dna_scannernew,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "shN" = (
 /obj/structure/cable{
@@ -37334,6 +37276,9 @@
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "sjW" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
 	},
@@ -37343,23 +37288,10 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple,
 /obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/machinery/light{
 	dir = 4
 	},
+/obj/structure/closet/wardrobe/grey,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "skw" = (
@@ -37600,8 +37532,10 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "srB" = (
@@ -38673,15 +38607,21 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "sXl" = (
+/obj/structure/table/glass,
+/obj/item/storage/box/disks{
+	pixel_x = 2;
+	pixel_y = 2
+	},
 /obj/machinery/light{
 	dir = 1
 	},
-/mob/living/carbon/monkey,
-/obj/structure/window/reinforced{
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/obj/structure/flora/ausbushes/grassybush,
-/turf/open/floor/grass,
+/turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "sXs" = (
 /obj/effect/turf_decal/stripes/line,
@@ -38867,6 +38807,7 @@
 /obj/item/radio/intercom{
 	pixel_y = 20
 	},
+/obj/machinery/vending/wardrobe/chem_wardrobe,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
@@ -38875,18 +38816,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Chemistry"
-	},
-/obj/structure/table/glass,
-/obj/machinery/reagentgrinder{
-	pixel_y = 8
-	},
-/obj/item/reagent_containers/glass/beaker{
-	pixel_x = 8;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/glass/beaker{
-	pixel_x = 8;
-	pixel_y = 2
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
@@ -39280,15 +39209,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/clonepod,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/genetics)
+/turf/closed/wall/r_wall,
+/area/medical/medbay/central)
 "toa" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -39955,12 +39880,19 @@
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "tHr" = (
+/obj/structure/closet/secure_closet/medical1,
+/obj/item/storage/box/rxglasses,
 /obj/item/radio/intercom{
 	pixel_x = 25
 	},
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Genetics Research";
+	dir = 8;
+	network = list("ss13","medbay")
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
@@ -40160,9 +40092,6 @@
 /obj/item/reagent_containers/glass/beaker/cryoxadone{
 	pixel_x = 10
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
 "tML" = (
@@ -40191,15 +40120,9 @@
 /turf/open/floor/plasteel/dark,
 /area/science/server)
 "tNq" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor/heavy,
-/obj/machinery/door/window/westleft{
-	dir = 1;
-	name = "Monkey Pen";
-	req_access_txt = "9"
-	},
-/turf/open/floor/plating,
-/area/medical/genetics)
+/obj/structure/disposalpipe/segment,
+/turf/closed/wall,
+/area/medical/medbay/central)
 "tNX" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -40978,7 +40901,9 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "ujD" = (
-/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
 "ujE" = (
@@ -41322,6 +41247,9 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "uuD" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -41330,10 +41258,6 @@
 	},
 /obj/structure/bed/roller,
 /obj/machinery/iv_drip,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "uuU" = (
@@ -41839,11 +41763,11 @@
 /turf/open/floor/plating,
 /area/engine/atmospherics_engine)
 "uKI" = (
-/obj/structure/window/reinforced,
-/mob/living/carbon/monkey,
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/open/floor/grass,
+/obj/structure/chair/office/light{
+	dir = 1
+	},
+/obj/effect/landmark/start/geneticist,
+/turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "uKM" = (
 /obj/machinery/light{
@@ -42100,20 +42024,8 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "uUl" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/machinery/computer/cloning{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/genetics)
+/turf/closed/wall/r_wall,
+/area/medical/medbay/central)
 "uUr" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -42125,7 +42037,6 @@
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
 "uUJ" = (
@@ -42275,8 +42186,8 @@
 /turf/open/floor/circuit/off,
 /area/ai_monitored/turret_protected/ai)
 "uXB" = (
-/obj/structure/disposalpipe/junction{
-	dir = 4
+/obj/structure/disposalpipe/segment{
+	dir = 10
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -42421,11 +42332,15 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/chair/office/light{
-	dir = 4
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "vaB" = (
@@ -42814,17 +42729,20 @@
 /turf/open/floor/wood,
 /area/library)
 "vkY" = (
+/obj/machinery/door/airlock/medical/glass{
+	id_tag = "GeneticsDoor";
+	name = "Genetics";
+	req_access_txt = "5; 68"
+	},
+/obj/machinery/door/firedoor/border_only,
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/junction{
-	dir = 8
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
+/area/medical/genetics)
 "vlv" = (
 /obj/effect/landmark/start/prisoner,
 /obj/effect/landmark/start/prisoner,
@@ -43004,12 +42922,15 @@
 /area/maintenance/aft/secondary)
 "vqF" = (
 /obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "vqP" = (
@@ -43200,7 +43121,6 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/medical_doctor,
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
 "vvM" = (
@@ -43346,10 +43266,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
 "vyJ" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
+/mob/living/carbon/monkey,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "vyM" = (
@@ -43411,14 +43328,7 @@
 /area/medical/surgery)
 "vAp" = (
 /obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/vending/wardrobe/gene_wardrobe,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
+	dir = 6
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
@@ -43441,10 +43351,6 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/machinery/disposal/bin,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "vAF" = (
@@ -43627,13 +43533,9 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/chair/office/light,
-/obj/effect/landmark/start/geneticist,
-/obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/mob/living/carbon/monkey,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "vEA" = (
@@ -43747,11 +43649,8 @@
 /turf/open/floor/wood,
 /area/hallway/primary/central)
 "vIA" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
@@ -43878,9 +43777,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/camera{
-	c_tag = "Northwestern Hall 8";
-	dir = 4
+/obj/machinery/light{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
@@ -43961,6 +43859,9 @@
 /turf/open/floor/plasteel/white/side,
 /area/hallway/primary/port)
 "vNu" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
@@ -44935,8 +44836,8 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/obj/machinery/computer/scan_consolenew{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
@@ -45369,11 +45270,8 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "wzH" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
@@ -45683,13 +45581,16 @@
 /turf/open/floor/plating,
 /area/science/robotics/lab)
 "wJN" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue,
-/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable{
-	icon_state = "0-8"
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
@@ -45706,7 +45607,6 @@
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
 "wKL" = (
@@ -45714,14 +45614,12 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "wKN" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/vending/wallmed{
+	pixel_y = -28
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
+/obj/structure/closet/crate/freezer/blood,
+/turf/open/floor/plasteel/freezer,
+/area/medical/surgery)
 "wKU" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -46375,17 +46273,13 @@
 /turf/open/floor/plating,
 /area/engine/atmospherics_engine)
 "xgq" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/closet/crate/freezer/surplus_limbs,
+/obj/item/reagent_containers/glass/beaker/synthflesh,
+/obj/machinery/light_switch{
+	pixel_y = -23
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
+/turf/open/floor/plasteel/freezer,
+/area/medical/surgery)
 "xgu" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
@@ -46756,9 +46650,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "xrW" = (
@@ -46891,9 +46783,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "xwO" = (
@@ -47224,14 +47114,18 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "xGj" = (
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
 "xGo" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -47334,10 +47228,8 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -27;
-	pixel_y = 1
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -47844,18 +47736,6 @@
 	},
 /turf/open/floor/wood,
 /area/hallway/secondary/exit/departure_lounge)
-"xZh" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/port)
 "xZp" = (
 /obj/structure/chair/stool/bar,
 /obj/machinery/camera{
@@ -63761,9 +63641,9 @@ pZD
 cGu
 qsz
 aPp
-oKr
-aqP
-ash
+wKN
+oto
+fUX
 ash
 ash
 hEQ
@@ -64017,12 +63897,12 @@ sVL
 pZD
 dfV
 oKr
-anK
 oKr
-cwW
-ash
+xgq
+oto
+gkx
 kMc
-djL
+anm
 nsi
 cEf
 eLX
@@ -64277,7 +64157,7 @@ hIe
 kYE
 nOj
 oto
-ash
+iRy
 anm
 anm
 anJ
@@ -64787,7 +64667,7 @@ puS
 iIg
 pZD
 fDi
-pED
+lIn
 fgp
 poT
 rFk
@@ -64795,7 +64675,7 @@ sTe
 jih
 jih
 wkM
-uUk
+anm
 alR
 anm
 anm
@@ -65044,7 +64924,7 @@ sXV
 laE
 pZD
 aaS
-ann
+aba
 aba
 aba
 oto
@@ -65312,10 +65192,10 @@ lgq
 rsy
 pxE
 jmd
-aoj
-ash
-aoj
-qWg
+rkL
+tNq
+jTh
+mdq
 aoj
 qWg
 anm
@@ -65565,7 +65445,7 @@ nhz
 pRf
 duu
 dJZ
-ash
+nwq
 hWn
 eSP
 uan
@@ -65573,10 +65453,10 @@ sMA
 uAe
 ykb
 tMt
-mdq
-nwq
-rkL
-vkY
+sMA
+xGP
+anm
+iEa
 lDj
 gzk
 eiR
@@ -65825,11 +65705,11 @@ ofF
 lCW
 fXH
 eSP
-gNq
-inU
+uan
+sMA
 uUC
-inU
-jIu
+sMA
+sMA
 sMA
 xGP
 anm
@@ -66080,14 +65960,14 @@ fKM
 adA
 hom
 lIm
-ujD
+sMA
 vvH
 ujD
-ujD
+sMA
 wKC
 nDC
 wzH
-mEI
+sMA
 xGP
 anm
 dSH
@@ -66327,14 +66207,14 @@ tlu
 wAW
 xhb
 uCi
-uYa
+aqP
 xFQ
 pZD
 eEy
 gzW
 ueK
 pZD
-anm
+ady
 ycQ
 ash
 tmy
@@ -66343,17 +66223,17 @@ tmy
 sMA
 vMf
 epK
-jTh
-mVh
-nOR
-rqQ
+wKC
+wzH
+xGP
+anm
 iEa
 anm
 sxa
 amD
-haL
 anm
 anm
+cwW
 jXh
 tUF
 tkr
@@ -66593,24 +66473,24 @@ pZD
 pZD
 pZD
 gZX
-gZX
-gZX
-gZX
-gZX
+seZ
+qfd
+qfd
+qfd
 rHS
-gZX
-nYZ
+rqQ
+mVh
 kEf
-nnj
-nYZ
-nYZ
+iGg
+mVN
+nOR
 wXj
 xAi
 aoX
 aoX
-aoX
+ann
 ivQ
-aaH
+aoX
 aoX
 tUF
 gIG
@@ -66852,15 +66732,15 @@ pZD
 tyH
 vNu
 gCS
-eSQ
+gCS
 gCS
 ipu
 pbP
 qZP
 tnX
 uUl
-qfd
-nYZ
+uUl
+uUl
 wXj
 anm
 vmO
@@ -66868,7 +66748,7 @@ hik
 mAx
 ndm
 rQN
-aaH
+aoX
 soN
 ojv
 oTu
@@ -67109,15 +66989,15 @@ pZD
 jFY
 vIA
 rYD
-fUX
 rYD
-iGg
+rYD
+rYD
 gId
 oTF
 dTL
 bLM
 gbg
-nnj
+nYZ
 fJs
 jBr
 mYT
@@ -67369,17 +67249,17 @@ mYd
 bLW
 cDS
 wJN
-pbP
+mQJ
 hpG
 fNO
 rjO
 gXE
-rPD
+nmR
 nIR
 xhD
 xur
 lqg
-yds
+qVD
 pyD
 guR
 aaH
@@ -67631,17 +67511,17 @@ nYZ
 dcg
 fLL
 jNp
-seZ
+nnj
 adM
 anm
 aoX
 vAy
 yds
-yds
+anK
 gTb
-aoX
-rJw
-xZh
+mEI
+xGj
+eDr
 fYQ
 tXN
 tXN
@@ -67886,17 +67766,17 @@ nRX
 jbE
 nmR
 sjW
-mVN
+eFU
 pXl
-nYZ
-uUk
+nnj
+adM
 anm
 aoX
 tcP
 yds
-yds
+inU
 iWu
-bgz
+aoX
 rJw
 tkr
 fYQ
@@ -68141,12 +68021,12 @@ hxr
 uKI
 vAp
 ouB
-nYZ
-nYZ
+eSQ
+gNq
 dCI
-nnj
-nYZ
-uUk
+jIu
+vkY
+heR
 anm
 aoX
 ali
@@ -68154,7 +68034,7 @@ yds
 yds
 aon
 aoX
-laS
+rJw
 tkr
 fYQ
 oZE
@@ -68398,19 +68278,19 @@ sXl
 eFU
 jyA
 goK
-iRy
-lIn
+nYZ
+nYZ
 pZJ
-qVD
-nnj
-wKN
+nYZ
+nYZ
+uUk
 anm
 aoX
 mLD
 yds
 yds
-guR
-aaH
+gev
+aoX
 gsM
 tkr
 ayG
@@ -68651,21 +68531,21 @@ mbm
 mbm
 mbm
 nYZ
-gkx
-heR
+hxr
+uKI
 fBf
 vqF
 vax
 lMx
 keC
 vEr
-tNq
-xgq
-qxz
+nnj
+uUk
+xAi
 aoX
 nVv
-gjf
-rwU
+yds
+yds
 qWL
 aoX
 gsM
@@ -68917,14 +68797,14 @@ hhI
 vyJ
 fgM
 nnj
-xGj
+uUk
 anm
 aoX
 jWx
 nBI
 anL
 aoo
-aaH
+aoX
 gsM
 tkr
 wje
@@ -69169,7 +69049,7 @@ nYZ
 nYZ
 nYZ
 nYZ
-nYZ
+djL
 nYZ
 nYZ
 ktd
@@ -69178,9 +69058,9 @@ hxP
 uWY
 aoX
 aoX
-aaH
-eVY
-aaH
+aoX
+aoX
+aoX
 aoX
 gsM
 tkr
@@ -69433,9 +69313,9 @@ xrU
 yij
 iWY
 iTY
-kAt
+yij
 vLr
-gKt
+rPD
 srq
 cXi
 gKt

--- a/_maps/map_files/Snaxi/Snaxi_Lumos.dmm
+++ b/_maps/map_files/Snaxi/Snaxi_Lumos.dmm
@@ -65,11 +65,22 @@
 /turf/open/floor/plasteel/white,
 /area/security/prison)
 "abs" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
+/obj/machinery/vending/wardrobe/viro_wardrobe,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
 	},
-/turf/open/floor/carpet,
-/area/medical/psych)
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/machinery/camera{
+	c_tag = "Virology Break Room";
+	network = list("ss13","medbay")
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "abG" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -102,13 +113,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"abZ" = (
-/obj/effect/landmark/start/medical_doctor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/freezer,
-/area/medical/surgery)
 "ace" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -244,29 +248,50 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "adu" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "psyshu";
-	name = "psy shutters"
+/obj/machinery/iv_drip,
+/obj/item/radio/intercom{
+	pixel_y = 25
 	},
-/turf/open/floor/plating,
-/area/medical/psych)
-"adw" = (
-/obj/machinery/firealarm{
-	pixel_y = 29
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
-"adx" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
 /turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
+/area/medical/virology)
+"adw" = (
+/obj/item/storage/secure/safe{
+	pixel_x = 5;
+	pixel_y = 29
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
+"adx" = (
+/obj/structure/bed,
+/obj/item/bedsheet/medical,
+/obj/machinery/requests_console{
+	department = "Virology";
+	name = "Virology Requests Console";
+	pixel_x = 32
+	},
+/obj/machinery/light_switch{
+	pixel_y = 26
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "ady" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -394,16 +419,20 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "adZ" = (
-/obj/machinery/light{
+/obj/structure/table,
+/obj/machinery/microwave{
+	pixel_y = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "aet" = (
@@ -1064,17 +1093,12 @@
 /turf/open/floor/wood,
 /area/library)
 "aqP" = (
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/door/airlock/virology{
+	name = "Break Room";
+	req_access_txt = "39"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/port)
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "arl" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -1096,6 +1120,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
+	},
+/obj/machinery/airalarm{
+	pixel_y = 32
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
@@ -3221,15 +3248,15 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "aPp" = (
-/obj/machinery/firealarm{
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/machinery/airalarm{
 	dir = 4;
-	pixel_x = -24
+	pixel_x = -22
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
-/obj/structure/table/reinforced,
-/obj/item/storage/backpack/duffelbag/med/surgery,
 /turf/open/floor/plasteel/freezer,
 /area/medical/surgery)
 "aPw" = (
@@ -6673,15 +6700,17 @@
 /turf/open/floor/carpet,
 /area/chapel/office)
 "bSb" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 12
+/obj/item/radio/intercom{
+	frequency = 1485;
+	name = "Station Intercom (Medbay)";
+	pixel_y = 30
 	},
-/obj/structure/mirror{
-	pixel_x = 25
+/obj/machinery/light{
+	dir = 4
 	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
+/obj/structure/closet/secure_closet/psychologist,
+/turf/open/floor/wood,
+/area/medical/psych)
 "bSd" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -8519,9 +8548,16 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "cGu" = (
-/obj/structure/filingcabinet,
-/turf/open/floor/wood,
-/area/medical/psych)
+/obj/machinery/camera{
+	c_tag = "Surgery A";
+	network = list("ss13","medbay");
+	pixel_x = 22
+	},
+/obj/machinery/computer/operating{
+	dir = 4
+	},
+/turf/open/floor/plasteel/freezer,
+/area/medical/surgery)
 "cGz" = (
 /obj/structure/table,
 /obj/item/storage/backpack/duffelbag/med/surgery,
@@ -9115,16 +9151,7 @@
 /area/hydroponics/garden)
 "cVu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "cVG" = (
@@ -9605,12 +9632,12 @@
 /turf/open/floor/circuit/off,
 /area/ai_monitored/turret_protected/ai)
 "dfV" = (
-/obj/structure/table,
-/obj/machinery/microwave{
-	pixel_y = 4
+/obj/item/radio/intercom{
+	pixel_y = 25
 	},
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
+/obj/structure/table/optable,
+/turf/open/floor/plasteel/freezer,
+/area/medical/surgery)
 "dhg" = (
 /turf/closed/wall,
 /area/construction/storage)
@@ -10464,6 +10491,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/bed/roller,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "dFp" = (
@@ -10674,13 +10702,6 @@
 	},
 /turf/open/floor/wood,
 /area/security/vacantoffice/a)
-"dML" = (
-/obj/item/radio/intercom{
-	pixel_y = 25
-	},
-/obj/structure/table/optable,
-/turf/open/floor/plasteel/freezer,
-/area/medical/surgery)
 "dMR" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -11305,15 +11326,9 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "efp" = (
-/obj/machinery/iv_drip,
-/obj/item/radio/intercom{
-	pixel_y = 25
-	},
-/obj/effect/turf_decal/tile/green{
+/obj/structure/chair/stool,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -11356,8 +11371,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/bed/roller,
-/obj/machinery/iv_drip,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "egk" = (
@@ -11566,9 +11579,11 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
 "eoW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -11581,7 +11596,9 @@
 /turf/open/floor/plating,
 /area/crew_quarters/fitness)
 "epK" = (
-/obj/machinery/atmospherics/components/unary/cryo_cell,
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
 "epU" = (
@@ -11706,32 +11723,26 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "esE" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"esK" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
 "esY" = (
 /turf/open/openspace/icemoon,
 /area/engine/atmos)
 "ets" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
 /obj/machinery/camera{
 	c_tag = "Medbay Treatment Center";
 	dir = 8;
 	network = list("ss13","medbay")
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/machinery/computer/med_data{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
 "etz" = (
@@ -11786,11 +11797,9 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
 "eut" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/medical/psych)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/turf/open/floor/plasteel/freezer,
+/area/medical/surgery)
 "euz" = (
 /obj/structure/closet/wardrobe/mixed,
 /turf/open/floor/plating,
@@ -11887,10 +11896,20 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/obj/structure/closet/crate/bin,
-/obj/machinery/light{
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/structure/chair/comfy/black{
+	dir = 8
+	},
+/obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "exE" = (
@@ -12037,11 +12056,12 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
 "eDm" = (
-/obj/structure/chair/sofa/right{
-	dir = 4
+/obj/machinery/light{
+	dir = 1
 	},
-/turf/open/floor/carpet,
-/area/medical/psych)
+/obj/structure/table/optable,
+/turf/open/floor/plasteel/freezer,
+/area/medical/surgery)
 "eDr" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -12768,7 +12788,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
 "eSQ" = (
@@ -13246,11 +13265,12 @@
 /turf/open/floor/plating,
 /area/engine/atmos)
 "fgp" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/backpack/duffelbag/med/surgery,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
 	},
+/obj/structure/closet/secure_closet/medical2,
+/obj/item/tank/internals/anesthetic,
+/obj/item/tank/internals/anesthetic,
 /turf/open/floor/plasteel/freezer,
 /area/medical/surgery)
 "fgM" = (
@@ -13407,9 +13427,6 @@
 /turf/closed/wall/r_wall,
 /area/engine/engineering)
 "fkF" = (
-/obj/machinery/door/airlock/medical{
-	name = "Psychologist Lobby"
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -13419,6 +13436,10 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8;
 	name = "west facing firelock"
+	},
+/obj/machinery/door/airlock/medical{
+	name = "Medbay Break Room";
+	req_access_txt = "5"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -13676,27 +13697,21 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "fqM" = (
-/obj/structure/table,
 /obj/machinery/newscaster{
 	pixel_x = -30
 	},
-/obj/item/storage/box/donkpockets{
-	pixel_x = 3;
-	pixel_y = 5
-	},
-/obj/item/reagent_containers/spray/cleaner,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 6
+	},
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -14
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -13854,12 +13869,26 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "fva" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/structure/table,
+/obj/item/storage/box/donkpockets{
+	pixel_x = -6;
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/spray/cleaner,
+/obj/machinery/camera{
+	c_tag = "Medbay Break Room";
+	network = list("ss13","medbay")
+	},
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/item/kirbyplants{
-	icon_state = "plant-04"
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
 	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "fve" = (
@@ -14073,9 +14102,11 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/dorms)
 "fDi" = (
-/obj/machinery/light/small,
-/turf/open/floor/plating/asteroid/snow/icemoon,
-/area/medical/psych)
+/obj/machinery/computer/operating{
+	dir = 8
+	},
+/turf/open/floor/plasteel/freezer,
+/area/medical/surgery)
 "fDl" = (
 /obj/structure/bodycontainer/morgue{
 	dir = 8
@@ -14156,13 +14187,12 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "fGi" = (
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp/green{
-	pixel_x = 1;
-	pixel_y = 5
+/obj/effect/landmark/start/medical_doctor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
-/turf/open/floor/carpet,
-/area/medical/psych)
+/turf/open/floor/plasteel/freezer,
+/area/medical/surgery)
 "fGl" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
@@ -14651,8 +14681,9 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "fRS" = (
+/obj/machinery/smartfridge/organ/preloaded,
 /turf/closed/wall,
-/area/medical/psych)
+/area/medical/surgery)
 "fSs" = (
 /obj/structure/bookcase/random/fiction,
 /turf/open/floor/wood,
@@ -14711,11 +14742,11 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
 "fUX" = (
-/obj/structure/cable{
-	icon_state = "2-8"
+/obj/machinery/vending/medical{
+	pixel_x = -2
 	},
-/turf/open/floor/wood,
-/area/medical/psych)
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "fVm" = (
 /turf/open/floor/wood{
 	icon_state = "wood-broken5"
@@ -14745,14 +14776,25 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/zone3)
 "fWo" = (
-/obj/machinery/door/airlock/medical{
-	name = "Patient Room"
-	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
+/obj/machinery/door/airlock/medical{
+	id_tag = "psy1";
+	name = "Psychology Office";
+	req_access_txt = "71"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/wood,
+/area/medical/psych)
 "fWB" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -14799,9 +14841,8 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "fXH" = (
-/obj/structure/closet/secure_closet/medical1{
-	anchored = 1;
-	pixel_x = -3
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
@@ -15272,9 +15313,11 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "gkx" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/airalarm{
+	pixel_y = 23
+	},
 /turf/open/floor/plasteel/white,
-/area/medical/virology)
+/area/medical/medbay/central)
 "gky" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -15599,11 +15642,9 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "gtO" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
+/obj/structure/bookcase/random,
+/turf/open/floor/wood,
+/area/medical/psych)
 "gtR" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/engine_waste{
 	dir = 8
@@ -15692,7 +15733,6 @@
 	icon_state = "1-2"
 	},
 /obj/structure/bed/roller,
-/obj/machinery/iv_drip,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "gvA" = (
@@ -17150,8 +17190,10 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -17996,7 +18038,9 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hop)
 "hIe" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
 /turf/open/floor/plasteel/freezer,
 /area/medical/surgery)
 "hIl" = (
@@ -18096,16 +18140,6 @@
 "hKt" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -18341,13 +18375,26 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "hQb" = (
-/obj/structure/table,
-/obj/item/soap/nanotrasen,
-/obj/item/clothing/mask/muzzle,
-/obj/item/clothing/suit/straight_jacket,
-/obj/machinery/vending/wallmed{
-	pixel_x = -28
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
 	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/chair/comfy/black{
+	dir = 4
+	},
+/obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "hQl" = (
@@ -18563,19 +18610,14 @@
 /turf/open/floor/wood,
 /area/hallway/primary/fore)
 "hVm" = (
-/obj/machinery/vending/wardrobe/viro_wardrobe,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
+/obj/machinery/light/small{
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/green{
 	dir = 8
-	},
-/obj/machinery/camera{
-	c_tag = "Virology Break Room";
-	network = list("ss13","medbay")
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -18650,11 +18692,16 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "hWn" = (
-/obj/machinery/sleeper,
 /obj/structure/mirror{
 	pixel_y = 28
 	},
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/machinery/shower{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "hWQ" = (
 /obj/structure/chair/sofa/corp/left{
@@ -19693,21 +19740,11 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
 "iyW" = (
-/obj/item/radio/intercom{
-	frequency = 1485;
-	name = "Station Intercom (Medbay)";
-	pixel_x = -30
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
 	},
-/obj/machinery/camera{
-	c_tag = "Medbay Patient Room";
-	dir = 4;
-	network = list("ss13","medbay")
-	},
-/obj/structure/bed,
-/obj/item/bedsheet/medical,
-/obj/machinery/iv_drip,
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
+/turf/open/floor/wood,
+/area/medical/psych)
 "iza" = (
 /obj/structure/chair{
 	dir = 1
@@ -20032,13 +20069,14 @@
 /area/security/prison)
 "iGg" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
-	dir = 8
-	},
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = 24
 	},
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
 "iGB" = (
@@ -20136,12 +20174,8 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "iIg" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -20446,12 +20480,11 @@
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/quartermaster/storage)
 "iRy" = (
-/obj/structure/chair/comfy/brown,
 /obj/machinery/firealarm{
 	pixel_y = 29
 	},
-/turf/open/floor/carpet,
-/area/medical/psych)
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "iRE" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -20664,7 +20697,7 @@
 	},
 /area/security/execution/education)
 "iZH" = (
-/turf/closed/wall/r_wall,
+/turf/closed/wall,
 /area/medical/psych)
 "iZZ" = (
 /obj/structure/cable{
@@ -20956,18 +20989,11 @@
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "jiV" = (
-/obj/structure/table,
-/obj/item/storage/firstaid/brute,
-/obj/item/storage/firstaid/brute{
-	pixel_x = 3;
-	pixel_y = 3
+/obj/machinery/light/small{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/plasteel/white,
-/area/medical/storage)
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/medical/psych)
 "jiY" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -21081,7 +21107,13 @@
 /area/maintenance/disposal)
 "jmd" = (
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/white,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
 "jmf" = (
 /obj/structure/cable{
@@ -21142,6 +21174,9 @@
 	},
 /obj/structure/chair{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/surgery)
@@ -21362,15 +21397,15 @@
 /area/hallway/primary/port)
 "jxr" = (
 /obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "jxw" = (
@@ -21673,13 +21708,16 @@
 /turf/open/floor/plating,
 /area/maintenance/aft/secondary)
 "jDK" = (
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp/green{
+	pixel_x = 1;
+	pixel_y = 5
+	},
+/obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "0-4"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/wood,
+/turf/open/floor/carpet,
 /area/medical/psych)
 "jEb" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -22599,13 +22637,12 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "kgx" = (
-/obj/structure/table,
-/obj/machinery/reagentgrinder{
-	desc = "Used to grind things up into raw materials and liquids.";
-	pixel_y = 5
+/obj/structure/chair/comfy/brown,
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
+/turf/open/floor/carpet,
+/area/medical/psych)
 "kgM" = (
 /obj/machinery/telecomms/server/presets/engineering,
 /turf/open/floor/plasteel/dark/telecomms,
@@ -22775,8 +22812,12 @@
 /turf/open/floor/plating,
 /area/security/courtroom)
 "kmj" = (
-/obj/structure/reagent_dispensers/water_cooler,
-/turf/open/floor/wood,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "psyshu";
+	name = "psy shutters"
+	},
+/turf/open/floor/plating,
 /area/medical/psych)
 "kms" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -23137,11 +23178,18 @@
 /area/medical/storage)
 "kuy" = (
 /obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "kuU" = (
@@ -23421,12 +23469,10 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
 /obj/structure/chair{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
 /area/medical/surgery)
 "kHd" = (
@@ -23473,12 +23519,10 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "kHX" = (
-/obj/machinery/holopad,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/chair/sofa/left{
+	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/wood,
+/turf/open/floor/carpet,
 /area/medical/psych)
 "kIp" = (
 /obj/structure/cable{
@@ -23513,6 +23557,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -23592,9 +23639,6 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
 "kMc" = (
-/obj/machinery/airalarm{
-	pixel_y = 23
-	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
 	},
@@ -23880,19 +23924,12 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "kUo" = (
-/obj/machinery/door/airlock/virology{
-	name = "Break Room";
-	req_access_txt = "39"
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	name = "east facing firelock"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
+/obj/effect/landmark/start/psychologist,
+/turf/open/floor/carpet,
+/area/medical/psych)
 "kUy" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -23991,7 +24028,9 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "kYE" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
 /turf/open/floor/plasteel/freezer,
 /area/medical/surgery)
 "kYF" = (
@@ -24068,11 +24107,18 @@
 /turf/open/floor/plasteel/dark,
 /area/teleporter)
 "laE" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
+/obj/machinery/door/airlock/virology{
+	name = "Break Room";
+	req_access_txt = "39"
 	},
-/turf/open/floor/plating,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4;
+	name = "east facing firelock"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/virology)
 "laL" = (
 /obj/structure/window/reinforced{
@@ -24630,14 +24676,19 @@
 /turf/open/floor/plasteel,
 /area/storage/atmos)
 "lqR" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/light,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "lqW" = (
@@ -24677,17 +24728,10 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/camera{
-	c_tag = "Medbay Break Room";
-	network = list("ss13","medbay")
-	},
+/obj/structure/closet/secure_closet,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "ltk" = (
@@ -24954,15 +24998,8 @@
 	},
 /area/engine/break_room)
 "lAS" = (
-/obj/item/storage/secure/safe{
-	pixel_x = 5;
-	pixel_y = 29
-	},
-/obj/effect/turf_decal/tile/green{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -25028,11 +25065,12 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
 "lCW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
+/turf/open/floor/plasteel/dark,
+/area/medical/medbay/central)
 "lDi" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -25233,20 +25271,16 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "lIm" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
 "lIn" = (
-/obj/machinery/computer/operating{
-	dir = 8
+/obj/structure/table/reinforced,
+/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel/freezer,
 /area/medical/surgery)
@@ -25384,15 +25418,10 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
 "lOX" = (
-/obj/structure/chair/office/dark,
-/obj/effect/landmark/start/psychologist,
-/obj/structure/cable{
-	icon_state = "1-4"
+/obj/structure/chair/sofa/right{
+	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/wood,
+/turf/open/floor/carpet,
 /area/medical/psych)
 "lPB" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
@@ -25632,45 +25661,17 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/atmospherics_engine)
 "lYk" = (
-/obj/structure/table,
-/obj/item/storage/firstaid/regular{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/storage/firstaid/regular,
-/obj/item/storage/firstaid/regular{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/storage/firstaid/regular{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/machinery/power/apc/auto_name/south{
-	pixel_y = -27
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel/white,
-/area/medical/storage)
-"lYq" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/door/airlock/medical{
-	id_tag = "psy1";
-	name = "Psychology Office";
-	req_access_txt = "71"
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor/border_only{
-	name = "south facing firelock"
+/turf/open/floor/plasteel/white,
+/area/medical/storage)
+"lYq" = (
+/obj/machinery/holopad,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/open/floor/wood,
+/turf/open/floor/carpet,
 /area/medical/psych)
 "lYJ" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -26433,6 +26434,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "mwW" = (
@@ -26525,11 +26529,20 @@
 /turf/open/floor/plasteel/white,
 /area/security/prison)
 "mAk" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
+/obj/machinery/computer/arcade/tetris,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
 	},
-/obj/structure/disposalpipe/trunk,
-/obj/machinery/disposal/bin,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "mAn" = (
@@ -26826,9 +26839,16 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "mIS" = (
-/obj/structure/closet/wardrobe/pjs,
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/table/wood,
+/obj/machinery/computer/med_data/laptop{
+	dir = 1;
+	pixel_y = 4
+	},
+/turf/open/floor/wood,
+/area/medical/psych)
 "mJd" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -26929,14 +26949,14 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "mLB" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
+	dir = 4
 	},
 /obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
+	icon_state = "2-4"
 	},
 /turf/open/floor/wood,
 /area/medical/psych)
@@ -27042,10 +27062,10 @@
 /turf/open/floor/plasteel,
 /area/janitor)
 "mNP" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
-/turf/open/floor/plating/asteroid/snow/icemoon,
+/turf/open/floor/wood,
 /area/medical/psych)
 "mNS" = (
 /obj/machinery/door/airlock/security/glass{
@@ -27342,7 +27362,6 @@
 	dir = 9
 	},
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
 "mWc" = (
@@ -28142,25 +28161,23 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/pool)
 "ntd" = (
-/obj/machinery/door/airlock/medical{
-	name = "Medbay Break Room";
-	req_access_txt = "5"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/closed/wall,
 /area/medical/medbay/central)
 "ntO" = (
-/obj/machinery/limbgrower,
-/turf/open/floor/plasteel/freezer,
-/area/medical/surgery)
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/medical/psych)
 "ntV" = (
 /obj/machinery/camera{
 	c_tag = "AI Chamber - Port";
@@ -28581,17 +28598,8 @@
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors)
 "nDC" = (
-/obj/structure/table/glass,
-/obj/item/reagent_containers/glass/beaker/cryoxadone{
-	pixel_x = 10
-	},
-/obj/item/reagent_containers/glass/beaker/cryoxadone{
-	pixel_x = 10
-	},
-/obj/item/wrench/medical,
-/obj/machinery/camera{
-	c_tag = "Medbay Cryogenics";
-	network = list("ss13","medbay")
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
@@ -28852,6 +28860,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "nKU" = (
@@ -28919,9 +28933,7 @@
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "nOj" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
+/obj/machinery/limbgrower,
 /turf/open/floor/plasteel/freezer,
 /area/medical/surgery)
 "nOk" = (
@@ -29377,9 +29389,15 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "oaC" = (
-/obj/machinery/computer/med_data,
-/turf/open/floor/plasteel/dark,
-/area/medical/medbay/central)
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/medical/psych)
 "oaF" = (
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/white/corner{
@@ -29577,11 +29595,11 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -29641,9 +29659,12 @@
 /turf/open/floor/plasteel/dark,
 /area/teleporter)
 "ohi" = (
-/obj/effect/landmark/start/medical_doctor,
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
+/obj/structure/bookcase/random,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/medical/psych)
 "ohk" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -29781,9 +29802,25 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/junction/flip{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "ojs" = (
@@ -29849,11 +29886,8 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "okY" = (
-/obj/structure/bed,
-/obj/item/bedsheet/medical,
-/obj/machinery/iv_drip,
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
+/turf/open/floor/wood,
+/area/medical/psych)
 "old" = (
 /obj/item/kirbyplants{
 	icon_state = "applebush"
@@ -30694,9 +30728,6 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "oKr" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /turf/open/floor/plasteel/freezer,
 /area/medical/surgery)
 "oKD" = (
@@ -31225,10 +31256,10 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "pbk" = (
+/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
 	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "pbs" = (
@@ -31241,15 +31272,15 @@
 /turf/open/floor/plasteel/dark,
 /area/blueshield)
 "pbw" = (
-/obj/structure/closet/secure_closet/psychologist,
-/obj/machinery/light{
-	dir = 8
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "psyshu";
+	name = "psy shutters"
 	},
-/obj/machinery/power/apc/auto_name/north,
-/obj/structure/cable{
-	icon_state = "0-4"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
-/turf/open/floor/wood,
+/turf/open/floor/plating,
 /area/medical/psych)
 "pbP" = (
 /obj/structure/table,
@@ -31482,8 +31513,10 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/pool)
 "pfN" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/structure/table,
+/obj/machinery/reagentgrinder{
+	desc = "Used to grind things up into raw materials and liquids.";
+	pixel_y = 5
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -31798,12 +31831,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "poT" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
-/obj/structure/closet/secure_closet/medical2,
-/obj/item/tank/internals/anesthetic,
-/obj/item/tank/internals/anesthetic,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/freezer,
 /area/medical/surgery)
 "poU" = (
@@ -32068,21 +32096,12 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
 "puS" = (
-/obj/structure/bed,
-/obj/item/bedsheet/medical,
-/obj/machinery/requests_console{
-	department = "Virology";
-	name = "Virology Requests Console";
-	pixel_x = 32
-	},
-/obj/machinery/light_switch{
-	pixel_y = 26
-	},
-/obj/effect/turf_decal/tile/green{
+/obj/machinery/light/small{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -32220,8 +32239,10 @@
 "pxE" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
 "pxS" = (
 /obj/structure/cable{
@@ -32257,8 +32278,19 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "pxZ" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "pyw" = (
@@ -32528,10 +32560,9 @@
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "pED" = (
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
-/obj/structure/table/optable,
 /turf/open/floor/plasteel/freezer,
 /area/medical/surgery)
 "pEF" = (
@@ -32600,17 +32631,20 @@
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "pFM" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
 	},
-/turf/open/floor/wood,
-/area/medical/psych)
+/obj/effect/turf_decal/tile/blue,
+/obj/structure/chair/comfy/black,
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "pFR" = (
 /turf/closed/wall,
 /area/hallway/primary/fore)
@@ -32958,16 +32992,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -33904,26 +33928,15 @@
 /turf/open/floor/plasteel/dark,
 /area/teleporter)
 "qrA" = (
-/obj/structure/chair/comfy/black{
-	dir = 4
-	},
 /obj/machinery/airalarm{
 	dir = 4;
 	pixel_x = -22
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 30
+/obj/machinery/shower{
+	pixel_y = 20
 	},
-/obj/effect/landmark/start/medical_doctor,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -33979,14 +33992,12 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "qsz" = (
-/obj/machinery/camera{
-	c_tag = "Surgery A";
-	network = list("ss13","medbay");
-	pixel_x = 22
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -24
 	},
-/obj/machinery/computer/operating{
-	dir = 4
-	},
+/obj/structure/table/reinforced,
+/obj/item/storage/backpack/duffelbag/med/surgery,
 /turf/open/floor/plasteel/freezer,
 /area/medical/surgery)
 "qsD" = (
@@ -34555,16 +34566,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/structure/bed,
+/obj/item/bedsheet/medical,
+/obj/machinery/iv_drip,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "qJU" = (
@@ -34708,11 +34712,18 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "qOA" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/turf/closed/wall,
-/area/medical/psych)
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "qOJ" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -35498,10 +35509,8 @@
 /area/tcommsat/computer)
 "rkL" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/medical/medbay/central)
 "rkP" = (
 /obj/structure/window/reinforced{
@@ -35878,7 +35887,8 @@
 "rsy" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
-/turf/closed/wall,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/medical/medbay/central)
 "rsD" = (
 /obj/structure/table/wood,
@@ -36011,9 +36021,35 @@
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
 "rwW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/closed/wall,
-/area/medical/medbay/central)
+/obj/machinery/button/door{
+	id = "psyshu";
+	name = "Shutter button";
+	pixel_x = -25;
+	pixel_y = 6;
+	req_access_txt = "71"
+	},
+/obj/machinery/button/door{
+	id = "psy1";
+	name = "Bolt Control";
+	normaldoorcontrol = 1;
+	pixel_x = -25;
+	pixel_y = -6;
+	req_access_txt = "71";
+	specialfunctions = 4
+	},
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8;
+	pixel_x = 4
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/medical/psych)
 "rxc" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -36235,8 +36271,15 @@
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
 "rFk" = (
+/obj/machinery/door/airlock/medical{
+	name = "Operating Theatre";
+	req_access_txt = "45"
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/freezer,
+/obj/machinery/door/firedoor/border_only{
+	name = "south facing firelock"
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "rFB" = (
 /obj/effect/turf_decal/tile/yellow,
@@ -36385,23 +36428,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "rJl" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/structure/table/wood,
-/obj/machinery/button/door{
-	id = "psyshu";
-	name = "Shutter button";
-	pixel_x = -25;
-	pixel_y = 6;
-	req_access_txt = "71"
-	},
-/obj/machinery/button/door{
-	id = "psy1";
-	name = "Bolt Control";
-	normaldoorcontrol = 1;
-	pixel_x = -25;
-	pixel_y = -6;
-	req_access_txt = "71";
-	specialfunctions = 4
-	},
 /turf/open/floor/wood,
 /area/medical/psych)
 "rJw" = (
@@ -36651,6 +36681,19 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "rRk" = (
@@ -36682,9 +36725,6 @@
 /area/medical/storage)
 "rSn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/chair{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
@@ -38382,11 +38422,16 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "sSs" = (
-/obj/machinery/shower{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 9
 	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/structure/reagent_dispensers/water_cooler,
+/turf/open/floor/wood,
+/area/medical/psych)
 "sSy" = (
 /obj/effect/turf_decal/stripes,
 /turf/open/floor/plasteel,
@@ -38422,16 +38467,15 @@
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "sTe" = (
-/obj/machinery/door/airlock/medical{
-	name = "Operating Theatre";
-	req_access_txt = "45"
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/door/firedoor/border_only{
-	name = "south facing firelock"
-	},
 /turf/open/floor/plasteel/white,
-/area/medical/surgery)
+/area/medical/medbay/central)
 "sTq" = (
 /turf/open/openspace/icemoon,
 /area/engine/atmospherics_engine)
@@ -38516,14 +38560,9 @@
 /turf/open/floor/plasteel,
 /area/engine/atmospherics_engine)
 "sVL" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
+/obj/structure/table,
+/obj/machinery/microwave{
+	pixel_y = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -38600,7 +38639,7 @@
 /area/crew_quarters/heads/cmo)
 "sXV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
+	dir = 4
 	},
 /turf/closed/wall/r_wall,
 /area/medical/virology)
@@ -38868,14 +38907,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"tfm" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/sleeper,
-/obj/structure/mirror{
-	pixel_y = 28
-	},
-/turf/open/floor/plasteel/dark,
-/area/medical/medbay/central)
 "tfq" = (
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=2";
@@ -39135,13 +39166,10 @@
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "tmy" = (
-/obj/machinery/shower{
+/obj/machinery/sleeper{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/end{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
 "tmI" = (
 /obj/structure/cable{
@@ -39386,18 +39414,18 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "tsq" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
 /obj/structure/table,
-/obj/structure/bedsheetbin{
-	pixel_x = 2
-	},
-/obj/machinery/camera{
-	c_tag = "Medbay Psychologist Lobby";
-	dir = 1;
-	network = list("ss13","medbay")
-	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "tsK" = (
@@ -40056,6 +40084,14 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/structure/table/glass,
+/obj/item/wrench/medical,
+/obj/item/reagent_containers/glass/beaker/cryoxadone{
+	pixel_x = 10
+	},
+/obj/item/reagent_containers/glass/beaker/cryoxadone{
+	pixel_x = 10
+	},
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
 "tML" = (
@@ -40099,13 +40135,21 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "tOs" = (
-/obj/structure/closet/crate/freezer/surplus_limbs,
-/obj/item/reagent_containers/glass/beaker/synthflesh,
-/obj/machinery/light_switch{
-	pixel_y = -23
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_y = -28
 	},
-/turf/open/floor/plasteel/freezer,
-/area/medical/surgery)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/filingcabinet,
+/obj/machinery/camera{
+	c_tag = "Psychologist's Office";
+	dir = 1;
+	network = list("ss13","medbay")
+	},
+/turf/open/floor/wood,
+/area/medical/psych)
 "tOz" = (
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/pool)
@@ -40317,19 +40361,8 @@
 /turf/open/floor/plating,
 /area/security/detectives_office)
 "tUi" = (
-/obj/machinery/computer/arcade/orion_trail{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/structure/table,
+/obj/structure/bedsheetbin/color,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "tUF" = (
@@ -40511,18 +40544,11 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "uan" = (
-/obj/structure/table/wood,
-/obj/machinery/computer/med_data/laptop{
-	dir = 1;
-	pixel_y = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
-/obj/machinery/camera{
-	c_tag = "Psychologist Office";
-	dir = 1;
-	network = list("ss13","medbay")
-	},
-/turf/open/floor/wood,
-/area/medical/psych)
+/turf/open/floor/plasteel/dark,
+/area/medical/medbay/central)
 "uap" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -40585,23 +40611,12 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
 "uba" = (
-/obj/structure/table,
-/obj/machinery/microwave{
-	pixel_y = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/structure/bed,
+/obj/item/bedsheet/medical,
+/obj/machinery/iv_drip,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "ubd" = (
@@ -40886,14 +40901,11 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "ujD" = (
-/obj/machinery/airalarm{
-	pixel_y = 32
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/port)
+/turf/open/floor/plasteel/dark,
+/area/medical/medbay/central)
 "ujE" = (
 /obj/machinery/light{
 	dir = 4
@@ -41212,11 +41224,10 @@
 /turf/open/floor/plating,
 /area/storage/atmos)
 "utS" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
+/obj/machinery/light/small{
+	dir = 1
 	},
-/turf/open/floor/wood,
+/turf/open/floor/plating/asteroid/snow/icemoon,
 /area/medical/psych)
 "uup" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -41402,12 +41413,11 @@
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "uAe" = (
-/obj/machinery/vending/wallmed{
-	pixel_y = -28
+/obj/machinery/atmospherics/components/unary/cryo_cell{
+	dir = 4
 	},
-/obj/structure/closet/crate/freezer/blood,
-/turf/open/floor/plasteel/freezer,
-/area/medical/surgery)
+/turf/open/floor/plasteel/dark,
+/area/medical/medbay/central)
 "uAj" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -42024,13 +42034,11 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "uUC" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 8
 	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/wood,
-/area/medical/psych)
+/turf/open/floor/plasteel/dark,
+/area/medical/medbay/central)
 "uUJ" = (
 /obj/structure/bed,
 /obj/item/bedsheet/syndie,
@@ -43088,16 +43096,15 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/structure/table,
+/obj/item/folder/white,
+/obj/item/clothing/neck/stethoscope,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "vuO" = (
@@ -43113,7 +43120,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
 "vvM" = (
@@ -43796,8 +43803,11 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "vMf" = (
-/turf/open/floor/carpet,
-/area/medical/psych)
+/obj/machinery/atmospherics/components/unary/cryo_cell{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/medical/medbay/central)
 "vMg" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -43967,9 +43977,18 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
 "vRa" = (
-/obj/structure/bookcase/random,
-/turf/open/floor/wood,
-/area/medical/psych)
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/structure/table,
+/obj/item/storage/firstaid/brute{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/firstaid/brute,
+/turf/open/floor/plasteel/white,
+/area/medical/storage)
 "vRc" = (
 /obj/structure/bookcase{
 	name = "Forbidden Knowledge"
@@ -44214,9 +44233,16 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "vWt" = (
-/obj/structure/chair/stool,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
+/obj/structure/table,
+/obj/item/stack/sheet/mineral/plasma,
+/obj/item/stack/sheet/mineral/plasma,
+/obj/item/storage/box/donkpockets{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -22
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -44393,7 +44419,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
@@ -44410,8 +44435,26 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
 "wbg" = (
-/turf/open/floor/wood,
-/area/medical/psych)
+/obj/machinery/power/apc/auto_name/south{
+	pixel_y = -27
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/structure/table,
+/obj/item/storage/firstaid/regular{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/storage/firstaid/regular,
+/obj/item/storage/firstaid/regular{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel/white,
+/area/medical/storage)
 "wbE" = (
 /turf/open/floor/carpet,
 /area/hallway/secondary/exit/departure_lounge)
@@ -44574,11 +44617,11 @@
 /turf/open/floor/plating,
 /area/hallway/primary/aft)
 "wfK" = (
-/obj/structure/table,
-/obj/item/clothing/neck/stethoscope,
-/obj/item/folder/white,
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
+/obj/item/kirbyplants{
+	icon_state = "plant-08"
+	},
+/turf/open/floor/wood,
+/area/medical/psych)
 "wfN" = (
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
@@ -45047,18 +45090,21 @@
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
 "wut" = (
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
 	},
-/obj/item/kirbyplants{
-	icon_state = "plant-08"
+/obj/effect/turf_decal/tile/blue,
+/obj/structure/table,
+/obj/item/storage/firstaid/fire{
+	pixel_x = 3;
+	pixel_y = 3
 	},
-/obj/machinery/light{
+/obj/item/storage/firstaid/fire,
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/turf/open/floor/wood,
-/area/medical/psych)
+/turf/open/floor/plasteel/white,
+/area/medical/storage)
 "wuC" = (
 /obj/structure/cable,
 /obj/machinery/power/solar{
@@ -45415,17 +45461,8 @@
 /turf/open/floor/plating,
 /area/engine/storage)
 "wFR" = (
-/obj/structure/table,
-/obj/item/storage/firstaid/fire,
-/obj/item/storage/firstaid/fire{
-	pixel_x = 3;
-	pixel_y = 3
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/white,
@@ -45567,7 +45604,9 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
 "wKC" = (
-/obj/machinery/atmospherics/pipe/manifold4w/general/visible,
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
 "wKL" = (
@@ -45575,18 +45614,10 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "wKN" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
+/obj/machinery/vending/wallmed{
+	pixel_y = -28
 	},
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -22
-	},
+/obj/structure/closet/crate/freezer/blood,
 /turf/open/floor/plasteel/freezer,
 /area/medical/surgery)
 "wKU" = (
@@ -46242,6 +46273,11 @@
 /turf/open/floor/plating,
 /area/engine/atmospherics_engine)
 "xgq" = (
+/obj/structure/closet/crate/freezer/surplus_limbs,
+/obj/item/reagent_containers/glass/beaker/synthflesh,
+/obj/machinery/light_switch{
+	pixel_y = -23
+	},
 /turf/open/floor/plasteel/freezer,
 /area/medical/surgery)
 "xgu" = (
@@ -46402,11 +46438,14 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "xlg" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
-/area/medical/medbay/central)
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
 "xlm" = (
 /obj/machinery/vending/wardrobe/atmos_wardrobe,
 /turf/open/floor/plasteel,
@@ -46822,17 +46861,24 @@
 /area/hallway/primary/aft)
 "xAa" = (
 /obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
 /obj/structure/disposalpipe/segment{
-	dir = 5
+	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "xAi" = (
@@ -47036,15 +47082,11 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "xFy" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/structure/bed,
-/obj/item/bedsheet/medical,
-/obj/machinery/iv_drip,
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
+/turf/open/floor/wood,
+/area/medical/psych)
 "xFQ" = (
 /obj/machinery/doorButtons/airlock_controller{
 	idExterior = "virology_airlock_exterior";
@@ -47174,25 +47216,23 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "xHU" = (
-/obj/machinery/smartfridge/organ/preloaded,
-/turf/closed/wall,
-/area/medical/surgery)
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "xIJ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -47200,29 +47240,19 @@
 /turf/open/floor/circuit/off,
 /area/ai_monitored/turret_protected/ai)
 "xIT" = (
-/obj/structure/chair/comfy/black{
-	dir = 4
-	},
 /obj/item/radio/intercom{
 	frequency = 1485;
 	name = "Station Intercom (Medbay)";
 	pixel_x = -30
 	},
-/obj/effect/landmark/start/medical_doctor,
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/table,
+/obj/item/soap,
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/clothing/mask/muzzle,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "xJn" = (
@@ -47282,19 +47312,11 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "xKu" = (
-/obj/structure/table,
-/obj/item/stack/sheet/mineral/plasma,
-/obj/item/stack/sheet/mineral/plasma,
-/obj/item/storage/box/donkpockets{
-	pixel_x = 3;
-	pixel_y = 3
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
 	},
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
 "xKv" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/effect/turf_decal/tile/neutral{
@@ -47484,11 +47506,14 @@
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
 "xQH" = (
-/obj/structure/chair/sofa/left{
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/carpet,
-/area/medical/psych)
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
 "xRq" = (
 /turf/closed/wall/r_wall,
 /area/blueshield)
@@ -47702,13 +47727,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/quartermaster/sorting)
-"xYN" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/medical/surgery)
 "xZg" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -47743,12 +47761,12 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
 "xZX" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/bed/roller,
+/obj/machinery/iv_drip,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "yae" = (
@@ -47802,15 +47820,10 @@
 /turf/open/floor/pod/dark,
 /area/maintenance/starboard)
 "ycQ" = (
-/obj/machinery/vending/medical{
-	pixel_x = -2
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "ydl" = (
@@ -57983,7 +57996,7 @@ ydp
 ydp
 ydp
 ydp
-avT
+ydp
 avT
 bBh
 apJ
@@ -58497,7 +58510,7 @@ ydp
 ydp
 ydp
 ydp
-ydp
+avT
 avT
 bBh
 apJ
@@ -58753,8 +58766,8 @@ ydp
 ydp
 ydp
 ydp
-ydp
-ydp
+avT
+avT
 avT
 bBh
 apJ
@@ -59009,9 +59022,9 @@ ydp
 ydp
 ydp
 ydp
-ydp
-ydp
-ydp
+avT
+avT
+avT
 avT
 bBh
 apJ
@@ -59262,13 +59275,13 @@ ydp
 ydp
 ydp
 ydp
-cUC
-cUC
-cUC
-cUC
-cUC
 ydp
 ydp
+ydp
+avT
+avT
+avT
+avT
 avT
 bBh
 apJ
@@ -59519,13 +59532,13 @@ ydp
 ydp
 ydp
 ydp
-cUC
-kRI
-fdJ
-hGU
-cUC
 ydp
-ydp
+avT
+avT
+avT
+avT
+avT
+avT
 avT
 bBh
 apJ
@@ -59776,13 +59789,13 @@ ydp
 ydp
 ydp
 ydp
-cUC
-vSJ
-kZL
-kZL
-maR
 ydp
-ydp
+avT
+avT
+avT
+avT
+avT
+avT
 avT
 bBh
 apJ
@@ -60033,14 +60046,14 @@ ydp
 ydp
 ydp
 ydp
-cUC
-ehh
-kZL
-hap
-cUC
-ydp
-ydp
-ydp
+avT
+avT
+avT
+avT
+avT
+avT
+avT
+avT
 bBh
 avT
 apJ
@@ -60290,14 +60303,14 @@ ydp
 ydp
 ydp
 ydp
-cUC
-cUC
-cUC
-cUC
-cUC
-ydp
-ydp
-ydp
+avT
+avT
+avT
+avT
+avT
+avT
+avT
+avT
 bBh
 avT
 avT
@@ -60546,14 +60559,14 @@ ydp
 ydp
 ydp
 ydp
-ydp
-ydp
-ydp
-ydp
-ydp
-ydp
-ydp
-ydp
+avT
+avT
+avT
+avT
+avT
+avT
+avT
+avT
 avT
 bBh
 avT
@@ -60801,16 +60814,16 @@ ydp
 ydp
 ydp
 ydp
+ydp
+ydp
 avT
 avT
-ydp
-ydp
-ydp
-ydp
-ydp
-ydp
-ydp
-ydp
+jiV
+avT
+avT
+avT
+jiV
+avT
 avT
 bBh
 avT
@@ -61056,19 +61069,19 @@ ydp
 ydp
 ydp
 ydp
-avT
-avT
-avT
-avT
-ydp
-ydp
-ydp
-ydp
 ydp
 ydp
 ydp
 ydp
 avT
+iZH
+iZH
+kmj
+kmj
+kmj
+iZH
+iZH
+utS
 bBh
 avT
 avT
@@ -61311,20 +61324,20 @@ ydp
 ydp
 ydp
 ydp
-avT
-avT
-avT
-avT
-avT
-avT
-avT
 ydp
 ydp
 ydp
 ydp
 ydp
 ydp
-ydp
+avT
+iZH
+jDK
+kHX
+lOX
+okY
+rwW
+kmj
 avT
 bBh
 fDo
@@ -61568,20 +61581,20 @@ ydp
 ydp
 ydp
 ydp
+ydp
+ydp
+ydp
+ydp
+ydp
+ydp
 avT
-avT
+iZH
+kgx
+kUo
+lYq
 mNP
-avT
-avT
-avT
-mNP
-ash
-ash
-ash
-ash
-ash
-ash
-ash
+rJl
+kmj
 avT
 bBh
 wSc
@@ -61824,21 +61837,21 @@ ydp
 ydp
 ydp
 ydp
+ydp
+ydp
+ydp
+ydp
+ydp
+ydp
+ydp
 avT
-avT
-fRS
-fRS
-adu
-adu
-adu
-fRS
-ash
+iZH
 wfK
 okY
 iyW
 xFy
 mIS
-ash
+kmj
 avT
 rUq
 tGQ
@@ -62080,23 +62093,23 @@ ydp
 ydp
 ydp
 ydp
+ydp
+ydp
+ydp
+ydp
+ydp
+ydp
+ydp
+ydp
 avT
-avT
-fDi
-fRS
-pbw
-utS
-kmj
-wbg
-rJl
-ash
+iZH
 gtO
-anm
+gtO
 ohi
-anm
-xAi
-ash
-avT
+ntO
+tOs
+iZH
+utS
 avT
 fDo
 iOd
@@ -62336,21 +62349,21 @@ ydp
 ydp
 ydp
 ydp
+ydp
+avT
+ydp
+ydp
+ydp
+ydp
+ydp
+ydp
 avT
 avT
-avT
-avT
-adu
-fUX
-jDK
-kHX
-lOX
-uan
-ash
+iZH
 bSb
-esK
-esK
-esK
+okY
+mLB
+oaC
 sSs
 sXJ
 sXJ
@@ -62592,23 +62605,23 @@ ydp
 ydp
 ydp
 ydp
+ydp
 avT
 avT
 avT
+ydp
+ydp
+ydp
+ydp
 avT
 avT
-adu
-vRa
-vRa
-vRa
-pFM
-cGu
-ash
-ash
-aoj
+avT
+iZH
+iZH
+kmj
 fWo
-aoj
-ash
+pbw
+iZH
 sXJ
 tyI
 kmM
@@ -62848,19 +62861,19 @@ ydp
 ydp
 ydp
 ydp
+ydp
 avT
 avT
 avT
 avT
 avT
+ydp
+ydp
 avT
-adu
-fGi
-xQH
-eDm
-mLB
-uUC
-lYq
+avT
+avT
+avT
+ash
 adZ
 jxr
 xAa
@@ -63104,24 +63117,24 @@ ydp
 ydp
 ydp
 ydp
+ydp
+ydp
 avT
 avT
 avT
 avT
 avT
 avT
-fDi
-fRS
-iRy
-vMf
-abs
-eut
-wut
-adu
+avT
+avT
+avT
+avT
+avT
+ash
 fva
-pIE
+lqR
 rQU
-anm
+pFM
 tsq
 gIm
 vTh
@@ -63136,8 +63149,8 @@ tUi
 lmF
 tVS
 fpa
-jiV
-lmF
+fpa
+vRa
 ash
 aoj
 ash
@@ -63367,18 +63380,18 @@ avT
 avT
 avT
 avT
-avT
-iZH
-fRS
-fRS
-qOA
-fRS
-fRS
-fRS
+aaS
+oto
+oto
+oto
+oto
+oto
+ash
+ash
 mAk
 pxZ
 ojp
-anm
+qOA
 exq
 gIm
 pNO
@@ -63389,13 +63402,13 @@ sXJ
 hEQ
 vXs
 gZQ
-aoj
+ash
 lmF
 lSN
 rrD
 lYk
-lmF
-wje
+wbg
+tmO
 arI
 syN
 atr
@@ -63620,17 +63633,17 @@ ydp
 ydp
 ydp
 ydp
-ydp
 pZD
 mpj
 mpj
 mpj
-aaS
+pZD
+cGu
 qsz
 aPp
 wKN
-uAe
 oto
+fUX
 ash
 ash
 hEQ
@@ -63651,8 +63664,8 @@ lUd
 kqV
 jPh
 wFR
-lmF
-ujD
+wut
+tmO
 arH
 auV
 auV
@@ -63877,19 +63890,19 @@ ydp
 ydp
 ydp
 ydp
-ydp
 pZD
+abs
 hVm
 sVL
+pZD
 dfV
-aaS
-dML
+oKr
 oKr
 xgq
-tOs
 oto
+gkx
 kMc
-eLX
+anm
 nsi
 cEf
 eLX
@@ -63909,9 +63922,9 @@ olz
 wuj
 bwm
 lmF
-aqP
+tmO
 waP
-aDh
+xKu
 aDh
 lmu
 mNo
@@ -64133,19 +64146,19 @@ ydp
 ydp
 ydp
 ydp
-ydp
-ydp
+avT
 pZD
+adu
 efp
 vWt
-xKu
-aaS
+pZD
+eut
 hIe
 kYE
 nOj
-ntO
 oto
-adw
+iRy
+anm
 anm
 anJ
 lUb
@@ -64166,9 +64179,9 @@ lmF
 hIP
 nBx
 oUC
-tUF
+xlg
 jGF
-uBi
+xQH
 iKM
 bNb
 bNb
@@ -64390,19 +64403,19 @@ ydp
 ydp
 ydp
 ydp
-ydp
-ydp
+avT
 pZD
+adw
 lAS
 pfN
-kgx
-aaS
+pZD
+eDm
 pED
+fGi
 oKr
-abZ
-xgq
+fRS
 xHU
-ady
+anm
 anm
 anJ
 uXB
@@ -64424,8 +64437,8 @@ aol
 akB
 ecD
 esE
-oDm
-wje
+nDl
+lZs
 avU
 avX
 avX
@@ -64647,19 +64660,19 @@ ydp
 ydp
 ydp
 ydp
-ydp
-ydp
+avT
 pZD
+adx
 puS
 iIg
-lCW
-aaS
+pZD
+fDi
 lIn
 fgp
 poT
 rFk
 sTe
-adx
+jih
 jih
 wkM
 anm
@@ -64909,12 +64922,12 @@ pZD
 pZD
 sXV
 laE
-kUo
+pZD
 aaS
 aba
-xYN
 aba
 aba
+oto
 oto
 adz
 iIz
@@ -65165,8 +65178,8 @@ nnV
 cni
 qbY
 fYU
-uYa
 vST
+uYa
 aaS
 joT
 kGS
@@ -65422,7 +65435,7 @@ tAa
 xkR
 pfY
 wlD
-gkx
+xwO
 xwh
 aaS
 gWj
@@ -65435,9 +65448,9 @@ dJZ
 nwq
 hWn
 eSP
-anm
-anJ
-ash
+uan
+sMA
+uAe
 ykb
 tMt
 sMA
@@ -65689,14 +65702,14 @@ pZD
 pZD
 ady
 ofF
-ash
+lCW
 fXH
 eSP
-anm
-anJ
-aoj
-epK
-wzH
+uan
+sMA
+uUC
+sMA
+sMA
 sMA
 xGP
 anm
@@ -65946,14 +65959,14 @@ iFK
 fKM
 adA
 hom
-aoj
-oaC
+lIm
+sMA
 vvH
-anm
-lqR
-ash
+ujD
+sMA
+wKC
 nDC
-xlg
+wzH
 sMA
 xGP
 anm
@@ -66194,21 +66207,21 @@ tlu
 wAW
 xhb
 uCi
-uYa
+aqP
 xFQ
 pZD
 eEy
 gzW
 ueK
 pZD
-lIm
+ady
 ycQ
-rwW
-tfm
+ash
+tmy
 ets
 tmy
-anm
-aoj
+sMA
+vMf
 epK
 wKC
 wzH


### PR DESCRIPTION
## About The Pull Request

The cloning room on Meta had two air alarms, which it did not need, so I moved a smoking sign in genetics and gave genetics an air alarm by the door. It didn't have one before.

## Why It's Good For The Game

Genetics has an air alarm now.

## Changelog
:cl:
add: Genetics Air Alarm
del: Second Cloning Air Alarm
tweak: Move genetics smoking sign into monkey pen
/:cl:
