### PR TITLE
Metastation Air Alarm Changes

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation_Lumos.dmm
+++ b/_maps/map_files/MetaStation/MetaStation_Lumos.dmm
@@ -62113,12 +62113,13 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "cxy" = (
-/obj/structure/sign/warning/nosmoking{
-	pixel_x = 28
-	},
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 8
+	},
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics)
@@ -63219,10 +63220,6 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics/cloning)
 "cAb" = (
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics/cloning)
 "cAc" = (
@@ -79721,6 +79718,9 @@
 /obj/structure/flora/ausbushes/fernybush{
 	pixel_x = -3;
 	pixel_y = 3
+	},
+/obj/structure/sign/warning/nosmoking{
+	pixel_x = 28
 	},
 /turf/open/floor/grass,
 /area/medical/genetics)


### PR DESCRIPTION
## About The Pull Request

Removed cloning room's second alarm. Added an air alarm to genetics.

## Why It's Good For The Game

Genetics didn't have an air alarm, but now it does.

## Changelog
:cl:
add: Genetics Air Alarm
del: Cloning Room Second Air Alarm
tweak: Put Genetics Smoking Poster in Monkey Pen (smoker monkeys = epic)
/:cl:
