### PR TITLE
Fridgestation Tune-Up

### DIFF
--- a/_maps/map_files/FridgeStation/FridgeStation.dmm
+++ b/_maps/map_files/FridgeStation/FridgeStation.dmm
@@ -89,6 +89,16 @@
 	name = "Central Access"
 	},
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "adb" = (
@@ -96,10 +106,7 @@
 /area/maintenance/starboard/fore)
 "ady" = (
 /obj/machinery/computer/pandemic,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
+/obj/effect/turf_decal/trimline/green/filled/line,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "adA" = (
@@ -114,17 +121,14 @@
 /obj/machinery/airalarm{
 	pixel_y = 23
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
 /obj/machinery/light/small{
 	dir = 4
 	},
 /obj/item/storage/box/gloves,
 /obj/structure/closet/secure_closet/medical1,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "adY" = (
@@ -136,15 +140,10 @@
 /turf/closed/wall,
 /area/hallway/secondary/service)
 "afm" = (
-/obj/machinery/power/solar_control{
-	id = "auxsolareast";
-	name = "Starboard Bow Solar Control"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating,
-/area/maintenance/solars/starboard/fore)
+/obj/machinery/light/floor/fakeday,
+/obj/structure/flora/rock/pile/icy,
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors)
 "afo" = (
 /obj/structure/dresser,
 /obj/structure/cable{
@@ -185,14 +184,11 @@
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
 "agr" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -225,14 +221,11 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "ahf" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
-	icon_state = "1-4"
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -291,11 +284,11 @@
 	pixel_y = -25;
 	req_access_txt = "57"
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_x = 30
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
@@ -319,6 +312,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
@@ -367,10 +363,7 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/auto_name/north,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -445,14 +438,8 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
@@ -476,9 +463,10 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "anD" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/maintenance/solars/starboard/fore)
+/obj/machinery/light/floor/fakeday,
+/obj/structure/flora/tree/pine,
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors)
 "anK" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -494,11 +482,11 @@
 	pixel_y = 4
 	},
 /obj/item/pen,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
@@ -515,12 +503,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "apx" = (
-/obj/structure/table,
-/obj/item/storage/firstaid/regular{
-	pixel_y = 5
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
+/obj/machinery/light/floor/fakeday,
+/obj/structure/flora/grass/brown,
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors)
 "apE" = (
 /obj/structure/trash_pile,
 /turf/open/floor/plating,
@@ -529,6 +515,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "aqx" = (
@@ -714,8 +701,7 @@
 /obj/structure/chair{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -751,10 +737,7 @@
 	},
 /area/ai_monitored/nuke_storage)
 "awe" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -815,14 +798,11 @@
 /area/chapel/main)
 "awM" = (
 /obj/structure/cable{
-	icon_state = "2-4"
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
 "awV" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood{
 	icon_state = "wood-broken5"
@@ -875,7 +855,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "axE" = (
-/obj/machinery/space_heater,
+/obj/structure/table,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "axN" = (
@@ -997,6 +977,9 @@
 /obj/item/radio/intercom{
 	pixel_y = 25
 	},
+/obj/machinery/light/small{
+	dir = 4
+	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "aAT" = (
@@ -1015,10 +998,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/engine/engineering)
-"aBh" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/crew_quarters/bar)
 "aBi" = (
 /obj/machinery/vending/medical{
 	pixel_x = -2
@@ -1103,15 +1082,12 @@
 /area/crew_quarters/locker)
 "aFh" = (
 /obj/structure/chair/comfy/shuttle,
-/turf/open/floor/mineral/titanium/yellow/airless,
+/turf/open/floor/mineral/titanium/yellow,
 /area/icemoon/surface/outdoors)
 "aFi" = (
-/obj/structure/cable,
-/obj/machinery/power/solar{
-	id = "auxsolareast";
-	name = "Port Auxiliary Solar Array"
-	},
-/turf/open/floor/plating/asteroid/snow/ice/icemoon/solarpanel,
+/obj/machinery/light/floor/fakeday,
+/obj/structure/flora/grass/green,
+/turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors)
 "aFv" = (
 /obj/machinery/door/poddoor/shutters{
@@ -1131,11 +1107,8 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -1165,10 +1138,9 @@
 /area/security/brig)
 "aGj" = (
 /obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -22
+	dir = 1;
+	pixel_y = -22
 	},
-/obj/item/kirbyplants/random,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "aGv" = (
@@ -1217,10 +1189,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "aJj" = (
@@ -1232,6 +1203,9 @@
 /obj/machinery/camera{
 	c_tag = "Service External Access";
 	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
@@ -1325,24 +1299,25 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
+/obj/machinery/door/poddoor/preopen{
+	id = "bridge blast";
+	name = "bridge blast door"
+	},
 /turf/open/floor/plating,
 /area/bridge)
 "aLM" = (
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "aMf" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 2
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=Security";
 	location = "EVA2"
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
@@ -1354,6 +1329,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
@@ -1367,17 +1345,14 @@
 	},
 /obj/item/healthanalyzer,
 /obj/item/clothing/glasses/hud/health,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /obj/item/soap,
 /obj/item/clothing/glasses/science,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "aMH" = (
@@ -1466,6 +1441,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -1607,6 +1585,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -1756,6 +1737,7 @@
 /area/hallway/secondary/entry)
 "aYM" = (
 /obj/machinery/recharge_station,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
 /area/bridge)
 "aYQ" = (
@@ -1765,9 +1747,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aYV" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
 	},
@@ -1778,7 +1757,7 @@
 	dir = 1
 	},
 /obj/machinery/light/floor/fakeday,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/icemoon/surface/outdoors)
 "aZI" = (
 /obj/structure/table,
@@ -1791,12 +1770,6 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
 "baG" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -1804,17 +1777,17 @@
 	name = "Station Intercom (General)";
 	pixel_y = 20
 	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/warden)
 "baI" = (
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
@@ -1940,10 +1913,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -2000,9 +1970,8 @@
 /turf/open/floor/plating,
 /area/science/server)
 "beO" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
+/turf/closed/mineral/random/snow/no_caves,
+/area/icemoon/surface/outdoors/unexplored/rivers/no_monsters)
 "beY" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
@@ -2038,10 +2007,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -2111,23 +2077,12 @@
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "bhp" = (
-/obj/structure/disposalpipe/segment{
+/obj/machinery/light/floor/fakeday,
+/obj/structure/fence{
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors)
 "bht" = (
 /obj/machinery/air_sensor/atmos/nitrogen_tank{
 	pixel_y = -25
@@ -2154,6 +2109,9 @@
 	},
 /obj/structure/table/optable,
 /obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "bhP" = (
@@ -2180,14 +2138,13 @@
 /area/science/research)
 "bif" = (
 /obj/machinery/disposal/bin,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /obj/structure/disposalpipe/trunk,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "biv" = (
@@ -2301,6 +2258,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "bll" = (
@@ -2390,13 +2350,10 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "bmk" = (
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "bmr" = (
@@ -2462,6 +2419,7 @@
 /obj/effect/turf_decal/loading_area{
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "boD" = (
@@ -2492,20 +2450,18 @@
 /turf/open/floor/plasteel/dark,
 /area/blueshield)
 "boY" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/atmospherics/pipe/heat_exchanging/manifold{
-	dir = 8
+/obj/structure/sign/poster/official/no_erp{
+	pixel_y = 32
+	},
+/obj/structure/chair/sofa/corp{
+	dir = 4;
+	pixel_x = -7
+	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer1{
+	dir = 6
 	},
 /turf/open/floor/wood,
-/area/maintenance/bar)
-"bpB" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/canister/water_vapor,
-/turf/open/floor/plating,
-/area/maintenance/bar)
+/area/crew_quarters/fitness)
 "bpE" = (
 /obj/machinery/space_heater,
 /obj/machinery/airalarm{
@@ -2557,6 +2513,9 @@
 	icon_state = "4-8"
 	},
 /obj/effect/landmark/start/prisoner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "bse" = (
@@ -2661,17 +2620,14 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "bvs" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -2754,6 +2710,9 @@
 "byX" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bzL" = (
@@ -2795,6 +2754,12 @@
 /obj/structure/disposalpipe/junction{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bBJ" = (
@@ -2829,16 +2794,6 @@
 /obj/structure/table/glass,
 /obj/item/storage/box/bodybags,
 /obj/item/reagent_containers/spray/cleaner,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
 /obj/item/reagent_containers/blood,
 /obj/machinery/vending/wallmed{
 	pixel_x = 28
@@ -2846,14 +2801,14 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "bDm" = (
 /obj/machinery/computer/station_alert,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -2910,14 +2865,11 @@
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/machinery/camera{
 	c_tag = "Brig Control";
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel/dark,
 /area/security/warden)
 "bEY" = (
@@ -2928,6 +2880,9 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bFc" = (
@@ -2937,9 +2892,14 @@
 	},
 /area/ai_monitored/turret_protected/ai)
 "bFe" = (
-/obj/machinery/vending/cigarette,
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer1{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/fitness)
 "bFJ" = (
 /obj/structure/closet/secure_closet/bar{
 	pixel_x = -3;
@@ -2953,6 +2913,7 @@
 /obj/machinery/mech_bay_recharge_port{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "bFZ" = (
@@ -3030,11 +2991,8 @@
 /area/hallway/primary/aft)
 "bHe" = (
 /obj/structure/table,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
 /obj/machinery/recharger,
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "bHo" = (
@@ -3080,6 +3038,29 @@
 "bHO" = (
 /obj/machinery/computer/crew{
 	dir = 4
+	},
+/obj/machinery/button/door{
+	id = "innerbrig";
+	name = "Brig Interior Doors Control";
+	normaldoorcontrol = 1;
+	pixel_x = -24;
+	pixel_y = -2;
+	req_access_txt = "2"
+	},
+/obj/machinery/button/door{
+	id = "outerbrig";
+	name = "Brig Exterior Doors Control";
+	normaldoorcontrol = 1;
+	pixel_x = -24;
+	pixel_y = -10;
+	req_access_txt = "2"
+	},
+/obj/machinery/button/door{
+	id = "permalock";
+	name = "Permabrig Lockdown button";
+	pixel_x = -24;
+	pixel_y = 6;
+	req_access_txt = "2;63"
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/warden)
@@ -3174,10 +3155,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
 "bLs" = (
@@ -3251,19 +3229,15 @@
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
 "bMv" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
+/obj/structure/chair/sofa/corp{
+	dir = 8;
+	pixel_x = 7
 	},
-/obj/machinery/door/airlock/external{
-	name = "Mining Dock Airlock";
-	req_access_txt = "48";
-	shuttledocked = 1
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer1{
+	dir = 10
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/quartermaster/miningdock)
+/turf/open/floor/wood,
+/area/crew_quarters/fitness)
 "bMU" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
@@ -3301,12 +3275,8 @@
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors)
 "bOk" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/light/floor/fakeday,
-/turf/open/floor/plating/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors)
+/turf/closed/wall,
+/area/security/execution/education)
 "bOp" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -3418,8 +3388,8 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
 	},
-/obj/structure/disposalpipe/junction{
-	dir = 4
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
@@ -3466,20 +3436,25 @@
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat/hallway)
 "bSW" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 10
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/janitor)
 "bTk" = (
-/turf/open/floor/plasteel/cafeteria,
-/area/icemoon/surface/outdoors)
+/obj/structure/chair/sofa/corp{
+	dir = 4;
+	pixel_x = -7
+	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer1,
+/turf/open/floor/wood,
+/area/crew_quarters/fitness)
 "bTp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -3540,6 +3515,12 @@
 "bUU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/green/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/green/filled/corner{
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -3642,38 +3623,32 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/bridge)
 "bWs" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "bWu" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "bWw" = (
@@ -3720,6 +3695,7 @@
 	c_tag = "Mech Bay";
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "bXv" = (
@@ -3742,10 +3718,7 @@
 /area/bridge)
 "bXA" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -3821,11 +3794,13 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "caE" = (
-/obj/structure/cable{
-	icon_state = "0-4"
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer1,
+/obj/structure/chair/sofa/corp{
+	dir = 8;
+	pixel_x = 7
 	},
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/surface/outdoors)
+/turf/open/floor/wood,
+/area/crew_quarters/fitness)
 "caH" = (
 /turf/closed/wall,
 /area/security/brig)
@@ -3851,11 +3826,12 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
 "caU" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
 	},
-/turf/closed/wall,
-/area/maintenance/disposal)
+/obj/machinery/light/small,
+/turf/open/floor/plating,
+/area/security/execution/education)
 "cbu" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 5
@@ -3863,11 +3839,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/teleporter)
@@ -3889,7 +3862,7 @@
 	pixel_y = 6
 	},
 /obj/item/pen,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -3941,10 +3914,11 @@
 /turf/open/floor/carpet,
 /area/medical/psych)
 "cdq" = (
-/obj/machinery/light,
-/obj/machinery/light/floor/fakeday,
-/turf/open/floor/plating/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors)
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/security/execution/education)
 "cdw" = (
 /obj/structure/punching_bag,
 /turf/open/floor/wood,
@@ -3980,6 +3954,7 @@
 /obj/machinery/computer/mech_bay_power_console{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "cfv" = (
@@ -4102,7 +4077,6 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
 "cig" = (
-/obj/structure/fans/tiny,
 /obj/machinery/door/airlock/external{
 	name = "External Access";
 	req_access_txt = "13"
@@ -4152,6 +4126,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
 /turf/open/floor/wood,
@@ -4228,6 +4205,9 @@
 /area/hallway/primary/aft)
 "cnD" = (
 /obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "cnE" = (
@@ -4313,11 +4293,8 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
@@ -4325,6 +4302,9 @@
 /obj/machinery/vending/clothing,
 /obj/machinery/light_switch{
 	pixel_y = 28
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
@@ -4386,10 +4366,9 @@
 /area/ai_monitored/turret_protected/aisat/hallway)
 "cqT" = (
 /obj/machinery/vending/games,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "cre" = (
@@ -4418,9 +4397,8 @@
 /area/medical/sleeper)
 "cst" = (
 /obj/machinery/vending/cigarette,
-/obj/effect/turf_decal/tile/brown,
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "csy" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -4428,7 +4406,7 @@
 /obj/structure/shuttle/engine/heater{
 	dir = 4
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/icemoon/surface/outdoors)
 "csA" = (
 /obj/structure/window{
@@ -4491,6 +4469,9 @@
 /area/bridge)
 "ctT" = (
 /obj/machinery/mecha_part_fabricator,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "ctZ" = (
@@ -4498,6 +4479,9 @@
 	dir = 4
 	},
 /obj/machinery/light,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "cuc" = (
@@ -4515,18 +4499,19 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "cuv" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/chair/sofa/corp{
+	dir = 4;
+	pixel_x = -7
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = -32
 	},
-/obj/machinery/door/airlock/external{
-	name = "Solar Maintenance";
-	req_access_txt = "10; 13"
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer1{
+	dir = 5
 	},
-/turf/open/floor/plating,
-/area/maintenance/solars/starboard/fore)
+/turf/open/floor/wood,
+/area/crew_quarters/fitness)
 "cuB" = (
 /obj/machinery/door/airlock/external{
 	name = "Supply Dock Airlock";
@@ -4535,7 +4520,6 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
-/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/quartermaster/storage)
 "cvy" = (
@@ -4639,28 +4623,19 @@
 	pixel_y = -24
 	},
 /obj/machinery/light,
+/obj/structure/closet/lasertag/red,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "cxs" = (
-/obj/structure/toilet/secret/high_loot{
-	dir = 8
+/obj/machinery/atmospherics/pipe/heat_exchanging/manifold/layer1{
+	dir = 1
 	},
-/turf/open/floor/plasteel/cafeteria,
-/area/icemoon/surface/outdoors)
+/turf/open/floor/wood,
+/area/crew_quarters/fitness)
 "cxX" = (
 /obj/structure/reagent_dispensers/fueltank,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"cxZ" = (
-/obj/effect/turf_decal/tile/red,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "cya" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -4714,9 +4689,16 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
 "czz" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer1{
+	dir = 9
+	},
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos,
+/obj/structure/chair/sofa/corp{
+	dir = 8;
+	pixel_x = 7
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/fitness)
 "czA" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -4788,13 +4770,10 @@
 /obj/structure/table/glass,
 /obj/item/slime_scanner,
 /obj/item/storage/box/beakers,
-/obj/effect/turf_decal/tile/purple{
+/obj/item/reagent_containers/dropper,
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/item/reagent_containers/dropper,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "cCK" = (
@@ -4806,11 +4785,11 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "cCN" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "cDa" = (
@@ -4900,19 +4879,20 @@
 	req_access_txt = "35"
 	},
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/trimline/green/filled/line,
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"cFE" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 5
-	},
-/turf/open/floor/carpet,
-/area/chapel/main)
 "cFL" = (
-/obj/machinery/light/floor/fakeday,
-/turf/open/space/basic,
-/area/icemoon/surface/outdoors)
+/obj/machinery/door/airlock/public/glass{
+	desc = "A great place to relax. No ERP.";
+	name = "Sauna"
+	},
+/obj/structure/fans/tiny,
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction/layer1{
+	dir = 1
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/crew_quarters/fitness)
 "cFU" = (
 /obj/structure/beebox,
 /obj/machinery/light/floor/fakeday,
@@ -4966,9 +4946,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
-	},
 /turf/open/floor/plating,
 /area/security/execution/education)
 "cHA" = (
@@ -5006,14 +4983,8 @@
 /area/science/research)
 "cIz" = (
 /obj/structure/closet/l3closet/scientist,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 9
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
@@ -5025,11 +4996,8 @@
 /turf/open/floor/light/colour_cycle,
 /area/maintenance/starboard/aft)
 "cJq" = (
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -5066,10 +5034,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 2
-	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -5079,21 +5044,15 @@
 	dir = 8;
 	pixel_x = 28
 	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 2
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "cKO" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
@@ -5115,7 +5074,6 @@
 "cLw" = (
 /obj/structure/table,
 /obj/machinery/microwave{
-	pixel_x = -3;
 	pixel_y = 6
 	},
 /turf/open/floor/plasteel/cafeteria,
@@ -5127,6 +5085,9 @@
 "cLR" = (
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 6
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "cMi" = (
@@ -5163,14 +5124,8 @@
 	},
 /obj/item/radio/off,
 /obj/item/pen,
-/obj/effect/turf_decal/tile/purple{
-	dir = 2
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 6
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
@@ -5198,6 +5153,7 @@
 	name = "HoP Queue Shutters"
 	},
 /obj/effect/turf_decal/loading_area,
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "cNQ" = (
@@ -5224,14 +5180,9 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
 "cOJ" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/solars/starboard/fore)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/closed/wall,
+/area/crew_quarters/fitness)
 "cPO" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plasteel,
@@ -5283,11 +5234,22 @@
 /turf/open/floor/wood,
 /area/crew_quarters/fitness)
 "cSb" = (
-/obj/structure/chair/stool{
-	pixel_y = 8
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
 	},
-/turf/open/floor/plating,
-/area/maintenance/solars/starboard/fore)
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
+	},
+/obj/structure/closet/secure_closet/genpop,
+/obj/item/clothing/suit/hooded/wintercoat,
+/obj/item/radio/headset{
+	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
+	name = "prisoner headset";
+	prison_radio = 1
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "cSF" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -5401,9 +5363,7 @@
 /turf/open/floor/plasteel/dark,
 /area/science/server)
 "cUX" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 2
-	},
+/obj/effect/turf_decal/trimline/purple/filled/corner,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "cUZ" = (
@@ -5449,20 +5409,16 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/brown{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "cWm" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "cWr" = (
@@ -5486,6 +5442,9 @@
 	pixel_x = 5;
 	pixel_y = -1
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/crew_quarters/abandoned_gambling_den)
 "cWY" = (
@@ -5500,7 +5459,7 @@
 /area/science/server)
 "cXf" = (
 /obj/effect/decal/cleanable/glass,
-/turf/open/floor/mineral/plastitanium/airless,
+/turf/open/floor/mineral/plastitanium,
 /area/icemoon/surface/outdoors)
 "cXv" = (
 /obj/machinery/telecomms/processor/preset_four,
@@ -5734,16 +5693,17 @@
 /area/hallway/primary/starboard)
 "dcy" = (
 /obj/effect/decal/cleanable/insectguts,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/crew_quarters/abandoned_gambling_den)
 "dcz" = (
-/obj/structure/chair/sofa/left,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 10
+/obj/machinery/atmospherics/components/binary/valve{
+	name = "Steam Valve"
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood,
-/area/maintenance/bar)
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
 "dcD" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -5783,19 +5743,15 @@
 /turf/open/floor/plating,
 /area/science/mixing)
 "ddU" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
 /obj/machinery/vending/wallmed{
 	pixel_y = 28
 	},
 /obj/item/kirbyplants/random,
 /obj/machinery/camera{
 	c_tag = "Engineering Hallway East"
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -5851,11 +5807,9 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "deF" = (
-/obj/machinery/door/airlock/external,
-/obj/structure/fans/tiny,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors)
 "deQ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
@@ -6000,6 +5954,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "dhG" = (
@@ -6020,7 +5975,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
 "dik" = (
 /obj/effect/turf_decal/stripes/line{
@@ -6145,14 +6100,11 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "dmf" = (
+/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security/glass{
-	id_tag = "outerbrig";
+	id_tag = "innerbrig";
 	name = "Brig";
 	req_access_txt = "63"
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -6178,6 +6130,7 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "dmX" = (
+/obj/structure/flora/tree/palm,
 /turf/open/floor/grass,
 /area/medical/virology)
 "dnr" = (
@@ -6194,15 +6147,12 @@
 /turf/open/openspace,
 /area/maintenance/starboard/fore)
 "dnF" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/machinery/camera{
 	c_tag = "Departures Security Checkpoint";
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/checkpoint/auxiliary)
@@ -6232,12 +6182,15 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "doh" = (
-/obj/structure/table,
 /obj/item/hatchet,
 /obj/item/reagent_containers/glass/bucket,
 /obj/item/storage/bag/plants/portaseeder,
 /obj/item/plant_analyzer,
 /obj/item/plant_analyzer,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "doz" = (
@@ -6440,18 +6393,15 @@
 /turf/open/floor/plasteel,
 /area/teleporter)
 "dtR" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/bridge)
 "dtW" = (
@@ -6529,9 +6479,12 @@
 /turf/open/floor/plasteel/dark/corner,
 /area/hallway/primary/starboard)
 "dvm" = (
-/obj/item/kirbyplants/random,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/broken,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "dvq" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -6540,6 +6493,7 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/effect/turf_decal/trimline/green/filled/line,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "dvG" = (
@@ -6575,6 +6529,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "dwB" = (
@@ -6584,8 +6541,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -6627,11 +6584,11 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "dyp" = (
-/obj/structure/cable{
-	icon_state = "2-4"
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
 	},
-/turf/open/floor/plating,
-/area/maintenance/solars/port/fore)
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "dyV" = (
 /obj/machinery/conveyor{
 	dir = 8;
@@ -6726,10 +6683,9 @@
 /turf/open/floor/plating,
 /area/crew_quarters/abandoned_gambling_den)
 "dDs" = (
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel/dark,
 /area/security/checkpoint/auxiliary)
 "dDx" = (
@@ -6976,9 +6932,9 @@
 /turf/open/floor/carpet,
 /area/science/robotics/lab)
 "dHB" = (
-/obj/machinery/light/floor/fakeday,
-/turf/open/floor/plating/airless,
-/area/icemoon/surface/outdoors)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "dHJ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -7092,16 +7048,13 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "dKi" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
 /obj/structure/chair{
 	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
 	},
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel/dark,
 /area/security/checkpoint/auxiliary)
 "dKk" = (
@@ -7163,17 +7116,9 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "dLV" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
-/turf/open/floor/plating,
-/area/maintenance/fore)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "dMa" = (
 /obj/structure/sign/warning/securearea{
 	desc = "A warning sign which reads 'SERVER ROOM'.";
@@ -7206,10 +7151,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -7414,7 +7356,6 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "dQZ" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -7526,14 +7467,11 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "dUK" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -7651,9 +7589,6 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "dZn" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -24
@@ -7661,7 +7596,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "eaP" = (
@@ -7699,10 +7634,7 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -7713,17 +7645,12 @@
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "eca" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel/white,
-/area/science/robotics/lab)
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "ece" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -7732,17 +7659,26 @@
 	dir = 1;
 	pixel_x = 1
 	},
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 5
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "ech" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
-/area/science/robotics/lab)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "ecF" = (
 /obj/structure/chair/wood/normal,
 /turf/open/floor/wood,
@@ -7796,7 +7732,7 @@
 /obj/item/lighter/gold{
 	desc = "A shiny and relatively expensive zippo lighter. This is a limited series, only ten were produced. It's engraved with a ornate 'NT' on the bottom. This is clearly a badly made replica."
 	},
-/turf/open/floor/carpet/red/airless,
+/turf/open/floor/carpet/red,
 /area/icemoon/surface/outdoors)
 "edN" = (
 /obj/structure/window/reinforced{
@@ -7828,8 +7764,7 @@
 	pixel_x = 6;
 	pixel_y = 2
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -7963,6 +7898,13 @@
 /area/science/misc_lab)
 "egI" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "bridge blast";
+	name = "bridge blast door"
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
 /turf/open/floor/plating,
 /area/bridge)
 "ehs" = (
@@ -7992,9 +7934,6 @@
 "ejq" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -8066,27 +8005,21 @@
 /area/security/brig)
 "elY" = (
 /obj/structure/closet/l3closet/virology,
-/obj/effect/turf_decal/tile/green{
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "ema" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
 /obj/structure/closet/secure_closet/personal/patient,
 /obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -8122,14 +8055,14 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
 "emy" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
+	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
-	},
-/turf/open/floor/wood,
-/area/library)
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "emz" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 9
@@ -8145,6 +8078,14 @@
 	req_access_txt = "69"
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/preopen{
+	id = "permalock";
+	name = "Permabrig Lockdown Door"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "permalock";
+	name = "Perma Lockdown Shutter"
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "end" = (
@@ -8182,9 +8123,11 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "enA" = (
-/obj/structure/frame,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
 "enE" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
@@ -8231,13 +8174,12 @@
 /area/medical/sleeper)
 "epo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/visible,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_x = 29
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -8340,6 +8282,16 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "erj" = (
@@ -8365,11 +8317,11 @@
 	dir = 4;
 	pixel_y = 9
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
@@ -8431,10 +8383,9 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
 "esN" = (
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "etf" = (
@@ -8517,10 +8468,10 @@
 /turf/open/floor/wood,
 /area/medical/psych)
 "euV" = (
-/obj/effect/turf_decal/tile/green{
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "evh" = (
@@ -8629,8 +8580,7 @@
 /area/science/research)
 "exl" = (
 /obj/structure/closet/secure_closet/warden,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -8640,12 +8590,8 @@
 	icon_state = "plant-18"
 	},
 /obj/machinery/light,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
@@ -8715,9 +8661,6 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
 "eyq" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/light{
 	dir = 1
 	},
@@ -8769,31 +8712,27 @@
 	},
 /area/maintenance/bar)
 "eBI" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/atm{
 	pixel_y = 30
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "eBK" = (
-/obj/machinery/door/airlock/wood,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
+/obj/machinery/power/apc{
+	areastring = "/area/maintenance/disposal";
+	name = "Disposal APC";
+	pixel_y = -24
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "0-8"
 	},
-/turf/open/floor/wood,
-/area/maintenance/bar)
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "eBV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "eCa" = (
@@ -8821,9 +8760,6 @@
 /turf/open/floor/plasteel,
 /area/science/lab)
 "eCB" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
@@ -8902,10 +8838,7 @@
 /area/science/mixing)
 "eDU" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -8962,12 +8895,11 @@
 /area/bridge/meeting_room)
 "eFe" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -8975,13 +8907,6 @@
 /obj/structure/mineral_door/woodrustic,
 /turf/open/floor/wood,
 /area/icemoon/surface/outdoors)
-"eFK" = (
-/obj/structure/grille,
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "eFU" = (
 /obj/structure/disposalpipe/junction/flip{
 	dir = 8
@@ -9048,8 +8973,7 @@
 	pixel_x = -6;
 	pixel_y = 3
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -9116,6 +9040,7 @@
 /obj/item/storage/toolbox/emergency,
 /obj/item/multitool,
 /obj/machinery/light,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
 /area/bridge)
 "eJU" = (
@@ -9151,6 +9076,7 @@
 	dir = 1
 	},
 /obj/machinery/light,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
 /area/bridge)
 "eKk" = (
@@ -9200,10 +9126,7 @@
 /turf/open/floor/plating/airless,
 /area/icemoon/surface/outdoors)
 "eLl" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -9272,6 +9195,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "eOt" = (
@@ -9322,13 +9248,17 @@
 	name = "Bridge APC";
 	pixel_y = -24
 	},
-/obj/structure/cable,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
 /turf/open/floor/mineral/titanium/blue,
 /area/bridge)
 "ePs" = (
-/obj/machinery/light/floor/fakeday,
-/turf/closed/wall/mineral/wood,
-/area/icemoon/surface/outdoors)
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "ePH" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -9346,10 +9276,6 @@
 /turf/open/floor/plasteel,
 /area/medical/medbay/central)
 "eQe" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow,
 /obj/structure/closet/secure_closet/engineering_electrical,
 /obj/item/storage/toolbox/artistic{
 	icon_state = "yellow";
@@ -9358,6 +9284,9 @@
 	pixel_y = 6
 	},
 /obj/item/electronics/apc,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "eQt" = (
@@ -9455,10 +9384,17 @@
 /turf/open/floor/carpet/orange,
 /area/engine/engineering)
 "eTE" = (
-/obj/item/stack/rods,
-/obj/machinery/light/floor/fakeday,
-/turf/open/floor/plating/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors)
+/obj/structure/closet/secure_closet/personal{
+	anchored = 1
+	},
+/obj/structure/window/reinforced/tinted{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/fitness)
 "eTL" = (
 /obj/machinery/light{
 	dir = 4
@@ -9493,6 +9429,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -9530,33 +9469,20 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
 "eVF" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/surface/outdoors)
-"eWs" = (
-/obj/structure/cable,
-/obj/machinery/power/apc{
-	areastring = "/area/security/prison";
-	dir = 4;
-	name = "Prison Wing APC";
-	pixel_y = -24
-	},
-/turf/open/floor/plating,
-/area/security/brig)
-"eWu" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/structure/window/reinforced/tinted{
 	dir = 8
+	},
+/turf/open/floor/plasteel/dark/side,
+/area/crew_quarters/fitness)
+"eWs" = (
+/turf/open/floor/plasteel/dark/side,
+/area/crew_quarters/fitness)
+"eWu" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
@@ -9580,14 +9506,11 @@
 /turf/open/floor/plating,
 /area/security/checkpoint/auxiliary)
 "eXd" = (
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/surface/outdoors)
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "eXj" = (
 /obj/structure/flora/grass/brown,
 /turf/open/floor/plating/asteroid/snow/icemoon,
@@ -9611,13 +9534,9 @@
 /area/quartermaster/miningoffice)
 "eYR" = (
 /obj/structure/reagent_dispensers/water_cooler,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 10
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "eZf" = (
@@ -9648,11 +9567,8 @@
 /area/bridge)
 "faD" = (
 /obj/machinery/computer/card/minor/qm,
-/obj/effect/turf_decal/tile/brown{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
@@ -9799,9 +9715,14 @@
 	id = "Cell 1";
 	name = "Cell 1"
 	},
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/door/firedoor/border_only{
+	name = "south facing firelock"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "ffg" = (
@@ -9814,11 +9735,20 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "ffq" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/heater{
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "ffO" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
@@ -9880,19 +9810,16 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
 "fhU" = (
-/obj/effect/turf_decal/tile/yellow{
+/obj/structure/chair,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 4
 	},
-/obj/structure/chair,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "fhZ" = (
@@ -9958,15 +9885,6 @@
 	name = "Floor Data Lattice"
 	},
 /area/ai_monitored/turret_protected/ai)
-"fjv" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/bridge)
 "fjB" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -10086,24 +10004,16 @@
 /turf/open/floor/grass,
 /area/medical/genetics)
 "flJ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/surface/outdoors)
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "flM" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_x = -28
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
@@ -10147,12 +10057,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "fnY" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
 /obj/structure/chair{
 	dir = 8
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/checkpoint/auxiliary)
@@ -10258,7 +10167,7 @@
 	pixel_x = 1;
 	pixel_y = 5
 	},
-/turf/open/floor/carpet/red/airless,
+/turf/open/floor/carpet/red,
 /area/icemoon/surface/outdoors)
 "frx" = (
 /obj/structure/disposalpipe/segment,
@@ -10303,9 +10212,6 @@
 /obj/machinery/computer/cargo{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 8
-	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "fsE" = (
@@ -10314,18 +10220,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"fsK" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/machinery/door/airlock/external{
-	name = "Mining Dock Airlock";
-	req_access_txt = "48";
-	shuttledocked = 1
-	},
-/obj/structure/fans/tiny,
-/turf/open/floor/plating,
-/area/quartermaster/miningdock)
 "fsT" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -10342,22 +10236,17 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "fsY" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/door/airlock/wood,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/maintenance/bar)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/security/main)
 "ftd" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/glass/beaker/large{
@@ -10456,13 +10345,19 @@
 	pixel_x = -32
 	},
 /obj/machinery/recharger,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "fxu" = (
 /obj/effect/landmark/start/roboticist,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/mechbay)
 "fyh" = (
@@ -10488,7 +10383,7 @@
 /area/hallway/primary/starboard)
 "fzj" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -10502,6 +10397,12 @@
 	},
 /obj/structure/disposalpipe/junction{
 	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
@@ -10528,9 +10429,6 @@
 /turf/closed/wall/r_wall,
 /area/tcommsat/server)
 "fAk" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/firealarm{
 	pixel_y = 29
 	},
@@ -10552,25 +10450,22 @@
 /turf/open/floor/plasteel,
 /area/gateway)
 "fBu" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
+/obj/machinery/light,
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/fitness)
 "fCq" = (
 /turf/closed/wall,
 /area/tcommsat/computer)
 "fCA" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green,
 /obj/structure/table/glass,
 /obj/item/paper_bin{
 	pixel_y = 6
 	},
 /obj/item/pen,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "fCG" = (
@@ -10644,9 +10539,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "fFl" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 2
-	},
+/obj/effect/turf_decal/trimline/purple/filled/corner,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "fFp" = (
@@ -10661,11 +10554,11 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "fFH" = (
-/obj/structure/cable{
-	icon_state = "1-4"
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
 	},
-/turf/open/floor/plating,
-/area/maintenance/solars/starboard/fore)
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "fFI" = (
 /obj/machinery/shieldgen,
 /turf/open/floor/engine,
@@ -10689,6 +10582,9 @@
 	pixel_y = 10
 	},
 /obj/item/book/manual/wiki/security_space_law,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
 /turf/open/floor/plasteel,
 /area/bridge)
 "fGP" = (
@@ -10705,14 +10601,14 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "fHB" = (
-/obj/machinery/computer/holodeck{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
+/turf/open/floor/mineral/titanium/blue,
+/area/bridge)
 "fHQ" = (
 /obj/machinery/vending/security,
 /obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -10792,10 +10688,8 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/service)
 "fJH" = (
-/obj/machinery/camera{
-	c_tag = "SecMed External Access";
-	dir = 1
-	},
+/obj/machinery/light,
+/obj/machinery/space_heater,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "fJS" = (
@@ -10923,6 +10817,9 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "fNz" = (
@@ -11012,7 +10909,7 @@
 	pixel_y = 9
 	},
 /obj/item/paper/fluff/fridgestation/syndie,
-/turf/open/floor/carpet/red/airless,
+/turf/open/floor/carpet/red,
 /area/icemoon/surface/outdoors)
 "fPR" = (
 /obj/structure/cable{
@@ -11049,6 +10946,10 @@
 "fQy" = (
 /obj/structure/table/wood/poker,
 /obj/effect/spawner/lootdrop/coins/iron/tenpercent,
+/obj/machinery/atmospherics/components/binary/valve{
+	dir = 4;
+	name = "Urnary Main to Viro"
+	},
 /turf/open/floor/plating,
 /area/crew_quarters/abandoned_gambling_den)
 "fQA" = (
@@ -11102,13 +11003,13 @@
 /turf/open/floor/plating,
 /area/crew_quarters/toilet)
 "fRQ" = (
-/obj/structure/reagent_dispensers/beerkeg,
 /obj/item/radio/intercom{
 	pixel_x = -30
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+/obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
+/obj/machinery/disposal/bin,
 /turf/open/floor/plasteel,
 /area/janitor)
 "fSJ" = (
@@ -11169,10 +11070,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -11191,10 +11089,6 @@
 	req_access_txt = "48";
 	shuttledocked = 1
 	},
-/obj/structure/fans/tiny,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /turf/open/floor/plating,
 /area/quartermaster/miningdock)
 "fVl" = (
@@ -11208,6 +11102,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
 "fVQ" = (
@@ -11258,9 +11153,6 @@
 "fWv" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -11407,7 +11299,7 @@
 /turf/open/floor/plasteel,
 /area/bridge)
 "fZj" = (
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -11436,20 +11328,16 @@
 /obj/structure/flora/grass/both,
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors)
-"gah" = (
-/turf/open/floor/plasteel/dark,
-/area/science/robotics/mechbay)
 "gaj" = (
 /obj/structure/sign/warning/securearea{
 	pixel_x = 32
 	},
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "gal" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plating,
 /area/crew_quarters/abandoned_gambling_den)
 "gaW" = (
@@ -11500,13 +11388,12 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "gcP" = (
-/obj/structure/chair/sofa,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 4
+/obj/machinery/power/terminal,
+/obj/structure/cable{
+	icon_state = "0-4"
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood,
-/area/maintenance/bar)
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "gdc" = (
 /obj/machinery/light{
 	dir = 1
@@ -11557,6 +11444,12 @@
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_y = -32
+	},
+/obj/structure/closet/secure_closet/personal{
+	anchored = 1
+	},
+/obj/structure/window/reinforced/tinted{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/fitness)
@@ -11720,10 +11613,9 @@
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
 "ghg" = (
-/obj/effect/turf_decal/tile/brown{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/brown,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
 "giB" = (
@@ -11784,10 +11676,9 @@
 /obj/structure/table,
 /obj/item/reagent_containers/rag/towel/random,
 /obj/item/razor,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "glm" = (
@@ -11806,6 +11697,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hos)
 "gma" = (
@@ -11921,23 +11813,21 @@
 "gnJ" = (
 /obj/structure/closet/l3closet/scientist,
 /obj/item/extinguisher,
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "gnM" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/power/port_gen/pacman,
+/obj/machinery/light/small{
 	dir = 4
 	},
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "0-8"
 	},
-/turf/open/floor/plasteel,
-/area/quartermaster/miningoffice)
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "gnO" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /obj/effect/landmark/start/atmospheric_technician,
@@ -11984,10 +11874,7 @@
 /turf/closed/wall/r_wall,
 /area/security/warden)
 "gor" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "gos" = (
@@ -12016,9 +11903,6 @@
 	name = "Engineering Station"
 	},
 /obj/effect/landmark/start/captain,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /turf/open/floor/plasteel,
 /area/bridge)
 "gpX" = (
@@ -12046,10 +11930,9 @@
 /area/medical/psych)
 "gqu" = (
 /obj/machinery/vending/tool,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "gqE" = (
@@ -12075,6 +11958,7 @@
 	dir = 8
 	},
 /obj/machinery/vending/security,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "gsh" = (
@@ -12108,17 +11992,13 @@
 /obj/item/reagent_containers/syringe/antiviral,
 /obj/item/reagent_containers/dropper,
 /obj/item/reagent_containers/spray/cleaner,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
 /obj/machinery/airalarm{
 	dir = 1;
 	pixel_y = -22
 	},
-/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 10
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "gsV" = (
@@ -12153,8 +12033,13 @@
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_y = -32
 	},
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/machinery/button/door{
+	id = "permalock";
+	name = "Permabrig Lockdown button";
+	pixel_x = -7;
+	pixel_y = -3;
+	plane = -4;
+	req_access_txt = "2;63"
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
@@ -12181,10 +12066,6 @@
 	},
 /area/ai_monitored/turret_protected/aisat/hallway)
 "gut" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -12192,6 +12073,7 @@
 	c_tag = "Brig North";
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "guQ" = (
@@ -12200,6 +12082,7 @@
 	},
 /obj/effect/landmark/start/virologist,
 /obj/machinery/light/small,
+/obj/effect/turf_decal/trimline/green/filled/line,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "gvz" = (
@@ -12246,11 +12129,17 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "gwA" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/surface/outdoors)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/disposalpipe/junction/flip{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "gxc" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -12393,6 +12282,9 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "gBm" = (
@@ -12543,14 +12435,17 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "gFn" = (
-/obj/structure/disposalpipe/junction/flip{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/maintenance/fore)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "gFt" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -12584,6 +12479,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "gGA" = (
@@ -12592,6 +12490,9 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "gGU" = (
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "gHp" = (
@@ -12665,15 +12566,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"gKG" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "gKM" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/airlock/external{
@@ -12696,6 +12588,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "gLx" = (
@@ -12727,11 +12622,6 @@
 /turf/closed/wall,
 /area/crew_quarters/abandoned_gambling_den)
 "gMi" = (
-/obj/machinery/door_timer{
-	id = "soli1";
-	name = "Solitary 1 door timer";
-	pixel_y = 32
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -12741,11 +12631,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
@@ -12788,10 +12678,16 @@
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
 "gNq" = (
-/obj/structure/frame,
-/obj/structure/spider/stickyweb/genetic,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "gNJ" = (
 /obj/structure/table,
 /obj/item/storage/firstaid/regular,
@@ -12804,8 +12700,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -12854,18 +12749,23 @@
 /area/hallway/primary/starboard)
 "gOH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "gOM" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 10
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "gOO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
@@ -12913,10 +12813,7 @@
 /area/engine/engineering)
 "gQG" = (
 /obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -12948,14 +12845,17 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -13129,12 +13029,14 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "gVI" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "bridge blast";
+	name = "bridge blast door"
 	},
-/obj/machinery/light/floor/fakeday,
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/surface/outdoors)
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/bridge)
 "gVT" = (
 /obj/item/toy/beach_ball/holoball,
 /obj/machinery/light/floor/fakeday,
@@ -13166,6 +13068,9 @@
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
@@ -13239,10 +13144,8 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "gXU" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
 /obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
 "gYb" = (
@@ -13271,8 +13174,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -13319,16 +13221,14 @@
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
 "haf" = (
-/obj/machinery/power/solar_control{
-	dir = 1;
-	id = "starboardsolar";
-	name = "Starboard Quarter Solar Control"
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
-	icon_state = "0-4"
+	icon_state = "1-4"
 	},
-/turf/open/floor/plating,
-/area/maintenance/solars/port/fore)
+/turf/open/floor/mineral/titanium/blue,
+/area/bridge)
 "haZ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -13366,12 +13266,8 @@
 /area/medical/medbay/central)
 "hbl" = (
 /obj/machinery/computer/atmos_alert,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -13383,12 +13279,12 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "hbP" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/power/smes,
+/obj/structure/cable{
+	icon_state = "0-4"
 	},
 /turf/open/floor/plating,
-/area/maintenance/disposal)
+/area/maintenance/starboard/fore)
 "hcc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -13408,17 +13304,8 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "hdn" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -13450,10 +13337,7 @@
 /turf/open/floor/plating,
 /area/quartermaster/office)
 "hem" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
 /area/bridge)
 "hez" = (
@@ -13461,12 +13345,6 @@
 /turf/open/floor/plating,
 /area/icemoon/surface/outdoors)
 "heB" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/effect/turf_decal/bot,
 /obj/item/clothing/suit/hooded/wintercoat/security,
 /obj/item/radio/intercom{
@@ -13474,6 +13352,9 @@
 	pixel_x = -30
 	},
 /obj/structure/closet/secure_closet/security/sec,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "heQ" = (
@@ -13650,6 +13531,9 @@
 /area/crew_quarters/cryopod)
 "hkm" = (
 /obj/machinery/vending/wardrobe/sec_wardrobe,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "hkz" = (
@@ -13675,18 +13559,14 @@
 	pixel_y = 2
 	},
 /obj/item/storage/box/deputy,
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
 "hlk" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/firealarm{
 	pixel_y = 24
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -13807,6 +13687,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "hoF" = (
@@ -13925,16 +13808,16 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/door/firedoor/border_only{
+	name = "south facing firelock"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"hrO" = (
-/mob/living/simple_animal/pet/penguin/baby,
-/obj/machinery/light/floor/fakeday,
-/turf/open/floor/plating/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors)
 "hrP" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plasteel,
@@ -13988,6 +13871,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "huC" = (
@@ -13996,14 +13882,11 @@
 "huE" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
 /obj/item/crowbar/large,
 /obj/item/stack/ore/silver,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
 "huT" = (
@@ -14025,20 +13908,18 @@
 /obj/item/stack/sheet/glass/fifty,
 /obj/item/stock_parts/cell/high/plus,
 /obj/item/stock_parts/cell/high/plus,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "hvd" = (
-/obj/structure/cable{
-	icon_state = "1-4"
+/obj/item/stack/sheet/mineral/plasma{
+	amount = 10
 	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/surface/outdoors)
+/obj/structure/rack,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "hvO" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -14066,10 +13947,6 @@
 /turf/open/floor/carpet/orange,
 /area/engine/engineering)
 "hwF" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 2
-	},
 /obj/machinery/power/apc{
 	areastring = "/area/janitor";
 	dir = 8;
@@ -14096,12 +13973,8 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
@@ -14122,7 +13995,7 @@
 	},
 /obj/machinery/power/smes,
 /turf/open/floor/plating,
-/area/maintenance/solars/port/fore)
+/area/maintenance/port)
 "hxB" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 6
@@ -14214,16 +14087,13 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "hzh" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_x = 1;
 	pixel_y = 29
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -14239,13 +14109,10 @@
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "hzp" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/structure/closet/radiation,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
-/obj/structure/closet/radiation,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "hzR" = (
@@ -14266,10 +14133,13 @@
 /area/security/brig)
 "hAv" = (
 /obj/structure/cable{
-	icon_state = "1-8"
+	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/surface/outdoors)
 "hAW" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 5
@@ -14289,10 +14159,7 @@
 	pixel_x = -3;
 	pixel_y = 6
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/trimline/green/filled/line,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "hCt" = (
@@ -14300,11 +14167,15 @@
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors)
 "hCP" = (
-/obj/item/flashlight/lantern{
-	on = 1
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/cafeteria,
-/area/icemoon/surface/outdoors)
+/obj/effect/turf_decal/arrows{
+	pixel_x = -11
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "hDh" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -14314,6 +14185,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -14347,9 +14221,6 @@
 "hEP" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "hFc" = (
@@ -14498,7 +14369,7 @@
 	req_access_txt = "29"
 	},
 /obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/dark,
 /area/science/robotics/mechbay)
 "hJf" = (
 /turf/open/floor/carpet/purple,
@@ -14553,10 +14424,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "hKL" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -14632,14 +14500,6 @@
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "hMq" = (
-/obj/machinery/door_timer{
-	id = "soli2";
-	name = "Solitary 2 door timer";
-	pixel_y = 32
-	},
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -14716,7 +14576,7 @@
 	picked_color = "Burgundy"
 	},
 /obj/machinery/light/floor/fakeday,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/icemoon/surface/outdoors)
 "hOE" = (
 /obj/structure/falsewall,
@@ -14734,16 +14594,13 @@
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "hOX" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
 /obj/machinery/vending/wallmed{
 	pixel_y = -28
 	},
+/obj/effect/turf_decal/trimline/green/filled/line,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "hPc" = (
@@ -14833,10 +14690,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
 "hQt" = (
@@ -14872,6 +14726,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
 	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner,
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "hRA" = (
@@ -14913,8 +14768,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -14961,14 +14815,11 @@
 /turf/open/floor/carpet,
 /area/hallway/primary/aft)
 "hUt" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
 /obj/structure/closet/secure_closet/engineering_personal{
 	anchored = 1
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -15058,10 +14909,7 @@
 	},
 /obj/item/pen,
 /obj/item/stamp/hop,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
 "hWg" = (
@@ -15120,18 +14968,18 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/port)
 "hXj" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/surface/outdoors)
 "hXl" = (
 /obj/machinery/vending/cigarette,
 /obj/machinery/camera{
 	c_tag = "Locker Room"
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
@@ -15173,15 +15021,14 @@
 /turf/open/floor/wood,
 /area/library)
 "hYq" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
 /obj/structure/cable{
-	icon_state = "0-2"
+	icon_state = "1-2"
 	},
-/obj/machinery/power/solar{
-	id = "starboardsolar";
-	name = "Starboard Solar Array"
-	},
-/turf/open/floor/plating/asteroid/snow/ice/icemoon/solarpanel,
-/area/icemoon/surface/outdoors)
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "hYt" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Hydroponics";
@@ -15207,10 +15054,9 @@
 	name = "Telecomms RC";
 	pixel_x = 30
 	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "hYD" = (
@@ -15254,10 +15100,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
 "hYX" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 2
-	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -15442,10 +15285,6 @@
 /turf/open/floor/wood,
 /area/maintenance/bar)
 "igo" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -15456,6 +15295,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -15476,7 +15318,7 @@
 /turf/open/floor/plating,
 /area/chapel/office)
 "igV" = (
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -15537,12 +15379,6 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "iix" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/effect/turf_decal/bot,
 /obj/item/clothing/suit/hooded/wintercoat/security,
 /obj/structure/closet/secure_closet/security/sec,
@@ -15550,12 +15386,19 @@
 	c_tag = "Brig Equipment Room";
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "iiB" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
 	icon_state = "0-2"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "permalock";
+	name = "Perma Lockdown Shutter"
 	},
 /turf/open/floor/plating,
 /area/security/prison)
@@ -15565,10 +15408,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"ijb" = (
-/obj/structure/sign/barsign,
-/turf/closed/wall,
-/area/crew_quarters/bar)
 "ijf" = (
 /obj/machinery/holopad,
 /obj/structure/cable{
@@ -15597,7 +15436,7 @@
 	dir = 1
 	},
 /obj/structure/cable{
-	icon_state = "2-4"
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -15644,11 +15483,8 @@
 /obj/machinery/computer/bounty{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/brown{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
@@ -15658,11 +15494,15 @@
 /turf/open/floor/wood,
 /area/icemoon/surface/outdoors)
 "imJ" = (
-/obj/machinery/door/airlock/external,
-/obj/structure/fans/tiny,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/obj/machinery/door/airlock/engineering{
+	name = "Starboard Bow Emergency Generator";
+	req_access_txt = "10"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "imQ" = (
 /turf/open/floor/plasteel/yellowsiding{
 	dir = 8
@@ -15688,6 +15528,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1;
 	pixel_x = 1
+	},
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 5
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -15741,13 +15584,21 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "ipF" = (
-/obj/structure/disposalpipe/segment,
-/turf/closed/wall,
-/area/maintenance/disposal)
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/broken{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "ipK" = (
 /obj/machinery/vending/snack/random,
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
@@ -15764,7 +15615,8 @@
 /area/blueshield)
 "iqM" = (
 /mob/living/simple_animal/pet/penguin/baby{
-	dir = 4
+	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0);
+	dir = 1
 	},
 /obj/machinery/light/floor/fakeday,
 /turf/open/floor/plating/asteroid/snow/icemoon,
@@ -15840,6 +15692,16 @@
 	req_access_txt = "39"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "iuI" = (
@@ -15938,9 +15800,6 @@
 /area/icemoon/surface/outdoors)
 "iyg" = (
 /obj/machinery/light/small,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /turf/open/floor/plating,
 /area/quartermaster/miningdock)
 "izp" = (
@@ -15981,10 +15840,9 @@
 /obj/machinery/newscaster/security_unit{
 	pixel_x = 30
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "iAf" = (
@@ -16060,23 +15918,19 @@
 	c_tag = "Virology Module";
 	network = list("ss13","medbay")
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "iAW" = (
 /obj/machinery/door/airlock/external,
-/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/hallway/primary/starboard)
 "iBb" = (
@@ -16099,9 +15953,6 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "iCb" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -16178,14 +16029,19 @@
 /area/quartermaster/storage)
 "iDU" = (
 /obj/structure/cable{
-	icon_state = "0-8"
+	icon_state = "4-8"
 	},
-/obj/machinery/power/terminal,
-/obj/machinery/light/small{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
 /turf/open/floor/plating,
-/area/maintenance/solars/starboard/fore)
+/area/maintenance/starboard/fore)
 "iDW" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
@@ -16193,15 +16049,16 @@
 /turf/open/floor/plating,
 /area/crew_quarters/abandoned_gambling_den)
 "iEE" = (
-/obj/structure/frame/computer,
-/obj/structure/spider/stickyweb/genetic,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"iFc" = (
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/door/airlock/public/glass{
+	name = "Holodeck Door"
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel,
+/area/crew_quarters/dorms)
+"iFc" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -16216,17 +16073,27 @@
 /turf/open/floor/grass,
 /area/medical/genetics)
 "iFr" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
 	},
-/turf/open/floor/carpet,
-/area/chapel/main)
+/turf/open/floor/plasteel,
+/area/crew_quarters/dorms)
 "iFu" = (
 /obj/machinery/door/airlock/command{
 	name = "Teleport Access";
 	req_access_txt = "17"
 	},
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/teleporter)
 "iFF" = (
@@ -16282,13 +16149,16 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "iHD" = (
-/obj/structure/cable,
-/obj/machinery/power/tracker,
-/turf/open/floor/plating/asteroid/snow/ice/icemoon/solarpanel,
-/area/icemoon/surface/outdoors)
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/turf/open/floor/plasteel,
+/area/janitor)
 "iHE" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/iv_drip,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "iHL" = (
@@ -16302,15 +16172,18 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -16388,6 +16261,10 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/green/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/green/filled/corner,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "iKl" = (
@@ -16412,13 +16289,13 @@
 /area/hallway/primary/central)
 "iKw" = (
 /obj/structure/cable{
-	icon_state = "1-8"
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-8"
 	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "iKy" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
@@ -16479,6 +16356,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "iLo" = (
@@ -16487,20 +16367,18 @@
 /area/medical/virology)
 "iLK" = (
 /obj/machinery/light,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "iMo" = (
-/obj/item/stack/cable_coil/random,
-/obj/machinery/light/floor/fakeday,
-/turf/open/floor/plating/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors)
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/dorms)
 "iNb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -16571,7 +16449,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "iOY" = (
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -16820,14 +16698,11 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "2-4"
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
@@ -16860,11 +16735,10 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/item/kirbyplants/random,
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "iZE" = (
@@ -16912,16 +16786,12 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "jcH" = (
-/obj/structure/disposalpipe/segment,
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
@@ -17001,17 +16871,12 @@
 	name = "Command Camode";
 	req_access_txt = "19"
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/mineral/titanium/blue,
 /area/bridge)
 "jgP" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/fore)
+/obj/machinery/vending/cigarette,
+/turf/open/floor/plasteel,
+/area/crew_quarters/dorms)
 "jgS" = (
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
@@ -17050,21 +16915,23 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "jhl" = (
-/obj/effect/spawner/structure/window,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/light/floor/fakeday,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
 	},
-/turf/open/floor/plating,
-/area/science/research)
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/surface/outdoors)
 "jhm" = (
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
 /area/maintenance/bar)
 "jhC" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/surface/outdoors)
 "jhJ" = (
 /obj/structure/flora/tree/palm,
 /obj/machinery/camera{
@@ -17097,13 +16964,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
-"jig" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
 "jiu" = (
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
@@ -17138,9 +16998,6 @@
 /obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/door/firedoor,
 /obj/machinery/light{
 	dir = 1
@@ -17148,23 +17005,17 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "jjb" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "jjt" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
-/turf/open/floor/wood,
-/area/maintenance/bar)
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "jki" = (
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
@@ -17222,16 +17073,15 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "jlu" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
 /obj/machinery/light{
 	dir = 4
 	},
 /obj/structure/chair,
 /obj/structure/window/reinforced{
 	dir = 1
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/checkpoint/auxiliary)
@@ -17309,6 +17159,7 @@
 	pixel_y = -28
 	},
 /obj/item/megaphone/command,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
 /area/bridge)
 "jny" = (
@@ -17333,19 +17184,15 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "jnC" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
 /obj/machinery/power/apc{
 	areastring = "/area/tcommsat/computer";
 	name = "Telecomms Monitoring APC";
 	pixel_y = -24
 	},
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 10
+	},
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "jnD" = (
@@ -17397,13 +17244,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
-"jnT" = (
-/mob/living/simple_animal/pet/penguin/baby{
-	dir = 8
-	},
-/obj/machinery/light/floor/fakeday,
-/turf/open/floor/plating/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors)
 "joe" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
@@ -17417,6 +17257,9 @@
 	pixel_y = -35
 	},
 /obj/effect/landmark/event_spawn,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "joq" = (
@@ -17450,11 +17293,16 @@
 /turf/open/floor/plating,
 /area/science/research)
 "jpo" = (
-/obj/effect/turf_decal/tile/bar{
-	dir = 4
+/obj/structure/table,
+/obj/item/paper/fluff/holodeck/disclaimer,
+/obj/item/storage/firstaid/regular{
+	pixel_y = 5
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
+/area/crew_quarters/dorms)
 "jpv" = (
 /obj/machinery/power/smes{
 	charge = 5e+006
@@ -17478,36 +17326,23 @@
 	dir = 4;
 	network = "tcommsat"
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "jqz" = (
-/obj/machinery/shower{
-	dir = 8;
-	pixel_y = -4
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/icemoon/surface/outdoors)
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "jqD" = (
 /obj/machinery/computer/med_data,
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
 "jqV" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
 /obj/machinery/camera{
 	c_tag = "Engineering Hall - Lockers";
 	dir = 4
@@ -17515,14 +17350,14 @@
 /obj/structure/closet/secure_closet/engineering_personal{
 	anchored = 1
 	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "jqY" = (
 /obj/structure/bed,
 /obj/item/bedsheet/black,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 1
-	},
 /turf/open/floor/wood,
 /area/library)
 "jrh" = (
@@ -17580,7 +17415,6 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
-/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "jrU" = (
@@ -17627,6 +17461,12 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
@@ -17688,10 +17528,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -17758,9 +17595,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "jvx" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -17768,6 +17602,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -17782,8 +17619,8 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "jvE" = (
-/obj/effect/turf_decal/tile/green,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/obj/effect/turf_decal/trimline/green/filled/corner,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "jwa" = (
@@ -17806,22 +17643,9 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/abandoned_gambling_den)
-"jwK" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
 "jwW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/visible,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -17837,12 +17661,11 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "jxf" = (
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
 	},
-/obj/machinery/light/floor/fakeday,
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/surface/outdoors)
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "jxi" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -17856,10 +17679,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -17898,24 +17718,17 @@
 	pixel_x = 25;
 	req_access_txt = "47"
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 2
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 5
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "jzd" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
 	},
-/turf/open/floor/wood,
-/area/maintenance/bar)
+/turf/open/floor/plasteel,
+/area/crew_quarters/dorms)
 "jzq" = (
 /obj/structure/chair,
 /turf/open/floor/carpet/purple,
@@ -17927,10 +17740,7 @@
 /obj/machinery/light,
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "jzH" = (
@@ -17992,10 +17802,9 @@
 	dir = 4
 	},
 /obj/machinery/vending/wardrobe/engi_wardrobe,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "jBh" = (
@@ -18093,15 +17902,10 @@
 	c_tag = "Security Office";
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "jGC" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
 /obj/machinery/airalarm{
 	pixel_y = 23
 	},
@@ -18112,6 +17916,9 @@
 	pixel_x = 24;
 	pixel_y = -8;
 	req_access_txt = "11"
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -18126,6 +17933,7 @@
 /area/engine/engineering)
 "jHP" = (
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
+/obj/effect/turf_decal/trimline/green/filled/line,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "jHS" = (
@@ -18204,7 +18012,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -18252,8 +18060,8 @@
 	pixel_x = -31
 	},
 /obj/effect/landmark/start/librarian,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 6
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4
 	},
 /turf/open/floor/wood,
 /area/library)
@@ -18276,12 +18084,9 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "jNf" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/light/floor/fakeday,
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/surface/outdoors)
+/obj/item/kirbyplants/random,
+/turf/open/floor/plasteel,
+/area/crew_quarters/dorms)
 "jNo" = (
 /obj/structure/chair/stool,
 /obj/effect/landmark/loneopspawn,
@@ -18304,23 +18109,23 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
 "jNy" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/maintenance/solars/port/fore)
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "jNR" = (
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "jNT" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "jOi" = (
@@ -18336,17 +18141,11 @@
 /turf/open/floor/wood,
 /area/bridge/meeting_room)
 "jQm" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
+/turf/open/floor/plasteel,
+/area/crew_quarters/dorms)
 "jRA" = (
 /obj/structure/table/glass,
 /obj/item/radio/intercom{
@@ -18360,10 +18159,7 @@
 	pixel_y = 2
 	},
 /obj/item/storage/box/syringes,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -18382,8 +18178,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -18465,11 +18260,8 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/auto_name/north,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
@@ -18513,9 +18305,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
+/obj/structure/disposalpipe/trunk,
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "jWM" = (
@@ -18525,9 +18315,6 @@
 "jXf" = (
 /obj/structure/chair/office/dark{
 	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
@@ -18578,7 +18365,7 @@
 /obj/machinery/airalarm{
 	pixel_y = 23
 	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -18588,7 +18375,9 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "jZI" = (
-/obj/structure/closet/lasertag/blue,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "jZL" = (
@@ -18625,10 +18414,7 @@
 /area/maintenance/port)
 "kbB" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "kbD" = (
@@ -18723,10 +18509,13 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/security{
-	name = "persuasion room";
-	req_access_txt = "2"
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
 	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc/auto_name/north,
 /turf/open/floor/plating,
 /area/security/execution/education)
 "keV" = (
@@ -18746,8 +18535,9 @@
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "keW" = (
-/turf/open/floor/plasteel/showroomfloor/shower,
-/area/icemoon/surface/outdoors)
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/turf/open/floor/plasteel,
+/area/crew_quarters/dorms)
 "keZ" = (
 /obj/structure/table/glass,
 /obj/effect/turf_decal/tile/blue{
@@ -18855,16 +18645,13 @@
 /turf/open/floor/wood,
 /area/maintenance/bar)
 "kho" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "khF" = (
@@ -18975,10 +18762,9 @@
 /area/engine/engineering)
 "kmP" = (
 /obj/structure/closet/athletic_mixed,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "kna" = (
@@ -19014,10 +18800,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "knx" = (
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/trimline/green/filled/corner,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "knB" = (
@@ -19092,10 +18878,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -19135,10 +18918,10 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/machinery/vending/tool,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 1
 	},
-/obj/machinery/vending/tool,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "ktr" = (
@@ -19177,17 +18960,13 @@
 /obj/structure/closet/secure_closet/quartermaster,
 /obj/item/megaphone/cargo,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown,
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "kum" = (
-/obj/effect/turf_decal/tile/brown{
+/obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -19293,6 +19072,9 @@
 	pixel_y = 30
 	},
 /obj/structure/reagent_dispensers/watertank/high,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "kxq" = (
@@ -19351,28 +19133,27 @@
 "kyq" = (
 /obj/structure/chair,
 /obj/item/storage/box/zipties,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/security/execution/education)
 "kyH" = (
-/obj/structure/disposalpipe/segment,
-/turf/closed/wall/r_wall,
-/area/crew_quarters/heads/hos)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/plasteel,
+/area/crew_quarters/dorms)
 "kzm" = (
 /obj/machinery/holopad,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "kzB" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/disposalpipe/segment{
+	dir = 5
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/door/airlock/external{
-	name = "Solar Maintenance";
-	req_access_txt = "10; 13"
-	},
-/obj/structure/fans/tiny,
-/turf/open/floor/plating,
-/area/maintenance/solars/starboard/fore)
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "kzO" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -19383,19 +19164,13 @@
 /turf/open/floor/plasteel,
 /area/medical/medbay/central)
 "kzY" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "Secure Brig Control";
-	name = "brig shutters"
+/obj/machinery/light/floor/fakeday,
+/obj/structure/ore_box,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plating,
-/area/security/warden)
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/surface/outdoors)
 "kAg" = (
 /obj/machinery/shower{
 	dir = 4
@@ -19422,10 +19197,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "kAE" = (
@@ -19447,12 +19219,8 @@
 /obj/structure/sign/warning/nosmoking{
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
@@ -19524,10 +19292,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -19613,18 +19378,17 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/bridge)
 "kED" = (
-/obj/structure/cable{
-	icon_state = "0-2"
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 8
 	},
-/obj/machinery/power/solar{
-	id = "auxsolareast";
-	name = "Port Auxiliary Solar Array"
-	},
-/turf/open/floor/plating/asteroid/snow/ice/icemoon/solarpanel,
-/area/icemoon/surface/outdoors)
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "kEG" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/reflector/single,
@@ -19659,11 +19423,8 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "kFA" = (
-/obj/effect/turf_decal/tile/brown{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
@@ -19672,9 +19433,6 @@
 	name = "Station Intercom (General)";
 	pixel_x = 1;
 	pixel_y = 29
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
@@ -19812,10 +19570,9 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/brown{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/brown,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
 "kNt" = (
@@ -19824,7 +19581,7 @@
 /area/icemoon/surface/outdoors)
 "kNJ" = (
 /obj/structure/window/plastitanium,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/icemoon/surface/outdoors)
 "kNR" = (
 /obj/machinery/sleeper{
@@ -20019,10 +19776,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
+/obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "kTZ" = (
@@ -20044,11 +19798,9 @@
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "kUp" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
+/obj/machinery/space_heater,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "kUJ" = (
 /obj/structure/table,
 /obj/item/storage/box/rxglasses{
@@ -20106,7 +19858,6 @@
 /area/science/circuit)
 "kWp" = (
 /obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/tree/palm,
 /turf/open/floor/grass,
 /area/medical/virology)
 "kWt" = (
@@ -20153,23 +19904,20 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "kXp" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
 /obj/structure/chair{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "kXv" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -20178,11 +19926,8 @@
 	name = "Station Intercom (General)";
 	pixel_x = -30
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
@@ -20220,11 +19965,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -20274,8 +20016,7 @@
 "kZU" = (
 /obj/structure/table,
 /obj/structure/bedsheetbin/towel,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -20288,15 +20029,11 @@
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "laJ" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
 /obj/structure/chair{
 	dir = 1
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 6
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/checkpoint/auxiliary)
@@ -20304,14 +20041,10 @@
 /obj/machinery/computer/secure_data{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/light,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 6
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/warden)
 "lba" = (
@@ -20332,19 +20065,13 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
 "lbj" = (
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "lbr" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
@@ -20354,14 +20081,16 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
+	},
+/obj/structure/disposalpipe/junction/flip{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
 "lbG" = (
-/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "lcw" = (
@@ -20412,13 +20141,14 @@
 /obj/structure/chair/office/dark{
 	dir = 4
 	},
-/turf/open/floor/carpet/red/airless,
+/turf/open/floor/carpet/red,
 /area/icemoon/surface/outdoors)
 "ldy" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood,
-/area/maintenance/bar)
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "lee" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/stripes/line{
@@ -20445,6 +20175,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 9
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "lfP" = (
@@ -20453,27 +20186,17 @@
 "lfS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "lfW" = (
-/obj/structure/cable{
-	icon_state = "0-4"
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
 	},
-/obj/machinery/power/apc{
-	areastring = "/area/maintenance/solars/starboard/fore";
-	dir = 8;
-	name = "Starboard Bow Solar APC";
-	pixel_x = -25;
-	pixel_y = 3
-	},
-/turf/open/floor/plating,
-/area/maintenance/solars/starboard/fore)
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "lgj" = (
 /obj/structure/disposalpipe/junction{
 	dir = 4
@@ -20483,6 +20206,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -20585,7 +20311,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -20644,13 +20370,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 6
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown,
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "lkt" = (
@@ -20675,12 +20397,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"llz" = (
-/obj/structure/disposalpipe/junction{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "llU" = (
 /obj/effect/turf_decal/loading_area,
 /turf/open/floor/plasteel/white,
@@ -20720,7 +20436,6 @@
 /turf/open/floor/plasteel,
 /area/gateway)
 "lny" = (
-/obj/structure/fans/tiny,
 /obj/machinery/door/airlock/external{
 	name = "Engineering External Access";
 	req_access_txt = "10;13"
@@ -20735,7 +20450,7 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "lnB" = (
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -20780,20 +20495,6 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "lof" = (
-/obj/machinery/button/door{
-	id = "soli1";
-	name = "Solitary Cell 1";
-	pixel_x = -6;
-	pixel_y = 24;
-	req_access_txt = "3"
-	},
-/obj/machinery/button/door{
-	id = "soli2";
-	name = "Solitary Cell 2";
-	pixel_x = 6;
-	pixel_y = 24;
-	req_access_txt = "3"
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -20851,12 +20552,11 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "lpP" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
+/obj/structure/chair/comfy/brown{
+	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood,
-/area/maintenance/bar)
+/area/crew_quarters/bar)
 "lpR" = (
 /obj/machinery/camera{
 	c_tag = "Supermatter North"
@@ -20896,6 +20596,7 @@
 /obj/machinery/computer/operating{
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "lqM" = (
@@ -20941,6 +20642,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/trimline/green/filled/line,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "lrD" = (
@@ -21062,6 +20764,9 @@
 /obj/effect/turf_decal/loading_area{
 	dir = 8
 	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "lud" = (
@@ -21107,11 +20812,8 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -21186,11 +20888,9 @@
 	},
 /area/engine/engineering)
 "lwz" = (
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/surface/outdoors)
+/obj/machinery/light,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "lwB" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -21201,8 +20901,8 @@
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "lwK" = (
-/obj/structure/cable{
-	icon_state = "1-4"
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
@@ -21281,11 +20981,8 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
@@ -21353,18 +21050,13 @@
 /turf/open/floor/wood,
 /area/library)
 "lCa" = (
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
 /obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/hydroponics)
 "lCA" = (
 /obj/structure/chair/comfy/black,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -21429,8 +21121,8 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "lDX" = (
-/obj/effect/turf_decal/tile/red,
 /obj/item/kirbyplants/random,
+/obj/effect/turf_decal/trimline/red/filled/corner,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "lEa" = (
@@ -21583,9 +21275,8 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "lGK" = (
-/obj/structure/grille,
-/obj/structure/lattice,
 /obj/machinery/light/floor/fakeday,
+/obj/structure/flora/grass/both,
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors)
 "lGV" = (
@@ -21624,10 +21315,7 @@
 /obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -21686,10 +21374,7 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "lLe" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -21720,13 +21405,13 @@
 /turf/open/floor/engine,
 /area/engine/supermatter)
 "lLX" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/maintenance/disposal)
+/obj/structure/sign/barsign,
+/turf/closed/wall,
+/area/crew_quarters/bar)
 "lMa" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 10
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "lMe" = (
@@ -21749,14 +21434,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
-"lMH" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "lMY" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -21960,9 +21637,6 @@
 /area/crew_quarters/heads/cmo)
 "lSO" = (
 /obj/structure/closet/secure_closet/freezer/meat,
-/obj/machinery/light/small{
-	dir = 8
-	},
 /obj/item/reagent_containers/food/snacks/meat/slab/monkey,
 /obj/item/reagent_containers/food/snacks/meat/slab/monkey,
 /obj/item/reagent_containers/food/snacks/meat/slab/monkey,
@@ -22139,7 +21813,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "lXX" = (
-/turf/open/floor/carpet/red/airless,
+/turf/open/floor/carpet/red,
 /area/icemoon/surface/outdoors)
 "lYe" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
@@ -22206,8 +21880,8 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -22276,11 +21950,20 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Snow Airlock"
 	},
-/obj/structure/fans/tiny,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "mbc" = (
@@ -22299,20 +21982,14 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
 "mbD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -22336,10 +22013,7 @@
 	dir = 4;
 	pixel_x = -24
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -22373,7 +22047,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -22393,6 +22067,7 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "mda" = (
@@ -22403,7 +22078,10 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "mdx" = (
-/turf/open/floor/mineral/titanium/yellow/airless,
+/obj/structure/janitorialcart{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/yellow,
 /area/icemoon/surface/outdoors)
 "mdC" = (
 /obj/structure/cable{
@@ -22509,10 +22187,7 @@
 /obj/structure/sign/nanotrasen{
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
 /area/bridge)
 "mhv" = (
@@ -22569,25 +22244,19 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
 "miY" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/effect/turf_decal/bot,
 /obj/machinery/light{
 	dir = 8
 	},
 /obj/item/clothing/suit/hooded/wintercoat/security,
 /obj/structure/closet/secure_closet/security/sec,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "mjo" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "mjv" = (
@@ -22696,6 +22365,9 @@
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
 "mlS" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating,
 /area/hydroponics)
 "mlW" = (
@@ -22713,7 +22385,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 9
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
@@ -22730,12 +22402,8 @@
 /obj/structure/table,
 /obj/item/folder/blue,
 /obj/item/pen/blue,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
@@ -22881,10 +22549,7 @@
 /area/hallway/primary/central)
 "mss" = (
 /obj/machinery/washing_machine,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -22975,9 +22640,12 @@
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "muY" = (
-/obj/structure/sign/warning/electricshock,
-/turf/closed/wall/r_wall,
-/area/maintenance/solars/starboard/fore)
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass_large{
+	name = "Diner"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "mva" = (
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/white,
@@ -22986,9 +22654,10 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hop)
 "mwq" = (
-/obj/structure/mineral_door/woodrustic,
-/turf/open/floor/plasteel/cafeteria,
-/area/icemoon/surface/outdoors)
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "mwR" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -23055,12 +22724,10 @@
 /obj/structure/closet/secure_closet/personal{
 	anchored = 1
 	},
+/obj/structure/window/reinforced/tinted,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/fitness)
 "mzb" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/effect/landmark/start/shaft_miner,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
@@ -23075,33 +22742,28 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "mzU" = (
 /obj/machinery/door/unpowered/shuttle,
-/obj/structure/fans/tiny,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/icemoon/surface/outdoors)
 "mAb" = (
 /obj/machinery/door/airlock{
 	name = "Shower Room"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/toilet)
 "mAh" = (
 /obj/machinery/space_heater,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/checkpoint/auxiliary)
@@ -23156,7 +22818,7 @@
 	dir = 8
 	},
 /obj/machinery/light/floor/fakeday,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/icemoon/surface/outdoors)
 "mBx" = (
 /obj/effect/turf_decal/stripes/line{
@@ -23165,14 +22827,10 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "mBI" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/space_heater,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 6
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "mCa" = (
@@ -23247,13 +22905,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/crew_quarters/bar)
-"mEB" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "mEH" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
@@ -23268,7 +22919,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/loneopspawn,
-/turf/open/floor/mineral/titanium/yellow/airless,
+/turf/open/floor/mineral/titanium/yellow,
 /area/icemoon/surface/outdoors)
 "mFu" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -23277,11 +22928,8 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -23306,10 +22954,7 @@
 /area/medical/medbay/central)
 "mGf" = (
 /obj/machinery/door/firedoor/heavy,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "mGW" = (
@@ -23376,9 +23021,7 @@
 	dir = 4;
 	id = "garbage"
 	},
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
+/obj/structure/disposalpipe/trunk,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "mHY" = (
@@ -23403,9 +23046,6 @@
 	dir = 4;
 	name = "HoS Office";
 	req_access_txt = "58"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
 	},
 /obj/machinery/airalarm{
 	pixel_y = 23
@@ -23504,6 +23144,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/green/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/green/filled/corner,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "mLB" = (
@@ -23576,10 +23220,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -23635,10 +23276,7 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "mPB" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -23647,8 +23285,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/visible{
 	dir = 5
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -23656,9 +23293,7 @@
 "mPT" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/carpet,
 /area/chapel/main)
 "mQM" = (
@@ -23730,7 +23365,10 @@
 	req_access_txt = "29"
 	},
 /obj/machinery/door/firedoor,
-/turf/open/floor/plasteel,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/robotics/mechbay)
 "mSL" = (
 /obj/structure/table/glass,
@@ -23776,13 +23414,12 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "mTF" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/green/filled/line,
 /turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
+/area/hydroponics)
 "mTK" = (
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -23793,6 +23430,7 @@
 	pixel_x = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "mUj" = (
@@ -23814,14 +23452,11 @@
 /area/hallway/secondary/entry)
 "mUy" = (
 /obj/structure/closet/secure_closet/security/sec,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /obj/effect/turf_decal/bot,
 /obj/item/clothing/suit/hooded/wintercoat/security,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "mUB" = (
@@ -23856,11 +23491,8 @@
 /area/maintenance/port)
 "mVc" = (
 /obj/machinery/chem_master,
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
@@ -23893,20 +23525,21 @@
 "mVN" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "mWa" = (
 /turf/closed/wall,
 /area/hallway/primary/starboard)
 "mWM" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/chair{
+	dir = 8
 	},
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/surface/outdoors)
+/obj/effect/landmark/start/assistant,
+/obj/effect/turf_decal/tile/bar{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "mWP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -23934,11 +23567,17 @@
 	},
 /obj/item/watertank,
 /obj/item/reagent_containers/spray/plantbgone,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 10
+	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "mXS" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
 /turf/open/floor/circuit{
 	name = "Floor Data Lattice"
@@ -23962,6 +23601,16 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel,
 /area/bridge)
 "mYi" = (
@@ -24006,20 +23655,8 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hop)
-"mZP" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 2
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
 "nat" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/trimline/green/filled/corner,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "naZ" = (
@@ -24040,17 +23677,18 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "nbj" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/maintenance/disposal)
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "nbH" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 6
 	},
 /obj/machinery/smartfridge/chemistry/virology/preloaded,
 /turf/open/floor/plasteel/white,
@@ -24070,17 +23708,14 @@
 /turf/open/floor/grass,
 /area/bridge)
 "neu" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/surface/outdoors)
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "nez" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -24097,13 +23732,13 @@
 /area/quartermaster/miningoffice)
 "neE" = (
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
-/obj/structure/cable{
-	icon_state = "2-8"
+/obj/structure/disposalpipe/broken{
+	dir = 8
 	},
 /turf/open/floor/plating,
-/area/maintenance/solars/port/fore)
+/area/maintenance/fore)
 "nfi" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -24112,7 +23747,7 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "nfn" = (
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -24151,25 +23786,19 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/maintenance/disposal/incinerator)
 "nfI" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "ngu" = (
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
@@ -24208,15 +23837,14 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "nhv" = (
 /obj/effect/landmark/loneopspawn,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/icemoon/surface/outdoors)
 "nhw" = (
 /obj/structure/flora/ausbushes/ywflowers,
@@ -24308,12 +23936,17 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "nkn" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 6
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/structure/chair/sofa/corp,
-/turf/open/floor/plasteel/showroomfloor,
-/area/crew_quarters/fitness)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
 "nkt" = (
 /obj/structure/sign/warning/nosmoking{
 	pixel_x = -28
@@ -24350,7 +23983,7 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/bridge)
 "nkL" = (
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -24417,7 +24050,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/warden)
 "nmD" = (
@@ -24448,7 +24080,6 @@
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
 	},
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -24466,6 +24097,9 @@
 	dir = 1
 	},
 /obj/machinery/vending/autodrobe,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "nnh" = (
@@ -24481,15 +24115,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"nnw" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/bridge)
 "nnG" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -24498,9 +24123,6 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "nod" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -31
 	},
@@ -24510,10 +24132,10 @@
 /obj/structure/chair/comfy/brown{
 	dir = 8
 	},
-/turf/open/floor/wood,
+/turf/open/floor/carpet,
 /area/crew_quarters/bar)
 "nos" = (
-/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/plasteel,
 /area/bridge)
 "not" = (
@@ -24536,14 +24158,17 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "noT" = (
-/obj/effect/turf_decal/tile/purple,
 /obj/machinery/light,
+/obj/effect/turf_decal/trimline/purple/filled/corner,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "noY" = (
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_y = 20
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
@@ -24626,14 +24251,15 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "nqR" = (
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "2-8"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
+/obj/machinery/light/floor,
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "2-4"
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
@@ -24801,17 +24427,14 @@
 /area/medical/virology)
 "nvQ" = (
 /obj/structure/closet/secure_closet/security/sec,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /obj/effect/turf_decal/bot,
 /obj/machinery/light{
 	dir = 1
 	},
 /obj/item/clothing/suit/hooded/wintercoat/security,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "nwl" = (
@@ -24821,20 +24444,27 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "nwv" = (
 /obj/structure/closet/secure_closet/security/sec,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /obj/effect/turf_decal/bot,
 /obj/item/clothing/suit/hooded/wintercoat/security,
 /obj/machinery/airalarm{
 	pixel_y = 26
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -24882,11 +24512,8 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "nxW" = (
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
@@ -24919,11 +24546,14 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "nyY" = (
-/obj/structure/cable{
-	icon_state = "2-4"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
 /obj/structure/cable{
-	icon_state = "1-4"
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
@@ -25114,21 +24744,15 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "nEF" = (
 /obj/machinery/door/firedoor/heavy,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -25196,7 +24820,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/maintenance/fore)
+/area/security/execution/education)
 "nGu" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -25209,10 +24833,7 @@
 	},
 /area/crew_quarters/fitness)
 "nGO" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "nGV" = (
@@ -25267,11 +24888,9 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "nHH" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 4
-	},
-/obj/structure/chair/sofa/corp,
-/turf/open/floor/plasteel/showroomfloor,
+/obj/structure/table/glass,
+/obj/structure/bedsheetbin/towel,
+/turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "nHL" = (
 /obj/machinery/computer/upload/ai,
@@ -25383,7 +25002,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -25410,14 +25029,8 @@
 /turf/closed/wall/r_wall,
 /area/science/research)
 "nMs" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 10
-	},
-/obj/structure/chair/sofa/corp,
-/obj/structure/sign/poster/official/no_erp{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/showroomfloor,
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "nMI" = (
 /obj/structure/window/plasma/reinforced{
@@ -25527,7 +25140,7 @@
 /obj/machinery/computer{
 	dir = 4
 	},
-/turf/open/floor/mineral/titanium/white/airless,
+/turf/open/floor/mineral/titanium/white,
 /area/icemoon/surface/outdoors)
 "nPx" = (
 /obj/machinery/door/firedoor,
@@ -25546,6 +25159,10 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/fans/tiny,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "permalock";
+	name = "Perma Lockdown Shutter"
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "nQs" = (
@@ -25586,25 +25203,23 @@
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors)
 "nSr" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/closet/secure_closet/personal/patient,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "nSA" = (
 /turf/closed/wall/mineral/titanium,
 /area/icemoon/surface/outdoors)
 "nTG" = (
-/turf/closed/mineral/random/snow/more_caves,
-/area/maintenance/bar)
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "nUn" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -25631,6 +25246,9 @@
 /obj/machinery/airalarm{
 	pixel_y = 26
 	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "nUV" = (
@@ -25645,7 +25263,7 @@
 	dir = 8
 	},
 /obj/machinery/space_heater,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -25657,7 +25275,6 @@
 /turf/open/floor/engine,
 /area/science/misc_lab)
 "nVs" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -25727,7 +25344,7 @@
 /area/crew_quarters/bar)
 "nWu" = (
 /obj/effect/landmark/loneopspawn,
-/turf/open/floor/mineral/plastitanium/red/airless,
+/turf/open/floor/mineral/plastitanium/red,
 /area/icemoon/surface/outdoors)
 "nWA" = (
 /obj/structure/disposalpipe/junction/yjunction{
@@ -25747,11 +25364,11 @@
 /area/hallway/primary/central)
 "nWJ" = (
 /obj/machinery/door/unpowered/shuttle,
-/obj/structure/fans/tiny,
 /obj/structure/barricade/wooden/crude/snow{
 	max_integrity = 15;
 	obj_integrity = 15
 	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
 /area/icemoon/surface/outdoors)
 "nWM" = (
@@ -25818,6 +25435,16 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "nYV" = (
@@ -25912,12 +25539,6 @@
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "oea" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
@@ -25926,6 +25547,9 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
@@ -25968,7 +25592,7 @@
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
 	},
-/turf/open/floor/mineral/titanium/yellow/airless,
+/turf/open/floor/mineral/titanium/yellow,
 /area/icemoon/surface/outdoors)
 "ofi" = (
 /obj/effect/turf_decal/tile/blue,
@@ -26173,12 +25797,14 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
 "okB" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment{
-	dir = 10
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/maintenance/disposal)
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/surface/outdoors)
 "okS" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -26299,8 +25925,7 @@
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -26391,17 +26016,18 @@
 /turf/open/floor/wood,
 /area/library)
 "opC" = (
-/obj/structure/bed,
-/obj/machinery/camera{
-	c_tag = "Permabrig Iso Cell 2";
-	network = list("ss13","prison")
-	},
-/obj/machinery/light/small{
+/obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/mineral/titanium/white{
-	name = "secure isolation floor"
+/obj/structure/closet/secure_closet/genpop,
+/obj/item/clothing/suit/hooded/wintercoat,
+/obj/item/radio/headset{
+	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
+	name = "prisoner headset";
+	prison_radio = 1
 	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "opE" = (
 /obj/structure/disposalpipe/segment{
@@ -26419,10 +26045,9 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "opN" = (
-/obj/structure/table/glass,
-/obj/structure/bedsheetbin/towel,
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
+/obj/structure/statue/snow/snowman,
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors)
 "opO" = (
 /obj/structure/table,
 /turf/open/floor/plating,
@@ -26447,15 +26072,9 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
 "oqk" = (
-/obj/structure/chair/sofa/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 6
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood,
-/area/maintenance/bar)
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/surface/outdoors)
 "oqN" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
@@ -26463,13 +26082,16 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "oqR" = (
-/obj/structure/chair/stool,
 /obj/machinery/camera{
-	c_tag = "Aft Starboard Solar Control";
+	c_tag = "Aft Starboard Generator";
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/port_gen/pacman,
 /turf/open/floor/plating,
-/area/maintenance/solars/port/fore)
+/area/maintenance/port)
 "orf" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin{
@@ -26536,16 +26158,6 @@
 /obj/machinery/light/floor/fakeday,
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors)
-"osq" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/bridge)
 "osX" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -26571,18 +26183,12 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "ouA" = (
-/obj/effect/turf_decal/tile/brown{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "ouN" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -26605,10 +26211,7 @@
 "ovq" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -26660,20 +26263,18 @@
 /turf/open/floor/plasteel,
 /area/science/lab)
 "owU" = (
-/obj/item/kirbyplants/random,
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_x = 28
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
+/turf/open/floor/plating,
+/area/hallway/primary/starboard)
 "owY" = (
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "oxc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/obj/structure/fans/tiny,
 /obj/machinery/door/airlock/external{
 	name = "Atmospherics External Airlock";
 	req_access_txt = "24"
@@ -26688,6 +26289,9 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "oxm" = (
@@ -26733,15 +26337,6 @@
 /obj/machinery/light/floor/fakeday,
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors)
-"oyK" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "oyS" = (
 /obj/structure/table/wood,
 /obj/machinery/recharger{
@@ -26815,6 +26410,9 @@
 	icon_state = "4-8"
 	},
 /obj/effect/landmark/start/prisoner,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "oBC" = (
@@ -26933,7 +26531,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "oEf" = (
-/obj/structure/table,
+/obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "oEn" = (
@@ -27071,15 +26669,15 @@
 "oHq" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
 /area/bridge)
 "oHt" = (
 /obj/structure/sign/warning/securearea{
 	pixel_x = 32
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -27098,10 +26696,6 @@
 	},
 /obj/item/pen/fountain,
 /obj/item/stamp/qm,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown,
 /obj/machinery/light_switch{
 	pixel_y = -25
 	},
@@ -27117,38 +26711,31 @@
 /obj/item/phone{
 	pixel_x = 16
 	},
+/obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "oIc" = (
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
 "oIf" = (
-/obj/structure/cable,
-/obj/machinery/power/solar{
-	id = "starboardsolar";
-	name = "Starboard Solar Array"
-	},
-/turf/open/floor/plating/asteroid/snow/ice/icemoon/solarpanel,
-/area/icemoon/surface/outdoors)
-"oIE" = (
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
+/turf/open/floor/plating,
+/area/hallway/primary/central)
+"oIE" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 10
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/checkpoint/auxiliary)
@@ -27186,7 +26773,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/maintenance/solars/port/fore)
+/area/maintenance/port)
 "oJU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -27233,6 +26820,16 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
 "oLO" = (
@@ -27282,10 +26879,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -27299,10 +26893,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "oOc" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "oOj" = (
@@ -27390,15 +26981,11 @@
 /turf/open/floor/circuit/telecomms/server,
 /area/science/server)
 "oQd" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -27457,9 +27044,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "oRh" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/heater{
-	dir = 4
-	},
 /turf/open/floor/plating,
 /area/maintenance/bar)
 "oRv" = (
@@ -27557,18 +27141,12 @@
 /turf/open/floor/plasteel/white,
 /area/science/storage)
 "oVL" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/space_heater,
 /obj/machinery/camera{
 	c_tag = "Reeducation Entry"
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -27613,11 +27191,8 @@
 /turf/open/floor/wood,
 /area/icemoon/surface/outdoors)
 "oWL" = (
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
@@ -27711,11 +27286,15 @@
 /turf/open/floor/plating,
 /area/crew_quarters/abandoned_gambling_den)
 "oYt" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/bridge)
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/hallway/primary/central)
 "oYw" = (
 /obj/structure/chair/office/light{
 	dir = 8
@@ -27775,10 +27354,9 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "pao" = (
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "paF" = (
@@ -27807,9 +27385,6 @@
 	pixel_x = -30
 	},
 /obj/structure/chair/office/dark,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1
-	},
 /turf/open/floor/wood,
 /area/library)
 "pbf" = (
@@ -27965,28 +27540,21 @@
 /turf/open/floor/plasteel,
 /area/medical/sleeper)
 "peL" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
 /obj/machinery/camera{
 	c_tag = "Command Plaza West";
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/bridge)
 "pfw" = (
-/obj/structure/chair/sofa/right{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 9
-	},
-/turf/open/floor/wood,
-/area/maintenance/bar)
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/surface/outdoors)
 "pfH" = (
 /obj/machinery/door/unpowered/shuttle,
 /turf/open/floor/plating,
@@ -28034,13 +27602,7 @@
 /turf/open/floor/wood,
 /area/icemoon/surface/outdoors)
 "pgp" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -28049,6 +27611,9 @@
 /obj/structure/table,
 /obj/machinery/plantgenes{
 	pixel_y = 6
+	},
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
@@ -28093,15 +27658,17 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/mineral/titanium/yellow/airless,
+/turf/open/floor/mineral/titanium/yellow,
 /area/icemoon/surface/outdoors)
 "phY" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/obj/machinery/light/small{
-	dir = 8
+/obj/machinery/computer/shuttle/snow_taxi{
+	dir = 4
 	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/crew_quarters/fitness)
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "pit" = (
 /obj/structure/table,
 /obj/item/crowbar/red,
@@ -28153,14 +27720,10 @@
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "piL" = (
-/obj/machinery/power/apc{
-	areastring = "/area/maintenance/disposal";
-	name = "Disposal APC";
-	pixel_y = -24
-	},
 /obj/structure/cable{
-	icon_state = "0-8"
+	icon_state = "4-8"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "piR" = (
@@ -28207,12 +27770,11 @@
 /obj/structure/sign/warning/securearea{
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -28253,7 +27815,7 @@
 	dir = 1;
 	network = list("ss13","prison")
 	},
-/turf/open/floor/circuit/green,
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "plh" = (
 /obj/machinery/door/airlock/research{
@@ -28274,10 +27836,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
 /area/bridge)
 "plA" = (
@@ -28405,11 +27964,8 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
 /obj/structure/bed/roller,
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "poN" = (
@@ -28425,7 +27981,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -28516,12 +28072,8 @@
 	icon_state = "plant-22"
 	},
 /obj/machinery/light,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
@@ -28531,19 +28083,28 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "psU" = (
-/obj/machinery/holopad,
+/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
+	},
+/turf/open/floor/carpet,
+/area/chapel/main)
 "ptl" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "ptz" = (
-/obj/structure/chair{
+/obj/machinery/computer/holodeck{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -28680,7 +28241,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/mineral/titanium/white/airless,
+/turf/open/floor/mineral/titanium/white,
 /area/icemoon/surface/outdoors)
 "pAG" = (
 /obj/structure/table,
@@ -28744,10 +28305,10 @@
 /obj/machinery/computer/card/minor/hos{
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
 /obj/machinery/power/apc/auto_name/west,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
 "pBD" = (
@@ -28791,11 +28352,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -28848,7 +28406,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "pDB" = (
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -28862,20 +28420,9 @@
 /turf/open/floor/wood,
 /area/icemoon/surface/outdoors)
 "pDO" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel,
-/area/bridge)
+/obj/machinery/holopad,
+/turf/open/floor/wood,
+/area/library)
 "pEg" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/toxins_mixing_output{
 	dir = 1
@@ -28921,13 +28468,10 @@
 	pixel_x = 5;
 	pixel_y = 29
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
+/obj/effect/landmark/start/virologist,
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
 	},
-/obj/effect/landmark/start/virologist,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "pFA" = (
@@ -28985,11 +28529,8 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "pHB" = (
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
@@ -29007,11 +28548,8 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -29058,7 +28596,7 @@
 /obj/structure/shuttle/engine/propulsion{
 	dir = 4
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/icemoon/surface/outdoors)
 "pKh" = (
 /obj/structure/rack,
@@ -29075,26 +28613,39 @@
 	pixel_y = 30
 	},
 /obj/machinery/iv_drip,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
 /obj/machinery/light{
 	dir = 8
+	},
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 9
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "pKt" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/closet/emcloset{
+	name = "External Supply Closet"
 	},
-/turf/open/floor/plating,
-/area/maintenance/solars/port/fore)
+/obj/item/pickaxe,
+/obj/item/pickaxe,
+/obj/item/pickaxe,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/shoes/winterboots,
+/obj/item/clothing/shoes/winterboots,
+/obj/item/clothing/shoes/winterboots,
+/obj/item/clothing/suit/hooded/wintercoat,
+/obj/item/clothing/suit/hooded/wintercoat,
+/obj/item/clothing/suit/hooded/wintercoat,
+/obj/machinery/camera{
+	c_tag = "SecMed External Access";
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "pKF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -29157,11 +28708,8 @@
 /area/maintenance/disposal)
 "pLN" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown,
 /obj/machinery/power/apc/auto_name/south,
+/obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "pLT" = (
@@ -29268,10 +28816,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "pOL" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -29356,7 +28901,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -29382,19 +28927,33 @@
 	normalspeed = 0;
 	req_access_txt = "150"
 	},
-/turf/open/floor/mineral/plastitanium/red/airless,
+/turf/open/floor/mineral/plastitanium/red,
 /area/icemoon/surface/outdoors)
 "pRK" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "pRL" = (
-/obj/structure/cable,
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/surface/outdoors)
+/obj/structure/closet/emcloset{
+	name = "External Supply Closet"
+	},
+/obj/item/pickaxe,
+/obj/item/pickaxe,
+/obj/item/pickaxe,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/shoes/winterboots,
+/obj/item/clothing/shoes/winterboots,
+/obj/item/clothing/shoes/winterboots,
+/obj/item/clothing/suit/hooded/wintercoat,
+/obj/item/clothing/suit/hooded/wintercoat,
+/obj/item/clothing/suit/hooded/wintercoat,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "pSd" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/virology/glass{
@@ -29402,6 +28961,16 @@
 	req_access_txt = "39"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "pSx" = (
@@ -29474,6 +29043,9 @@
 /area/crew_quarters/locker)
 "pUi" = (
 /obj/structure/closet/secure_closet/brig_phys,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "pUK" = (
@@ -29543,12 +29115,12 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "pXf" = (
-/obj/structure/cable{
-	icon_state = "0-4"
+/obj/structure/rack,
+/obj/item/stack/sheet/mineral/plasma{
+	amount = 10
 	},
-/obj/machinery/power/apc/auto_name/west,
 /turf/open/floor/plating,
-/area/maintenance/solars/port/fore)
+/area/maintenance/port)
 "pXr" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/red{
@@ -29595,6 +29167,12 @@
 /obj/machinery/door/airlock/virology/glass{
 	name = "Monkey Pen";
 	req_access_txt = "39"
+	},
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -29685,8 +29263,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -29736,10 +29313,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
 	},
-/obj/effect/turf_decal/tile/brown{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/brown,
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "qax" = (
@@ -29828,33 +29404,25 @@
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "qdy" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/solars/starboard/fore)
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "qdG" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/sleeper)
 "qdV" = (
 /obj/structure/table,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
 /obj/machinery/airalarm{
 	pixel_y = 23
 	},
 /obj/item/paper/fluff/fridgestation/nt,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 9
+	},
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "qdX" = (
@@ -29865,7 +29433,6 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/service)
 "qeq" = (
-/obj/structure/fans/tiny,
 /obj/machinery/door/airlock/external{
 	name = "Engineering External Access";
 	req_access_txt = "10;13"
@@ -29885,24 +29452,21 @@
 /area/hallway/secondary/entry)
 "qey" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_y = 20
 	},
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 1
+	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "qfr" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
@@ -29922,12 +29486,12 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
+/obj/machinery/door/poddoor/preopen{
+	id = "bridge blast";
+	name = "bridge blast door"
+	},
 /turf/open/floor/plating,
 /area/bridge)
-"qfO" = (
-/obj/machinery/light,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "qfW" = (
 /obj/effect/landmark/start/medical_doctor,
 /obj/effect/turf_decal/tile/blue,
@@ -29970,7 +29534,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "qgt" = (
-/turf/open/floor/mineral/plastitanium/red/airless,
+/turf/open/floor/mineral/plastitanium/red,
 /area/icemoon/surface/outdoors)
 "qgW" = (
 /turf/open/floor/plating/beach/coastline_t,
@@ -30057,7 +29621,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -30066,11 +29630,8 @@
 /obj/machinery/atmospherics/pipe/manifold/orange/visible{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -30176,6 +29737,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "qlo" = (
@@ -30203,7 +29767,7 @@
 /obj/machinery/atm{
 	pixel_y = 30
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -30213,10 +29777,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -30228,24 +29789,9 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/prison)
 "qmZ" = (
-/obj/structure/closet/emcloset{
-	name = "External Supply Closet"
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/obj/item/pickaxe,
-/obj/item/pickaxe,
-/obj/item/pickaxe,
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/shoes/winterboots,
-/obj/item/clothing/shoes/winterboots,
-/obj/item/clothing/shoes/winterboots,
-/obj/item/clothing/suit/hooded/wintercoat,
-/obj/item/clothing/suit/hooded/wintercoat,
-/obj/item/clothing/suit/hooded/wintercoat,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "qnS" = (
@@ -30312,10 +29858,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -30341,6 +29884,9 @@
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
@@ -30374,12 +29920,12 @@
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "qqO" = (
-/obj/structure/sign/warning/vacuum/external{
-	pixel_y = -32
+/obj/machinery/vending/coffee,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
 	},
-/obj/structure/rack,
-/turf/open/floor/plating,
-/area/maintenance/solars/port/fore)
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "qri" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
@@ -30402,10 +29948,7 @@
 	pixel_y = 24
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -30418,17 +29961,9 @@
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "qrY" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/surface/outdoors)
+/obj/effect/landmark/barthpot,
+/turf/open/floor/carpet,
+/area/library)
 "qse" = (
 /obj/machinery/rnd/server,
 /turf/open/floor/circuit/telecomms/server,
@@ -30436,10 +29971,7 @@
 "qsM" = (
 /obj/structure/chair/office/dark,
 /obj/effect/landmark/start/head_of_personnel,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
 "qsS" = (
@@ -30454,6 +29986,7 @@
 	c_tag = "Dorms West";
 	dir = 1
 	},
+/obj/structure/closet/lasertag/blue,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "qts" = (
@@ -30493,17 +30026,14 @@
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors)
 "qvo" = (
-/obj/structure/chair/sofa{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/obj/machinery/light/small{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood,
-/area/maintenance/bar)
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/checkpoint/auxiliary)
 "qvp" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -30516,6 +30046,9 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/head_of_security,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
 "qvV" = (
@@ -30534,11 +30067,8 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/teleporter)
@@ -30630,6 +30160,9 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
 	},
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 9
+	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "qyX" = (
@@ -30661,13 +30194,10 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 10
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "qzu" = (
@@ -30679,9 +30209,14 @@
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors)
 "qzB" = (
-/obj/structure/disposalpipe/segment,
-/turf/closed/wall/r_wall,
-/area/security/main)
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
 "qAa" = (
 /obj/machinery/light,
 /turf/open/floor/plating/beach/water,
@@ -30692,10 +30227,9 @@
 	pixel_x = 32;
 	pixel_y = 20
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "qAE" = (
@@ -30739,11 +30273,8 @@
 /area/maintenance/disposal/incinerator)
 "qBR" = (
 /obj/machinery/door/firedoor/heavy,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -30778,10 +30309,7 @@
 /obj/structure/sign/nanotrasen{
 	pixel_y = 32
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -30831,11 +30359,8 @@
 /obj/machinery/airalarm{
 	pixel_y = 23
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
@@ -30975,6 +30500,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "qJW" = (
@@ -31022,11 +30550,11 @@
 /obj/structure/chair{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
@@ -31064,10 +30592,7 @@
 /obj/machinery/vending/wallmed{
 	pixel_y = 28
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -31076,11 +30601,8 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 2
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
@@ -31104,11 +30626,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -31196,19 +30715,20 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/hallway)
 "qOR" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
 /obj/structure/closet/secure_closet/engineering_welding,
 /obj/item/clothing/glasses/welding,
 /obj/item/electronics/airlock,
 /obj/item/electronics/airlock,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "qOS" = (
 /obj/structure/closet/secure_closet/personal{
 	anchored = 1
 	},
+/obj/structure/window/reinforced/tinted,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/fitness)
 "qOW" = (
@@ -31281,15 +30801,9 @@
 /turf/open/floor/mech_bay_recharge_floor,
 /area/quartermaster/miningoffice)
 "qQJ" = (
-/obj/structure/chair/sofa/corner{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 5
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood,
-/area/maintenance/bar)
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
 "qRF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/components/binary/pump{
@@ -31336,7 +30850,7 @@
 /area/bridge)
 "qSy" = (
 /obj/machinery/door/poddoor/preopen,
-/turf/open/floor/mineral/titanium/yellow/airless,
+/turf/open/floor/mineral/titanium/yellow,
 /area/icemoon/surface/outdoors)
 "qSF" = (
 /obj/effect/turf_decal/tile/blue{
@@ -31381,6 +30895,7 @@
 "qTx" = (
 /obj/structure/table,
 /obj/item/flashlight/lamp,
+/obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plating,
 /area/security/execution/education)
 "qTF" = (
@@ -31400,6 +30915,16 @@
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Engineering Equipment";
 	req_access_txt = "11"
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -31430,13 +30955,12 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/machinery/camera{
 	c_tag = "Command Plaza East";
 	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
@@ -31503,10 +31027,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -31532,7 +31056,10 @@
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors)
 "qYN" = (
-/turf/open/floor/plasteel/showroomfloor/shower,
+/obj/machinery/atmospherics/components/unary/thermomachine/heater{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "qZg" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -31543,9 +31070,6 @@
 	name = "Station Intercom (General)";
 	pixel_x = 1;
 	pixel_y = 29
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
@@ -31615,15 +31139,12 @@
 	name = "Turbine Access";
 	req_access_txt = "24"
 	},
-/obj/structure/fans/tiny,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "rcg" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
 /obj/structure/bed/roller,
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "rci" = (
@@ -31637,20 +31158,14 @@
 	dir = 8
 	},
 /obj/structure/closet/l3closet/security,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "rcJ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "rcM" = (
@@ -31678,13 +31193,10 @@
 /area/medical/sleeper)
 "rcP" = (
 /obj/machinery/vending/wardrobe/viro_wardrobe,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/green/filled/line,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "rdc" = (
@@ -31725,9 +31237,9 @@
 /turf/open/floor/plasteel,
 /area/teleporter)
 "ree" = (
-/obj/effect/turf_decal/tile/brown,
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/crew_quarters/bar)
 "rei" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/window/reinforced,
@@ -31761,15 +31273,13 @@
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
 "rfS" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/broken,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "rgg" = (
@@ -31792,6 +31302,9 @@
 "rgs" = (
 /obj/structure/table,
 /obj/machinery/light,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "rgD" = (
@@ -31843,13 +31356,9 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "riZ" = (
-/obj/structure/closet/lasertag/red,
-/obj/machinery/camera{
-	c_tag = "Dorms West - Holodeck";
-	dir = 8
-	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
+/area/hallway/secondary/exit/departure_lounge)
 "rjb" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -31876,13 +31385,10 @@
 /turf/open/floor/plating,
 /area/security/brig)
 "rjq" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green,
 /obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
+/obj/effect/turf_decal/trimline/green/filled/line,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "rjs" = (
@@ -31903,7 +31409,7 @@
 /area/security/main)
 "rjG" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -31916,6 +31422,9 @@
 "rkn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "rkx" = (
@@ -31969,9 +31478,6 @@
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/hor)
 "rlY" = (
-/obj/structure/disposalpipe/junction/flip{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -31981,8 +31487,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
@@ -31998,7 +31507,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/maintenance/fore)
+/area/security/execution/education)
 "rmF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -32098,10 +31607,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "rpk" = (
@@ -32117,26 +31623,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "rpD" = (
-/obj/structure/closet/emcloset{
-	name = "External Supply Closet"
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/item/pickaxe,
-/obj/item/pickaxe,
-/obj/item/pickaxe,
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/shoes/winterboots,
-/obj/item/clothing/shoes/winterboots,
-/obj/item/clothing/shoes/winterboots,
-/obj/item/clothing/suit/hooded/wintercoat,
-/obj/item/clothing/suit/hooded/wintercoat,
-/obj/item/clothing/suit/hooded/wintercoat,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/surface/outdoors)
 "rpR" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /mob/living/carbon/monkey,
@@ -32270,9 +31761,6 @@
 /obj/structure/closet/bombcloset,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
-"rsL" = (
-/turf/open/floor/mineral/titanium/white/airless,
-/area/icemoon/surface/outdoors)
 "rth" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lantern{
@@ -32296,14 +31784,11 @@
 	name = "Brig APC";
 	pixel_y = 24
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "0-2"
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -32345,6 +31830,9 @@
 /obj/item/stack/sheet/plasteel{
 	amount = 10
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "ruD" = (
@@ -32359,11 +31847,8 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -32381,16 +31866,14 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "rvQ" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/chair{
+	dir = 4
 	},
-/obj/machinery/door/airlock/engineering{
-	name = "Starboard Bow Solar Access";
-	req_access_txt = "10"
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
 	},
-/obj/structure/fans/tiny,
-/turf/open/floor/plating,
-/area/maintenance/solars/starboard/fore)
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
 "rwc" = (
 /obj/structure/chair,
 /turf/open/floor/plasteel,
@@ -32408,13 +31891,9 @@
 /obj/machinery/keycard_auth{
 	pixel_y = -24
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 10
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown,
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "rwU" = (
@@ -32493,10 +31972,7 @@
 /obj/machinery/computer/message_monitor{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -32535,14 +32011,9 @@
 /turf/open/floor/plating,
 /area/hydroponics)
 "rzb" = (
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
+/obj/machinery/space_heater,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "rzg" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -32588,17 +32059,14 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "rzR" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-4"
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/secondary/exit/departure_lounge)
 "rAH" = (
 /obj/machinery/telecomms/server/presets/science,
 /turf/open/floor/plasteel/dark/telecomms,
@@ -32635,8 +32103,11 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
 "rBQ" = (
-/turf/open/floor/plating/airless,
-/area/icemoon/surface/outdoors)
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
 "rCs" = (
 /obj/machinery/camera{
 	c_tag = "Server Room";
@@ -32697,10 +32168,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel,
 /area/bridge)
 "rEF" = (
@@ -32796,15 +32266,11 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "rHa" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/bar{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
+/area/hallway/secondary/exit/departure_lounge)
 "rHk" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/tile/yellow,
@@ -32837,15 +32303,15 @@
 	dir = 1;
 	pixel_y = -24
 	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "rIB" = (
 /obj/machinery/atmospherics/pipe/simple/dark/visible,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -32856,12 +32322,11 @@
 	name = "Cell 3";
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
 /obj/structure/cable{
 	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -32890,8 +32355,10 @@
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/fitness)
 "rKg" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/light/small{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -32952,6 +32419,9 @@
 /obj/structure/sign/poster/official/no_erp{
 	pixel_y = 32
 	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "rKZ" = (
@@ -32966,21 +32436,20 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "rLF" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
 	},
-/turf/open/floor/plating,
-/area/science/robotics/mechbay)
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
 "rLK" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
@@ -33031,16 +32500,11 @@
 /turf/closed/wall/r_wall,
 /area/science/mixing)
 "rMP" = (
-/obj/machinery/camera{
-	c_tag = "Fore Starboard Solars";
-	dir = 1
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/power/smes,
-/turf/open/floor/plating,
-/area/maintenance/solars/starboard/fore)
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
 "rMS" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -33105,12 +32569,12 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
 "rPk" = (
-/obj/machinery/space_heater,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
+/obj/structure/chair/stool,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
+/turf/open/floor/plating,
+/area/crew_quarters/abandoned_gambling_den)
 "rPs" = (
 /obj/structure/chair,
 /obj/machinery/camera{
@@ -33179,6 +32643,12 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/trimline/green/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/green/filled/corner{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "rRk" = (
@@ -33192,7 +32662,7 @@
 /obj/machinery/computer{
 	dir = 8
 	},
-/turf/open/floor/mineral/titanium/white/airless,
+/turf/open/floor/mineral/titanium/white,
 /area/icemoon/surface/outdoors)
 "rSf" = (
 /obj/machinery/light,
@@ -33256,8 +32726,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -33284,19 +32753,15 @@
 /area/engine/supermatter)
 "rVP" = (
 /obj/structure/filingcabinet/chestdrawer,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /obj/machinery/light{
 	dir = 1
 	},
 /obj/machinery/airalarm{
 	dir = 8;
 	pixel_x = 24
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/warden)
@@ -33341,10 +32806,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "rYC" = (
@@ -33404,9 +32866,15 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "rZV" = (
-/obj/machinery/light/floor/fakeday,
-/obj/structure/flora/tree/dead,
-/turf/open/floor/plating/asteroid/snow/icemoon,
+/obj/machinery/light/floor,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
 "rZX" = (
 /obj/machinery/status_display/supply,
@@ -33418,11 +32886,8 @@
 	name = "Brig Control APC";
 	pixel_y = -24
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel/dark,
 /area/security/warden)
 "sap" = (
@@ -33433,11 +32898,29 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "sar" = (
-/obj/structure/cable{
-	icon_state = "1-4"
+/obj/structure/closet/emcloset{
+	name = "External Supply Closet"
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/item/pickaxe,
+/obj/item/pickaxe,
+/obj/item/pickaxe,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/shoes/winterboots,
+/obj/item/clothing/shoes/winterboots,
+/obj/item/clothing/shoes/winterboots,
+/obj/item/clothing/suit/hooded/wintercoat,
+/obj/item/clothing/suit/hooded/wintercoat,
+/obj/item/clothing/suit/hooded/wintercoat,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "sat" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -33458,16 +32941,13 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
-/turf/open/floor/mineral/titanium/yellow/airless,
+/turf/open/floor/mineral/titanium/yellow,
 /area/icemoon/surface/outdoors)
 "saY" = (
-/obj/effect/turf_decal/tile/purple{
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/item/kirbyplants/random,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "sbo" = (
@@ -33484,11 +32964,8 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/prison)
 "sbt" = (
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 2
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
@@ -33532,6 +33009,9 @@
 /area/hallway/primary/starboard)
 "sdk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "sdw" = (
@@ -33552,10 +33032,10 @@
 /turf/open/floor/mineral/titanium/yellow,
 /area/icemoon/surface/outdoors)
 "sep" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/manifold{
-	dir = 8
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
 	},
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "set" = (
 /obj/structure/window/reinforced{
@@ -33586,11 +33066,8 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
@@ -33672,6 +33149,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/green/filled/line,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "sgk" = (
@@ -33824,17 +33302,11 @@
 	c_tag = "Quartermaster's Office";
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
 /obj/item/radio/intercom{
 	pixel_y = 25
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
@@ -33949,7 +33421,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/landmark/event_spawn,
-/turf/open/floor/wood,
+/turf/open/floor/plasteel/grimy,
 /area/crew_quarters/bar)
 "snc" = (
 /obj/item/radio/intercom{
@@ -34078,11 +33550,8 @@
 /area/hydroponics)
 "spm" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
@@ -34106,14 +33575,11 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
 /obj/machinery/atm{
 	pixel_y = 30
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -34223,12 +33689,8 @@
 	dir = 8;
 	network = list("tcomms")
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
@@ -34264,14 +33726,11 @@
 /area/icemoon/surface/outdoors)
 "suh" = (
 /obj/machinery/vending/medical,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -34295,11 +33754,14 @@
 /obj/structure/disposalpipe/junction/flip{
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "suH" = (
@@ -34322,33 +33784,28 @@
 /turf/open/floor/plasteel/showroomfloor/shower,
 /area/crew_quarters/toilet)
 "svi" = (
-/obj/structure/chair/sofa{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood,
-/area/maintenance/bar)
+/obj/effect/turf_decal/trimline/green/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/green/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "svC" = (
 /obj/structure/chair/comfy/shuttle,
 /obj/machinery/light/floor/fakeday,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/icemoon/surface/outdoors)
 "sws" = (
 /turf/closed/wall,
 /area/maintenance/starboard/aft)
 "swu" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
-	dir = 8
-	},
-/obj/machinery/door/airlock/public/glass{
-	desc = "A great place to relaz. No ERP.";
-	name = "Sauna"
-	},
-/turf/open/floor/plasteel/showroomfloor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "swy" = (
 /obj/structure/disposalpipe/junction{
@@ -34400,6 +33857,9 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "sxa" = (
@@ -34444,6 +33904,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "sya" = (
@@ -34469,14 +33930,11 @@
 /area/science/xenobiology)
 "syY" = (
 /obj/structure/closet/bombcloset/security,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
 /obj/machinery/camera{
 	c_tag = "Brig General Hall";
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "sze" = (
@@ -34497,6 +33955,9 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "szC" = (
@@ -34557,14 +34018,9 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "sBM" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/miningoffice)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/maintenance/port)
 "sCk" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/camera{
@@ -34584,44 +34040,38 @@
 	name = "Prison Wing APC";
 	pixel_x = -24
 	},
-/obj/structure/cable{
-	icon_state = "0-4"
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "sCD" = (
-/obj/structure/bed,
-/obj/machinery/camera{
-	c_tag = "Permabrig Iso Cell 1";
-	network = list("ss13","prison")
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/light/small{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
-/turf/open/floor/mineral/titanium/white{
-	name = "secure isolation floor"
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 4
 	},
-/area/security/prison)
-"sCG" = (
-/obj/structure/table,
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "sCW" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
-	icon_state = "2-8"
+/obj/machinery/door/airlock/security{
+	name = "persuasion room";
+	req_access_txt = "2"
 	},
 /turf/open/floor/plating,
-/area/maintenance/fore)
+/area/security/execution/education)
 "sDk" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "sDz" = (
@@ -34751,14 +34201,24 @@
 /turf/open/floor/plating,
 /area/icemoon/surface/outdoors)
 "sHC" = (
-/obj/machinery/door/airlock/external,
-/obj/structure/fans/tiny,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/door/airlock/highsecurity{
+	name = "AI Upload Access";
+	req_access_txt = "16"
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/circuit{
+	name = "Floor Data Lattice"
+	},
+/area/ai_monitored/turret_protected/ai_upload)
 "sHT" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -34796,11 +34256,8 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "sIy" = (
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -34949,16 +34406,13 @@
 /obj/structure/sign/warning/securearea{
 	pixel_x = -32
 	},
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
 "sMC" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
 	},
-/turf/open/floor/mineral/plastitanium/red/airless,
+/turf/open/floor/mineral/plastitanium/red,
 /area/icemoon/surface/outdoors)
 "sMF" = (
 /obj/structure/disposalpipe/segment,
@@ -35001,13 +34455,13 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "sPO" = (
-/obj/machinery/door/poddoor{
-	id = "soli2"
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/open/floor/mineral/titanium/white{
-	name = "secure isolation floor"
+/turf/open/floor/circuit{
+	name = "Floor Data Lattice"
 	},
-/area/security/prison)
+/area/science/robotics/mechbay)
 "sPX" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/open/floor/plasteel,
@@ -35028,10 +34482,15 @@
 /area/maintenance/port)
 "sQz" = (
 /obj/structure/cable{
-	icon_state = "0-8"
+	icon_state = "4-8"
 	},
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/surface/outdoors)
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/circuit{
+	name = "Floor Data Lattice"
+	},
+/area/science/robotics/mechbay)
 "sQF" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -35130,9 +34589,8 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "sSs" = (
-/obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/wood,
+/turf/open/floor/carpet,
 /area/crew_quarters/bar)
 "sSy" = (
 /obj/machinery/atmospherics/pipe/simple/violet/hidden{
@@ -35267,14 +34725,14 @@
 /area/hallway/primary/central)
 "sYd" = (
 /obj/machinery/door/airlock/engineering{
-	name = "Starboard Quarter Solar Access";
+	name = "Starboard Quarter Emergency Generator";
 	req_access_txt = "10"
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
-/area/maintenance/solars/port/fore)
+/area/maintenance/port)
 "sYD" = (
 /obj/structure/chair/comfy/brown{
 	dir = 1
@@ -35294,6 +34752,9 @@
 	pixel_x = 24
 	},
 /obj/structure/table/glass,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
 "sYY" = (
@@ -35318,15 +34779,6 @@
 /obj/machinery/droneDispenser/preloaded,
 /turf/open/floor/plating,
 /area/maintenance/port)
-"sZE" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "sZL" = (
 /obj/structure/table/reinforced,
 /obj/item/book/manual/wiki/security_space_law,
@@ -35358,8 +34810,7 @@
 /obj/machinery/newscaster/security_unit{
 	pixel_x = 30
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -35487,20 +34938,15 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner,
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "teB" = (
 /obj/structure/chair{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
@@ -35525,6 +34971,16 @@
 	req_access_txt = "19"
 	},
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel,
 /area/bridge)
 "tfA" = (
@@ -35556,11 +35012,8 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "tfQ" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
 /obj/machinery/recharge_station,
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "tfU" = (
@@ -35575,10 +35028,18 @@
 /area/medical/sleeper)
 "tgo" = (
 /obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
-/area/science/robotics/lab)
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/circuit{
+	name = "Floor Data Lattice"
+	},
+/area/science/robotics/mechbay)
 "tgF" = (
 /obj/vehicle/ridden/atv/snowmobile,
 /obj/effect/turf_decal/tile/yellow{
@@ -35638,10 +35099,10 @@
 /area/maintenance/fore)
 "tip" = (
 /obj/machinery/vending/cart,
-/obj/effect/turf_decal/tile/blue,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
 	},
+/obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
 "tiy" = (
@@ -35676,16 +35137,21 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "tiI" = (
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "outerbrig";
-	name = "Brig";
-	req_access_txt = "63"
-	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
+/obj/machinery/door/airlock/security/glass{
+	name = "Brig Control";
+	req_access_txt = "3"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/warden)
 "tiT" = (
 /obj/structure/table/glass,
@@ -35700,24 +35166,17 @@
 /obj/item/reagent_containers/syringe{
 	name = "steel point"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/item/storage/firstaid/regular,
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/item/storage/firstaid/regular,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "tjc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -35739,13 +35198,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/fitness)
-"tkj" = (
-/mob/living/simple_animal/pet/penguin/emperor{
-	dir = 1
-	},
-/obj/machinery/light/floor/fakeday,
-/turf/open/floor/plating/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors)
 "tkk" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel,
@@ -35755,10 +35207,7 @@
 /turf/open/floor/engine,
 /area/science/storage)
 "tky" = (
-/obj/structure/janitorialcart{
-	dir = 4
-	},
-/turf/open/floor/mineral/titanium/white/airless,
+/turf/open/floor/mineral/titanium/white,
 /area/icemoon/surface/outdoors)
 "tlh" = (
 /obj/structure/window/reinforced{
@@ -35787,19 +35236,13 @@
 /area/crew_quarters/heads/hor)
 "tlW" = (
 /obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "tmo" = (
 /obj/structure/chair/comfy/brown{
 	dir = 4
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
@@ -35823,30 +35266,22 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/service)
 "tni" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/surface/outdoors)
+/obj/effect/turf_decal/trimline/yellow/filled/corner,
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "tnt" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "tnH" = (
 /obj/machinery/mech_bay_recharge_port,
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "tnM" = (
@@ -35856,14 +35291,11 @@
 /turf/open/floor/plasteel,
 /area/medical/sleeper)
 "tnQ" = (
-/obj/structure/cable{
-	icon_state = "1-4"
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/solars/port/fore)
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "tnW" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/n2{
 	dir = 1
@@ -35900,10 +35332,10 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "tos" = (
-/mob/living/simple_animal/pet/penguin/emperor{
-	dir = 8
-	},
 /obj/machinery/light/floor/fakeday,
+/mob/living/simple_animal/pet/penguin/emperor{
+	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
+	},
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors)
 "toD" = (
@@ -35918,14 +35350,11 @@
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "tpg" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/chair,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "tpt" = (
@@ -35996,10 +35425,7 @@
 	dir = 1;
 	pixel_y = -24
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "trX" = (
@@ -36012,13 +35438,10 @@
 /turf/open/floor/wood,
 /area/icemoon/surface/outdoors)
 "tsl" = (
-/obj/effect/turf_decal/tile/red{
+/obj/structure/chair,
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/structure/chair,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "tsr" = (
@@ -36044,10 +35467,9 @@
 /area/chapel/office)
 "tsO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "ttr" = (
@@ -36066,22 +35488,17 @@
 /turf/open/floor/engine/airless,
 /area/engine/atmos)
 "ttP" = (
-/obj/structure/grille/broken,
-/obj/machinery/light/floor/fakeday,
-/turf/open/floor/plating/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors)
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "ttR" = (
-/obj/structure/cable{
-	icon_state = "2-4"
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/surface/outdoors)
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "ttZ" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -36186,8 +35603,7 @@
 /obj/machinery/computer/prisoner/management{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -36294,11 +35710,11 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
 "tzr" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
+/area/engine/engineering)
 "tzA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -36350,12 +35766,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/carpet,
 /area/hallway/primary/central)
-"tBQ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
 "tBT" = (
 /obj/structure/dresser,
 /obj/effect/turf_decal/tile/yellow,
@@ -36384,10 +35794,7 @@
 /area/hydroponics)
 "tCo" = (
 /obj/machinery/light,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "tCC" = (
@@ -36399,7 +35806,7 @@
 	dir = 4
 	},
 /obj/machinery/light/floor/fakeday,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/icemoon/surface/outdoors)
 "tDt" = (
 /obj/structure/chair{
@@ -36569,31 +35976,12 @@
 /obj/structure/chair/stool,
 /turf/open/floor/plasteel/white,
 /area/science/lab)
-"tGp" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 5
-	},
-/obj/structure/chair/sofa/corp{
-	dir = 1
-	},
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/crew_quarters/fitness)
 "tGq" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
-"tHp" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
 "tHB" = (
 /turf/closed/wall,
 /area/quartermaster/warehouse)
@@ -36868,6 +36256,14 @@
 	req_access_txt = "70"
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/preopen{
+	id = "permalock";
+	name = "Permabrig Lockdown Door"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "permalock";
+	name = "Perma Lockdown Shutter"
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "tOh" = (
@@ -36908,12 +36304,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
-"tPk" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/maintenance/solars/starboard/fore)
 "tPs" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -36935,20 +36325,13 @@
 /turf/open/floor/plating/beach/coastline_t,
 /area/science/research)
 "tQf" = (
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "tQg" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass_large{
-	name = "Diner"
-	},
-/turf/open/floor/wood,
+/turf/open/floor/carpet,
 /area/crew_quarters/bar)
 "tQl" = (
 /obj/structure/closet/secure_closet/brig{
@@ -37076,14 +36459,11 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "tSC" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "tSD" = (
@@ -37093,14 +36473,10 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "tSR" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
 /obj/item/kirbyplants/random,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 5
+	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "tSV" = (
@@ -37117,19 +36493,11 @@
 /obj/item/tank/internals/nitrogen/belt/full,
 /obj/item/tank/internals/nitrogen/belt/full,
 /obj/item/tank/internals/nitrogen/belt/full,
-/obj/item/clothing/suit/hooded/wintercoat,
-/obj/item/clothing/suit/hooded/wintercoat,
-/obj/item/clothing/suit/hooded/wintercoat,
-/obj/item/clothing/suit/hooded/wintercoat,
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
-"tTe" = (
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
 "tTi" = (
 /obj/structure/sink{
 	pixel_y = 28
@@ -37153,13 +36521,11 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "tTJ" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+/obj/machinery/portable_atmospherics/canister/water_vapor,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
 	},
-/obj/structure/chair/sofa/corp{
-	dir = 1
-	},
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "tTP" = (
 /obj/effect/turf_decal/tile/yellow{
@@ -37201,6 +36567,9 @@
 /obj/item/paper/guides/jobs/hydroponics{
 	pixel_x = -5;
 	pixel_y = 3
+	},
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
@@ -37423,10 +36792,9 @@
 /area/ai_monitored/turret_protected/ai)
 "ubm" = (
 /obj/effect/landmark/start/depsec/engineering,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "ubp" = (
@@ -37537,11 +36905,11 @@
 /area/icemoon/surface/outdoors)
 "ueb" = (
 /obj/effect/landmark/start/roboticist,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
@@ -37609,6 +36977,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 10
 	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "uhx" = (
@@ -37643,6 +37014,9 @@
 /obj/machinery/camera{
 	c_tag = "EngiSci Exterior Access"
 	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "uhY" = (
@@ -37652,12 +37026,6 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/fitness)
 "uim" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -37666,6 +37034,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
@@ -37684,6 +37055,9 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/bridge)
 "uiX" = (
@@ -37827,10 +37201,6 @@
 	icon_state = "carpetsymbol"
 	},
 /area/hallway/secondary/exit/departure_lounge)
-"umo" = (
-/obj/structure/frame/computer,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
 "umY" = (
 /turf/open/floor/engine,
 /area/engine/supermatter)
@@ -37920,11 +37290,8 @@
 /obj/machinery/newscaster{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
@@ -37943,16 +37310,11 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "urh" = (
-/obj/structure/closet/secure_closet/genpop,
-/obj/item/clothing/suit/hooded/wintercoat,
-/obj/item/radio/headset{
-	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
-	name = "prisoner headset";
-	prison_radio = 1
-	},
-/obj/effect/turf_decal/bot,
 /obj/machinery/camera{
 	dir = 8
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
@@ -37960,12 +37322,6 @@
 /obj/machinery/air_sensor/atmos/mix_tank,
 /turf/open/floor/engine/airless,
 /area/engine/atmos)
-"urs" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
 "urz" = (
 /obj/machinery/camera/motion{
 	c_tag = "MiniSat AI Hallway";
@@ -38086,12 +37442,7 @@
 	dir = 1;
 	network = list("ss13","rd")
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 2
-	},
+/obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "uvs" = (
@@ -38363,7 +37714,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "uCq" = (
-/turf/open/floor/mineral/plastitanium/airless,
+/turf/open/floor/mineral/plastitanium,
 /area/icemoon/surface/outdoors)
 "uCr" = (
 /turf/open/floor/plasteel/dark,
@@ -38421,11 +37772,8 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
@@ -38517,13 +37865,10 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "uFn" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -31
 	},
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "uFt" = (
@@ -38534,17 +37879,6 @@
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"uFy" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/door/airlock/external{
-	name = "Solar Maintenance";
-	req_access_txt = "10; 13"
-	},
-/turf/open/floor/plating,
-/area/maintenance/solars/port/fore)
 "uFX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -38562,14 +37896,11 @@
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/warden)
@@ -38657,9 +37988,6 @@
 /obj/structure/table/wood,
 /obj/structure/window/reinforced,
 /obj/item/stamp/hos,
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
 /obj/item/folder/blue,
 /obj/item/lighter/gold{
 	desc = "A shiny and relatively expensive zippo lighter. This is a limited series, only ten were produced. It's engraved with a ornate 'NT' on the bottom."
@@ -38670,6 +37998,9 @@
 	pixel_x = -7;
 	pixel_y = 7
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
 "uIP" = (
@@ -38679,15 +38010,6 @@
 /obj/structure/closet/secure_closet/atmospherics,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"uJt" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
 "uJx" = (
 /obj/structure/table,
 /obj/structure/sign/poster/official/love_ian{
@@ -38714,13 +38036,10 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "uJE" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "uJU" = (
@@ -38871,13 +38190,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "uNU" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "uOn" = (
@@ -38915,10 +38231,7 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "uPU" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
+/obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "uQx" = (
@@ -38963,10 +38276,7 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "uRz" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -39103,15 +38413,13 @@
 /obj/machinery/plate_chute/outputchute{
 	pixel_y = 25
 	},
+/obj/effect/turf_decal/loading_area,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "uVm" = (
 /obj/structure/sign/warning/electricshock,
 /turf/closed/wall/r_wall,
-/area/maintenance/solars/port/fore)
-"uVw" = (
-/turf/open/floor/plasteel/showroomfloor,
-/area/icemoon/surface/outdoors)
+/area/maintenance/port)
 "uWm" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -39147,6 +38455,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
@@ -39244,14 +38555,11 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
-"vaW" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Holodeck Door"
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
 "vba" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "stationawaygate";
@@ -39319,6 +38627,9 @@
 "vdv" = (
 /obj/machinery/computer/bounty{
 	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
@@ -39431,6 +38742,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "vgk" = (
@@ -39441,9 +38755,6 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "vgz" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -39466,6 +38777,9 @@
 	dir = 1;
 	pixel_x = 3;
 	pixel_y = 9
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
@@ -39566,9 +38880,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"vjq" = (
-/turf/closed/wall/r_wall,
-/area/maintenance/solars/port/fore)
 "vjv" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
@@ -39826,7 +39137,11 @@
 /obj/structure/mirror{
 	pixel_x = 28
 	},
-/turf/open/floor/plasteel/showroomfloor/shower,
+/obj/effect/turf_decal/lumos/shower,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "vpA" = (
 /turf/open/floor/plasteel,
@@ -39919,10 +39234,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
-"vsB" = (
-/obj/structure/mineral_door/woodrustic,
-/turf/open/floor/plasteel/showroomfloor,
-/area/icemoon/surface/outdoors)
 "vsM" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -40026,13 +39337,8 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "vxg" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 9
-	},
-/obj/structure/chair/sofa/corp{
-	dir = 1
-	},
-/turf/open/floor/plasteel/showroomfloor,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "vxh" = (
 /obj/structure/cable{
@@ -40060,10 +39366,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -40172,11 +39475,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
@@ -40194,8 +39494,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -40207,8 +39506,8 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "vBT" = (
-/obj/machinery/light{
-	dir = 4
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
@@ -40218,14 +39517,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"vCo" = (
-/obj/machinery/door/poddoor{
-	id = "soli1"
-	},
-/turf/open/floor/mineral/titanium/white{
-	name = "secure isolation floor"
-	},
-/area/security/prison)
 "vCu" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -40263,10 +39554,8 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "vDb" = (
@@ -40312,15 +39601,9 @@
 /turf/open/floor/plasteel/chapel,
 /area/chapel/main)
 "vEB" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
 /obj/item/kirbyplants/random,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 2
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 10
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
@@ -40331,14 +39614,11 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "vFo" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/atm{
 	pixel_y = 30
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -40422,13 +39702,6 @@
 /obj/machinery/light/floor/fakeday,
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors)
-"vJv" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood,
-/area/maintenance/bar)
 "vJI" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -40449,34 +39722,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"vKn" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/arrows{
-	dir = 8;
-	pixel_y = 10
-	},
-/turf/open/floor/plating,
-/area/maintenance/fore)
 "vKz" = (
 /obj/structure/chair/stool,
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
-"vKB" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8
-	},
-/turf/open/floor/carpet,
-/area/chapel/main)
 "vKU" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -40500,10 +39751,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "vLJ" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -40545,10 +39793,11 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "vMG" = (
+/obj/machinery/light/floor/fakeday,
 /mob/living/simple_animal/pet/penguin/baby{
+	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0);
 	dir = 1
 	},
-/obj/machinery/light/floor/fakeday,
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors)
 "vMN" = (
@@ -40713,14 +39962,8 @@
 /area/crew_quarters/fitness)
 "vRN" = (
 /obj/structure/chair/comfy/black,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/checkpoint/auxiliary)
@@ -40782,7 +40025,7 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "vTq" = (
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -40890,6 +40133,9 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
 "vXg" = (
@@ -40920,10 +40166,7 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/psych)
 "vXI" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -41022,12 +40265,8 @@
 /area/medical/chemistry)
 "vZF" = (
 /obj/machinery/announcement_system,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
@@ -41244,20 +40483,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"wgh" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/machinery/door/airlock/external{
-	name = "Solar Maintenance";
-	req_access_txt = "10; 13"
-	},
-/obj/structure/fans/tiny,
-/turf/open/floor/plating,
-/area/maintenance/solars/port/fore)
 "wgj" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -41341,11 +40566,8 @@
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "wij" = (
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
@@ -41364,10 +40586,10 @@
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
 "wiT" = (
-/obj/effect/turf_decal/tile/red{
+/obj/structure/closet/l3closet/scientist,
+/obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 8
 	},
-/obj/structure/closet/l3closet/scientist,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "wjP" = (
@@ -41446,31 +40668,18 @@
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
 	},
+/obj/machinery/door/firedoor,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/janitor)
 "wlB" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"wlG" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/portable_atmospherics/canister/water_vapor,
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
 "wlU" = (
 /obj/machinery/atmospherics/pipe/manifold4w/violet/hidden,
 /turf/open/floor/plasteel/white,
@@ -41559,28 +40768,15 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
 "woI" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/machinery/airalarm{
 	dir = 4;
 	pixel_x = -22
 	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
-"woZ" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/light/floor/fakeday,
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/surface/outdoors)
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "wpc" = (
 /obj/structure/table/glass,
 /obj/machinery/light/small{
@@ -41602,10 +40798,7 @@
 /turf/open/floor/plating,
 /area/library)
 "wpN" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "wpX" = (
@@ -41639,6 +40832,9 @@
 "wqT" = (
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/teleporter)
@@ -41681,10 +40877,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
 /area/bridge)
 "wsG" = (
@@ -41694,9 +40887,6 @@
 /turf/open/floor/carpet,
 /area/science/robotics/lab)
 "wsM" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
@@ -41769,8 +40959,8 @@
 /turf/open/floor/wood,
 /area/icemoon/surface/outdoors)
 "wvC" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
+/obj/structure/disposalpipe/junction/flip{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -41867,14 +41057,8 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "wxG" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
@@ -41906,7 +41090,9 @@
 /area/engine/atmos)
 "wyB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "wyM" = (
@@ -41929,9 +41115,6 @@
 	},
 /obj/structure/sink{
 	pixel_y = 28
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/bridge)
@@ -41980,12 +41163,11 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "wBb" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -42049,14 +41231,14 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -42083,18 +41265,15 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_x = 1;
 	pixel_y = 29
 	},
 /obj/structure/chair,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "wDW" = (
@@ -42103,14 +41282,11 @@
 /turf/open/floor/wood,
 /area/icemoon/surface/outdoors)
 "wEf" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "wEg" = (
@@ -42123,6 +41299,9 @@
 "wEj" = (
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -42144,15 +41323,12 @@
 	dir = 4
 	},
 /obj/machinery/light,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
 /area/bridge)
 "wEJ" = (
 /obj/structure/cable{
-	icon_state = "1-4"
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/mechbay)
@@ -42182,6 +41358,9 @@
 	},
 /obj/machinery/light{
 	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
@@ -42266,6 +41445,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "wIg" = (
@@ -42273,12 +41455,10 @@
 /turf/open/floor/carpet,
 /area/hallway/primary/aft)
 "wIY" = (
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "wJq" = (
@@ -42288,11 +41468,8 @@
 /obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -42349,7 +41526,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
 	},
-/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/plasteel,
 /area/bridge)
 "wLN" = (
@@ -42364,14 +41541,8 @@
 /area/maintenance/disposal/incinerator)
 "wMz" = (
 /obj/structure/reagent_dispensers/water_cooler,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 9
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
@@ -42436,6 +41607,9 @@
 	desc = "A fat little xeno-bug, about the size of a cat. Originally captured and gifted to the Janitor after Wags-His-Tail was lost in transit. Can be milked for a fairly nutritional milk in a pinch.";
 	name = "eats-the-gibs"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
+	},
 /turf/open/floor/plasteel,
 /area/janitor)
 "wPq" = (
@@ -42450,6 +41624,9 @@
 	},
 /obj/item/watertank,
 /obj/item/reagent_containers/spray/plantbgone,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "wPF" = (
@@ -42468,7 +41645,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "wPO" = (
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -42554,6 +41731,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/effect/turf_decal/trimline/green/filled/corner,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "wSX" = (
@@ -42577,21 +41755,15 @@
 /area/medical/sleeper)
 "wTt" = (
 /obj/machinery/monkey_recycler,
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "wTQ" = (
 /obj/structure/closet/l3closet/security,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
 /obj/machinery/light,
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "wTT" = (
@@ -42638,6 +41810,9 @@
 	c_tag = "Atmospherics Central";
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "wVi" = (
@@ -42657,8 +41832,7 @@
 "wVH" = (
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/atmospherics/pipe/simple/supply/visible,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -42679,6 +41853,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "wWS" = (
@@ -42731,19 +41908,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/engine/engineering)
-"wXI" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/light/floor/fakeday,
-/turf/open/floor/plating/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors)
-"wYb" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/surface/outdoors)
 "wYo" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4
@@ -42818,33 +41982,18 @@
 /obj/machinery/computer/rdconsole/experiment{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 2
-	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"xaA" = (
-/obj/structure/sink{
-	pixel_y = 28
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/icemoon/surface/outdoors)
 "xaP" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
 /obj/machinery/computer/telecomms/monitor{
 	dir = 4;
 	network = "tcommsat"
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
@@ -42940,15 +42089,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/research)
-"xcj" = (
-/obj/structure/rack,
-/obj/item/clothing/mask/gas,
-/obj/structure/sign/warning/vacuum/external{
-	pixel_y = 32
-	},
-/obj/item/multitool,
-/turf/open/floor/plating,
-/area/maintenance/solars/starboard/fore)
 "xck" = (
 /obj/machinery/suit_storage_unit/security,
 /obj/effect/turf_decal/delivery,
@@ -42960,10 +42100,9 @@
 /area/security/brig)
 "xcv" = (
 /obj/machinery/vending/engivend,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "xcJ" = (
@@ -43097,13 +42236,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
-"xeM" = (
-/obj/structure/closet/firecloset/full,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "xfH" = (
 /obj/machinery/chem_master/condimaster{
 	name = "HoochMaster 2000"
@@ -43191,6 +42323,16 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "xip" = (
@@ -43233,11 +42375,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
@@ -43247,12 +42386,6 @@
 	name = "formal uniform crate";
 	req_access = "3"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/machinery/airalarm{
 	dir = 4;
 	pixel_x = -22
@@ -43261,6 +42394,9 @@
 	pixel_y = -32
 	},
 /obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -43298,6 +42434,9 @@
 /obj/machinery/airalarm{
 	pixel_y = 26
 	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "xlg" = (
@@ -43323,6 +42462,9 @@
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 8
+	},
+/obj/machinery/status_display/evac{
+	pixel_y = 32
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -43402,12 +42544,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
@@ -43415,6 +42553,7 @@
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 4
 	},
+/mob/living/carbon/monkey,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "xov" = (
@@ -43448,9 +42587,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"xpm" = (
-/turf/open/floor/circuit/green,
-/area/security/prison)
 "xpX" = (
 /obj/docking_port/stationary{
 	dwidth = 3;
@@ -43556,9 +42692,6 @@
 "xtU" = (
 /turf/closed/wall,
 /area/quartermaster/storage)
-"xtZ" = (
-/turf/closed/wall/r_wall,
-/area/maintenance/solars/starboard/fore)
 "xuj" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -43593,6 +42726,9 @@
 /area/maintenance/starboard/aft)
 "xuH" = (
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "xuQ" = (
@@ -43614,11 +42750,14 @@
 /obj/structure/disposalpipe/junction{
 	dir = 1
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1
+	},
 /turf/open/floor/carpet,
 /area/chapel/main)
 "xvD" = (
 /obj/item/paper/fluff/fridgestation,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/icemoon/surface/outdoors)
 "xvM" = (
 /obj/machinery/air_sensor/atmos/oxygen_tank{
@@ -43679,11 +42818,8 @@
 /obj/machinery/atm{
 	pixel_x = -30
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
@@ -43827,8 +42963,10 @@
 	pixel_x = 24
 	},
 /obj/item/phone{
-	pixel_x = -3;
 	pixel_y = 13
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
@@ -43853,11 +42991,8 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
 /obj/structure/bed/roller,
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "xBO" = (
@@ -43898,13 +43033,6 @@
 /obj/machinery/light,
 /turf/open/floor/light/colour_cycle,
 /area/maintenance/starboard/aft)
-"xCA" = (
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/power/tracker,
-/turf/open/floor/plating/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors)
 "xCI" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood{
@@ -43925,11 +43053,8 @@
 /obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -43938,7 +43063,7 @@
 /obj/machinery/airalarm{
 	pixel_y = 23
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -43951,6 +43076,16 @@
 	name = "Atmospherics";
 	req_access_txt = "24"
 	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "xDw" = (
@@ -44044,8 +43179,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -44081,12 +43215,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"xHa" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "xHj" = (
 /obj/structure/sink{
 	pixel_y = 28
@@ -44176,6 +43304,16 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/teleporter)
 "xIP" = (
@@ -44219,11 +43357,8 @@
 /area/crew_quarters/toilet)
 "xKb" = (
 /obj/effect/landmark/start/station_engineer,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -44283,11 +43418,8 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -44361,13 +43493,12 @@
 /area/storage/primary)
 "xML" = (
 /obj/machinery/atmospherics/pipe/simple/supply/visible,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
 /obj/machinery/camera{
 	c_tag = "Engineering Hallway South";
 	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -44410,10 +43541,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -44500,20 +43628,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"xQl" = (
-/obj/structure/table,
-/obj/item/paper/fluff/holodeck/disclaimer,
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
 "xQL" = (
 /obj/structure/chair{
 	dir = 4
 	},
 /obj/effect/landmark/start/assistant,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -44543,11 +43663,8 @@
 /obj/machinery/atmospherics/components/binary/pump{
 	name = "Ports to Incinerator"
 	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -44560,7 +43677,24 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "xSf" = (
-/obj/machinery/space_heater,
+/obj/structure/closet/emcloset{
+	name = "External Supply Closet"
+	},
+/obj/item/pickaxe,
+/obj/item/pickaxe,
+/obj/item/pickaxe,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/shoes/winterboots,
+/obj/item/clothing/shoes/winterboots,
+/obj/item/clothing/shoes/winterboots,
+/obj/item/clothing/suit/hooded/wintercoat,
+/obj/item/clothing/suit/hooded/wintercoat,
+/obj/item/clothing/suit/hooded/wintercoat,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "xSs" = (
@@ -44618,12 +43752,6 @@
 /obj/machinery/firealarm{
 	pixel_y = 29
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
 /obj/item/stack/sheet/mineral/plasma{
 	amount = 30
 	},
@@ -44632,6 +43760,9 @@
 	},
 /obj/item/stack/sheet/mineral/silver,
 /obj/item/stack/sheet/mineral/uranium,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "xTD" = (
@@ -44659,11 +43790,8 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -44697,6 +43825,9 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 9
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "xUu" = (
@@ -44712,7 +43843,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -44772,9 +43903,14 @@
 	id = "Cell 3";
 	name = "Cell 3"
 	},
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/door/firedoor/border_only{
+	name = "south facing firelock"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "xWi" = (
@@ -44782,6 +43918,14 @@
 /area/science/lab)
 "xWN" = (
 /obj/machinery/light,
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/secure_closet/genpop,
+/obj/item/clothing/suit/hooded/wintercoat,
+/obj/item/radio/headset{
+	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
+	name = "prisoner headset";
+	prison_radio = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "xXN" = (
@@ -44791,20 +43935,17 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
 "xXW" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
 /obj/item/radio/intercom{
 	pixel_y = 25
+	},
+/obj/effect/turf_decal/trimline/green/filled/corner{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
@@ -44834,11 +43975,8 @@
 /turf/open/floor/plating,
 /area/hallway/primary/aft)
 "xYP" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
 /obj/machinery/light,
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "xYZ" = (
@@ -44896,7 +44034,7 @@
 "yad" = (
 /obj/machinery/light/floor/fakeday,
 /obj/structure/lattice/catwalk,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/icemoon/surface/outdoors)
 "yag" = (
 /obj/machinery/computer{
@@ -44952,14 +44090,14 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "ybc" = (
-/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/trimline/red/filled/corner,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "ybi" = (
 /obj/structure/fluff/empty_sleeper/syndicate{
 	dir = 8
 	},
-/turf/open/floor/mineral/plastitanium/red/airless,
+/turf/open/floor/mineral/plastitanium/red,
 /area/icemoon/surface/outdoors)
 "ybx" = (
 /obj/machinery/door/poddoor/shutters{
@@ -44992,10 +44130,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "ycv" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel/dark,
 /area/security/checkpoint/auxiliary)
 "ycB" = (
@@ -45026,6 +44161,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "ycU" = (
@@ -45048,13 +44186,13 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "ydv" = (
 /obj/structure/grille,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "ydw" = (
@@ -45068,8 +44206,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -45110,11 +44247,11 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/blue,
 /obj/machinery/camera{
 	c_tag = "Bridge East";
 	dir = 8
 	},
+/obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/plasteel,
 /area/bridge)
 "yfb" = (
@@ -45161,12 +44298,13 @@
 /obj/structure/chair/stool{
 	pixel_y = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
+/obj/structure/disposalpipe/junction/flip{
+	dir = 1
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "yhp" = (
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "yhw" = (
@@ -45198,6 +44336,9 @@
 /area/crew_quarters/bar)
 "yhS" = (
 /obj/machinery/biogenerator,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "yhW" = (
@@ -45290,14 +44431,11 @@
 /area/crew_quarters/heads/hop)
 "ykl" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "2-4"
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -45382,9 +44520,9 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -45617,7 +44755,7 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
@@ -45633,15 +44771,15 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -45875,29 +45013,29 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 cyH
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
-bCe
-jsJ
-jsJ
-jsJ
+kgx
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
+jsJ
+jsJ
+jsJ
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -46027,10 +45165,10 @@ jsJ
 uSY
 jsJ
 jsJ
-ctd
+tXu
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 cyH
 jsJ
@@ -46129,17 +45267,12 @@ roU
 (4,1,1) = {"
 jsJ
 jsJ
-ctd
+tXu
 jsJ
 jsJ
 jsJ
 jsJ
-ctd
-jsJ
-jsJ
-jsJ
-jsJ
-jsJ
+tXu
 jsJ
 jsJ
 jsJ
@@ -46149,11 +45282,16 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
 jsJ
-rLU
-rLU
-rLU
+jsJ
+jsJ
+jsJ
+jsJ
+kgx
+jsJ
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -46290,11 +45428,11 @@ jsJ
 jsJ
 gna
 jsJ
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -46365,23 +45503,23 @@ roU
 roU
 hOr
 nXe
-dHB
+awA
 nSA
 nOZ
 nOZ
-mdx
-mdx
-mdx
-mdx
-mdx
-mdx
+rwX
+rwX
+rwX
+rwX
+rwX
+rwX
 mdx
 nSA
-dHB
-dHB
-dHB
-dHB
-dHB
+awA
+awA
+awA
+awA
+awA
 "}
 (5,1,1) = {"
 jsJ
@@ -46408,14 +45546,14 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -46538,23 +45676,23 @@ jsJ
 jsJ
 jsJ
 jsJ
-ctd
+tXu
 jsJ
 jsJ
-bCe
+kgx
 jsJ
-ctd
+tXu
 uSY
 jsJ
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 uSY
 jsJ
 jsJ
@@ -46624,20 +45762,20 @@ iec
 piz
 roU
 xdt
-rsL
-rsL
-rBQ
+tky
+tky
+kgv
 xvD
-rBQ
-rBQ
-rBQ
+kgv
+kgv
+kgv
 aFh
-mdx
+rwX
 xdt
 roU
-dHB
+awA
 roU
-dHB
+awA
 roU
 "}
 (6,1,1) = {"
@@ -46647,34 +45785,25 @@ jsJ
 jsJ
 jsJ
 jsJ
+kgx
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+kgx
+jsJ
+jsJ
+jsJ
 bCe
 jsJ
 jsJ
-jsJ
-jsJ
-jsJ
-jsJ
-jsJ
-bCe
-jsJ
-jsJ
-jsJ
-bCe
-jsJ
-jsJ
-bCe
+kgx
 jsJ
 jsJ
 kSg
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -46689,7 +45818,16 @@ rMm
 rMm
 rMm
 rMm
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 rLU
 rLU
 rLU
@@ -46712,7 +45850,7 @@ rLU
 rLU
 jsJ
 jsJ
-ctd
+tXu
 jsJ
 uSY
 jsJ
@@ -46803,42 +45941,42 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 uSY
@@ -46882,19 +46020,19 @@ nXe
 roU
 xdt
 tky
-rsL
-rBQ
-rBQ
-rBQ
+tky
+kgv
+kgv
+kgv
 nhv
 off
 aFh
-mdx
+rwX
 xdt
 roU
-dHB
+awA
 roU
-dHB
+awA
 roU
 "}
 (7,1,1) = {"
@@ -46906,13 +46044,10 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
-bCe
-jsJ
-jsJ
-jsJ
+kgx
 jsJ
 jsJ
 jsJ
@@ -46921,23 +46056,11 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
+jsJ
+jsJ
+jsJ
+rMm
 kSg
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -46945,9 +46068,24 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
 kSg
@@ -46982,7 +46120,7 @@ jsJ
 jsJ
 jsJ
 jsJ
-ctd
+tXu
 jsJ
 uSY
 jsJ
@@ -46993,7 +46131,7 @@ jsJ
 jsJ
 jsJ
 jsJ
-ctd
+tXu
 jsJ
 jsJ
 jsJ
@@ -47047,7 +46185,7 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 cyH
 jsJ
@@ -47057,24 +46195,8 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
-rLU
-rLU
-rLU
-rMm
-rMm
-rMm
-rMm
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -47090,13 +46212,29 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -47138,30 +46276,24 @@ iec
 piz
 roU
 xdt
-rsL
-rBQ
-rBQ
-rBQ
+tky
+kgv
+kgv
+kgv
 aFh
-mdx
+rwX
 off
 aFh
-mdx
+rwX
 xdt
 roU
-dHB
+awA
 roU
-dHB
+awA
 roU
 "}
 (8,1,1) = {"
 jsJ
-bCe
-cyH
-jsJ
-jsJ
-jsJ
-jsJ
 jsJ
 cyH
 jsJ
@@ -47169,41 +46301,47 @@ jsJ
 jsJ
 jsJ
 jsJ
-jsJ
-bCe
-jsJ
+cyH
 jsJ
 jsJ
 jsJ
 jsJ
-bCe
 jsJ
-rLU
+jsJ
+kgx
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+kgx
+jsJ
+rMm
 kSg
 kSg
-rLU
-rLU
-rLU
-kSg
-kSg
-kSg
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
 kSg
@@ -47230,7 +46368,7 @@ jsJ
 uSY
 jsJ
 jsJ
-ctd
+tXu
 jsJ
 uSY
 jsJ
@@ -47309,27 +46447,13 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
-ctd
+tXu
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rLU
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -47351,10 +46475,24 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 cyH
 jsJ
@@ -47393,74 +46531,74 @@ roU
 roU
 hOr
 piz
-dHB
+awA
 nSA
 rRZ
 pzJ
-rBQ
+kgv
 nhv
 phN
 phN
 mFk
 saQ
-mdx
+rwX
 nSA
-dHB
-dHB
-dHB
-dHB
-dHB
+awA
+awA
+awA
+awA
+awA
 "}
 (9,1,1) = {"
 jsJ
 jsJ
+kgx
+jsJ
+jsJ
+jsJ
+kgx
+jsJ
+jsJ
+kgx
+jsJ
+jsJ
+jsJ
+tXu
+jsJ
+jsJ
+jsJ
+kgx
 jsJ
 jsJ
 jsJ
 jsJ
-bCe
 jsJ
-jsJ
-bCe
-jsJ
-jsJ
-jsJ
-ctd
-jsJ
-jsJ
-jsJ
-bCe
-jsJ
-jsJ
-jsJ
-jsJ
-jsJ
-rLU
-rLU
+rMm
+rMm
 kSg
 kSg
 kSg
 kSg
 kSg
-rLU
 kSg
 kSg
 kSg
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+kSg
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
 rLU
@@ -47500,7 +46638,7 @@ uSY
 jsJ
 jsJ
 jsJ
-ctd
+tXu
 jsJ
 jsJ
 jsJ
@@ -47510,7 +46648,7 @@ uSY
 jsJ
 jsJ
 jsJ
-ctd
+tXu
 jsJ
 jsJ
 jsJ
@@ -47557,15 +46695,15 @@ gna
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
-ctd
+tXu
 jsJ
 cyH
 jsJ
@@ -47573,9 +46711,6 @@ jsJ
 jsJ
 jsJ
 uSY
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -47610,11 +46745,14 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -47691,17 +46829,17 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
 kSg
@@ -47709,15 +46847,15 @@ kSg
 kSg
 kSg
 kSg
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 rLU
 rLU
@@ -47745,13 +46883,13 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
@@ -47771,7 +46909,7 @@ uSY
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 rLU
@@ -47809,7 +46947,7 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
@@ -47824,14 +46962,11 @@ jsJ
 jsJ
 jsJ
 jsJ
-ctd
+tXu
 jsJ
 jsJ
-ctd
+tXu
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -47868,13 +47003,16 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -47938,42 +47076,42 @@ uSY
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
 kSg
 kSg
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
 rLU
@@ -47996,7 +47134,7 @@ kSg
 kSg
 kSg
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
@@ -48005,24 +47143,24 @@ jsJ
 jsJ
 uSY
 jsJ
-ctd
-jsJ
-jsJ
-jsJ
-jsJ
-jsJ
-cFL
-bCe
+tXu
 jsJ
 jsJ
 jsJ
 jsJ
 jsJ
 jsJ
+kgx
 jsJ
 jsJ
 jsJ
-bCe
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+kgx
 jsJ
 jsJ
 jsJ
@@ -48072,23 +47210,17 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 cyH
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -48126,15 +47258,21 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -48172,10 +47310,10 @@ roU
 jmp
 jmp
 jmp
-dHB
+awA
 svC
 mBj
-dHB
+awA
 roU
 roU
 roU
@@ -48186,7 +47324,7 @@ roU
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
@@ -48204,33 +47342,33 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
 rMm
-rLU
-rLU
-rLU
-rLU
-rLU
 rMm
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
 kSg
 kSg
-rLU
-rLU
+rMm
+rMm
 kSg
 kSg
 srK
@@ -48266,7 +47404,7 @@ jsJ
 jsJ
 jsJ
 jsJ
-ctd
+tXu
 jsJ
 jsJ
 jsJ
@@ -48328,7 +47466,7 @@ jsJ
 cyH
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
@@ -48337,13 +47475,6 @@ jsJ
 cyH
 jsJ
 jsJ
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -48386,14 +47517,21 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -48429,10 +47567,10 @@ roU
 jmp
 jmp
 jmp
-dHB
+awA
 tCR
 aZl
-dHB
+awA
 roU
 roU
 roU
@@ -48449,7 +47587,7 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
@@ -48459,11 +47597,8 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -48473,18 +47608,21 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
 kSg
@@ -48492,21 +47630,21 @@ kSg
 kSg
 srK
 wsM
-thT
-thT
-thT
-thT
-thT
-thT
-thT
-thT
-thT
-eyb
-thT
+vjO
+vjO
+dvm
+eca
+eca
+eca
+eca
+eca
+eca
+hCP
+ipF
 dQZ
-thT
+vjO
 nmK
-qLd
+jjt
 xjf
 srK
 rLU
@@ -48541,7 +47679,7 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 rLU
 rLU
@@ -48591,13 +47729,6 @@ jsJ
 jsJ
 jsJ
 cyH
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -48646,13 +47777,20 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -48686,10 +47824,10 @@ roU
 jmp
 jmp
 jmp
-dHB
-dHB
-dHB
-dHB
+awA
+awA
+awA
+awA
 roU
 roU
 roU
@@ -48700,27 +47838,24 @@ roU
 jsJ
 jsJ
 jsJ
-ctd
+tXu
 jsJ
 jsJ
-bCe
-jsJ
-jsJ
-jsJ
-jsJ
-jsJ
-jsJ
-bCe
-jsJ
-jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
+jsJ
+jsJ
+kgx
+jsJ
+jsJ
+kgx
+jsJ
+jsJ
+jsJ
+jsJ
 rMm
 rMm
 rMm
@@ -48736,19 +47871,22 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
 kSg
 srK
-dLV
+fDn
 diy
 diy
 diy
@@ -48763,7 +47901,7 @@ iJl
 iJl
 iJl
 iJl
-jZU
+vUF
 xjf
 srK
 rLU
@@ -48840,20 +47978,12 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 cyH
 jsJ
 jsJ
 jsJ
-bCe
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+kgx
 rMm
 rMm
 rMm
@@ -48906,11 +48036,19 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -48965,7 +48103,7 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
@@ -48974,9 +48112,6 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -48996,16 +48131,19 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
 kSg
 srK
-jZU
+vUF
 diy
 pBy
 wFg
@@ -49020,12 +48158,12 @@ gzG
 gzG
 fMq
 iJl
-jZU
-cMk
+vUF
+jqz
 srK
 srK
 srK
-uea
+lwK
 gzo
 jsJ
 jsJ
@@ -49100,14 +48238,9 @@ rLU
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
-rLU
-rLU
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -49166,9 +48299,14 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -49215,7 +48353,7 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
@@ -49227,13 +48365,10 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -49255,14 +48390,17 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
 kSg
 srK
-jZU
+vUF
 diy
 kFK
 qvG
@@ -49277,16 +48415,16 @@ pEA
 pEA
 ocm
 iJl
-jZU
+vUF
 qri
 nin
 cMk
 pon
-uea
+rAX
 gzo
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 gzo
 kSg
@@ -49360,9 +48498,6 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -49423,9 +48558,12 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -49470,13 +48608,13 @@ roU
 (17,1,1) = {"
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
@@ -49488,9 +48626,6 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -49512,14 +48647,17 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
 kSg
 srK
-vKn
+vUF
 diy
 mIA
 uIF
@@ -49534,12 +48672,12 @@ sSo
 sAS
 fLT
 iJl
-jZU
-cMk
+vUF
+jxf
 srK
 srK
 srK
-uea
+jhC
 gzo
 jsJ
 jsJ
@@ -49613,11 +48751,8 @@ rLU
 rLU
 kSg
 kSg
+eXj
 kSg
-kSg
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -49681,9 +48816,12 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -49734,19 +48872,16 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
-bCe
-jsJ
-jsJ
-jsJ
+kgx
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
+jsJ
+jsJ
+jsJ
 rMm
 rMm
 rMm
@@ -49769,14 +48904,17 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
 kSg
 srK
-jZU
+vUF
 diy
 bGv
 fgZ
@@ -49791,7 +48929,7 @@ vwb
 qoT
 ovi
 iJl
-jZU
+vUF
 xjf
 srK
 rLU
@@ -49867,14 +49005,11 @@ rLU
 rLU
 rLU
 kSg
-xlg
 kSg
-xlg
+eXj
 kSg
 kSg
-rLU
-rLU
-rLU
+kSg
 rMm
 rMm
 rMm
@@ -49938,9 +49073,12 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -49984,7 +49122,7 @@ roU
 (19,1,1) = {"
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
@@ -50001,9 +49139,6 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -50026,29 +49161,32 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
 kSg
 srK
-gFn
-kyH
+vUF
+diy
 hlb
 nVs
 gXU
 glr
 dhu
-pEA
-pEA
+flJ
+flJ
 bkY
 nrk
 jcZ
 wYT
 lnY
 iJl
-jZU
+vUF
 xjf
 srK
 rLU
@@ -50056,7 +49194,7 @@ rLU
 rLU
 rLU
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 gzo
@@ -50129,9 +49267,6 @@ kSg
 kSg
 kSg
 kSg
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -50198,8 +49333,11 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -50249,17 +49387,14 @@ jsJ
 jsJ
 cyH
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
-ctd
+tXu
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -50284,13 +49419,16 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
 srK
-jZU
+vUF
 diy
 oyS
 rEF
@@ -50305,7 +49443,7 @@ iJl
 iJl
 iJl
 iJl
-jZU
+vUF
 cMk
 srK
 srK
@@ -50383,10 +49521,6 @@ rLU
 kSg
 kSg
 kSg
-rLU
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -50455,11 +49589,15 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -50500,7 +49638,7 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
@@ -50514,9 +49652,6 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -50541,13 +49676,16 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
 srK
-jZU
+vUF
 diy
 cUe
 oMP
@@ -50562,7 +49700,7 @@ iJl
 srl
 xjf
 xjf
-jZU
+vUF
 tCC
 cMk
 cMk
@@ -50637,12 +49775,9 @@ rMm
 rLU
 rLU
 rLU
-xlg
 kSg
 kSg
-rLU
-rLU
-rLU
+kSg
 rMm
 rMm
 rMm
@@ -50712,13 +49847,16 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -50758,7 +49896,7 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 gna
 jsJ
@@ -50771,9 +49909,6 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -50798,13 +49933,16 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
 srK
-jZU
+vUF
 diy
 szx
 aaU
@@ -50894,12 +50032,9 @@ rLU
 rLU
 rLU
 kSg
+eXj
 kSg
 kSg
-xlg
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -50971,12 +50106,15 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -51017,20 +50155,17 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -51055,23 +50190,26 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
 srK
-jgP
-qzB
+vUF
+mLE
 jWI
 sxE
 grT
 jGx
 mcL
-myN
+fsY
 wIY
-vZe
-cxZ
+gwA
+uJE
 nGV
 vUF
 cMk
@@ -51152,9 +50290,9 @@ rLU
 rLU
 kSg
 kSg
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -51231,12 +50369,12 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -51285,9 +50423,6 @@ jsJ
 jsJ
 jsJ
 gna
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -51312,9 +50447,12 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
 srK
@@ -51326,8 +50464,8 @@ qWl
 iDz
 utq
 myN
-wIY
-vZe
+fFH
+gFn
 uJE
 nGV
 vUF
@@ -51409,9 +50547,9 @@ rLU
 rLU
 kSg
 kSg
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -51490,11 +50628,11 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -51529,7 +50667,7 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
@@ -51539,12 +50677,9 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -51569,9 +50704,12 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
 srK
@@ -51583,8 +50721,8 @@ jIn
 mYi
 sat
 myN
-wIY
-vZe
+fFH
+gFn
 iLK
 nGV
 mcv
@@ -51625,7 +50763,7 @@ kSg
 kSg
 gzo
 jsJ
-bCe
+kgx
 jsJ
 rLU
 rLU
@@ -51664,11 +50802,11 @@ rLU
 rLU
 rLU
 kSg
-xlg
+eXj
 kSg
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -51748,11 +50886,11 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 pxz
 jsJ
@@ -51790,7 +50928,7 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
@@ -51799,9 +50937,6 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -51826,9 +50961,12 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
 srK
@@ -51840,8 +50978,8 @@ hpF
 mYi
 lZI
 myN
-wIY
-vZe
+fFH
+gFn
 uJE
 nGV
 vUF
@@ -51923,9 +51061,9 @@ rLU
 kSg
 kSg
 kSg
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -52007,9 +51145,9 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -52042,7 +51180,7 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
@@ -52056,9 +51194,6 @@ jsJ
 cyH
 jsJ
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -52083,9 +51218,12 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
 srK
@@ -52097,8 +51235,8 @@ czo
 mYi
 ohq
 myN
-wIY
-vZe
+fFH
+gFn
 uJE
 nGV
 vUF
@@ -52119,7 +51257,7 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 dwP
@@ -52139,7 +51277,7 @@ jsJ
 jsJ
 jsJ
 jsJ
-ctd
+tXu
 jsJ
 jsJ
 rLU
@@ -52179,9 +51317,9 @@ rLU
 rLU
 kSg
 kSg
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -52265,9 +51403,9 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -52297,11 +51435,11 @@ roU
 (28,1,1) = {"
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 cyH
 jsJ
@@ -52313,9 +51451,6 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -52340,9 +51475,12 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
 srK
@@ -52355,7 +51493,7 @@ wff
 qZX
 gni
 nfI
-wwd
+gNq
 kho
 nGV
 vUF
@@ -52434,11 +51572,11 @@ rLU
 rLU
 rLU
 rLU
+eXj
 kSg
-kSg
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -52522,9 +51660,9 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -52563,16 +51701,13 @@ jsJ
 jsJ
 jsJ
 jsJ
-ctd
+tXu
 jsJ
 jsJ
 jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -52597,9 +51732,12 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
 srK
@@ -52611,8 +51749,8 @@ fuX
 hOT
 gfB
 tfL
-wIY
-vZe
+fFH
+gFn
 gut
 nGV
 eEF
@@ -52693,9 +51831,9 @@ rLU
 kSg
 kSg
 kSg
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -52779,9 +51917,9 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -52817,19 +51955,16 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -52854,9 +51989,12 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 rLU
 srK
@@ -52869,7 +52007,7 @@ mLE
 mLE
 mLE
 pIc
-vZe
+gFn
 kXv
 awe
 agr
@@ -52893,19 +52031,19 @@ dwP
 vRN
 hKL
 dnF
-hKL
+qvo
 oIE
 dwP
-fcM
+qzB
 qKK
-qKK
-qKK
-qKK
+rvQ
+rvQ
+rvQ
 erq
+rzR
 fcM
-jII
 fcM
-jII
+rMP
 jII
 hlt
 jgW
@@ -52926,8 +52064,8 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -52948,11 +52086,11 @@ rLU
 jsJ
 jsJ
 jsJ
-cyH
-kSg
-rLU
-rLU
-rLU
+jsJ
+eXj
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -53037,9 +52175,9 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -53068,24 +52206,21 @@ roU
 (31,1,1) = {"
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
-bCe
-jsJ
-jsJ
-jsJ
-jsJ
+kgx
 jsJ
 jsJ
 jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
+jsJ
+jsJ
+jsJ
+jsJ
 rMm
 rMm
 rMm
@@ -53111,9 +52246,12 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 rLU
 srK
@@ -53126,7 +52264,7 @@ hAo
 qbz
 nGV
 xDt
-aLo
+gOM
 sqC
 qFg
 uOY
@@ -53183,32 +52321,32 @@ rLU
 rLU
 rLU
 rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-jsJ
-jsJ
-jsJ
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 rLU
 rLU
 rLU
 jsJ
 jsJ
 jsJ
-bCe
+rLU
+rLU
+rLU
 jsJ
 jsJ
-rLU
-rLU
-rLU
+jsJ
+kgx
+jsJ
+jsJ
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -53294,9 +52432,9 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 jsJ
 pxz
 jsJ
@@ -53340,9 +52478,6 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -53368,9 +52503,12 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 rLU
 srK
@@ -53383,7 +52521,7 @@ xhV
 auB
 nGV
 vFo
-etD
+lMG
 vZe
 jKJ
 ybc
@@ -53410,13 +52548,13 @@ drn
 duo
 dKi
 dwP
-jII
+qQJ
 auU
 auU
 jRL
 auU
 auU
-jII
+rBQ
 jII
 dqk
 jII
@@ -53440,20 +52578,20 @@ rLU
 rLU
 rLU
 rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 rLU
 rLU
 jsJ
 jsJ
 jsJ
-jsJ
-bCe
+kgx
 jsJ
 jsJ
 cyH
@@ -53463,9 +52601,9 @@ sfb
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -53551,9 +52689,9 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -53590,16 +52728,13 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -53625,8 +52760,11 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
 kSg
@@ -53655,7 +52793,7 @@ tqd
 rSf
 nGV
 xjf
-jZU
+neE
 srK
 tEF
 jII
@@ -53667,13 +52805,13 @@ jlu
 dDs
 laJ
 dwP
-jII
+riZ
 mMP
 kDl
 gCn
 mMP
 gCn
-jII
+rHa
 uGd
 xZj
 jII
@@ -53697,82 +52835,28 @@ rLU
 rLU
 rLU
 rLU
-kSg
-kSg
+rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 rLU
 rLU
 rLU
-rLU
-rLU
-rLU
 jsJ
 jsJ
 jsJ
 jsJ
 jsJ
-jsJ
-jsJ
-bCe
+kgx
 jsJ
 sfb
 sfb
 sfb
 sfb
-bCe
-jsJ
-rLU
-rLU
-rLU
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rMm
-rMm
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-jsJ
-ioQ
-ioQ
-ioQ
-ioQ
-ioQ
-ioQ
-ioQ
-jsJ
+kgx
 jsJ
 rMm
 rMm
@@ -53783,35 +52867,89 @@ rMm
 rMm
 rMm
 rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
+rLU
+rLU
+rLU
+rLU
+rLU
+rLU
 rMm
 rMm
 rLU
 rLU
 rLU
+rLU
+rLU
+rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+jsJ
+ioQ
+ioQ
+ioQ
+ioQ
+ioQ
+ioQ
+ioQ
+jsJ
+jsJ
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 bCe
 jsJ
@@ -53848,14 +52986,11 @@ jsJ
 uUy
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -53882,8 +53017,11 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
 kSg
@@ -53897,7 +53035,7 @@ bWs
 xiU
 caH
 hlk
-etD
+lMG
 vZe
 jKJ
 tfQ
@@ -53925,12 +53063,12 @@ dwP
 dwP
 fgp
 noY
-qKK
-qKK
+rvQ
+rvQ
 mNR
-qKK
-qKK
-jII
+rvQ
+rvQ
+rLF
 jII
 uBs
 jII
@@ -53950,22 +53088,22 @@ rMm
 rMm
 rLU
 rLU
-xTt
-lGK
-lGK
-lGK
-lGK
-lGK
-lGK
-lGK
-lGK
-lGK
+kSg
+kSg
+rLU
+rLU
+rLU
+rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rLU
+rLU
+rLU
 jsJ
-lGK
-lGK
-lGK
-lGK
-lGK
+jsJ
 jsJ
 jsJ
 jsJ
@@ -53977,9 +53115,9 @@ sfb
 sfb
 cyH
 jsJ
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -54066,9 +53204,9 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -54110,9 +53248,6 @@ jsJ
 jsJ
 jsJ
 uSY
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -54139,8 +53274,11 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
 kSg
@@ -54153,8 +53291,8 @@ rvq
 iUa
 dFw
 gKa
-wIY
-etD
+fFH
+lMG
 vZe
 jKJ
 nGO
@@ -54206,23 +53344,23 @@ rLU
 rLU
 rLU
 rLU
-kSg
-jsJ
-lGK
-jsJ
-jsJ
-jsJ
-iMo
 jsJ
 jsJ
 jsJ
 jsJ
 jsJ
+rLU
+rLU
+rLU
+rMm
+rMm
+rMm
+rMm
+rLU
+rLU
+rLU
 jsJ
 jsJ
-jsJ
-jsJ
-lGK
 jsJ
 jsJ
 sfb
@@ -54234,9 +53372,9 @@ sfb
 sfb
 jsJ
 jsJ
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -54323,9 +53461,9 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 jsJ
 jsJ
 rbs
@@ -54355,7 +53493,7 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
@@ -54367,9 +53505,6 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -54395,9 +53530,12 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
 rLU
@@ -54463,38 +53601,38 @@ rLU
 rLU
 rLU
 rLU
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+kSg
+rLU
+rLU
+rMm
+rMm
+rMm
+rMm
+rLU
+rLU
 kSg
 jsJ
-lGK
 jsJ
-hYq
-nyY
-oIf
-jsJ
-hYq
-nyY
-oIf
-jsJ
-hYq
-hvd
-oIf
-jsJ
-lGK
 cyH
 jsJ
 sfb
 sfb
 sfb
-bCe
+kgx
 jsJ
 cyH
 sfb
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -54511,7 +53649,7 @@ rLU
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 rLU
@@ -54581,9 +53719,9 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -54617,16 +53755,13 @@ jsJ
 cyH
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
 gna
 jsJ
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -54652,9 +53787,12 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
 rLU
@@ -54667,8 +53805,8 @@ xeE
 kIj
 rvq
 lkE
-wIY
-etD
+fFH
+lMG
 vZe
 jKJ
 nGO
@@ -54683,7 +53821,7 @@ bCe
 jsJ
 nUn
 tNv
-eDG
+nkn
 tNv
 cas
 jII
@@ -54720,23 +53858,23 @@ rLU
 rLU
 rLU
 kSg
-kgx
+bCe
 jsJ
 jsJ
 jsJ
-hYq
-ttR
-oIf
+bCe
+kSg
+rLU
+rLU
+rLU
+rLU
+rMm
+rMm
+rLU
+rLU
+kSg
 jsJ
-hYq
-ttR
-oIf
 jsJ
-hYq
-tni
-oIf
-jsJ
-lGK
 jsJ
 jsJ
 sfb
@@ -54749,9 +53887,9 @@ sfb
 sfb
 jsJ
 cyH
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -54838,9 +53976,9 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -54870,20 +54008,17 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -54909,9 +54044,12 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
 rLU
@@ -54924,8 +54062,8 @@ lMe
 rvq
 rvq
 gKa
-wIY
-etD
+fFH
+lMG
 vZe
 jKJ
 nGO
@@ -54975,28 +54113,28 @@ jsJ
 jsJ
 jsJ
 rLU
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
 kSg
 kSg
 kSg
+rLU
+rLU
+rMm
+rLU
+rLU
+rLU
+kSg
+kgx
 jsJ
 jsJ
 jsJ
-hYq
-ttR
-oIf
-jsJ
-hYq
-ttR
-oIf
-jsJ
-hYq
-tni
-oIf
-jsJ
-lGK
-jsJ
-jsJ
-bCe
+kgx
 sfb
 sfb
 pxz
@@ -55006,9 +54144,9 @@ sfb
 sfb
 jsJ
 jsJ
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -55095,9 +54233,9 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -55130,16 +54268,13 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -55166,9 +54301,12 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
 hmR
@@ -55197,7 +54335,7 @@ uea
 uea
 nUn
 tNv
-eDG
+nkn
 tNv
 ahd
 awq
@@ -55236,36 +54374,36 @@ jsJ
 bCe
 jsJ
 jsJ
-bCe
-jsJ
-hYq
-ttR
-oIf
-jsJ
-hYq
-ttR
-oIf
-jsJ
-hYq
-tni
-oIf
+kgx
 jsJ
 jsJ
-jsJ
-jsJ
-jsJ
-sfb
-sfb
-sfb
-bCe
-sfb
-sfb
-sfb
-jsJ
-jsJ
+kSg
+kSg
+kSg
 rLU
 rLU
 rLU
+rLU
+rLU
+kSg
+kSg
+kSg
+jsJ
+jsJ
+jsJ
+jsJ
+sfb
+sfb
+sfb
+kgx
+sfb
+sfb
+sfb
+jsJ
+jsJ
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -55352,9 +54490,9 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -55394,9 +54532,9 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -55439,7 +54577,7 @@ gKa
 nGV
 nGV
 wJq
-etD
+lMG
 kxG
 jKJ
 rck
@@ -55454,7 +54592,7 @@ uea
 uea
 nUn
 nuG
-eDG
+nkn
 tNv
 ahd
 uhd
@@ -55481,11 +54619,11 @@ dwo
 hLE
 kIP
 pak
-vjq
-vjq
-vjq
-vjq
-jNy
+hWW
+hWW
+hWW
+hWW
+rLU
 jsJ
 jsJ
 jsJ
@@ -55495,22 +54633,22 @@ jsJ
 jsJ
 jsJ
 jsJ
-hYq
-ttR
-oIf
 jsJ
-hYq
-ttR
-oIf
+kSg
+kSg
+kSg
+kSg
+kSg
+rLU
+rLU
+rLU
+kSg
+kSg
+kSg
 jsJ
-hYq
-tni
-oIf
 jsJ
 jsJ
-lGK
-lGK
-lGK
+jsJ
 sfb
 sfb
 sfb
@@ -55521,9 +54659,9 @@ sfb
 jsJ
 cyH
 jsJ
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rLU
@@ -55542,7 +54680,7 @@ iwY
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 rLU
 rLU
@@ -55609,9 +54747,9 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 jsJ
 pxz
 jsJ
@@ -55642,7 +54780,7 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
@@ -55651,9 +54789,9 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -55692,10 +54830,10 @@ nGV
 nUQ
 pUi
 rvq
-etD
+ePs
 bhI
 gKa
-wIY
+fFH
 sdk
 aTj
 aUp
@@ -55711,7 +54849,7 @@ uea
 uea
 nUn
 tNv
-eDG
+nkn
 tNv
 ahd
 rol
@@ -55738,36 +54876,36 @@ dwo
 hLE
 kIP
 ieY
-vjq
+hWW
 pXf
 oqR
-haf
-jNy
-jNy
-jNy
-gzo
-gzo
-jsJ
-jsJ
-bCe
-jsJ
-jsJ
-jsJ
-sQz
-jsJ
-jsJ
-jsJ
-sQz
-jsJ
-jsJ
-jsJ
-sQz
+hWW
+rLU
 jsJ
 jsJ
 jsJ
 jsJ
 jsJ
-lGK
+jsJ
+kgx
+jsJ
+jsJ
+jsJ
+kgx
+kSg
+kSg
+kSg
+kSg
+rLU
+kSg
+kSg
+kSg
+kSg
+kSg
+jsJ
+jsJ
+jsJ
+jsJ
 cyH
 sfb
 sfb
@@ -55778,11 +54916,11 @@ sfb
 jsJ
 jsJ
 cyH
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
 rLU
 rLU
 rLU
@@ -55791,7 +54929,7 @@ cdw
 mXA
 oWE
 rNe
-bCe
+kgx
 jsJ
 jsJ
 vXT
@@ -55867,9 +55005,9 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -55894,7 +55032,7 @@ roU
 "}
 (42,1,1) = {"
 jsJ
-ctd
+tXu
 jsJ
 jsJ
 jsJ
@@ -55908,40 +55046,40 @@ jsJ
 cyH
 jsJ
 jsJ
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 rLU
 rLU
 rLU
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
 rLU
 rLU
-rLU
-rLU
-rLU
-bRT
-bRT
-cWJ
-bRT
-bRT
+piz
+piz
+kSg
+piz
+piz
 hmR
 fRi
 cMk
@@ -55952,8 +55090,8 @@ bni
 owg
 lqE
 gKa
-wIY
-etD
+fFH
+lMG
 vZe
 jKJ
 syY
@@ -55968,7 +55106,7 @@ uea
 vCR
 rym
 tNv
-eDG
+nkn
 kQs
 hZT
 hZT
@@ -55996,50 +55134,50 @@ jnB
 niE
 niE
 sYd
-tnQ
-dyp
-neE
-uFy
-pKt
-wgh
-gwA
-gwA
-gwA
-gwA
-gwA
-gwA
-gwA
-pRL
-uea
-uea
-uea
-uea
-uea
-lwz
-gwA
-pRL
-uea
-lwz
-gwA
-gwA
-iHD
-jsJ
-lGK
-jsJ
-sfb
-sfb
-sfb
-sfb
-sfb
-jsJ
-jsJ
-jsJ
-jsJ
-jsJ
+jll
+cMs
+hWW
 rLU
 rLU
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+kgx
+jsJ
+kSg
+kSg
+kSg
+kSg
+kSg
+kSg
+kSg
 rLU
 rLU
+kSg
+kSg
+kSg
+kSg
+jsJ
+jsJ
+jsJ
+sfb
+sfb
+sfb
+sfb
+sfb
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+rMm
+rMm
+rMm
+rMm
 rLU
 rLU
 rLU
@@ -56062,7 +55200,7 @@ jsJ
 rLU
 rLU
 rLU
-rLU
+rMm
 rMm
 rMm
 rMm
@@ -56124,9 +55262,9 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -56154,7 +55292,7 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
@@ -56165,9 +55303,9 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -56225,7 +55363,7 @@ uea
 uea
 nUn
 owd
-eDG
+nkn
 gFe
 vCS
 jny
@@ -56255,48 +55393,48 @@ kIP
 uVm
 hxx
 oJv
-qqO
-jNy
-jNy
-jNy
-gzo
-gzo
-jsJ
-bCe
-jsJ
-jsJ
-jsJ
-jsJ
-caE
-jsJ
-jsJ
-jsJ
-caE
-jsJ
-jsJ
-jsJ
-caE
-jsJ
-jsJ
-jsJ
-jsJ
-jsJ
-lGK
-jsJ
-sfb
-sfb
-sfb
-sfb
-sfb
-jsJ
-bCe
-jsJ
-jsJ
-bCe
-jsJ
-jsJ
+hWW
 rLU
 rLU
+jsJ
+jsJ
+jsJ
+jsJ
+kgx
+jsJ
+jsJ
+jsJ
+jsJ
+kSg
+kSg
+kSg
+kSg
+kSg
+rLU
+rLU
+rLU
+rLU
+rLU
+kSg
+jsJ
+jsJ
+kgx
+jsJ
+jsJ
+sfb
+sfb
+sfb
+sfb
+sfb
+jsJ
+kgx
+jsJ
+jsJ
+kgx
+jsJ
+jsJ
+rMm
+rMm
 rLU
 rLU
 rLU
@@ -56315,12 +55453,12 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 rLU
 rLU
 rLU
-rLU
-rLU
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -56381,9 +55519,9 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -56416,15 +55554,15 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 uSY
 jsJ
 jsJ
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -56509,36 +55647,36 @@ dwo
 wgj
 nnG
 pse
-vjq
-vjq
-vjq
-vjq
-jNy
+hWW
+hWW
+hWW
+hWW
+rLU
+rLU
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+kgx
+jsJ
+nSm
 kSg
 kSg
+kSg
+kSg
+rLU
+rLU
+rLU
+rLU
+rLU
+rLU
+rLU
+rLU
 jsJ
 jsJ
 jsJ
 jsJ
-jsJ
-jsJ
-jsJ
-hYq
-nqR
-oIf
-jsJ
-hYq
-nqR
-oIf
-jsJ
-hYq
-neu
-oIf
-jsJ
-jsJ
-lGK
-lGK
-lGK
 jsJ
 sfb
 sfb
@@ -56552,7 +55690,7 @@ jsJ
 cyH
 jsJ
 jsJ
-bCe
+kgx
 cyH
 rLU
 rLU
@@ -56576,9 +55714,9 @@ jsJ
 rLU
 rLU
 rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -56638,9 +55776,9 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -56679,9 +55817,9 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -56778,20 +55916,20 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
-hYq
-nqR
-oIf
-jsJ
-hYq
-nqR
-oIf
-jsJ
-hYq
-neu
-oIf
-jsJ
+kSg
+kgx
+kSg
+rLU
+rLU
+rLU
+rLU
+rLU
+rLU
+rLU
+rLU
+rLU
 jsJ
 jsJ
 jsJ
@@ -56830,10 +55968,6 @@ jsJ
 cFU
 jsJ
 olu
-rNe
-rNe
-rNe
-rNe
 rLU
 rLU
 rLU
@@ -56852,6 +55986,10 @@ rMm
 rMm
 rMm
 rMm
+rMm
+rMm
+rMm
+rMm
 ioQ
 ioQ
 ioQ
@@ -56895,9 +56033,9 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -56907,7 +56045,7 @@ rbs
 jsJ
 jsJ
 jsJ
-ctd
+tXu
 jsJ
 uSY
 jsJ
@@ -56926,19 +56064,19 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 pxz
 jsJ
 jsJ
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -56970,10 +56108,10 @@ bZM
 dpj
 cWJ
 cWJ
-hmR
+bRT
 sCW
-eWs
-nGV
+bRT
+bRT
 nGV
 gKa
 eWB
@@ -57032,24 +56170,24 @@ rLU
 rLU
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
 jsJ
-hYq
-nqR
-oIf
+kSg
+kSg
+rLU
+rLU
+rLU
+rLU
+rLU
+rLU
+rLU
+rLU
+rLU
+rLU
 jsJ
-hYq
-nqR
-oIf
-jsJ
-hYq
-neu
-oIf
-jsJ
-lGK
 jsJ
 jsJ
 jsJ
@@ -57061,19 +56199,19 @@ jsJ
 pxz
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 cyH
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 rLU
 rLU
 rLU
 kSg
-bCe
+kgx
 bNT
 jsJ
 jsJ
@@ -57087,13 +56225,13 @@ jsJ
 jsJ
 jsJ
 jsJ
-vsB
-keW
-uVw
-rNe
 rLU
 rLU
 rLU
+rMm
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -57152,9 +56290,9 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -57192,9 +56330,9 @@ jsJ
 cyH
 jsJ
 jsJ
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -57229,7 +56367,7 @@ cWJ
 nvx
 bRT
 kev
-bRT
+caU
 bRT
 oVL
 awe
@@ -57291,22 +56429,22 @@ jsJ
 cyH
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
-hYq
-nqR
-oIf
+kSg
+rLU
+rLU
+rLU
+rLU
+rLU
+rLU
+rLU
+rLU
+rLU
+rLU
+rLU
 jsJ
-hYq
-nqR
-oIf
-jsJ
-hYq
-neu
-oIf
-jsJ
-lGK
 jsJ
 jsJ
 jsJ
@@ -57316,13 +56454,13 @@ sfb
 cyH
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 nDG
 jsJ
@@ -57342,15 +56480,15 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 cyH
-rNe
-jqz
-jqz
-rNe
 rLU
 rLU
 rLU
+rMm
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -57410,13 +56548,13 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
-ctd
+tXu
 jsJ
 jsJ
 jsJ
@@ -57449,9 +56587,9 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -57542,7 +56680,7 @@ kIP
 pON
 dwo
 rLU
-kSg
+jsJ
 cyH
 jsJ
 jsJ
@@ -57550,23 +56688,23 @@ jsJ
 jsJ
 jsJ
 jsJ
+kgx
+kSg
+rLU
+rLU
+rLU
+rLU
+rLU
+rLU
+rLU
+rLU
+rLU
+rLU
+rLU
 jsJ
-hYq
-eXd
-oIf
-jsJ
-hYq
-eXd
-oIf
-jsJ
-hYq
-eXd
-oIf
-jsJ
-lGK
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 sfb
 sfb
@@ -57574,11 +56712,11 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
@@ -57588,7 +56726,7 @@ rLU
 rLU
 rLU
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 sfb
@@ -57601,13 +56739,13 @@ xTt
 jsJ
 jsJ
 jsJ
-rNe
-rNe
-rNe
-rNe
 rLU
 rLU
 rLU
+rMm
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -57667,11 +56805,11 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 jsJ
-ctd
+tXu
 jsJ
 jsJ
 uSY
@@ -57702,12 +56840,12 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -57799,46 +56937,46 @@ kIP
 iNU
 dwo
 rLU
-kSg
+jsJ
 jsJ
 pxz
 jsJ
-jsJ
-jsJ
-jsJ
-lGK
-jsJ
+gOS
 jsJ
 jsJ
 jsJ
 jsJ
 jsJ
-jsJ
-jsJ
-jsJ
-jsJ
-jsJ
-jsJ
-jsJ
-jsJ
+rLU
+rLU
+rLU
+rLU
+rLU
+rLU
+rLU
+rLU
+rLU
+rLU
+rLU
+rLU
 jsJ
 jsJ
 cyH
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 cyH
 jsJ
 rLU
@@ -57861,9 +56999,9 @@ jsJ
 rLU
 rLU
 rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -57924,9 +57062,9 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -57951,45 +57089,45 @@ jsJ
 (50,1,1) = {"
 jsJ
 jsJ
-ctd
+tXu
 jsJ
 jsJ
 jsJ
-ctd
+tXu
 jsJ
 jsJ
 jsJ
 jsJ
 jsJ
 jsJ
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 rLU
 rLU
 rLU
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
 rLU
-rLU
-rLU
-cWJ
 cWJ
 cWJ
 cWJ
@@ -58002,8 +57140,8 @@ bRT
 qTx
 xEP
 pIR
-pIR
-qtV
+cSb
+dyp
 gMi
 eWu
 fwh
@@ -58013,7 +57151,7 @@ xlx
 fWv
 vfU
 msL
-caH
+oZy
 sMo
 rTM
 mkq
@@ -58062,22 +57200,22 @@ jsJ
 jsJ
 jsJ
 jsJ
+kgx
 jsJ
-lGK
-lGK
-lGK
-lGK
-lGK
-lGK
-lGK
-lGK
-lGK
-lGK
-lGK
-lGK
-lGK
-lGK
-lGK
+jsJ
+jsJ
+rLU
+rLU
+rLU
+rLU
+rLU
+rLU
+rLU
+rLU
+rLU
+rLU
+rLU
+rLU
 qIu
 qIu
 kSg
@@ -58088,7 +57226,7 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 uUy
 jsJ
@@ -58112,14 +57250,14 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 rLU
 rLU
 rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -58181,9 +57319,9 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -58193,7 +57331,7 @@ jsJ
 jsJ
 jsJ
 jsJ
-ctd
+tXu
 jsJ
 jsJ
 jsJ
@@ -58219,34 +57357,34 @@ jsJ
 jsJ
 jsJ
 jsJ
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 rLU
 rLU
 rLU
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
 rLU
 rLU
 rLU
 rLU
-rLU
-rLU
-cWJ
 cWJ
 cWJ
 cWJ
@@ -58255,14 +57393,14 @@ cWJ
 cWJ
 rLU
 rLU
-piz
-hmR
+bRT
+bRT
 rmb
 pIR
-sCD
-vCo
-hcr
-xeG
+toD
+jiu
+rnL
+jiu
 jXf
 gtN
 pIR
@@ -58323,9 +57461,9 @@ cyH
 jsJ
 jsJ
 jsJ
-jsJ
-jsJ
-jsJ
+rLU
+rLU
+rLU
 rLU
 rLU
 rLU
@@ -58338,7 +57476,7 @@ rLU
 rLU
 rLU
 kSg
-bCe
+kgx
 jsJ
 jsJ
 cyH
@@ -58348,24 +57486,24 @@ cyH
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 cyH
 jsJ
 pxz
 jsJ
 jsJ
-bCe
+kgx
 rLU
 rLU
 jrH
 jrH
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
@@ -58373,9 +57511,9 @@ cyH
 rLU
 rLU
 rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -58438,12 +57576,12 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 jsJ
 jsJ
-ctd
+tXu
 jsJ
 pxz
 jsJ
@@ -58467,7 +57605,7 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
@@ -58475,9 +57613,6 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -58497,34 +57632,37 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
-rLU
-bRT
-bRT
-bRT
-cWJ
-bRT
-bRT
+rMm
+rMm
+rMm
 rLU
 rLU
 rLU
 rLU
 rLU
-srK
-vUF
+piz
+piz
+piz
+kSg
+piz
+piz
+rLU
+rLU
+rLU
+rLU
+rLU
+bOk
+cdq
 pIR
-pIR
-pIR
+toD
+jiu
 lof
 aVA
 jiu
 toD
 pIR
 ikW
-iKw
+etD
 vZe
 srI
 sXs
@@ -58569,7 +57707,7 @@ dwo
 kSX
 kSX
 dwo
-kSg
+jsJ
 jsJ
 jsJ
 jsJ
@@ -58578,7 +57716,7 @@ pxz
 jsJ
 jsJ
 jsJ
-jsJ
+kgx
 jsJ
 jsJ
 rLU
@@ -58615,23 +57753,23 @@ jsJ
 jsJ
 jsJ
 jrH
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
 cyH
 jsJ
 jsJ
 jsJ
 pxz
 jsJ
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -58696,9 +57834,9 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -58728,13 +57866,10 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
-ctd
+tXu
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -58752,8 +57887,11 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
 rLU
 jsJ
 cXC
@@ -58770,18 +57908,18 @@ cXC
 rLU
 rLU
 rLU
-srK
+bOk
 nGt
 pIR
 opC
-sPO
+jiu
 lOZ
 kzm
 jiu
 dIb
 pIR
 tiI
-kzY
+hqR
 nmb
 uFX
 gog
@@ -58825,8 +57963,8 @@ hLE
 cOf
 kIP
 kIP
-dwo
-kSg
+sBM
+jsJ
 jsJ
 jsJ
 jsJ
@@ -58865,30 +58003,30 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
 jsJ
 cyH
 kSg
-rLU
-rLU
-rLU
-rNe
-rNe
-mwq
-rNe
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jrH
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -58953,9 +58091,9 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 jsJ
 rbs
 jsJ
@@ -58989,9 +58127,6 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -59008,9 +58143,12 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 mrm
 xIt
@@ -59030,8 +58168,8 @@ bkg
 ttZ
 luG
 pIR
-pIR
-qtV
+jiu
+jiu
 hMq
 beY
 jiu
@@ -59084,69 +58222,69 @@ hHw
 kIP
 dwo
 rLU
+jsJ
+cyH
+jsJ
+jsJ
+cyH
+jsJ
+jsJ
+rLU
+rLU
+rLU
+rLU
+rLU
+rLU
+rLU
+rLU
+rLU
+rLU
+rLU
+rLU
+rLU
+rLU
+rLU
+rLU
+rLU
+rLU
+rLU
+rLU
+rLU
+rLU
 kSg
-cyH
-jsJ
-jsJ
-cyH
-jsJ
-jsJ
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-kSg
-bCe
+kgx
 cyH
 jsJ
 jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
-rLU
-rLU
-rNe
-xaA
-bTk
-rNe
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jrH
 jrH
 kSg
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -59179,9 +58317,6 @@ ioQ
 ioQ
 ioQ
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -59211,9 +58346,12 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -59238,16 +58376,13 @@ jsJ
 pxz
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -59265,9 +58400,12 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 cXC
 qcU
 daC
@@ -59375,7 +58513,7 @@ pxz
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
@@ -59383,31 +58521,31 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
-rLU
-rLU
-rLU
-rLU
-rLU
-rNe
-cxs
-hCP
-rNe
-rLU
-rLU
-rLU
+kgx
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
 kSg
 kSg
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -59436,12 +58574,6 @@ ioQ
 ioQ
 ioQ
 jsJ
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -59468,9 +58600,15 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -59502,9 +58640,6 @@ uSY
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -59522,9 +58657,12 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 cXC
 lEC
 nCY
@@ -59546,9 +58684,9 @@ pIR
 pIR
 rKV
 ltV
-rnL
+ech
 urh
-toD
+eXd
 rHP
 pIR
 rVP
@@ -59616,11 +58754,11 @@ rLU
 rLU
 rLU
 rLU
-hoF
-hoF
-hoF
-hoF
-hoF
+rLU
+rLU
+rLU
+rLU
+rLU
 rLU
 rLU
 rLU
@@ -59633,77 +58771,33 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rNe
-rNe
-rNe
-rNe
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
 eXj
 kSg
 kSg
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rLU
-rLU
-rLU
-jsJ
-ioQ
-ioQ
-ioQ
-ioQ
-ioQ
-ioQ
-ioQ
-jsJ
-jsJ
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rMm
-rMm
-rMm
 rMm
 rMm
 rMm
@@ -59729,7 +58823,51 @@ rLU
 rLU
 rLU
 jsJ
-ctd
+ioQ
+ioQ
+ioQ
+ioQ
+ioQ
+ioQ
+ioQ
+jsJ
+jsJ
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+jsJ
+tXu
 jsJ
 jsJ
 jsJ
@@ -59759,9 +58897,6 @@ jsJ
 jsJ
 jsJ
 uUy
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -59779,9 +58914,12 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 cXC
 lEC
 nCY
@@ -59873,11 +59011,11 @@ rLU
 rLU
 rLU
 rLU
-hoF
-oqk
-qvo
-qQJ
-hoF
+rLU
+rLU
+rLU
+rLU
+rLU
 rLU
 rLU
 rLU
@@ -59897,33 +59035,33 @@ jsJ
 jsJ
 cyH
 jsJ
-rLU
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
 kSg
 kSg
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -59953,18 +59091,6 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rMm
-rLU
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -59982,14 +59108,26 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
 jsJ
-ctd
+tXu
 jsJ
 jsJ
 jsJ
@@ -60009,16 +59147,13 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -60036,9 +59171,12 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 lEC
 nCY
@@ -60130,11 +59268,11 @@ rLU
 rLU
 rLU
 rLU
-hoF
-gcP
-ldy
-svi
-hoF
+rLU
+rLU
+rLU
+rLU
+rLU
 rLU
 rLU
 rLU
@@ -60151,37 +59289,37 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
-rLU
-rLU
 rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 eXj
 kSg
 kSg
 eXj
 kSg
 kSg
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -60213,16 +59351,6 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -60239,9 +59367,19 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -60259,7 +59397,7 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 "}
 (59,1,1) = {"
 jsJ
@@ -60273,9 +59411,6 @@ jsJ
 jsJ
 uSY
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -60293,9 +59428,12 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 lEC
 nCY
@@ -60315,9 +59453,9 @@ jsJ
 jsJ
 pIR
 bsd
-beO
-czz
-jQm
+jiu
+jiu
+rnL
 uzE
 asS
 hPR
@@ -60387,11 +59525,11 @@ rLU
 rLU
 rLU
 rLU
-hoF
-dcz
-boY
-pfw
-hoF
+rLU
+rLU
+rLU
+rLU
+rLU
 rLU
 rLU
 rLU
@@ -60401,45 +59539,45 @@ rLU
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
 jsJ
 jsJ
-rLU
 rMm
 rMm
 rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
 kSg
 kSg
 jrH
 jrH
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -60465,22 +59603,13 @@ ioQ
 ioQ
 ioQ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -60496,9 +59625,18 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 pxz
@@ -60530,9 +59668,6 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -60550,9 +59685,12 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 lEC
 nCY
@@ -60573,7 +59711,7 @@ jsJ
 iiB
 htx
 jiu
-jiu
+dHB
 aiz
 pIR
 pIR
@@ -60644,18 +59782,18 @@ rLU
 rLU
 rLU
 rLU
-hoF
-hoF
-fsY
-hoF
-hoF
 rLU
 rLU
 rLU
 rLU
 rLU
 rLU
-bCe
+rLU
+rLU
+rLU
+rLU
+rLU
+kgx
 jsJ
 jsJ
 jsJ
@@ -60664,10 +59802,6 @@ jsJ
 jsJ
 pxz
 jsJ
-rLU
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -60685,18 +59819,22 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jrH
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -60724,21 +59862,18 @@ ioQ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 rNe
 rNe
 rNe
 rNe
 rNe
-rLU
+rMm
 rNe
 rNe
 rNe
 rNe
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -60753,15 +59888,18 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
 jsJ
 jsJ
-ctd
+tXu
 jsJ
 jsJ
 jsJ
@@ -60787,9 +59925,6 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -60807,9 +59942,12 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 cXC
 lEC
 nCY
@@ -60830,7 +59968,7 @@ jsJ
 iiB
 oBz
 oCg
-psU
+kzm
 mnG
 bgW
 vig
@@ -60886,7 +60024,7 @@ jll
 dwo
 jsJ
 kSg
-bCe
+kgx
 jsJ
 jsJ
 rLU
@@ -60901,10 +60039,10 @@ rLU
 rLU
 rLU
 rLU
-nTG
-hoF
-jzd
-hoF
+rLU
+rLU
+rLU
+rLU
 rLU
 rLU
 rLU
@@ -60915,15 +60053,10 @@ rLU
 kSg
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
-bCe
-rLU
-rLU
-rLU
-rLU
-rLU
+kgx
 rMm
 rMm
 rMm
@@ -60944,17 +60077,22 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -60993,9 +60131,6 @@ rNe
 slR
 imG
 rNe
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -61011,11 +60146,14 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
-ctd
+tXu
 jsJ
 jsJ
 jsJ
@@ -61029,7 +60167,7 @@ pxz
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 "}
 (62,1,1) = {"
@@ -61042,11 +60180,8 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -61064,9 +60199,12 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 cXC
 lEC
 nCY
@@ -61087,8 +60225,8 @@ jsJ
 iiB
 htx
 jiu
-jiu
-vdy
+dLV
+emy
 qae
 mix
 mjL
@@ -61160,7 +60298,7 @@ rLU
 rLU
 hoF
 hoF
-eBK
+hoF
 hoF
 hoF
 hoF
@@ -61174,13 +60312,6 @@ kSg
 jsJ
 jsJ
 kSg
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -61204,16 +60335,23 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
 kSg
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -61225,7 +60363,7 @@ rLU
 rLU
 rLU
 jsJ
-ctd
+tXu
 jsJ
 ioQ
 ioQ
@@ -61250,9 +60388,6 @@ rNe
 blZ
 vvw
 rNe
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -61268,26 +60403,29 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
-bCe
+kgx
 "}
 (63,1,1) = {"
 jsJ
@@ -61297,12 +60435,9 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -61321,9 +60456,12 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 cXC
 lEC
 nCY
@@ -61417,9 +60555,9 @@ rLU
 rLU
 hoF
 fgT
-vJv
+jse
 oRh
-bpB
+oRh
 piR
 hoF
 rLU
@@ -61430,11 +60568,6 @@ rLU
 kSg
 kSg
 kSg
-rLU
-rLU
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -61463,15 +60596,20 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
 kSg
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -61507,9 +60645,6 @@ rNe
 eFG
 rNe
 rNe
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -61525,9 +60660,12 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -61557,9 +60695,6 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -61578,9 +60713,12 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 lEC
 nCY
@@ -61675,8 +60813,8 @@ rLU
 hoF
 nSd
 awV
-jjt
-lpP
+nSd
+jse
 oiJ
 hoF
 rLU
@@ -61687,9 +60825,6 @@ kSg
 kSg
 xlg
 kSg
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -61720,16 +60855,19 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 eXj
 kSg
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -61752,7 +60890,7 @@ ioQ
 ioQ
 ioQ
 jsJ
-bCe
+kgx
 jsJ
 rNe
 yjf
@@ -61765,9 +60903,6 @@ kSg
 kSg
 kSg
 kSg
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -61782,25 +60917,28 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
 jsJ
 jsJ
-ctd
+tXu
 jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 "}
 (65,1,1) = {"
@@ -61813,9 +60951,6 @@ jsJ
 jsJ
 jsJ
 cyH
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -61835,9 +60970,12 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 lEC
 nCY
@@ -61943,9 +61081,6 @@ rLU
 eXj
 kSg
 kSg
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -61977,17 +61112,20 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
 kSg
 kSg
 kSg
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -61996,7 +61134,7 @@ rLU
 rLU
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
@@ -62023,9 +61161,6 @@ rNe
 rNe
 rNe
 rNe
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -62039,22 +61174,25 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
-ctd
+tXu
 jsJ
-ctd
-jsJ
-jsJ
-jsJ
+tXu
 jsJ
 jsJ
 jsJ
 jsJ
-bCe
+jsJ
+jsJ
+jsJ
+kgx
 jsJ
 jsJ
 jsJ
@@ -62070,9 +61208,6 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -62092,9 +61227,12 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 lEC
 nCY
@@ -62118,7 +61256,7 @@ jiu
 jiu
 aMH
 gfj
-xpm
+jiu
 pkS
 pIR
 apv
@@ -62199,9 +61337,6 @@ rLU
 rLU
 kSg
 kSg
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -62236,15 +61371,18 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -62280,9 +61418,6 @@ rNe
 mXA
 fkN
 rNe
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -62296,9 +61431,12 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -62308,13 +61446,13 @@ pxz
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 cyH
 "}
 (67,1,1) = {"
@@ -62327,9 +61465,6 @@ jsJ
 jsJ
 bCe
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -62349,9 +61484,12 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 lEC
 nCY
@@ -62392,7 +61530,7 @@ wNX
 azP
 vWY
 vWY
-rzR
+vWY
 suD
 hhF
 vZv
@@ -62436,7 +61574,7 @@ szI
 quB
 jsJ
 jsJ
-bCe
+kgx
 rLU
 rLU
 kSg
@@ -62456,9 +61594,6 @@ rLU
 kSg
 kSg
 kSg
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -62494,21 +61629,24 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
 rLU
 rLU
 rLU
-ctd
+tXu
 jsJ
 jsJ
 jsJ
@@ -62537,9 +61675,6 @@ rNe
 uJU
 tJq
 rNe
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -62554,22 +61689,25 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 cyH
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
@@ -62584,9 +61722,6 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -62606,9 +61741,12 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 cXC
 lEC
 nCY
@@ -62649,7 +61787,7 @@ oHt
 mJB
 hhF
 hhF
-fWw
+hhF
 hDh
 hhF
 vZv
@@ -62677,7 +61815,7 @@ kAg
 vuf
 khY
 pKj
-tzA
+svi
 aMF
 jRA
 gsM
@@ -62712,9 +61850,6 @@ rLU
 rLU
 kSg
 kSg
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -62751,16 +61886,19 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
-rLU
-rLU
-rLU
 rMm
 rMm
+rMm
+rMm
+rMm
 rLU
 rLU
 rLU
@@ -62770,7 +61908,7 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jmp
 jmp
@@ -62794,9 +61932,6 @@ rNe
 hts
 rNe
 rNe
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -62809,27 +61944,30 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
 jsJ
-ctd
+tXu
 jsJ
 jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 "}
 (69,1,1) = {"
 jsJ
@@ -62841,9 +61979,6 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -62863,9 +61998,12 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 cXC
 lEC
 nCY
@@ -62969,9 +62107,6 @@ rLU
 lDG
 kSg
 kSg
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -63009,13 +62144,16 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 eXj
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rLU
@@ -63051,9 +62189,6 @@ nOK
 kSg
 kSg
 kSg
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -63064,21 +62199,24 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
-ctd
+tXu
 jsJ
 jsJ
 jsJ
 jsJ
-ctd
+tXu
 jsJ
 jsJ
 jsJ
@@ -63097,9 +62235,6 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -63120,9 +62255,12 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 cXC
 lEC
 nCY
@@ -63151,7 +62289,7 @@ flM
 xxq
 peL
 oIc
-nnw
+pgp
 xiN
 oIc
 kXA
@@ -63226,9 +62364,6 @@ rLU
 kSg
 kSg
 eXj
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -63265,14 +62400,17 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rLU
@@ -63280,7 +62418,7 @@ rLU
 rLU
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
@@ -63308,9 +62446,6 @@ kSg
 kSg
 kSg
 kSg
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -63320,15 +62455,18 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 jrH
 jsJ
-ctd
+tXu
 jsJ
 jsJ
 jsJ
@@ -63341,7 +62479,7 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 "}
@@ -63354,9 +62492,6 @@ jsJ
 jsJ
 uSY
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -63377,14 +62512,17 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 cXC
 lEC
 nCY
 jsJ
-tsr
+bhp
 uSY
 gzo
 gzo
@@ -63483,9 +62621,6 @@ rLU
 kSg
 kSg
 kSg
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -63521,15 +62656,18 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
 rLU
 rLU
 rLU
@@ -63540,7 +62678,7 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 ioQ
@@ -63559,15 +62697,12 @@ mTB
 mTB
 mTB
 jsJ
-bCe
+kgx
 jsJ
 xPs
 kSg
 kSg
 jWM
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -63576,10 +62711,13 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
 kSg
@@ -63590,14 +62728,14 @@ jsJ
 jsJ
 jsJ
 jsJ
-ctd
+tXu
 cyH
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 cyH
@@ -63611,9 +62749,6 @@ jsJ
 jsJ
 ctd
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -63634,14 +62769,17 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 lEC
 nCY
 jsJ
-tsr
+bhp
 jsJ
 gzo
 gzo
@@ -63677,7 +62815,7 @@ orD
 gqE
 dnx
 pya
-fWw
+hhF
 hDh
 hhF
 aSA
@@ -63739,9 +62877,6 @@ rLU
 rLU
 kSg
 kSg
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -63777,15 +62912,18 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rLU
 rLU
 rLU
@@ -63822,9 +62960,6 @@ rNe
 rNe
 rNe
 rNe
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -63832,9 +62967,12 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
 kSg
@@ -63868,9 +63006,6 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -63891,9 +63026,12 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 lEC
 nCY
@@ -63934,7 +63072,7 @@ uxl
 gqE
 puA
 pya
-fWw
+hhF
 hDh
 hhF
 aSA
@@ -63996,9 +63134,6 @@ rLU
 rLU
 kSg
 kSg
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -64033,11 +63168,14 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jrH
 jrH
 rLU
@@ -64079,18 +63217,18 @@ eFG
 thw
 ukb
 rNe
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
 kSg
@@ -64101,20 +63239,20 @@ kSg
 jrH
 jsJ
 jsJ
-ctd
+tXu
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
-bCe
+kgx
 jsJ
-ctd
+tXu
 jsJ
 jsJ
-bCe
+kgx
 jsJ
-bCe
+jsJ
 "}
 (74,1,1) = {"
 jsJ
@@ -64124,9 +63262,6 @@ jsJ
 jsJ
 bCe
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -64148,9 +63283,12 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 lEC
 nCY
@@ -64191,7 +63329,7 @@ mxz
 gqE
 xRt
 pya
-fWw
+hhF
 hDh
 hhF
 aSA
@@ -64253,9 +63391,6 @@ rLU
 rLU
 xlg
 kSg
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -64286,15 +63421,18 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jrH
 jsJ
 jsJ
@@ -64310,7 +63448,7 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
@@ -64324,39 +63462,39 @@ ioQ
 ioQ
 ioQ
 kSg
-ctd
+tXu
 jsJ
 jsJ
 ikL
 jsJ
 jsJ
-ctd
+tXu
 jsJ
 rNe
 kJQ
 qCm
 rNe
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
 kSg
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -64381,9 +63519,6 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -64405,9 +63540,12 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 lEC
 nCY
@@ -64448,9 +63586,9 @@ dbO
 eej
 tru
 pya
-fWw
+hhF
 hDh
-sYa
+nTG
 aSA
 lbj
 pao
@@ -64510,9 +63648,6 @@ kSg
 kSg
 kSg
 kSg
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -64540,17 +63675,20 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 uSY
 jsJ
@@ -64593,41 +63731,41 @@ rNe
 rNe
 rNe
 rNe
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
 kSg
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
-ctd
-jsJ
-jsJ
+tXu
 jsJ
 jsJ
 jsJ
 jsJ
-bCe
+jsJ
+jsJ
+kgx
 jsJ
 "}
 (76,1,1) = {"
@@ -64638,9 +63776,6 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -64662,9 +63797,12 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 qcU
 nXC
@@ -64705,7 +63843,7 @@ ggU
 gqE
 dnx
 vYi
-fWw
+hhF
 hDh
 gor
 yla
@@ -64767,9 +63905,6 @@ kSg
 kSg
 kSg
 kSg
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -64797,13 +63932,16 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -64821,14 +63959,14 @@ jsJ
 quB
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 ioQ
@@ -64849,38 +63987,38 @@ jsJ
 kSg
 qac
 kSg
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
 kSg
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
-bCe
+kgx
 jsJ
-ctd
-jsJ
-jsJ
+tXu
 jsJ
 jsJ
 jsJ
-bCe
+jsJ
+jsJ
+kgx
 jsJ
 jsJ
 jsJ
@@ -64894,9 +64032,6 @@ jsJ
 jsJ
 bCe
 pxz
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -64920,9 +64055,12 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 czA
 pLX
 pLX
@@ -64947,10 +64085,10 @@ rHu
 mRT
 mPB
 rlY
-osq
 pgp
-fjv
-fjv
+pgp
+pgp
+pgp
 jJS
 oiS
 mhf
@@ -65024,8 +64162,6 @@ hoF
 hoF
 hoF
 hoF
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -65050,15 +64186,17 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
-ctd
+tXu
 jsJ
 jsJ
 jsJ
@@ -65080,7 +64218,7 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 uUy
 jsJ
 jsJ
@@ -65102,33 +64240,33 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 kSg
 kSg
 qac
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
 kSg
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -65140,7 +64278,7 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 "}
@@ -65151,9 +64289,6 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -65179,8 +64314,11 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -65281,8 +64419,6 @@ fML
 nSd
 nSd
 hoF
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -65301,16 +64437,18 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 cyH
 jsJ
@@ -65341,7 +64479,7 @@ jsJ
 cyH
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
@@ -65353,7 +64491,7 @@ ioQ
 ioQ
 ioQ
 jsJ
-ctd
+tXu
 jsJ
 jsJ
 jsJ
@@ -65363,38 +64501,38 @@ jsJ
 jsJ
 kSg
 kSg
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 cyH
 jsJ
-ctd
+tXu
 jsJ
 jsJ
 jsJ
@@ -65408,9 +64546,6 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -65436,8 +64571,11 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 cXC
@@ -65462,7 +64600,7 @@ uSN
 egI
 uiv
 jsS
-egI
+gVI
 nlQ
 xTD
 nlQ
@@ -65525,7 +64663,7 @@ hoF
 hoF
 kSg
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 bFZ
@@ -65538,8 +64676,6 @@ hoF
 uXU
 biv
 hoF
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -65554,20 +64690,22 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -65577,7 +64715,7 @@ jsJ
 jsJ
 jsJ
 jsJ
-ctd
+tXu
 jsJ
 jsJ
 rLU
@@ -65596,13 +64734,13 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 ioQ
 ioQ
 ioQ
@@ -65620,54 +64758,51 @@ jsJ
 jsJ
 kSg
 kSg
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 cyH
 "}
 (80,1,1) = {"
 jsJ
 jsJ
-jsJ
+anD
 jsJ
 uSY
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -65693,10 +64828,13 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -65795,8 +64933,6 @@ hoF
 hoF
 hoF
 hoF
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -65804,23 +64940,25 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 bCe
 jsJ
 jsJ
@@ -65831,7 +64969,7 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 cyH
 rLU
@@ -65854,7 +64992,7 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
@@ -65876,55 +65014,52 @@ jsJ
 lFA
 jsJ
 qac
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
 kSg
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
 jsJ
-ctd
+tXu
 jsJ
 jsJ
 ctd
 pxz
-bCe
+kgx
 jsJ
 jsJ
 jsJ
 "}
 (81,1,1) = {"
 jsJ
-bCe
 jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
+jsJ
 rMm
 rMm
 rMm
@@ -65952,25 +65087,28 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
 kSg
 jsJ
-bCe
+kgx
 aLK
 drz
 fYZ
-oiS
+awM
 hSQ
 oiS
 oiS
@@ -65990,7 +65128,7 @@ lbi
 tVl
 wxZ
 gsK
-fWw
+hhF
 hDh
 hhF
 aQp
@@ -66014,7 +65152,7 @@ fWr
 jzH
 fWr
 gjt
-fWr
+rPk
 xbC
 uqh
 hLE
@@ -66041,7 +65179,7 @@ pDC
 kSg
 jsJ
 jsJ
-bCe
+kgx
 kSg
 kSg
 rHp
@@ -66050,28 +65188,28 @@ kSg
 xlg
 kSg
 kSg
-rLU
-rLU
-rLU
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -66083,20 +65221,20 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -66114,7 +65252,7 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 ioQ
@@ -66132,34 +65270,34 @@ jsJ
 jsJ
 jsJ
 kSg
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
-ctd
+tXu
 jsJ
 jsJ
 jsJ
@@ -66169,7 +65307,7 @@ jsJ
 jsJ
 cyH
 jsJ
-bCe
+kgx
 jsJ
 "}
 (82,1,1) = {"
@@ -66178,9 +65316,6 @@ jsJ
 jsJ
 cyH
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -66209,16 +65344,19 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -66229,10 +65367,10 @@ qge
 oiS
 awM
 gpx
-oYt
-oYt
-oYt
-pDO
+oiS
+oiS
+oiS
+pIT
 jmS
 nlQ
 pDz
@@ -66247,7 +65385,7 @@ hQq
 tVl
 wxZ
 gsK
-fWw
+hhF
 hDh
 hhF
 hZo
@@ -66307,24 +65445,24 @@ kSg
 kSg
 kSg
 kSg
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -66336,21 +65474,21 @@ cyH
 jsJ
 jsJ
 ctd
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -66382,30 +65520,27 @@ ioQ
 ioQ
 jsJ
 jsJ
-ePs
-ePs
-ePs
-ePs
+rNe
+rNe
+rNe
+rNe
 jsJ
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
 kSg
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -66413,17 +65548,20 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 cyH
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
@@ -66435,9 +65573,6 @@ uSY
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -66468,14 +65603,17 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -66563,20 +65701,20 @@ kSg
 kSg
 kSg
 kSg
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 cyH
@@ -66587,24 +65725,24 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -66628,7 +65766,7 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 ioQ
@@ -66643,25 +65781,22 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
 kSg
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -66670,9 +65805,12 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -66683,7 +65821,7 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 "}
 (84,1,1) = {"
@@ -66691,9 +65829,6 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -66730,13 +65865,16 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 aLK
 bXv
@@ -66819,17 +65957,17 @@ hoF
 hoF
 kSg
 kSg
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
@@ -66840,20 +65978,20 @@ jsJ
 bCe
 jsJ
 cyH
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -66903,20 +66041,17 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -66927,16 +66062,19 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
-ctd
+tXu
 jsJ
 jsJ
 jsJ
-ctd
+tXu
 jsJ
 jsJ
 jsJ
@@ -66948,9 +66086,6 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -66988,9 +66123,12 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 uSY
 jsJ
@@ -67023,10 +66161,10 @@ bTz
 uNM
 mUb
 wyB
-lMH
+wyB
 ngV
 pDB
-apv
+qqO
 hZo
 kRh
 fMo
@@ -67076,11 +66214,11 @@ jse
 hoF
 eXj
 kSg
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -67090,23 +66228,23 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -67154,26 +66292,22 @@ ioQ
 ioQ
 ioQ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jrH
 kSg
 kSg
-rLU
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -67185,17 +66319,21 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 cyH
 jsJ
@@ -67205,9 +66343,6 @@ jsJ
 cyH
 jsJ
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -67245,9 +66380,12 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -67333,74 +66471,74 @@ vZP
 hoF
 kSg
 kSg
-rLU
-rLU
+rMm
+rMm
+kSg
 jsJ
 jsJ
 jsJ
 jsJ
 jsJ
-jsJ
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 rLU
 rLU
 rLU
 rLU
 rLU
 rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
 rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
 jsJ
 jsJ
 ioQ
@@ -67412,24 +66550,20 @@ ioQ
 ioQ
 jsJ
 jsJ
-rLU
-rLU
+rMm
+rMm
 pxz
 jsJ
 jsJ
 jsJ
-rLU
+rMm
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jrH
 jrH
-rLU
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -67442,17 +66576,21 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
-ctd
+tXu
 pxz
 jsJ
 jsJ
-ctd
+tXu
 jsJ
 jsJ
 jsJ
@@ -67462,9 +66600,6 @@ jsJ
 pxz
 jsJ
 uSY
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -67502,11 +66637,14 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
@@ -67518,7 +66656,7 @@ jsJ
 uSN
 eCB
 cLh
-cLh
+haf
 dtl
 nUv
 nUv
@@ -67591,73 +66729,73 @@ hoF
 kSg
 jrH
 jrH
-jsJ
-jsJ
-jsJ
+kSg
+kSg
+kSg
 jsJ
 cyH
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 rLU
 rLU
 rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
 rMm
 rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rLU
-rLU
-rLU
-rLU
-rLU
 jsJ
 jsJ
 ioQ
@@ -67669,9 +66807,9 @@ ioQ
 ioQ
 jsJ
 jsJ
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -67682,9 +66820,6 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -67700,18 +66835,21 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
-bCe
+kgx
 pxz
 "}
 (88,1,1) = {"
@@ -67719,9 +66857,6 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -67759,22 +66894,25 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 rLU
 uSN
 wzh
-cLh
+fHB
 ePn
 uSN
 lqo
@@ -67796,7 +66934,7 @@ max
 axE
 hhF
 fWw
-hhF
+pKt
 hZo
 dwo
 hOE
@@ -67846,21 +66984,9 @@ rLU
 rLU
 kSg
 kSg
-rLU
+rMm
 jrH
-uSY
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+eXj
 rMm
 rMm
 rMm
@@ -67912,9 +67038,21 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 ioQ
@@ -67925,11 +67063,11 @@ ioQ
 ioQ
 ioQ
 jsJ
-rLU
-rLU
-rLU
-rLU
-bCe
+rMm
+rMm
+rMm
+rMm
+kgx
 jsJ
 jsJ
 jsJ
@@ -67940,9 +67078,6 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -67959,9 +67094,12 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -67976,9 +67114,6 @@ jsJ
 jsJ
 jsJ
 cyH
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -68016,9 +67151,12 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -68050,10 +67188,10 @@ uea
 cab
 vcQ
 max
-oEf
+hhF
 hhF
 fWw
-hhF
+pRL
 hZo
 kIP
 sXw
@@ -68073,7 +67211,7 @@ rLU
 rLU
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
@@ -68102,16 +67240,6 @@ rLU
 kSg
 eXj
 kSg
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -68170,9 +67298,19 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 ioQ
 ioQ
@@ -68182,11 +67320,11 @@ ioQ
 ioQ
 ioQ
 jsJ
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 uea
@@ -68196,10 +67334,7 @@ xbX
 xbX
 jsJ
 jsJ
-ctd
-rLU
-rLU
-rLU
+tXu
 rMm
 rMm
 rMm
@@ -68216,14 +67351,17 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
@@ -68233,10 +67371,6 @@ jsJ
 uSY
 jsJ
 jsJ
-rLU
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -68273,9 +67407,13 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -68283,7 +67421,7 @@ uSY
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 rLU
 uSN
@@ -68307,7 +67445,7 @@ uea
 cab
 vcQ
 max
-oEf
+hhF
 hhF
 fWw
 fJH
@@ -68326,7 +67464,7 @@ rLU
 rLU
 rLU
 rLU
-jsJ
+rLU
 jsJ
 jsJ
 jsJ
@@ -68336,7 +67474,7 @@ cyH
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 rLU
@@ -68359,14 +67497,6 @@ kSg
 kSg
 kSg
 kSg
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -68427,9 +67557,17 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 ioQ
 ioQ
@@ -68439,11 +67577,11 @@ ioQ
 ioQ
 ioQ
 jsJ
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 olu
 vVZ
@@ -68454,9 +67592,6 @@ xbX
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -68474,11 +67609,14 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 cyH
@@ -68490,85 +67628,85 @@ jsJ
 jsJ
 jsJ
 jsJ
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+jsJ
+jsJ
+jsJ
+kgx
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
 rLU
 rLU
 rLU
 rLU
 rLU
 rLU
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
+rLU
+rLU
+rLU
+rLU
 rLU
 rLU
 rLU
 rLU
 jsJ
 jsJ
-jsJ
-bCe
-jsJ
-jsJ
-jsJ
-jsJ
-jsJ
-jsJ
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-jsJ
-jsJ
-piz
+kSg
 uea
 cab
 vcQ
 hZo
 oEf
-hhF
-fWw
-hhF
-hZo
+vsk
+msa
+qdy
+czn
 udV
 uMY
 veZ
@@ -68580,12 +67718,12 @@ dwo
 rLU
 rLU
 rLU
-jsJ
-jsJ
+rLU
+rLU
 pxz
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
@@ -68616,9 +67754,6 @@ kSg
 kSg
 kSg
 eXj
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -68685,10 +67820,13 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 ioQ
 ioQ
 ioQ
@@ -68696,12 +67834,12 @@ ioQ
 ioQ
 ioQ
 jsJ
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 kNJ
 uCq
@@ -68711,9 +67849,6 @@ kNJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -68733,11 +67868,14 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -68745,15 +67883,10 @@ jsJ
 (92,1,1) = {"
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 pxz
 jsJ
-rLU
-rLU
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -68784,18 +67917,23 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
@@ -68815,17 +67953,17 @@ rLU
 rLU
 rLU
 rLU
-piz
-kgv
+kSg
+kSg
 uea
 cab
 vcQ
-imJ
-lMY
-hhF
-fWw
-hhF
 hZo
+max
+oIf
+oYt
+max
+czn
 kIP
 fCT
 jSv
@@ -68839,7 +67977,7 @@ rLU
 rLU
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
@@ -68874,9 +68012,6 @@ xyr
 xyr
 kSg
 kSg
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -68943,9 +68078,12 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 ioQ
 ioQ
 ioQ
@@ -68953,12 +68091,12 @@ ioQ
 ioQ
 ioQ
 jsJ
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 xbX
 sMC
@@ -68967,9 +68105,6 @@ sMC
 xbX
 jsJ
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -68991,11 +68126,14 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 "}
@@ -69008,10 +68146,6 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -69040,23 +68174,27 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+jrH
+jrH
 kSg
 kSg
-kSg
-kSg
-rLU
-rLU
+rMm
+rMm
 rLU
 rLU
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 rLU
 rLU
@@ -69072,17 +68210,17 @@ rLU
 rLU
 rLU
 rLU
-piz
-kgv
+rLU
+kSg
 uea
-qrY
-flJ
-sHC
+cab
+vcQ
+uea
 hXj
-nGu
+qWB
 hAv
 jhC
-hZo
+hWW
 lPb
 kIP
 jhh
@@ -69103,7 +68241,7 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
@@ -69132,9 +68270,6 @@ xyr
 xyr
 kSg
 kSg
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -69200,9 +68335,12 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 ioQ
 ioQ
 ioQ
@@ -69211,11 +68349,11 @@ ioQ
 ioQ
 jsJ
 jsJ
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 pRn
 qgt
@@ -69224,9 +68362,6 @@ qgt
 pRn
 jsJ
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -69250,19 +68385,72 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 "}
 (94,1,1) = {"
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+kSg
+kSg
+kSg
+kSg
+jrH
+rMm
+rMm
+rMm
+rMm
+rMm
+rLU
+rLU
+rLU
 jsJ
 jsJ
 jsJ
@@ -69270,76 +68458,26 @@ jsJ
 rLU
 rLU
 rLU
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
+rLU
+rLU
+rLU
+rLU
+rLU
 rLU
 rLU
 rLU
 rLU
 rLU
 kSg
-kSg
-kSg
-kSg
-kSg
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-jsJ
-jsJ
-jsJ
-jsJ
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-piz
-kgv
 uea
-bes
-vcQ
-hZo
+nqR
+okB
 rpD
 rpD
-oEf
-dvm
-czn
+rpD
+pfw
+uea
+hWW
 hWW
 dwo
 dwo
@@ -69354,11 +68492,11 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
@@ -69390,9 +68528,6 @@ xyr
 xyr
 eXj
 kSg
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -69457,9 +68592,12 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 ioQ
@@ -69468,11 +68606,11 @@ ioQ
 ioQ
 ioQ
 jsJ
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 xbX
 qgt
@@ -69481,9 +68619,6 @@ nWu
 xbX
 jsJ
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -69507,9 +68642,12 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 "}
@@ -69518,16 +68656,13 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -69551,22 +68686,25 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
 kSg
 kSg
 kSg
 kSg
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 rLU
 rLU
 rLU
@@ -69587,16 +68725,16 @@ rLU
 rLU
 rLU
 rLU
-piz
+kSg
 uea
-xSO
+nyY
 vcQ
-hZo
-max
-max
-max
-czn
-czn
+uea
+uea
+uea
+uea
+uea
+rLU
 rLU
 rLU
 rLU
@@ -69608,7 +68746,7 @@ rLU
 rLU
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
@@ -69647,9 +68785,9 @@ xyr
 xyr
 xyr
 kSg
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -69725,10 +68863,10 @@ ioQ
 ioQ
 ioQ
 jsJ
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 kNJ
@@ -69738,9 +68876,6 @@ ybi
 kNJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -69764,9 +68899,12 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 "}
@@ -69782,10 +68920,6 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -69808,18 +68942,22 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
 kSg
 kSg
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -69846,13 +68984,13 @@ rLU
 rLU
 jsJ
 uea
-xSO
+nyY
 vcQ
 kSg
-kSg
-kSg
-kSg
-kSg
+jsJ
+jsJ
+jsJ
+jsJ
 rLU
 rLU
 rLU
@@ -69872,7 +69010,7 @@ jsJ
 jsJ
 cyH
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
@@ -69904,9 +69042,9 @@ oXe
 xyr
 xyr
 kSg
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -69982,10 +69120,10 @@ ioQ
 ioQ
 ioQ
 ioQ
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 xbX
@@ -69995,9 +69133,6 @@ csy
 xbX
 jsJ
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -70021,9 +69156,12 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 "}
@@ -70031,19 +69169,16 @@ jsJ
 roU
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 pxz
 jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 cyH
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -70063,19 +69198,22 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
 kSg
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -70103,13 +69241,13 @@ rLU
 rLU
 jsJ
 uea
-xSO
+nyY
 vcQ
 kSg
 jsJ
 jsJ
 jsJ
-bCe
+jsJ
 jsJ
 rLU
 rLU
@@ -70123,16 +69261,16 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 agQ
@@ -70161,14 +69299,14 @@ dUt
 xyr
 xyr
 kSg
-rLU
-rLU
-rLU
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -70239,11 +69377,11 @@ ioQ
 ioQ
 ioQ
 ioQ
-rLU
-rLU
-rLU
-rLU
-ctd
+rMm
+rMm
+rMm
+rMm
+tXu
 jsJ
 xbX
 pJk
@@ -70251,9 +69389,6 @@ pJk
 pJk
 xbX
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -70278,9 +69413,12 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 "}
@@ -70299,9 +69437,6 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -70319,19 +69454,22 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-jrH
-jrH
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+kSg
+kSg
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -70363,20 +69501,20 @@ uea
 xSO
 vcQ
 kSg
-pxz
 jsJ
 jsJ
 jsJ
 jsJ
-bCe
+jsJ
+kgx
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
@@ -70418,15 +69556,15 @@ dUt
 xyr
 xyr
 kSg
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -70498,9 +69636,9 @@ ioQ
 ioQ
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -70508,9 +69646,6 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -70534,9 +69669,12 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -70551,15 +69689,11 @@ roU
 roU
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -70576,16 +69710,20 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
-jrH
-rLU
-rLU
-rLU
-rLU
-rLU
+kSg
+rMm
+rMm
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -70610,7 +69748,7 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
@@ -70636,16 +69774,16 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 cyH
 jsJ
 jsJ
-bCe
+kgx
 pxz
 uSY
 jsJ
@@ -70676,15 +69814,15 @@ xyr
 xyr
 kSg
 kSg
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -70756,18 +69894,15 @@ ioQ
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
 jsJ
 jsJ
-ctd
-rLU
-rLU
-rLU
+tXu
 rMm
 rMm
 rMm
@@ -70791,9 +69926,12 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -70814,10 +69952,6 @@ jsJ
 gna
 jsJ
 jsJ
-rLU
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -70833,34 +69967,38 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 rLU
 rLU
 rLU
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rLU
-rLU
-rLU
 jsJ
 jsJ
 jsJ
@@ -70870,14 +70008,14 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 uea
 bes
 vcQ
 kSg
-bCe
+jsJ
 jsJ
 uSY
 jsJ
@@ -70885,18 +70023,18 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
@@ -70934,15 +70072,15 @@ xyr
 kSg
 kSg
 kSg
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 kSg
 kSg
 kSg
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -71014,16 +70152,13 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -71048,9 +70183,12 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -71071,13 +70209,6 @@ jsJ
 jsJ
 jsJ
 pxz
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -71090,13 +70221,20 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -71122,7 +70260,7 @@ rLU
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
@@ -71138,12 +70276,12 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 uSY
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
@@ -71198,9 +70336,9 @@ eXj
 kSg
 kSg
 kSg
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -71272,14 +70410,6 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -71305,9 +70435,17 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -71330,13 +70468,6 @@ jsJ
 jsJ
 jsJ
 uSY
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -71347,14 +70478,21 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -71385,40 +70523,40 @@ rLU
 rLU
 rLU
 kSg
-bCe
+kgx
 jsJ
 uea
 xSO
 vcQ
 kSg
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 cyH
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 pxz
 cyH
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 cyH
 jsJ
 jsJ
-bCe
+kgx
 rLU
 agQ
 agQ
@@ -71530,12 +70668,6 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -71562,9 +70694,15 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -71584,16 +70722,11 @@ roU
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -71604,14 +70737,19 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -71652,7 +70790,7 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
@@ -71662,11 +70800,11 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
@@ -71789,9 +70927,6 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -71820,9 +70955,12 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 "}
@@ -71844,14 +70982,11 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -71862,13 +70997,16 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -71905,7 +71043,7 @@ uea
 xSO
 vcQ
 kSg
-bCe
+kgx
 jsJ
 cyH
 jsJ
@@ -71913,19 +71051,19 @@ jsJ
 nDG
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 uUy
 jsJ
@@ -72078,9 +71216,9 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 jsJ
 "}
 (105,1,1) = {"
@@ -72105,12 +71243,9 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -72119,13 +71254,16 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -72173,14 +71311,14 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 cyH
 jsJ
 uSY
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 cyH
@@ -72200,7 +71338,7 @@ ibn
 ibn
 ugL
 ugL
-tiH
+sHC
 ugL
 ugL
 ugL
@@ -72336,9 +71474,9 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 "}
 (106,1,1) = {"
 roU
@@ -72355,7 +71493,7 @@ roU
 roU
 roU
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
@@ -72365,9 +71503,6 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -72376,13 +71511,16 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -72421,12 +71559,12 @@ vcQ
 fZF
 jsJ
 jsJ
-bCe
+kgx
 uSY
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
@@ -72434,7 +71572,7 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 cyH
 jsJ
@@ -72594,8 +71732,8 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
+rMm
+rMm
 "}
 (107,1,1) = {"
 roU
@@ -72615,7 +71753,7 @@ roU
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 cyH
 jsJ
 jsJ
@@ -72623,9 +71761,6 @@ jsJ
 jsJ
 jsJ
 cyH
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -72633,13 +71768,16 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -72689,14 +71827,14 @@ cyH
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 rLU
@@ -72852,7 +71990,7 @@ rMm
 rMm
 rMm
 rMm
-rLU
+rMm
 "}
 (108,1,1) = {"
 roU
@@ -72878,25 +72016,22 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -72925,7 +72060,10 @@ rMm
 rMm
 rMm
 rMm
-rLU
+rMm
+rMm
+rMm
+rMm
 rLU
 rLU
 rLU
@@ -72934,14 +72072,14 @@ xSO
 vcQ
 kSg
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
@@ -73139,22 +72277,19 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -73182,7 +72317,10 @@ rMm
 rMm
 rMm
 rMm
-rLU
+rMm
+rMm
+rMm
+rMm
 rLU
 rLU
 rLU
@@ -73208,12 +72346,12 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 kSg
 rLU
 ibn
@@ -73396,22 +72534,19 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
-rLU
-rLU
-rLU
+kgx
 rMm
 rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -73439,7 +72574,10 @@ rMm
 rMm
 rMm
 rMm
-rLU
+rMm
+rMm
+rMm
+rMm
 rLU
 rLU
 rLU
@@ -73449,20 +72587,20 @@ vcQ
 kSg
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 cyH
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
@@ -73654,21 +72792,18 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -73696,7 +72831,10 @@ rMm
 rMm
 rMm
 rMm
-rLU
+rMm
+rMm
+rMm
+rMm
 rLU
 rLU
 rLU
@@ -73717,7 +72855,7 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 cyH
@@ -73725,7 +72863,7 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 kSg
 kSg
 eXj
@@ -73905,7 +73043,7 @@ roU
 jsJ
 jsJ
 jsJ
-utM
+tos
 jsJ
 jsJ
 jsJ
@@ -73913,19 +73051,16 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -73953,7 +73088,10 @@ rMm
 rMm
 rMm
 rMm
-rLU
+rMm
+rMm
+rMm
+rMm
 rLU
 rLU
 rLU
@@ -73962,12 +73100,12 @@ bes
 vcQ
 kSg
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
@@ -74160,29 +73298,26 @@ roU
 roU
 roU
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
-xsy
+tos
 jsJ
 jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -74210,7 +73345,10 @@ rMm
 rMm
 rMm
 rMm
-rLU
+rMm
+rMm
+rMm
+rMm
 rLU
 rLU
 rLU
@@ -74229,13 +73367,13 @@ cyH
 jsJ
 uSY
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 cyH
@@ -74423,23 +73561,23 @@ jsJ
 jsJ
 jsJ
 jsJ
-utM
+tos
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -74480,7 +73618,7 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 pxz
 jsJ
 jsJ
@@ -74489,7 +73627,7 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
@@ -74677,25 +73815,25 @@ roU
 jsJ
 jsJ
 jsJ
-utM
+tos
 jsJ
 jsJ
-jnT
+vMG
 jsJ
 tos
 jsJ
 jsJ
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
 kSg
 kSg
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -74732,7 +73870,7 @@ uea
 xSO
 vcQ
 kSg
-sVn
+jsJ
 jsJ
 jsJ
 jsJ
@@ -74932,27 +74070,27 @@ roU
 roU
 roU
 jsJ
-tkj
+tos
 jsJ
 jsJ
 tos
 jsJ
-utM
+tos
 jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
 kSg
 kSg
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -74988,10 +74126,10 @@ jsJ
 uea
 xSO
 vcQ
-kSg
+opN
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
@@ -75008,9 +74146,9 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
-kSg
-kSg
+kgx
+uea
+oqk
 pLE
 uhX
 gFu
@@ -75029,7 +74167,7 @@ ppr
 vMh
 xDI
 iHn
-mtl
+tni
 wBP
 fhU
 iHn
@@ -75048,7 +74186,7 @@ qOR
 gEB
 gEB
 siQ
-wpN
+ttP
 dml
 ahe
 gWO
@@ -75195,8 +74333,8 @@ jsJ
 jsJ
 jsJ
 jsJ
-vMG
 jsJ
+vMG
 jsJ
 jsJ
 jrH
@@ -75207,9 +74345,9 @@ kSg
 kSg
 kSg
 kSg
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -75267,7 +74405,7 @@ uea
 uea
 uea
 uea
-uea
+qQw
 xfP
 aVl
 iHn
@@ -75305,7 +74443,7 @@ bDm
 lXA
 kmH
 siQ
-wpN
+ttR
 pTA
 chg
 gWO
@@ -75448,9 +74586,9 @@ roU
 jsJ
 jsJ
 vMG
-utM
+tos
 jsJ
-utM
+tos
 jsJ
 jsJ
 jsJ
@@ -75460,12 +74598,12 @@ jrH
 jrH
 kSg
 kSg
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -75524,7 +74662,7 @@ aSZ
 aSZ
 aSZ
 aSZ
-iWf
+rZV
 xYK
 wWG
 vCu
@@ -75709,19 +74847,19 @@ jsJ
 iqM
 jsJ
 jsJ
-tkj
+tos
 jsJ
-vMG
+iqM
 jsJ
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -75781,7 +74919,7 @@ uea
 uea
 uea
 uea
-uea
+qQw
 xfP
 aVl
 iHn
@@ -75962,22 +75100,22 @@ roU
 jsJ
 jsJ
 jsJ
-xsy
+tos
 jsJ
 jsJ
-utM
+tos
 jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -76011,7 +75149,7 @@ rLU
 rLU
 rLU
 jsJ
-bCe
+kgx
 jsJ
 uea
 xSO
@@ -76020,7 +75158,7 @@ kSg
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 kSg
 jsJ
@@ -76032,15 +75170,15 @@ jsJ
 kSg
 kSg
 kSg
-piz
-kgv
-kgv
-kgv
-piz
 kSg
 kSg
+kSg
+kSg
+kSg
+uea
+hXj
 pLE
-qlo
+sar
 iHn
 hrP
 pLE
@@ -76057,7 +75195,7 @@ goI
 lpr
 tNM
 iHn
-qKh
+tnQ
 wBP
 ktf
 iHn
@@ -76227,10 +75365,10 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -76284,15 +75422,15 @@ rLU
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 rLU
 rLU
 rLU
 kSg
 kSg
-piz
-piz
-piz
+kSg
+kSg
+kSg
 kSg
 kSg
 kSg
@@ -76474,7 +75612,7 @@ roU
 roU
 roU
 roU
-rZV
+tXu
 jsJ
 sVn
 jsJ
@@ -76482,11 +75620,11 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -76736,13 +75874,13 @@ jsJ
 jsJ
 jsJ
 jsJ
-tkj
+tos
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -76991,15 +76129,15 @@ roU
 roU
 jsJ
 jsJ
-hrO
+vMG
 jsJ
 jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -77046,7 +76184,7 @@ bes
 vcQ
 kSg
 jsJ
-bCe
+kgx
 jsJ
 rLU
 rLU
@@ -77085,7 +76223,7 @@ lAl
 vyS
 wgJ
 mXS
-gah
+wEJ
 tnH
 lAl
 tIL
@@ -77104,15 +76242,15 @@ hNu
 hNu
 spO
 siQ
-wJu
+tzr
 aFT
 dUK
 qNc
-sZE
-sZE
-sZE
-sZE
-sZE
+vXI
+vXI
+vXI
+vXI
+vXI
 qBR
 qiw
 xRD
@@ -77253,9 +76391,9 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -77341,7 +76479,7 @@ vHx
 lAl
 dPg
 arT
-mKP
+sPO
 mKP
 iRZ
 lAl
@@ -77357,7 +76495,7 @@ qwM
 lww
 jXF
 jXF
-mEB
+wpN
 qTI
 cJq
 pFC
@@ -77505,14 +76643,14 @@ roU
 roU
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -77598,8 +76736,8 @@ kqk
 lAl
 cjk
 uvD
-mKP
-gah
+sQz
+wEJ
 bXl
 lAl
 gWz
@@ -77767,9 +76905,9 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -77855,7 +76993,7 @@ wgK
 lAl
 xoE
 qNB
-mKP
+sQz
 fxu
 cfi
 lAl
@@ -78023,10 +77161,7 @@ cyH
 jsJ
 jsJ
 jsJ
-bCe
-rLU
-rLU
-rLU
+kgx
 rMm
 rMm
 rMm
@@ -78065,7 +77200,10 @@ rMm
 rMm
 rMm
 rMm
-rLU
+rMm
+rMm
+rMm
+rMm
 rLU
 rLU
 rLU
@@ -78112,7 +77250,7 @@ lDq
 lAl
 lqN
 mKP
-mKP
+sPO
 mKP
 tRg
 lAl
@@ -78281,9 +77419,6 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -78322,7 +77457,10 @@ rMm
 rMm
 rMm
 rMm
-rLU
+rMm
+rMm
+rMm
+rMm
 rLU
 rLU
 rLU
@@ -78369,8 +77507,8 @@ xnC
 lAl
 ulE
 wEJ
-mKP
-gah
+tgo
+wEJ
 bFL
 lAl
 aWZ
@@ -78539,9 +77677,6 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -78579,7 +77714,10 @@ rMm
 rMm
 rMm
 rMm
-rLU
+rMm
+rMm
+rMm
+rMm
 rLU
 rLU
 rLU
@@ -78591,7 +77729,7 @@ jsJ
 rLU
 rLU
 rLU
-ctd
+tXu
 jsJ
 kSg
 kSg
@@ -78625,7 +77763,7 @@ axA
 xWi
 lAl
 lAl
-rLF
+etm
 mSu
 etm
 lAl
@@ -78791,14 +77929,11 @@ roU
 roU
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -78836,7 +77971,10 @@ rMm
 rMm
 rMm
 rMm
-rLU
+rMm
+rMm
+rMm
+rMm
 rLU
 rLU
 rLU
@@ -78860,7 +77998,7 @@ rLU
 rLU
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 sws
 bTp
@@ -79053,9 +78191,6 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -79093,7 +78228,10 @@ rMm
 rMm
 rMm
 rMm
-rLU
+rMm
+rMm
+rMm
+rMm
 rLU
 rLU
 rLU
@@ -79127,7 +78265,7 @@ lOX
 pxY
 sKY
 wMz
-jwK
+kXp
 kXp
 uim
 vEB
@@ -79139,7 +78277,7 @@ qJW
 pmV
 jDQ
 sXF
-tgo
+xqf
 ctT
 sXF
 vyX
@@ -79311,9 +78449,6 @@ cyH
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -79349,8 +78484,11 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
 rLU
 rLU
 rLU
@@ -79396,7 +78534,7 @@ nll
 pmV
 uds
 xqf
-tgo
+xqf
 ruA
 xqf
 aDR
@@ -79568,9 +78706,9 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -79645,7 +78783,7 @@ gFh
 gFh
 oLO
 wPO
-jJz
+pHB
 fZj
 gFh
 uLT
@@ -79653,7 +78791,7 @@ lDX
 pHP
 enz
 qJy
-ech
+qJy
 qqi
 qJy
 eLa
@@ -79825,9 +78963,9 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -79878,7 +79016,7 @@ rLU
 rLU
 rLU
 jsJ
-ctd
+tXu
 rLU
 rLU
 rLU
@@ -79910,7 +79048,7 @@ bWu
 wVi
 veY
 veY
-eca
+veY
 vXe
 qMg
 tOC
@@ -80080,11 +79218,11 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -80155,11 +79293,11 @@ mxI
 ubp
 naZ
 kZU
-jig
 sbt
-mZP
-mZP
-mZP
+sbt
+sbt
+sbt
+sbt
 aLM
 gFh
 wPF
@@ -80332,16 +79470,16 @@ roU
 roU
 roU
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 uSY
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -80385,7 +79523,7 @@ cyH
 uea
 xSO
 vcQ
-piz
+kSg
 jsJ
 jsJ
 jsJ
@@ -80597,9 +79735,9 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -80642,8 +79780,8 @@ jsJ
 uea
 xSO
 vcQ
-kgv
-piz
+kSg
+jsJ
 jsJ
 jsJ
 jsJ
@@ -80675,7 +79813,7 @@ qgW
 oXy
 xwR
 iGD
-wZR
+ngu
 wPF
 pRK
 dHn
@@ -80854,9 +79992,9 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -80883,24 +80021,24 @@ rLU
 rLU
 jsJ
 jsJ
-uRI
-uRI
-uRI
-uRI
-uRI
-uRI
-uRI
-uRI
-uRI
-uRI
-uRI
-uRI
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
 jsJ
 uea
 xSO
 vcQ
-kgv
-piz
+kSg
+jsJ
 jsJ
 jsJ
 jsJ
@@ -80932,7 +80070,7 @@ qgW
 huC
 qAa
 iGD
-wZR
+ngu
 wPF
 pRK
 wsG
@@ -81111,9 +80249,9 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -81141,26 +80279,26 @@ rLU
 cyH
 jsJ
 uRI
-bXK
-bXK
-bXK
-bXK
-bXK
-bXK
-bXK
-bXK
-bXK
-bXK
+uRI
+uRI
+uRI
+uRI
+uRI
+uRI
+uRI
+uRI
+uRI
+uRI
 uRI
 cyH
 uea
 xSO
 vcQ
-kgv
-piz
-jsJ
-uSY
-jsJ
+uea
+uea
+uea
+uea
+uea
 jsJ
 jsJ
 jsJ
@@ -81189,7 +80327,7 @@ qgW
 huC
 xwR
 iGD
-wZR
+ngu
 wPF
 pRK
 qEN
@@ -81360,17 +80498,17 @@ roU
 roU
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -81413,15 +80551,15 @@ jsJ
 uea
 xSO
 vcQ
-piz
+uea
+uea
+uea
+uea
+uea
 jsJ
 jsJ
 jsJ
-ctd
-jsJ
-jsJ
-jsJ
-ctd
+tXu
 jsJ
 jsJ
 jsJ
@@ -81446,7 +80584,7 @@ qgW
 huC
 oHu
 iGD
-wZR
+ngu
 wPF
 pRK
 sDP
@@ -81624,11 +80762,6 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -81646,7 +80779,12 @@ rMm
 rMm
 rMm
 rMm
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 rLU
 rLU
 rLU
@@ -81670,11 +80808,11 @@ jsJ
 uea
 bes
 vcQ
-jsJ
-jsJ
-jsJ
-jsJ
-jsJ
+oqk
+lcG
+lcG
+lwK
+uea
 gna
 jsJ
 jsJ
@@ -81686,7 +80824,7 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 rLU
 sws
@@ -81853,7 +80991,7 @@ rMm
 roU
 roU
 roU
-bCe
+kgx
 jsJ
 roU
 roU
@@ -81881,14 +81019,6 @@ jsJ
 jsJ
 uSY
 jsJ
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -81897,13 +81027,21 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 rLU
 rLU
 jsJ
@@ -81928,8 +81066,8 @@ uea
 xSO
 vcQ
 mWa
-juP
-juP
+owU
+owU
 juP
 mWa
 jsJ
@@ -81960,7 +81098,7 @@ qgW
 huC
 xwR
 iGD
-wZR
+ngu
 wPF
 pRK
 bvC
@@ -82112,7 +81250,7 @@ roU
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 roU
 roU
 roU
@@ -82141,26 +81279,26 @@ jrH
 jrH
 kSg
 kSg
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 rLU
 rLU
 jsJ
@@ -82217,7 +81355,7 @@ qgW
 huC
 xwR
 iGD
-wZR
+ngu
 wPF
 vGK
 bvC
@@ -82384,7 +81522,7 @@ roU
 roU
 roU
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
@@ -82392,7 +81530,7 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
+rMm
 jsJ
 jrH
 kSg
@@ -82400,51 +81538,51 @@ kSg
 kSg
 kSg
 kSg
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
 rLU
 rLU
 rLU
-rLU
-rLU
-rLU
-rLU
-ake
-ake
-ake
-ake
-ake
 jsJ
 jsJ
 jsJ
 jsJ
 uRI
-uRI
-uRI
-vaW
-uRI
-uRI
-uRI
-vaW
-uRI
-uRI
-uRI
+bXK
+bXK
+bXK
+bXK
+bXK
+bXK
+bXK
+bXK
+bXK
+bXK
 uRI
 jsJ
 uea
 xSO
 vcQ
-deF
-gOM
+juP
 bse
-sCG
+bse
+xSf
 juP
 kSg
 jsJ
@@ -82474,7 +81612,7 @@ cTG
 huC
 qAa
 iGD
-wZR
+ngu
 ctl
 fjB
 tMF
@@ -82647,12 +81785,12 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
-rLU
-rLU
-rLU
-rLU
-rLU
+kgx
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
 kSg
@@ -82660,46 +81798,46 @@ kSg
 kSg
 kSg
 kSg
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-jsJ
-jsJ
-bCe
-jsJ
-jsJ
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 ake
-nkn
-phY
-tGp
 ake
+ake
+ake
+ake
+ake
+ake
+ake
+ake
+rLU
+rLU
 jsJ
 jsJ
-jsJ
-jsJ
-jsJ
-qxJ
-mqz
-mqz
-fHB
-apx
-xQl
-mqz
-jZI
-qxJ
-jsJ
-jsJ
+uRI
+uRI
+uRI
+iEE
+uRI
+uRI
+uRI
+iEE
+uRI
+uRI
+uRI
+uRI
 uSY
 uea
 xSO
 vcQ
-deF
-gOM
+juP
+bse
 bse
 xSf
 juP
@@ -82709,12 +81847,12 @@ kSg
 xBg
 kSg
 jsJ
-ctd
+tXu
 jsJ
 jsJ
 jsJ
 jsJ
-jsJ
+rLU
 rLU
 rLU
 sws
@@ -82731,7 +81869,7 @@ qgW
 huC
 xwR
 iGD
-wZR
+ngu
 wPF
 oYk
 bvC
@@ -82904,14 +82042,14 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
 kSg
@@ -82919,36 +82057,36 @@ kSg
 kSg
 kSg
 kSg
-rLU
-rLU
-rLU
-rLU
-rLU
-jsJ
-cyH
-jsJ
-jsJ
-jsJ
-jsJ
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+ake
+boY
+bTk
+cuv
 ake
 nHH
 qYN
 tTJ
 ake
+rLU
+rLU
+rLU
 jsJ
 jsJ
-bCe
 jsJ
-jsJ
-qxJ
-owU
+uRI
 vBT
 ptz
-mqz
-mqz
-vBT
-riZ
-qxJ
+jpo
+jzd
+jQm
+uRI
+jsJ
 jsJ
 jsJ
 jsJ
@@ -82971,7 +82109,7 @@ jsJ
 jsJ
 jsJ
 jsJ
-jsJ
+rLU
 rLU
 rLU
 sws
@@ -83137,7 +82275,7 @@ rMm
 (148,1,1) = {"
 roU
 roU
-bCe
+kgx
 jsJ
 jsJ
 jsJ
@@ -83155,39 +82293,39 @@ roU
 roU
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 uSY
 jsJ
-jsJ
-jsJ
-jsJ
-jsJ
-jsJ
+rMm
 ake
+bFe
+iDf
+cxs
+cFL
 nMs
 sep
 vxg
@@ -83199,11 +82337,11 @@ qxJ
 qxJ
 qxJ
 qxJ
-qxJ
-vSi
-rmI
-vSi
-qxJ
+iFr
+iMo
+mqz
+mqz
+jZI
 ake
 ake
 ake
@@ -83227,20 +82365,20 @@ juP
 rll
 jsJ
 jsJ
-jsJ
-sws
-sws
-sws
+rLU
+rLU
+rLU
+rLU
 sws
 bTp
 vIt
 cIz
 oNo
-jJz
+pHB
 qfr
 pHB
-jJz
-jJz
+pHB
+pHB
 pHB
 pHB
 pHB
@@ -83397,7 +82535,7 @@ roU
 roU
 jsJ
 jsJ
-bCe
+kgx
 roU
 roU
 roU
@@ -83417,49 +82555,49 @@ jsJ
 jsJ
 jsJ
 cyH
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jrH
 jrH
 jsJ
 jsJ
-bCe
-jsJ
-jsJ
-jsJ
-jsJ
-jsJ
+kgx
+aFi
 jsJ
 ake
-ake
+bMv
+caE
+czz
+cOJ
+dcz
 swu
-ake
-ake
-qOS
+enA
+eTE
+kDw
 kDw
 ake
 hnO
 vKz
 lSd
 qxJ
-bFe
 mqz
 mqz
 mqz
+jNf
 aGj
 ake
 wEg
@@ -83472,7 +82610,7 @@ kiw
 mWa
 uqJ
 tQf
-fsE
+phY
 juP
 uea
 uea
@@ -83485,9 +82623,9 @@ juP
 jsJ
 jsJ
 rLU
-sws
-gNq
-enA
+rLU
+rLU
+rLU
 sws
 ojI
 dDJ
@@ -83673,9 +82811,6 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -83683,14 +82818,17 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jrH
 jsJ
 jsJ
@@ -83698,16 +82836,16 @@ uUy
 jsJ
 jsJ
 ake
-uCb
-uCb
-uCb
 ake
-opN
-tzr
-ffq
-wlG
+ake
+ake
+ake
+oWN
+oWN
+oWN
 cyW
 cyW
+fBu
 ake
 dTO
 aSI
@@ -83742,9 +82880,9 @@ juP
 jsJ
 jsJ
 rLU
-sws
-tZM
-yjB
+rLU
+rLU
+rLU
 sws
 eCO
 vIt
@@ -83927,11 +83065,8 @@ roU
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -83946,9 +83081,12 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 cyH
 jsJ
@@ -83960,10 +83098,10 @@ qOS
 qOS
 myU
 oWN
-tBQ
-mTF
-urs
-cyW
+oWN
+oWN
+kDw
+kDw
 geG
 ake
 xKN
@@ -83999,15 +83137,15 @@ juP
 jsJ
 jsJ
 rLU
+rLU
+rLU
+rLU
 sws
-umo
-tZM
-scb
 bTp
 vIt
 jyX
 wZY
-mZP
+sbt
 cMw
 vIt
 jZL
@@ -84184,10 +83322,6 @@ roU
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -84203,13 +83337,17 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-bCe
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+kgx
 jsJ
 jsJ
-ctd
+tXu
 jsJ
 uCb
 rDj
@@ -84219,7 +83357,7 @@ rDj
 rDj
 rDj
 xlo
-oWN
+cyW
 cyW
 szC
 ake
@@ -84256,9 +83394,9 @@ juP
 jsJ
 jsJ
 jsJ
-sws
-iEE
-tTe
+rLU
+rLU
+rLU
 sws
 bTp
 vIt
@@ -84441,9 +83579,6 @@ jsJ
 cyH
 jsJ
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -84461,10 +83596,13 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-bCe
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+kgx
 gna
 jsJ
 jsJ
@@ -84476,7 +83614,7 @@ xbG
 xbG
 xbG
 nGH
-oWN
+kDw
 gtR
 kDw
 ake
@@ -84485,7 +83623,7 @@ vKz
 lSd
 qxJ
 mPk
-mqz
+jgP
 rtG
 ptl
 mqz
@@ -84513,9 +83651,9 @@ juP
 jsJ
 jsJ
 jsJ
-sws
-sws
-sws
+rLU
+rLU
+rLU
 sws
 bTp
 vIt
@@ -84530,20 +83668,20 @@ egF
 nqV
 ujP
 snL
-wZR
-bhp
-kUp
-kUp
-kUp
+ngu
+wPF
+gFh
+gFh
+gFh
 mjo
-kUp
+gFh
 oea
-kUp
-jhl
+gFh
+onH
 wxG
-fBu
+iKz
 aYV
-tHp
+icn
 dBf
 ils
 xMh
@@ -84697,9 +83835,6 @@ roU
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -84719,9 +83854,12 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -84733,7 +83871,7 @@ xbG
 bWa
 xbG
 nGH
-oWN
+eVF
 uhY
 qcp
 ake
@@ -84797,7 +83935,7 @@ xwj
 iVB
 puU
 vIt
-uJt
+wxG
 iKz
 iKz
 icn
@@ -84952,11 +84090,8 @@ roU
 roU
 roU
 jsJ
-bCe
+kgx
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -84976,10 +84111,13 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-bCe
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+kgx
 jsJ
 jsJ
 uCb
@@ -84990,7 +84128,7 @@ xbG
 xbG
 xbG
 aKX
-oWN
+eWs
 sii
 kfr
 ake
@@ -85044,7 +84182,7 @@ pew
 nqV
 iYV
 snL
-wZR
+ngu
 xIP
 wZR
 mep
@@ -85211,9 +84349,6 @@ jsJ
 jsJ
 jsJ
 cyH
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -85233,9 +84368,12 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -85302,7 +84440,7 @@ ozY
 dkh
 jZL
 tSR
-xIP
+sCD
 beD
 cIu
 plA
@@ -85468,9 +84606,6 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -85490,10 +84625,13 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-ctd
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+tXu
 cyH
 jsJ
 uCb
@@ -85717,17 +84855,14 @@ roU
 roU
 roU
 jsJ
-bCe
+kgx
 cyH
 jsJ
 jsJ
 jsJ
 jsJ
 jsJ
-bCe
-rLU
-rLU
-rLU
+kgx
 rMm
 rMm
 rMm
@@ -85746,9 +84881,12 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -85784,8 +84922,8 @@ ccc
 wbv
 pPR
 mPT
-cFE
-xgr
+mPT
+psU
 xuW
 xgr
 xgr
@@ -85981,9 +85119,6 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -86003,12 +85138,15 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 uCb
 xbG
@@ -86040,8 +85178,8 @@ sNS
 tRL
 kMl
 fJS
-vKB
-iFr
+gCs
+gCs
 gCs
 gAp
 gCs
@@ -86059,8 +85197,8 @@ cyH
 jsJ
 rLU
 sws
-sws
-sws
+oIM
+ojG
 sws
 sws
 cJX
@@ -86233,14 +85371,11 @@ uSY
 nDG
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
-bCe
+kgx
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -86260,9 +85395,12 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -86315,9 +85453,9 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
+sws
+sws
+sws
 sws
 hmp
 ugq
@@ -86494,9 +85632,6 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -86517,9 +85652,12 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 uSY
 jsJ
@@ -86544,7 +85682,7 @@ qjY
 mqz
 dcD
 mqz
-mqz
+keW
 aoF
 xDm
 tKX
@@ -86570,7 +85708,7 @@ rLU
 rLU
 rLU
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 rLU
@@ -86750,9 +85888,6 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -86774,10 +85909,13 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-bCe
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+kgx
 jsJ
 jsJ
 jsJ
@@ -86801,7 +85939,7 @@ myA
 myA
 ojK
 myA
-myA
+kyH
 nKm
 iVp
 vHY
@@ -86999,16 +86137,12 @@ roU
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 uSY
 jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -87032,11 +86166,15 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
-bCe
+kgx
 uSY
 jsJ
 jsJ
@@ -87258,13 +86396,8 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 cyH
-rLU
-rLU
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -87289,9 +86422,14 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -87299,12 +86437,12 @@ jsJ
 jsJ
 gna
 jsJ
-lLX
+jNq
 mHS
 aqn
 piL
-oVT
-niA
+hEP
+ffq
 tIk
 qxJ
 qxJ
@@ -87516,11 +86654,6 @@ uSY
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -87547,21 +86680,26 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
-hbP
+jNq
 dzh
 gbd
-iuv
+eBK
 oVT
-niA
+jvx
 tIk
 bse
 xzy
@@ -87769,13 +86907,9 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 nDG
 uSY
-rLU
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -87806,14 +86940,18 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
 jsJ
-hbP
+jNq
 dzh
 lkk
 iuv
@@ -88021,16 +87159,10 @@ rMm
 roU
 roU
 jsJ
-bCe
+kgx
 uSY
 jsJ
 jsJ
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -88064,13 +87196,19 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
-hbP
+jNq
 bVB
 dzh
 iuv
@@ -88088,9 +87226,9 @@ aMf
 lnB
 bse
 nat
-nat
-nat
-nat
+ldy
+ldy
+ldy
 rjG
 bse
 rMS
@@ -88280,13 +87418,6 @@ roU
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -88321,24 +87452,31 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
-hbP
+jNq
 pLJ
 dzh
 pcK
 oVT
-niA
+jvx
 lqt
 fRM
 qOf
 lqt
 lqt
-lqt
+phf
 uoL
 bmc
 uoL
@@ -88533,16 +87671,10 @@ rMm
 "}
 (169,1,1) = {"
 roU
-bCe
+kgx
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -88576,26 +87708,32 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
 jsJ
 cyH
-hbP
+jNq
 dzh
 dzh
 xUe
 oVT
-niA
+jvx
 lqt
 tTi
 wGU
 lmw
 oCH
-lqt
+phf
 dan
 njk
 gZx
@@ -88791,14 +87929,7 @@ rMm
 (170,1,1) = {"
 jsJ
 jsJ
-bCe
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+kgx
 rMm
 rMm
 rMm
@@ -88832,27 +87963,34 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 xTt
 jsJ
 jsJ
 jsJ
 jsJ
-hbP
+jNq
 dzh
 dzh
 iuv
 oVT
-niA
+jvx
 lqt
 tTi
 iYM
 lqt
 lqt
-lqt
+phf
 dfG
 rnl
 gxc
@@ -89049,9 +88187,6 @@ rMm
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -89080,36 +88215,39 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
-ctd
+tXu
 jsJ
 jsJ
-hbP
+jNq
 dzh
 jNq
 iuv
 oVT
-niA
+jvx
 lqt
 tTi
 xKv
 jsN
 rMH
-lqt
+phf
 lOc
 eSd
 yaH
@@ -89138,7 +88276,7 @@ mmw
 mmw
 mmw
 gUu
-gUu
+rzb
 mmw
 rLU
 rLU
@@ -89306,9 +88444,6 @@ rMm
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -89336,37 +88471,40 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-kSg
-kSg
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
 jsJ
 jsJ
-hbP
+jsJ
+jsJ
+jNq
 dzh
 jNq
 hWD
 oVT
-niA
+jvx
 lqt
 uOs
 lOo
 lqt
 lqt
-lqt
+phf
 uqC
 eSd
 fGP
@@ -89561,11 +88699,7 @@ rMm
 "}
 (173,1,1) = {"
 jsJ
-bCe
-rLU
-rLU
-rLU
-rLU
+kgx
 rMm
 rMm
 rMm
@@ -89592,38 +88726,42 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
-kSg
-kSg
+jsJ
+jsJ
 cyH
 jsJ
 jsJ
 jsJ
 jsJ
-caU
+oVT
 xbo
 jNq
 cDa
 oVT
-niA
+jvx
 lqt
 iFF
 lHO
 fWh
 pMM
-lqt
+phf
 hUA
 eSd
 erp
@@ -89634,7 +88772,7 @@ dXC
 wpo
 dXC
 vsM
-gKG
+wij
 pxO
 bEz
 skT
@@ -89662,7 +88800,7 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 rLU
 rLU
 rLU
@@ -89819,10 +88957,6 @@ rMm
 (174,1,1) = {"
 jsJ
 jsJ
-rLU
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -89848,13 +88982,17 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 gzo
 gzo
 gzo
-bCe
+kgx
 cyH
 uea
 uea
@@ -89863,24 +89001,24 @@ uea
 kSg
 kSg
 kSg
-kSg
+jsJ
 gzo
 gzo
 gzo
 jsJ
 jsJ
-hbP
+jNq
 uBL
 oVT
 iuv
 oVT
-niA
+jvx
 lqt
 lqt
 mAb
 lqt
 lqt
-lqt
+phf
 phf
 dgx
 phf
@@ -89891,7 +89029,7 @@ dXC
 wpo
 dXC
 vsM
-gKG
+wij
 pxO
 caP
 skT
@@ -89942,7 +89080,7 @@ bEv
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 rLU
 rLU
@@ -90076,10 +89214,6 @@ rMm
 (175,1,1) = {"
 jsJ
 jsJ
-rLU
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -90105,9 +89239,13 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 gzo
 kuU
 fsb
@@ -90120,7 +89258,7 @@ prK
 prK
 prK
 prK
-prK
+fsb
 fsb
 fsb
 fsb
@@ -90131,7 +89269,7 @@ pTa
 iuv
 iuv
 oVT
-niA
+jvx
 lqt
 rWe
 hVy
@@ -90148,7 +89286,7 @@ dXC
 wpo
 idZ
 fcG
-gKG
+wij
 pxO
 aah
 skT
@@ -90182,7 +89320,7 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 rLU
 rPM
@@ -90333,9 +89471,6 @@ rMm
 (176,1,1) = {"
 jsJ
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -90361,33 +89496,36 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 gzo
 cUt
 gzo
 gzo
 gzo
-rLU
-rLU
+rMm
+rMm
 kSg
 kSg
 kSg
 uea
 uea
+uea
+jsJ
+aFi
+jsJ
+jsJ
 gzo
-jsJ
-jsJ
-jsJ
-jsJ
-gzo
-okB
-nbj
+jNq
+iuv
 jcH
-nbj
-ipF
+iuv
+oVT
 jvx
 lqt
 upz
@@ -90395,7 +89533,7 @@ svd
 lGr
 lqt
 nso
-heQ
+iHD
 wOE
 eGH
 phf
@@ -90416,7 +89554,7 @@ rYC
 rYC
 skT
 opA
-emy
+bwX
 jqY
 paN
 skT
@@ -90430,7 +89568,7 @@ rLU
 rLU
 jsJ
 jsJ
-ctd
+tXu
 jsJ
 jsJ
 jsJ
@@ -90589,9 +89727,6 @@ rMm
 "}
 (177,1,1) = {"
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -90618,28 +89753,31 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 cUt
 jsJ
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
+kSg
 jsJ
 jsJ
 jsJ
 jsJ
-jsJ
-jsJ
+kSg
 oVT
 uAi
 iuv
@@ -90693,7 +89831,7 @@ sfb
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
@@ -90709,7 +89847,7 @@ jsJ
 awA
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 rLU
 rLU
@@ -90846,9 +89984,6 @@ rMm
 "}
 (178,1,1) = {"
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -90875,28 +90010,31 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-bCe
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+kgx
 jsJ
 cUt
 jsJ
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-jsJ
-rLU
-rLU
-rLU
-jsJ
-jsJ
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+kSg
+rMm
+rMm
+rMm
+kSg
+kSg
 oVT
 oVT
 oVT
@@ -90954,7 +90092,7 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 xTt
 jsJ
 jsJ
@@ -91102,9 +90240,6 @@ rMm
 rMm
 "}
 (179,1,1) = {"
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -91132,47 +90267,50 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 uSY
 cUt
-bCe
+kgx
 jsJ
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-jsJ
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
+deF
 cig
 adb
 fAH
 xzc
 tIk
-eFK
+ydv
 ydv
 mVN
 mVN
-xeM
+wYw
 tlW
-nUv
+adb
 cxX
 ydv
-nUv
+adb
 ydv
-sar
+adb
 mQT
 mQT
 tIk
@@ -91216,7 +90354,7 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
@@ -91359,8 +90497,6 @@ rMm
 rMm
 "}
 (180,1,1) = {"
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -91389,28 +90525,30 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 gzo
 cUt
 gzo
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-cyH
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+kSg
 kSg
 tIk
 tIk
@@ -91418,15 +90556,15 @@ tIk
 tIk
 rmF
 hOb
-xHa
-adb
-rDh
-adb
-adb
-adb
-adb
-adb
-adb
+nUv
+nUv
+hYq
+nUv
+nUv
+iKw
+nUv
+nUv
+nUv
 mlS
 mlS
 lCa
@@ -91439,7 +90577,7 @@ bEz
 wpI
 gFt
 wBV
-vwD
+pDO
 rxr
 vwD
 slF
@@ -91616,7 +90754,6 @@ rMm
 rMm
 "}
 (181,1,1) = {"
-rLU
 rMm
 rMm
 rMm
@@ -91646,29 +90783,30 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
 uSY
 gzo
 cUt
 gzo
 uSY
-bCe
-rLU
-rLU
+kgx
 rMm
 rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
-rLU
-jsJ
-jsJ
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+kSg
+kSg
 tIk
 bbx
 adb
@@ -91873,9 +91011,6 @@ rMm
 rMm
 "}
 (182,1,1) = {"
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -91903,28 +91038,31 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
 ioQ
-bCe
+kgx
 gzo
 riv
 gzo
 ckZ
 ioQ
-rLU
-rLU
 rMm
 rMm
 rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-jsJ
-jsJ
+rMm
+rMm
+rMm
+rMm
+rMm
+kSg
+kSg
 rLU
 tIk
 bWf
@@ -91942,7 +91080,7 @@ gZn
 gkB
 qye
 pgE
-eXz
+kED
 bEY
 wPq
 mXE
@@ -92130,9 +91268,6 @@ rMm
 rMm
 "}
 (183,1,1) = {"
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -92160,8 +91295,11 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
 ioQ
 jsJ
 gzo
@@ -92169,19 +91307,19 @@ gzo
 gzo
 jsJ
 ioQ
-rLU
-rLU
 rMm
 rMm
 rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-jsJ
-jsJ
+rMm
+rMm
+rMm
+rMm
+rMm
+kSg
+kSg
 tIk
 tIk
 tIk
@@ -92197,12 +91335,12 @@ gdc
 sEs
 dha
 iKl
-sus
+jNy
 esd
 sus
 aaT
 sus
-sus
+mTF
 ilF
 cKO
 wak
@@ -92388,9 +91526,6 @@ rMm
 "}
 (184,1,1) = {"
 ioQ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -92417,8 +91552,11 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
 ioQ
 ioQ
 ckZ
@@ -92426,19 +91564,19 @@ jsJ
 xTt
 jsJ
 ioQ
-rLU
-rLU
 rMm
 rMm
 rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-jsJ
-jsJ
+rMm
+rMm
+rMm
+rMm
+rMm
+kSg
+kSg
 tIk
 hMZ
 adb
@@ -92469,7 +91607,7 @@ xkr
 xkr
 xkr
 xkr
-xkr
+qrY
 gpp
 bBT
 pWT
@@ -92493,7 +91631,7 @@ sfb
 sfb
 sfb
 jsJ
-rZV
+tXu
 jsJ
 sfb
 sfb
@@ -92645,9 +91783,6 @@ rMm
 "}
 (185,1,1) = {"
 ioQ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -92674,8 +91809,11 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
 ioQ
 ioQ
 jsJ
@@ -92683,19 +91821,19 @@ uSY
 ckZ
 uSY
 ioQ
-rLU
-rLU
 rMm
 rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-bCe
-jsJ
-jsJ
+rMm
+rMm
+rMm
+rMm
+rMm
+kSg
+kSg
+kSg
 tIk
 uuA
 adb
@@ -92902,9 +92040,6 @@ rMm
 "}
 (186,1,1) = {"
 ioQ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -92931,27 +92066,30 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
 ioQ
 ioQ
 ioQ
 ckZ
 jsJ
 ioQ
-rLU
-rLU
 rMm
 rMm
 rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-jsJ
-jsJ
+rMm
+rMm
+rMm
+rMm
+rMm
+kSg
+kSg
 rLU
 tIk
 dod
@@ -93159,9 +92297,6 @@ rMm
 "}
 (187,1,1) = {"
 ioQ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -93188,27 +92323,30 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 ioQ
 ioQ
 ioQ
 ioQ
 ioQ
-rLU
-rLU
 rMm
 rMm
 rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-jsJ
-jsJ
+rMm
+rMm
+rMm
+rMm
+rMm
+kSg
+kSg
 rLU
 tIk
 evl
@@ -93278,7 +92416,7 @@ jsJ
 jsJ
 gzo
 jsJ
-ctd
+tXu
 jsJ
 rLU
 rLU
@@ -93416,9 +92554,6 @@ rMm
 "}
 (188,1,1) = {"
 ioQ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -93447,13 +92582,6 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -93461,11 +92589,21 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-jsJ
-jsJ
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+kSg
+kSg
 rLU
 tIk
 tIk
@@ -93673,9 +92811,6 @@ rMm
 "}
 (189,1,1) = {"
 ioQ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -93704,12 +92839,6 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -93718,12 +92847,21 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-jsJ
-jsJ
-jsJ
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+kSg
+kSg
+kSg
 tIk
 pYO
 osk
@@ -93931,9 +93069,6 @@ rMm
 (190,1,1) = {"
 ioQ
 ioQ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -93975,12 +93110,15 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-jsJ
-jsJ
-jsJ
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+kSg
+kSg
+kSg
 tIk
 adb
 adb
@@ -94188,9 +93326,6 @@ rMm
 (191,1,1) = {"
 ioQ
 ioQ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -94232,12 +93367,15 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-jsJ
-jsJ
-bCe
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+kSg
+kSg
+kSg
 tIk
 uuA
 pYO
@@ -94445,9 +93583,6 @@ rMm
 (192,1,1) = {"
 ioQ
 ioQ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -94490,11 +93625,14 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-jsJ
-jsJ
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+kSg
+kSg
 tIk
 dod
 adb
@@ -94512,9 +93650,9 @@ hkE
 tLk
 eRe
 tmo
-aBh
-bse
-oyK
+jsQ
+lfW
+ree
 pOL
 xQL
 iOY
@@ -94555,7 +93693,7 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
@@ -94703,9 +93841,6 @@ rMm
 ioQ
 ioQ
 ioQ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -94746,12 +93881,15 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-jsJ
-jsJ
-jsJ
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+kSg
+kSg
+kSg
 tIk
 tIk
 tIk
@@ -94769,9 +93907,9 @@ jlz
 hKY
 jsQ
 cvO
-aBh
-bse
-tfO
+jsQ
+jsQ
+ree
 bse
 tfO
 bse
@@ -94816,7 +93954,7 @@ jsJ
 jsJ
 jsJ
 jsJ
-ctd
+tXu
 jsJ
 gzo
 jsJ
@@ -94960,9 +94098,6 @@ rMm
 ioQ
 ioQ
 ioQ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -95003,11 +94138,14 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-jsJ
-jsJ
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+kSg
+kSg
 rLU
 tIk
 fzy
@@ -95026,10 +94164,10 @@ wkD
 hKY
 jsQ
 nof
-aBh
+tQg
+tmo
+ree
 aXM
-oMG
-bse
 pXd
 bse
 pxO
@@ -95063,7 +94201,7 @@ rLU
 rLU
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 rLU
@@ -95217,9 +94355,6 @@ rMm
 ioQ
 ioQ
 ioQ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -95259,12 +94394,15 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-jsJ
-jsJ
-jsJ
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+kSg
+kSg
+kSg
 rLU
 tIk
 adb
@@ -95282,10 +94420,10 @@ tRK
 wkD
 dKk
 jsQ
-jsQ
-aBh
-hDW
-bse
+tQg
+tQg
+cvO
+ree
 bse
 bse
 bse
@@ -95474,9 +94612,6 @@ rMm
 ioQ
 ioQ
 ioQ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -95516,11 +94651,14 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-jsJ
-jsJ
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+kSg
+kSg
 rLU
 rLU
 tIk
@@ -95539,10 +94677,10 @@ lVU
 wkQ
 hKY
 lKS
-jsQ
-aBh
-tfO
-bse
+tQg
+tQg
+lpP
+ree
 hDW
 lux
 whh
@@ -95731,9 +94869,6 @@ rMm
 ioQ
 ioQ
 ioQ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -95772,11 +94907,14 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-jsJ
-jsJ
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+kSg
+kSg
 rLU
 tIk
 tIk
@@ -95796,10 +94934,10 @@ tGa
 bkf
 tjN
 bBK
-qfO
-ijb
-oMG
-bse
+tQg
+tQg
+lwz
+lLX
 tfO
 cEe
 bse
@@ -95989,9 +95127,6 @@ ioQ
 ioQ
 ioQ
 ioQ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -96029,11 +95164,14 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-jsJ
-jsJ
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+kSg
+kSg
 rLU
 tIk
 lIq
@@ -96053,11 +95191,11 @@ sng
 yhP
 jsQ
 bDV
+tQg
+tQg
 jsQ
 wXz
-jpo
-bse
-pXd
+mWM
 fbp
 iUY
 sRv
@@ -96106,7 +95244,7 @@ gzo
 gzo
 gzo
 jsJ
-ctd
+tXu
 jsJ
 rMm
 rMm
@@ -96246,9 +95384,6 @@ ioQ
 ioQ
 ioQ
 ioQ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -96286,11 +95421,14 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-jsJ
-jsJ
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+kSg
+kSg
 rLU
 tIk
 adb
@@ -96310,11 +95448,11 @@ vIV
 awa
 iOL
 sYD
-jsQ
 tQg
-rzb
-bse
-bse
+tQg
+jsQ
+muY
+nbj
 bse
 tLN
 pxO
@@ -96503,9 +95641,6 @@ ioQ
 ioQ
 ioQ
 ioQ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -96543,12 +95678,15 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-jsJ
-jsJ
-jsJ
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+kSg
+kSg
+kSg
 tIk
 sVA
 evl
@@ -96567,10 +95705,10 @@ vIV
 awa
 bHo
 ttr
-llz
 sSs
-rHa
-qhY
+sSs
+mOS
+mwq
 bBb
 qhY
 qhY
@@ -96613,7 +95751,7 @@ rMm
 rMm
 rMm
 jsJ
-ctd
+tXu
 jsJ
 jVF
 eLb
@@ -96760,10 +95898,6 @@ ioQ
 ioQ
 ioQ
 ioQ
-rLU
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -96800,11 +95934,15 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-jsJ
-ctd
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+kSg
+tXu
 jsJ
 tIk
 tIk
@@ -96824,11 +95962,11 @@ tVO
 jsQ
 jsQ
 lFf
-lFf
-aBh
-rPk
-bse
-kiw
+jsQ
+jsQ
+jsQ
+ree
+neu
 bse
 bse
 cof
@@ -97018,9 +96156,6 @@ ioQ
 ioQ
 ioQ
 ioQ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -97058,9 +96193,12 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -97081,8 +96219,8 @@ mOS
 tXC
 tXC
 ygW
-lFf
-aBh
+kzB
+kUp
 cst
 ree
 mRA
@@ -97275,9 +96413,6 @@ ioQ
 ioQ
 ioQ
 ioQ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -97315,13 +96450,16 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 cXC
 rLU
 rLU
@@ -97340,13 +96478,13 @@ nJN
 lYq
 oGq
 wXz
-heg
-heg
+wXz
+wXz
 kpg
 tSz
 heg
 iIc
-iIc
+heg
 iIc
 iIc
 xtU
@@ -97532,9 +96670,6 @@ ioQ
 ioQ
 ioQ
 ioQ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -97573,10 +96708,13 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -97585,10 +96723,10 @@ rLU
 tIk
 lYk
 tIk
-tIk
-tIk
-tIk
-tIk
+dHX
+dHX
+dHX
+dHX
 niA
 xIv
 xIv
@@ -97620,7 +96758,7 @@ qhT
 efk
 rLU
 jsJ
-bCe
+kgx
 rLU
 rLU
 rMm
@@ -97790,9 +96928,6 @@ ioQ
 ioQ
 ioQ
 ioQ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -97831,10 +96966,13 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 cXC
@@ -97842,10 +96980,10 @@ rLU
 tIk
 jrL
 tIk
-rLU
-cXC
-rLU
-tIk
+dHX
+gcP
+hbP
+dHX
 niA
 xIv
 eYH
@@ -98047,9 +97185,6 @@ ioQ
 ioQ
 ioQ
 ioQ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -98090,20 +97225,23 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 kSg
 kSg
 uea
 uea
 uea
-kgv
-kgv
-rLU
-tIk
-niA
+dHX
+tlW
+hcr
+imJ
+iDU
 xIv
 xdp
 hqX
@@ -98304,9 +97442,6 @@ ioQ
 ioQ
 ioQ
 ioQ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -98348,18 +97483,21 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 uea
 uea
 uea
-cXC
-rLU
-rLU
-tIk
+dHX
+gnM
+hvd
+dHX
 niA
 xIv
 ovG
@@ -98392,7 +97530,7 @@ efk
 rLU
 jsJ
 jsJ
-bCe
+kgx
 rLU
 rMm
 rMm
@@ -98562,9 +97700,6 @@ ioQ
 ioQ
 ioQ
 ioQ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -98605,17 +97740,20 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
 uea
 uea
-kgv
-kgv
-rLU
+dHX
+dHX
+dHX
 dHX
 niA
 xIv
@@ -98819,9 +97957,6 @@ ioQ
 ioQ
 ioQ
 ioQ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -98863,9 +97998,12 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 tTD
 uea
@@ -99075,10 +98213,6 @@ ioQ
 ioQ
 ioQ
 ioQ
-jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -99120,10 +98254,14 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -99332,59 +98470,59 @@ ioQ
 ioQ
 ioQ
 ioQ
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
-rLU
-rLU
-rLU
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rLU
-rLU
-rLU
-rLU
 jsJ
 jsJ
-jsJ
-bCe
+kgx
 jsJ
 yiv
 mGW
@@ -99393,7 +98531,7 @@ hqX
 mRF
 iAx
 lKx
-sBM
+lKx
 lKx
 byA
 qEl
@@ -99589,10 +98727,6 @@ ioQ
 ioQ
 ioQ
 ioQ
-jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -99634,10 +98768,14 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -99846,11 +98984,6 @@ ioQ
 ioQ
 ioQ
 ioQ
-jsJ
-jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -99891,11 +99024,16 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
-bCe
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+kgx
 jsJ
 jsJ
 jsJ
@@ -99907,7 +99045,7 @@ kFA
 mRF
 fVq
 aNL
-gnM
+aNL
 sYQ
 xIv
 kgl
@@ -99932,7 +99070,7 @@ xtU
 iGL
 chL
 rLU
-bCe
+kgx
 jsJ
 jsJ
 rLU
@@ -100103,59 +99241,59 @@ ioQ
 ioQ
 ioQ
 ioQ
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
-jsJ
-rLU
-rLU
-rLU
-rMm
-rMm
-rMm
-rMm
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-jsJ
-ctd
+tXu
 jsJ
 yiv
 lfP
@@ -100164,7 +99302,7 @@ huE
 sIX
 xIv
 lrD
-bMv
+lrD
 xIv
 xIv
 tHB
@@ -100360,25 +99498,6 @@ ioQ
 ioQ
 ioQ
 ioQ
-jsJ
-jsJ
-jsJ
-rLU
-rLU
-rLU
-rMm
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -100405,12 +99524,31 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -100617,32 +99755,6 @@ ioQ
 ioQ
 ioQ
 ioQ
-jsJ
-jsJ
-jsJ
-jsJ
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rMm
-rMm
-rLU
-rLU
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -100665,9 +99777,35 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -100874,34 +100012,22 @@ ioQ
 ioQ
 ioQ
 ioQ
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
-rLU
-rLU
 jsJ
 jsJ
 jsJ
-jsJ
-jsJ
-jsJ
-jsJ
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -100922,11 +100048,23 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -100934,7 +100072,7 @@ jsJ
 jsJ
 rLU
 yiv
-fsK
+fUJ
 fUJ
 yiv
 rLU
@@ -101131,13 +100269,13 @@ ioQ
 ioQ
 ioQ
 ioQ
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
-jsJ
-jsJ
-jsJ
-rLU
-rLU
-rLU
 jsJ
 jsJ
 jsJ
@@ -101149,17 +100287,7 @@ jsJ
 jsJ
 jsJ
 jsJ
-jsJ
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+aFi
 rMm
 rMm
 rMm
@@ -101179,21 +100307,31 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 rLU
 kSg
-bCe
+kgx
 jsJ
 jsJ
-gzo
+jhl
 rPg
-woZ
-bca
+rPg
+kzY
 rLU
 rLU
 rLU
@@ -101216,7 +100354,7 @@ uea
 jsJ
 jsJ
 jsJ
-ctd
+tXu
 rLU
 rLU
 rLU
@@ -101388,36 +100526,36 @@ ioQ
 ioQ
 ioQ
 ioQ
+rMm
+rMm
+rMm
+jsJ
+jsJ
+kgx
 jsJ
 jsJ
 jsJ
 jsJ
 jsJ
-rLU
-lGK
-jsJ
-lGK
-lGK
-lGK
-lGK
-lGK
-lGK
-lGK
-lGK
-lGK
-lGK
-jsJ
-rLU
-rLU
 jsJ
 jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-qIu
-qIu
+jsJ
+jsJ
+jsJ
+rMm
+rMm
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+rMm
+rMm
+beO
+beO
 rMm
 rMm
 rMm
@@ -101440,16 +100578,16 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rLU
 rLU
 jsJ
 jsJ
 gzo
 gzo
-gVI
+gzo
 bca
 piz
 rLU
@@ -101644,41 +100782,37 @@ ioQ
 ioQ
 ioQ
 ioQ
-jsJ
-jsJ
-jsJ
-jsJ
-jsJ
-jsJ
-rLU
-lGK
-jsJ
-jsJ
-jsJ
-jsJ
-jsJ
-jsJ
-jsJ
-jsJ
-jsJ
-jsJ
-jsJ
-jsJ
-jsJ
-jsJ
-jsJ
-jsJ
-jsJ
-bCe
-jsJ
-jsJ
-jsJ
-qIu
-qIu
-rLU
 rMm
-rLU
-rLU
+rMm
+rMm
+rMm
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+anD
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+kgx
+jsJ
+jsJ
+jsJ
+beO
+beO
 rMm
 rMm
 rMm
@@ -101697,16 +100831,20 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 rLU
 rLU
 jsJ
 gzo
 gzo
 gzo
-gVI
+gzo
 gzo
 jfH
 piz
@@ -101901,26 +101039,18 @@ ioQ
 ioQ
 ioQ
 ioQ
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
 jsJ
 jsJ
+kgx
 jsJ
 jsJ
-lGK
-jsJ
-kED
-hvd
-aFi
-jsJ
-kED
-hvd
-aFi
-jsJ
-kED
-hvd
-aFi
+cyH
 jsJ
 jsJ
 jsJ
@@ -101931,12 +101061,15 @@ jsJ
 jsJ
 jsJ
 jsJ
-qIu
-rLU
-rLU
-rLU
-rLU
-rLU
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+beO
 rMm
 rMm
 rMm
@@ -101954,8 +101087,13 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 rLU
 jsJ
 jsJ
@@ -101963,7 +101101,7 @@ jsJ
 gzo
 lys
 gzo
-gVI
+gzo
 gzo
 jfH
 piz
@@ -102158,29 +101296,8 @@ ioQ
 ioQ
 ioQ
 ioQ
-jsJ
-jsJ
-jsJ
-jsJ
-jsJ
-jsJ
-jsJ
-lGK
-jsJ
-kED
-eVF
-aFi
-jsJ
-kED
-eVF
-aFi
-jsJ
-kED
-eVF
-aFi
-jsJ
-jsJ
-bCe
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -102189,12 +101306,27 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+kgx
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
 rMm
 rMm
 rMm
@@ -102210,9 +101342,15 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 gzo
@@ -102220,7 +101358,7 @@ gzo
 gzo
 gzo
 gzo
-gVI
+gzo
 gzo
 jfH
 piz
@@ -102422,24 +101560,14 @@ jsJ
 jsJ
 jsJ
 jsJ
-lGK
-jsJ
-kED
-eVF
-aFi
-jsJ
-kED
-eVF
-aFi
-jsJ
-kED
-eVF
-aFi
+kgx
 jsJ
 jsJ
 jsJ
+kgx
 jsJ
 jsJ
+kgx
 jsJ
 jsJ
 jsJ
@@ -102447,12 +101575,19 @@ bCe
 jsJ
 jsJ
 jsJ
-rLU
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+kgx
+jsJ
+jsJ
+jsJ
+rMm
 kSg
 kSg
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -102466,9 +101601,12 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 gzo
@@ -102476,8 +101614,8 @@ gzo
 gzo
 gzo
 jsJ
-bCe
-gVI
+kgx
+gzo
 gzo
 piz
 rLU
@@ -102676,22 +101814,7 @@ jsJ
 jsJ
 jsJ
 jsJ
-jsJ
-jsJ
-jsJ
-jsJ
-jsJ
-kED
-eVF
-aFi
-jsJ
-kED
-eVF
-aFi
-jsJ
-kED
-eVF
-aFi
+kgx
 jsJ
 jsJ
 jsJ
@@ -102699,6 +101822,21 @@ jsJ
 jsJ
 jsJ
 jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+kgx
+jsJ
+jsJ
+jsJ
+jsJ
+kgx
 jsJ
 jsJ
 jsJ
@@ -102708,9 +101846,6 @@ kSg
 kSg
 kSg
 kSg
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -102722,9 +101857,12 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 jsJ
 gzo
@@ -102734,8 +101872,8 @@ gzo
 jsJ
 jsJ
 jsJ
-gVI
-gzo
+jsJ
+jsJ
 rLU
 rLU
 jsJ
@@ -102933,42 +102071,42 @@ jsJ
 jsJ
 jsJ
 jsJ
-lGK
-lGK
-lGK
-jsJ
-jsJ
-kED
-eVF
-aFi
-jsJ
-kED
-eVF
-aFi
-jsJ
-kED
-eVF
-aFi
 jsJ
 jsJ
 jsJ
 jsJ
-wXI
 jsJ
-anD
-xtZ
-xtZ
-xtZ
-xtZ
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+cyH
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+cyH
+jsJ
+jsJ
 kSg
 kSg
 kSg
 kSg
 kSg
-kSg
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -102979,8 +102117,8 @@ rNe
 rNe
 rNe
 rNe
-rLU
-rLU
+rMm
+rMm
 kSg
 kSg
 jsJ
@@ -102991,8 +102129,8 @@ rLU
 rLU
 jsJ
 jsJ
-gVI
-gzo
+jsJ
+jsJ
 uSY
 jsJ
 jsJ
@@ -103190,42 +102328,42 @@ jsJ
 jsJ
 jsJ
 jsJ
-lGK
+jsJ
+jsJ
+jsJ
+jsJ
+kgx
 jsJ
 jsJ
 jsJ
 jsJ
 jsJ
-sQz
 jsJ
-jsJ
-jsJ
-sQz
-jsJ
-jsJ
-jsJ
-sQz
+kgx
 jsJ
 jsJ
 jsJ
 jsJ
-cdq
-anD
-anD
-anD
-afm
-cSb
-lfW
-xtZ
+jsJ
+jsJ
+jsJ
+jsJ
+tXu
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
 kSg
 kSg
 kSg
 kSg
 kSg
-kSg
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -103248,8 +102386,8 @@ rLU
 rLU
 rLU
 jsJ
-gVI
-gzo
+jsJ
+jsJ
 jsJ
 jsJ
 jsJ
@@ -103444,45 +102582,45 @@ ioQ
 ioQ
 ioQ
 jsJ
+aFi
+jsJ
+jsJ
+kgx
 jsJ
 jsJ
 jsJ
-lGK
 jsJ
-xCA
-gwA
-gwA
-pRL
-uea
-lwz
-gwA
-pRL
-uea
-lwz
-gwA
-pRL
-uea
-lwz
-jNf
-jNf
-jNf
-jNf
-kzB
-tPk
-cuv
-qdy
-fFH
-cOJ
-rvQ
-gwA
-gwA
-gwA
-gwA
-gwA
-lwK
-rLU
-rLU
-rLU
+jsJ
+jsJ
+jsJ
+jsJ
+kgx
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+kgx
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+kSg
+kSg
+kSg
+kSg
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -103505,8 +102643,8 @@ rLU
 rLU
 rLU
 jsJ
-gVI
-gzo
+jsJ
+jsJ
 jsJ
 jsJ
 rLU
@@ -103704,42 +102842,42 @@ jsJ
 jsJ
 jsJ
 jsJ
-lGK
 jsJ
 jsJ
 jsJ
 jsJ
 jsJ
-caE
-jsJ
-jsJ
-jsJ
-caE
-jsJ
-jsJ
-jsJ
-caE
+aFi
 jsJ
 jsJ
 jsJ
 jsJ
-cdq
-anD
-anD
-anD
-xcj
-iDU
-rMP
-muY
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+kgx
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
 kSg
-uea
-uea
-uea
-uea
-mWM
-rLU
-rLU
-rLU
+kSg
+kSg
+kSg
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -103762,20 +102900,20 @@ rLU
 rLU
 rLU
 rLU
-gVI
-gzo
+jsJ
+jsJ
 jsJ
 jsJ
 rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 rMm
 rMm
 rLU
@@ -103961,42 +103099,42 @@ jsJ
 jsJ
 jsJ
 jsJ
-lGK
 jsJ
-lGK
-iMo
 jsJ
-kED
-neu
-aFi
+kgx
 jsJ
-kED
-neu
-aFi
 jsJ
-kED
-neu
+jsJ
+jsJ
+jsJ
 aFi
 jsJ
 jsJ
 jsJ
 jsJ
-bOk
 jsJ
-anD
-xtZ
-xtZ
-xtZ
-xtZ
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+kgx
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
 kSg
 kSg
 kSg
 kSg
-uea
-mWM
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -104007,7 +103145,7 @@ rNe
 rNe
 rNe
 rNe
-rLU
+rMm
 kSg
 kSg
 kSg
@@ -104019,13 +103157,13 @@ rLU
 rLU
 rLU
 rLU
-gVI
-gzo
 jsJ
-bCe
-rLU
-rLU
-rLU
+jsJ
+jsJ
+kgx
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -104215,25 +103353,9 @@ ioQ
 ioQ
 jsJ
 jsJ
+kgx
 jsJ
-jsJ
-jsJ
-jsJ
-jsJ
-jsJ
-jsJ
-jsJ
-kED
-neu
-aFi
-jsJ
-kED
-neu
-aFi
-jsJ
-kED
-neu
-aFi
+tXu
 jsJ
 jsJ
 jsJ
@@ -104244,16 +103366,29 @@ jsJ
 jsJ
 jsJ
 jsJ
+kgx
+jsJ
+jsJ
+kgx
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+tXu
 jsJ
 jsJ
 jsJ
 kSg
-rLU
-uea
-mWM
-rLU
-rLU
-rLU
+rMm
+kSg
+kSg
 rMm
 rMm
 rMm
@@ -104264,7 +103399,10 @@ rMm
 rMm
 rMm
 rMm
-rLU
+rMm
+rMm
+rMm
+rMm
 lDG
 kSg
 kSg
@@ -104276,13 +103414,13 @@ rLU
 rLU
 rLU
 rLU
-gVI
-gzo
 jsJ
 jsJ
-rLU
-rLU
-rLU
+jsJ
+jsJ
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -104478,22 +103616,24 @@ jsJ
 jsJ
 jsJ
 jsJ
-lGK
 jsJ
-kED
-neu
-aFi
 jsJ
-kED
-neu
-aFi
+kgx
 jsJ
-kED
-neu
+jsJ
 aFi
 jsJ
 jsJ
-bCe
+jsJ
+jsJ
+jsJ
+jsJ
+cyH
+jsJ
+jsJ
+kgx
+jsJ
+aFi
 jsJ
 jsJ
 jsJ
@@ -104502,15 +103642,10 @@ jsJ
 jsJ
 jsJ
 jsJ
-jsJ
-jsJ
-rLU
-rLU
-uea
-mWM
-rLU
-rLU
-rLU
+rMm
+rMm
+kSg
+kSg
 rMm
 rMm
 rMm
@@ -104521,8 +103656,11 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
 dMQ
@@ -104533,13 +103671,13 @@ rLU
 rLU
 rLU
 rLU
-gVI
-gzo
 jsJ
 jsJ
-rLU
-rLU
-rLU
+jsJ
+jsJ
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -104733,22 +103871,19 @@ jsJ
 jsJ
 jsJ
 jsJ
+kgx
 jsJ
 jsJ
-lGK
 jsJ
-kED
-neu
-aFi
 jsJ
-kED
-neu
-aFi
 jsJ
-kED
-neu
-aFi
 jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+kgx
 jsJ
 jsJ
 jsJ
@@ -104761,15 +103896,14 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-uea
-mWM
-uea
-rLU
-rLU
-rLU
-rLU
+jsJ
+jsJ
+jsJ
+rMm
+rMm
+kSg
+kSg
+kSg
 rMm
 rMm
 rMm
@@ -104778,8 +103912,12 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
 kSg
@@ -104790,13 +103928,13 @@ rLU
 rLU
 rLU
 jsJ
-gVI
-gzo
 jsJ
 jsJ
-rLU
-rLU
-rLU
+jsJ
+jsJ
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -104992,54 +104130,54 @@ jsJ
 jsJ
 jsJ
 jsJ
-lGK
 jsJ
-kED
-eXd
-aFi
 jsJ
-kED
-eXd
-aFi
 jsJ
-kED
-eXd
-aFi
+kgx
 jsJ
-lGK
+jsJ
+jsJ
+kgx
 jsJ
 jsJ
 jsJ
 jsJ
-bCe
+jsJ
+kgx
 jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
-kSg
-uea
-mWM
-uea
-kSg
-rLU
-rLU
-rLU
-rLU
-rLU
+jsJ
+kgx
+jsJ
+jsJ
+jsJ
+jsJ
 rMm
 rMm
 rMm
-rMm
-rMm
-rMm
-rLU
-rLU
 kSg
 kSg
 kSg
+kSg
+kSg
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+kSg
+kSg
+rLU
 rLU
 rLU
 rLU
@@ -105047,13 +104185,13 @@ rLU
 rLU
 rLU
 jsJ
-gVI
-gzo
 jsJ
 jsJ
-rLU
-rLU
-rLU
+jsJ
+jsJ
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -105243,10 +104381,10 @@ ioQ
 ioQ
 jsJ
 jsJ
+apx
 jsJ
 jsJ
-jsJ
-jsJ
+tXu
 jsJ
 jsJ
 lGK
@@ -105261,9 +104399,6 @@ jsJ
 jsJ
 jsJ
 jsJ
-eTE
-jsJ
-lGK
 jsJ
 jsJ
 jsJ
@@ -105272,31 +104407,34 @@ jsJ
 jsJ
 jsJ
 jsJ
-qIu
-rLU
-rLU
-rLU
+jsJ
+jsJ
+jsJ
+beO
+rMm
+rMm
+rMm
 kSg
 kSg
-mWM
-uea
 kSg
 kSg
-rLU
-rLU
-rLU
-rLU
-rLU
+kSg
+kSg
 rMm
 rMm
 rMm
 rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+kSg
+kSg
 rLU
 rLU
-kSg
-kSg
-kSg
-kSg
 rLU
 rLU
 rLU
@@ -105304,13 +104442,13 @@ rLU
 rLU
 rLU
 jsJ
-gVI
-gzo
 jsJ
 jsJ
-rLU
-rLU
-rLU
+jsJ
+jsJ
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -105506,21 +104644,21 @@ jsJ
 jsJ
 jsJ
 jsJ
-lGK
-lGK
-lGK
-lGK
-lGK
-lGK
-lGK
-lGK
-lGK
-lGK
-lGK
-lGK
-ttP
-lGK
-lGK
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+kgx
+jsJ
+jsJ
+kgx
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
 xTt
 jsJ
 jsJ
@@ -105528,30 +104666,27 @@ jsJ
 jsJ
 jsJ
 jsJ
-qIu
-qIu
-rLU
-rLU
-rLU
-rLU
-kSg
-mWM
-uea
-uea
+beO
+beO
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
 kSg
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
 kSg
 kSg
 kSg
+kSg
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
 rLU
@@ -105559,15 +104694,18 @@ rLU
 rLU
 rLU
 rLU
+rLU
+rLU
+rLU
 kSg
-bCe
-gVI
-gzo
+kgx
 jsJ
 jsJ
-rLU
-rLU
-rLU
+jsJ
+jsJ
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -105758,7 +104896,11 @@ ioQ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
+jsJ
+jsJ
+jsJ
+anD
 jsJ
 jsJ
 jsJ
@@ -105771,60 +104913,56 @@ jsJ
 jsJ
 jsJ
 jsJ
-kSg
-kSg
-kSg
-kSg
-kSg
-rLU
-rLU
-rLU
 jsJ
-jsJ
-jsJ
-jsJ
-jsJ
-rLU
-rLU
-rLU
 rMm
-rLU
-rLU
-rLU
-kSg
-wYb
-gwA
-gwA
-lwK
-uea
-kSg
-kSg
-kSg
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-kSg
-kSg
-kSg
-kSg
-kSg
-rLU
-rLU
-rLU
-rLU
-kSg
-kSg
-gzo
-gVI
-gzo
-bCe
+rMm
+rMm
 jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+kSg
+kSg
+kSg
+kSg
+kSg
+kSg
+kSg
+kSg
+kSg
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+kSg
+kSg
 rLU
 rLU
 rLU
+rLU
+rLU
+rLU
+rLU
+rLU
+rLU
+rLU
+jsJ
+gzo
+kgx
+jsJ
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -106023,64 +105161,64 @@ jsJ
 jsJ
 jsJ
 jsJ
+tXu
 jsJ
 jsJ
 jsJ
 jsJ
 jsJ
-kSg
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 nOK
-uea
-uea
-mWM
-uea
-uea
-uea
-uea
-rLU
-rLU
-rLU
-rLU
-rLU
 kSg
 kSg
 kSg
 kSg
 kSg
+kSg
+kSg
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
 kSg
 kSg
 rLU
-kSg
-uea
-uea
-gVI
+rLU
+rLU
+rLU
+rLU
+rLU
+rLU
+rLU
+rLU
+rLU
 jsJ
 jsJ
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -106283,60 +105421,60 @@ jsJ
 jsJ
 jsJ
 jsJ
+kgx
 jsJ
-jsJ
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
 rMm
 rMm
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+kSg
+kSg
+kSg
+kSg
+kSg
+kSg
+kSg
+kSg
+kSg
+kSg
+kSg
+kSg
+kSg
+kSg
+kSg
+kSg
+kSg
+kSg
+kSg
+kSg
+kSg
 rLU
 rLU
 kSg
 kSg
-wYb
-gwA
-gwA
-gwA
-gwA
-gwA
-gwA
-gwA
-gwA
-gwA
-gwA
-gwA
-gwA
-gwA
-gwA
-gwA
-gwA
-gwA
-gwA
-gwA
-gwA
-gwA
-gwA
-jxf
-jsJ
-rLU
-rLU
-rLU
+kSg
+kSg
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -106529,6 +105667,7 @@ ioQ
 ioQ
 jsJ
 jsJ
+tXu
 jsJ
 jsJ
 jsJ
@@ -106538,23 +105677,9 @@ jsJ
 jsJ
 jsJ
 jsJ
+aFi
 jsJ
 jsJ
-jsJ
-jsJ
-rLU
-rLU
-rLU
-rLU
-rLU
-rMm
-rMm
-rMm
-rLU
-rLU
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -106562,37 +105687,50 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
 kSg
-uea
-uea
-uea
-uea
-uea
-uea
-uea
-uea
-uea
-uea
-uea
-uea
-uea
-uea
-uea
-uea
-uea
-uea
-rLU
-rLU
-rLU
-rLU
+kSg
+kSg
+kSg
+kSg
+kSg
+kSg
+kSg
+kSg
+kSg
+kSg
+kSg
+kSg
+kSg
+kSg
+kSg
+kSg
+kSg
+kSg
+kSg
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -106787,22 +105925,19 @@ ioQ
 ioQ
 jsJ
 jsJ
+apx
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+kgx
 jsJ
 jsJ
 jsJ
 jsJ
 jsJ
 jsJ
-bCe
-jsJ
-jsJ
-jsJ
-jsJ
-jsJ
-jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -106820,35 +105955,38 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
 kSg
 kSg
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
 kSg
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -107037,7 +106175,7 @@ rMm
 "}
 (241,1,1) = {"
 jsJ
-bCe
+jsJ
 jsJ
 ioQ
 ioQ
@@ -107046,7 +106184,7 @@ jsJ
 jsJ
 jsJ
 jsJ
-jsJ
+kgx
 jsJ
 jsJ
 jsJ
@@ -107057,9 +106195,6 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -107078,33 +106213,36 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -107294,7 +106432,7 @@ rMm
 "}
 (242,1,1) = {"
 jsJ
-jsJ
+tXu
 jsJ
 ioQ
 ioQ
@@ -107311,12 +106449,9 @@ jsJ
 jsJ
 jsJ
 jsJ
+apx
 jsJ
 jsJ
-jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -107339,28 +106474,31 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -107551,7 +106689,7 @@ rMm
 "}
 (243,1,1) = {"
 jsJ
-jsJ
+afm
 jsJ
 ioQ
 ioQ
@@ -107559,6 +106697,9 @@ ioQ
 ioQ
 jsJ
 jsJ
+afm
+jsJ
+tXu
 jsJ
 jsJ
 jsJ
@@ -107568,12 +106709,6 @@ jsJ
 jsJ
 jsJ
 jsJ
-jsJ
-jsJ
-jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -107601,17 +106736,20 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -107820,18 +106958,18 @@ jsJ
 jsJ
 jsJ
 jsJ
+apx
+jsJ
+jsJ
+jsJ
+kgx
 jsJ
 jsJ
 jsJ
 jsJ
-bCe
-jsJ
-jsJ
-jsJ
-jsJ
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -108084,11 +107222,11 @@ jsJ
 jsJ
 jsJ
 jsJ
+tXu
 jsJ
-jsJ
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -108343,9 +107481,9 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -108580,7 +107718,7 @@ rMm
 (247,1,1) = {"
 jsJ
 jsJ
-jsJ
+apx
 jsJ
 jsJ
 ioQ
@@ -108597,12 +107735,12 @@ jsJ
 jsJ
 jsJ
 jsJ
+kgx
 jsJ
 jsJ
-jsJ
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -108857,9 +107995,9 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -109115,9 +108253,9 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -109353,7 +108491,7 @@ rLU
 jsJ
 jsJ
 jsJ
-bCe
+tXu
 jsJ
 jsJ
 ioQ
@@ -109370,12 +108508,12 @@ ioQ
 jsJ
 jsJ
 jsJ
+kgx
 jsJ
 jsJ
-jsJ
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -109630,9 +108768,9 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -109870,7 +109008,7 @@ dsM
 jsJ
 jsJ
 jsJ
-jsJ
+apx
 ioQ
 ioQ
 ioQ
@@ -109887,9 +109025,9 @@ ioQ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -110124,12 +109262,12 @@ rLU
 rLU
 jsJ
 jsJ
+apx
 jsJ
 jsJ
 jsJ
 jsJ
 jsJ
-jsJ
 ioQ
 ioQ
 ioQ
@@ -110144,9 +109282,9 @@ ioQ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -110383,12 +109521,12 @@ rLU
 jsJ
 jsJ
 jsJ
-bCe
+jsJ
+jsJ
+tXu
 jsJ
 jsJ
 jsJ
-jsJ
-jsJ
 ioQ
 ioQ
 ioQ
@@ -110401,9 +109539,9 @@ ioQ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -110658,9 +109796,9 @@ ioQ
 ioQ
 jsJ
 jsJ
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm

--- a/_maps/map_files/FridgeStation/FridgeStation.dmm
+++ b/_maps/map_files/FridgeStation/FridgeStation.dmm
@@ -15,14 +15,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "aaz" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/hallway/secondary/entry)
+/obj/machinery/light/floor/fakeday,
+/obj/structure/flora/rock/icy,
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors)
 "aaT" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -377,6 +373,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
+/obj/structure/closet/secure_closet/personal,
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "ajQ" = (
@@ -522,11 +519,10 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "aqn" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8
+/obj/machinery/mineral/stacking_unit_console{
+	machinedir = 4
 	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
+/turf/closed/wall,
 /area/maintenance/disposal)
 "aqx" = (
 /obj/structure/disposalpipe/segment,
@@ -624,7 +620,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/open/floor/plasteel/showroomfloor/shower,
+/turf/open/floor/plasteel/showroomfloor,
 /area/security/prison)
 "asW" = (
 /obj/effect/turf_decal/stripes/line{
@@ -654,15 +650,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"auf" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/brown,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "aug" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin{
@@ -845,6 +832,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 6
+	},
 /turf/open/floor/plasteel,
 /area/janitor)
 "axy" = (
@@ -1300,10 +1290,14 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "aKX" = (
-/obj/machinery/holopad,
-/turf/open/floor/plasteel/yellowsiding{
-	dir = 1
+/obj/structure/chair/sofa/corp{
+	dir = 8;
+	pixel_x = 7
 	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer1{
+	dir = 10
+	},
+/turf/open/floor/wood,
 /area/crew_quarters/fitness)
 "aKZ" = (
 /obj/machinery/light,
@@ -1669,6 +1663,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "aUz" = (
@@ -1793,15 +1790,10 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
 "aYE" = (
-/obj/structure/disposalpipe/junction/flip{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/brown,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "aYM" = (
@@ -2031,7 +2023,7 @@
 	pixel_y = 32
 	},
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple{
+/obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -2425,10 +2417,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/green,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "bmk" = (
@@ -2583,15 +2574,13 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
 "bsd" = (
-/obj/structure/bed,
-/obj/item/bedsheet/orange,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/landmark/start/prisoner,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
+/obj/machinery/space_heater,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "bse" = (
@@ -3292,16 +3281,11 @@
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
 "bMv" = (
-/obj/structure/sign/poster/official/no_erp{
-	pixel_y = 32
-	},
 /obj/structure/chair/sofa/corp{
 	dir = 4;
 	pixel_x = -7
 	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer1{
-	dir = 6
-	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer1,
 /turf/open/floor/wood,
 /area/crew_quarters/fitness)
 "bMF" = (
@@ -3350,11 +3334,15 @@
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors)
 "bOk" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/sign/poster/official/no_erp{
+	pixel_y = 32
+	},
+/obj/structure/chair/sofa/corp{
+	dir = 4;
+	pixel_x = -7
 	},
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer1{
-	dir = 4
+	dir = 6
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/fitness)
@@ -3535,6 +3523,9 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 10
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/janitor)
@@ -3758,6 +3749,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "bWG" = (
@@ -3891,12 +3885,8 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "caE" = (
-/obj/structure/chair/sofa/corp{
-	dir = 4;
-	pixel_x = -7
-	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer1,
-/turf/open/floor/wood,
+/obj/structure/weightmachine/stacklifter,
+/turf/open/floor/plasteel/grimy,
 /area/crew_quarters/fitness)
 "caH" = (
 /turf/closed/wall,
@@ -4018,7 +4008,10 @@
 /turf/open/floor/carpet,
 /area/medical/psych)
 "cdq" = (
-/obj/structure/weightmachine/stacklifter,
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
+	},
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/fitness)
 "cdw" = (
@@ -4168,8 +4161,11 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "chL" = (
-/turf/closed/wall/r_wall,
-/area/hallway/secondary/entry)
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/grimy,
+/area/crew_quarters/fitness)
 "cie" = (
 /obj/machinery/light,
 /obj/machinery/light/floor/fakeday,
@@ -4599,14 +4595,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "cuv" = (
-/obj/structure/weightmachine/weightlifter,
-/obj/machinery/camera{
-	c_tag = "Fitness Room";
-	desc = "It may or may not be recording you for muscle worship films."
-	},
-/obj/item/radio/intercom{
-	pixel_y = 25
-	},
+/obj/structure/punching_bag,
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/fitness)
 "cuB" = (
@@ -4697,6 +4686,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "cwU" = (
@@ -4732,8 +4722,13 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "cxs" = (
-/obj/machinery/light{
-	dir = 1
+/obj/structure/weightmachine/weightlifter,
+/obj/machinery/camera{
+	c_tag = "Fitness Room";
+	desc = "It may or may not be recording you for muscle worship films."
+	},
+/obj/item/radio/intercom{
+	pixel_y = 25
 	},
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/fitness)
@@ -4794,16 +4789,13 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
 "czz" = (
-/obj/structure/chair/sofa/corp{
-	dir = 4;
-	pixel_x = -7
-	},
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = -32
-	},
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer1{
-	dir = 5
+	dir = 9
+	},
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos,
+/obj/structure/chair/sofa/corp{
+	dir = 8;
+	pixel_x = 7
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/fitness)
@@ -4825,14 +4817,13 @@
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "czL" = (
-/obj/vehicle/ridden/atv/snowmobile,
+/obj/vehicle/ridden/atv/snowmobile{
+	dir = 1
+	},
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "czT" = (
@@ -4991,10 +4982,8 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "cFL" = (
-/obj/item/kirbyplants/random,
-/turf/open/floor/plasteel/yellowsiding{
-	dir = 8
-	},
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/plasteel/grimy,
 /area/crew_quarters/fitness)
 "cFU" = (
 /obj/structure/beebox,
@@ -5450,14 +5439,14 @@
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
 "cUM" = (
-/obj/machinery/atmospherics/pipe/simple{
-	dir = 10
-	},
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 10
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/server)
@@ -5578,10 +5567,8 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "cYK" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
 /obj/effect/turf_decal/delivery,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "cYM" = (
@@ -5799,9 +5786,8 @@
 /turf/open/floor/plating,
 /area/crew_quarters/abandoned_gambling_den)
 "dcz" = (
-/obj/structure/table/glass,
-/obj/structure/bedsheetbin/towel,
-/turf/open/floor/plasteel,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/closed/wall,
 /area/crew_quarters/fitness)
 "dcD" = (
 /obj/structure/disposalpipe/segment{
@@ -6014,10 +6000,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "dgK" = (
@@ -6688,7 +6671,8 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "dxG" = (
-/turf/open/floor/plasteel/yellowsiding/corner{
+/obj/item/kirbyplants/random,
+/turf/open/floor/plasteel/yellowsiding{
 	dir = 1
 	},
 /area/crew_quarters/fitness)
@@ -6814,15 +6798,23 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/white,
 /area/maintenance/starboard/aft)
 "dDJ" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/manifold/layer1{
-	dir = 1
+/obj/structure/chair/sofa/corp{
+	dir = 4;
+	pixel_x = -7
+	},
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = -32
+	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer1{
+	dir = 5
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/fitness)
@@ -6861,8 +6853,9 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "dEG" = (
@@ -6954,18 +6947,18 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "dFw" = (
-/obj/structure/closet/crate{
-	desc = "A rectangular steel crate designated for carrying a fair amount of sandbags in the inevitable case of martial law.";
-	name = "Sandbag Crate"
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/item/stack/sheet/mineral/sandbags{
-	amount = 50
+/obj/effect/turf_decal/tile/red{
+	dir = 4
 	},
-/obj/item/stack/sheet/mineral/sandbags{
-	amount = 50
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/brig)
+/obj/effect/landmark/start/security_officer,
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "dFG" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -7208,6 +7201,9 @@
 /area/ai_monitored/storage/eva)
 "dKG" = (
 /obj/machinery/biogenerator,
+/obj/structure/sign/poster/contraband/billyh2{
+	pixel_y = 31
+	},
 /turf/open/floor/plasteel/dark,
 /area/hydroponics)
 "dKZ" = (
@@ -7258,7 +7254,7 @@
 	pixel_y = -32
 	},
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple{
+/obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -7436,13 +7432,8 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "dPt" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer1{
-	dir = 9
-	},
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos,
-/obj/structure/chair/sofa/corp{
-	dir = 8;
-	pixel_x = 7
+/obj/machinery/atmospherics/pipe/heat_exchanging/manifold/layer1{
+	dir = 1
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/fitness)
@@ -7598,7 +7589,7 @@
 	dir = 1;
 	network = list("ss13","rd")
 	},
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -7858,9 +7849,13 @@
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "ecF" = (
-/obj/structure/chair/wood/normal,
-/turf/open/floor/wood,
-/area/maintenance/bar)
+/obj/structure/sign/poster/contraband/billyh{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/yellowsiding{
+	dir = 4
+	},
+/area/crew_quarters/fitness)
 "ecH" = (
 /obj/docking_port/stationary{
 	dheight = 1;
@@ -8312,14 +8307,9 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "enA" = (
-/obj/machinery/portable_atmospherics/canister/water_vapor,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+/turf/open/floor/plasteel/yellowsiding{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "enE" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
@@ -8542,6 +8532,9 @@
 	req_access_txt = "31"
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "erY" = (
@@ -8565,12 +8558,15 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "esd" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+/obj/effect/turf_decal/delivery,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/hydroponics)
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "esK" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/machinery/keycard_auth{
@@ -8843,6 +8839,9 @@
 /obj/structure/sign/poster/contraband/billyh2{
 	pixel_x = -32
 	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 9
+	},
 /turf/open/floor/plasteel,
 /area/janitor)
 "eyb" = (
@@ -9047,16 +9046,13 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "eEe" = (
-/obj/machinery/door/airlock/public/glass{
-	desc = "A great place to relax. No ERP.";
-	name = "Sauna"
+/obj/machinery/conveyor_switch/oneway{
+	dir = 8;
+	id = "garbage";
+	name = "disposal conveyor"
 	},
-/obj/structure/fans/tiny,
-/obj/machinery/atmospherics/pipe/heat_exchanging/junction/layer1{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/fitness)
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "eEz" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -9156,6 +9152,7 @@
 	},
 /obj/machinery/light,
 /obj/item/key/janitor,
+/obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/plasteel,
 /area/janitor)
 "eGM" = (
@@ -9460,11 +9457,9 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "ePH" = (
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
+/turf/open/floor/plasteel/yellowsiding/corner{
+	dir = 4
 	},
-/turf/open/floor/plasteel/grimy,
 /area/crew_quarters/fitness)
 "ePN" = (
 /obj/structure/disposalpipe/segment,
@@ -9577,15 +9572,17 @@
 /turf/closed/wall/r_wall,
 /area/blueshield)
 "eSY" = (
-/obj/machinery/airalarm{
+/obj/machinery/computer/security/telescreen/engine{
 	dir = 8;
-	pixel_x = 23
+	pixel_x = 30
 	},
 /turf/open/floor/carpet/orange,
 /area/engine/engineering)
 "eTE" = (
-/obj/structure/weightmachine/weightlifter,
-/turf/open/floor/plasteel/grimy,
+/obj/machinery/holopad,
+/turf/open/floor/plasteel/yellowsiding{
+	dir = 1
+	},
 /area/crew_quarters/fitness)
 "eTL" = (
 /obj/machinery/light{
@@ -9815,7 +9812,7 @@
 /area/science/research)
 "fbz" = (
 /obj/structure/chair/office/light,
-/obj/machinery/atmospherics/pipe/simple{
+/obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -9836,11 +9833,14 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
 "fcl" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/white,
-/area/science/mixing)
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "fcG" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -9930,17 +9930,10 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "ffO" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
@@ -10048,15 +10041,17 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "fiM" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 10
+/obj/item/stack/marker_beacon{
+	anchored = 1;
+	icon_state = "markerburgundy-on";
+	light_color = "#FA644B";
+	light_power = 3;
+	light_range = 3;
+	name = "Docking Beacon";
+	picked_color = "Burgundy"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/white,
-/area/science/mixing)
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/surface/outdoors)
 "fiW" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -10128,9 +10123,7 @@
 	name = "Station Intercom (General)";
 	pixel_x = 27
 	},
-/turf/open/floor/plasteel/yellowsiding{
-	dir = 8
-	},
+/turf/open/floor/plasteel/grimy,
 /area/crew_quarters/fitness)
 "fkN" = (
 /obj/structure/table/wood,
@@ -10348,13 +10341,10 @@
 /turf/open/floor/carpet/red,
 /area/icemoon/surface/outdoors)
 "frx" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/brown,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "frF" = (
@@ -10495,7 +10485,7 @@
 	dir = 8;
 	pixel_x = 28
 	},
-/obj/effect/landmark/start/security_officer,
+/obj/machinery/rnd/production/techfab/department/security,
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "fve" = (
@@ -10602,6 +10592,9 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/service)
 "fzV" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/janitor)
 "fzW" = (
@@ -10656,9 +10649,15 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "fCG" = (
-/obj/item/chair/wood,
-/turf/open/floor/wood,
-/area/maintenance/bar)
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/brown,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "fCT" = (
 /obj/item/clothing/under/costume/jabroni,
 /obj/item/chair/stool,
@@ -10712,10 +10711,10 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/hallway)
 "fDV" = (
-/obj/structure/closet/firecloset/full,
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/structure/trash_pile,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "fEE" = (
@@ -10741,6 +10740,7 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "fFH" = (
@@ -11223,6 +11223,9 @@
 	dir = 1
 	},
 /obj/machinery/disposal/bin,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 10
+	},
 /turf/open/floor/plasteel,
 /area/janitor)
 "fTp" = (
@@ -11311,9 +11314,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
 "fVQ" = (
-/obj/machinery/atmospherics/components/binary/valve{
-	name = "Steam Valve"
-	},
+/obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "fVV" = (
@@ -11352,12 +11353,10 @@
 /turf/open/floor/plating,
 /area/crew_quarters/abandoned_gambling_den)
 "fWv" = (
-/obj/structure/sign/poster/contraband/billyh{
-	pixel_y = 32
+/obj/machinery/atmospherics/components/binary/valve{
+	name = "Steam Valve"
 	},
-/turf/open/floor/plasteel/yellowsiding{
-	dir = 4
-	},
+/turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "fWw" = (
 /obj/structure/cable{
@@ -11465,14 +11464,14 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/engine/atmos)
 "fYw" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+/obj/structure/disposalpipe/segment{
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
+	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
@@ -11486,6 +11485,9 @@
 "fYV" = (
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
@@ -11503,10 +11505,11 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "fZk" = (
-/obj/structure/sink/well,
-/obj/machinery/light/floor/fakeday,
-/turf/open/floor/plating/ice/smooth,
-/area/icemoon/surface/outdoors)
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "fZs" = (
 /obj/effect/landmark/start/paramedic,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -11555,10 +11558,16 @@
 /turf/open/floor/wood,
 /area/hallway/primary/aft)
 "gbd" = (
-/obj/machinery/mineral/stacking_unit_console{
-	machinedir = 4
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "garbage"
 	},
-/turf/closed/wall,
+/obj/machinery/mineral/stacking_machine{
+	input_dir = 1;
+	stack_amt = 10
+	},
+/obj/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/maintenance/disposal)
 "gbF" = (
 /obj/machinery/keycard_auth{
@@ -11643,7 +11652,6 @@
 	name = "Station Intercom (General)";
 	pixel_y = -32
 	},
-/obj/structure/chair/stool,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/fitness)
 "geQ" = (
@@ -11685,7 +11693,6 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "gfB" = (
-/obj/machinery/rnd/production/techfab/department/security,
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -11693,6 +11700,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "gfC" = (
@@ -11973,7 +11981,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "gmO" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+/obj/machinery/atmospherics/components/unary/thermomachine/heater{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -12156,7 +12164,6 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/machinery/vending/security,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
 /area/security/main)
@@ -12338,6 +12345,9 @@
 /obj/structure/disposalpipe/junction/flip{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "gxc" = (
@@ -12473,7 +12483,9 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "gAA" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "gAC" = (
@@ -13047,12 +13059,8 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "gRM" = (
-/obj/effect/turf_decal/delivery,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/disposal)
+/turf/closed/wall/r_wall,
+/area/quartermaster/storage)
 "gRV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -13332,7 +13340,6 @@
 /obj/machinery/camera{
 	c_tag = "Arrivals South"
 	},
-/obj/machinery/vending/pdavendor,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "gXb" = (
@@ -13584,6 +13591,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/janitor)
 "hfb" = (
@@ -13715,6 +13725,9 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "hjc" = (
@@ -13732,6 +13745,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -14068,7 +14084,13 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "hsJ" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/machinery/portable_atmospherics/canister/water_vapor,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "hsX" = (
@@ -14180,6 +14202,9 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/janitor)
 "hwH" = (
@@ -14214,9 +14239,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
 "hxx" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "hxB" = (
@@ -14245,9 +14268,9 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "hyx" = (
-/obj/structure/punching_bag,
-/turf/open/floor/plasteel/grimy,
-/area/crew_quarters/fitness)
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "hyy" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -14289,12 +14312,12 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "hyT" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
+	},
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/maintenance/starboard/aft)
@@ -14340,9 +14363,6 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "hzR" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/brown,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
@@ -14452,11 +14472,11 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "hFc" = (
-/obj/machinery/atmospherics/pipe/simple{
-	dir = 9
-	},
 /obj/machinery/light/small{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/server)
@@ -14566,6 +14586,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
@@ -14821,7 +14844,6 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/structure/reagent_dispensers/water_cooler,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
 	},
@@ -15268,9 +15290,9 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "hYt" = (
-/obj/structure/chair/stool,
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/fitness)
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "hYA" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -15386,11 +15408,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "ibn" = (
@@ -15423,11 +15443,11 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/supermatter)
 "idr" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/brown,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "idZ" = (
@@ -15600,10 +15620,8 @@
 	dir = 4;
 	pixel_x = -26
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 6
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "iit" = (
@@ -15738,10 +15756,12 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "imQ" = (
-/turf/open/floor/plasteel/yellowsiding{
-	dir = 8
+/mob/living/simple_animal/opossum{
+	desc = "The Chaplain's pet, supposedly found somewhere in Maintenance badly hurt.";
+	name = "Crawls-The-Maint"
 	},
-/area/crew_quarters/fitness)
+/turf/open/floor/grass,
+/area/chapel/office)
 "imT" = (
 /obj/machinery/computer/mech_bay_power_console{
 	dir = 4
@@ -15772,15 +15792,16 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "ioq" = (
-/obj/effect/landmark/start/assistant,
+/obj/structure/weightmachine/weightlifter,
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/fitness)
 "ioG" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/light/floor/fakeday,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors)
 "ioL" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -16386,12 +16407,12 @@
 /turf/open/floor/plating,
 /area/science/research)
 "iGL" = (
-/obj/structure/cable{
-	icon_state = "0-8"
+/obj/machinery/light/floor/fakeday,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/obj/machinery/power/apc/auto_name/north,
-/turf/open/floor/plating,
-/area/quartermaster/storage)
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors)
 "iGT" = (
 /obj/structure/closet/secure_closet/bar{
 	req_access_txt = "25"
@@ -16994,9 +17015,6 @@
 /turf/open/floor/circuit,
 /area/science/misc_lab)
 "iZd" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 10
 	},
@@ -18042,8 +18060,10 @@
 "jzD" = (
 /obj/machinery/light,
 /obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk,
 /obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "jzH" = (
@@ -18116,6 +18136,9 @@
 "jBh" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "jCM" = (
@@ -18206,7 +18229,6 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/machinery/vending/wardrobe/sec_wardrobe,
 /obj/machinery/camera{
 	c_tag = "Security Office";
 	dir = 4
@@ -18448,11 +18470,12 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "jOi" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/light/floor/fakeday,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/hallway/secondary/entry)
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors)
 "jPM" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
@@ -18827,9 +18850,6 @@
 /turf/open/floor/plating,
 /area/engine/atmos)
 "keu" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 5
 	},
@@ -18969,6 +18989,9 @@
 "khl" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
@@ -20389,14 +20412,9 @@
 /turf/open/floor/plasteel,
 /area/medical/medbay/central)
 "kZf" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
+/obj/machinery/space_heater,
 /turf/open/floor/plating,
-/area/hallway/secondary/entry)
+/area/icemoon/surface/outdoors)
 "kZp" = (
 /obj/machinery/computer/communications,
 /obj/effect/turf_decal/tile/blue,
@@ -20750,17 +20768,9 @@
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
 "lkk" = (
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "garbage"
-	},
-/obj/machinery/mineral/stacking_machine{
-	input_dir = 1;
-	stack_amt = 10
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/maintenance/disposal)
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "lko" = (
 /obj/structure/table,
 /obj/item/cartridge/quartermaster{
@@ -21212,7 +21222,6 @@
 /turf/open/floor/plating,
 /area/bridge)
 "luM" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -21244,7 +21253,7 @@
 /area/engine/engineering)
 "luX" = (
 /obj/structure/closet/crate/coffin,
-/turf/open/floor/plasteel/freezer,
+/turf/open/floor/plasteel/showroomfloor,
 /area/chapel/office)
 "lvh" = (
 /obj/structure/cable{
@@ -21356,6 +21365,16 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "lxk" = (
@@ -21440,6 +21459,9 @@
 /area/crew_quarters/abandoned_gambling_den)
 "lAy" = (
 /obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "lAG" = (
@@ -21452,9 +21474,6 @@
 /area/engine/engineering)
 "lBa" = (
 /obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -21465,6 +21484,12 @@
 	},
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
@@ -21868,9 +21893,11 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "lMe" = (
-/obj/machinery/holopad,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/brig)
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "lMj" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/showroomfloor,
@@ -22871,10 +22898,7 @@
 /turf/open/floor/plating,
 /area/hydroponics)
 "mlW" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "mmw" = (
@@ -23223,8 +23247,15 @@
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat/hallway)
 "myU" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall,
+/obj/machinery/door/airlock/public/glass{
+	desc = "A great place to relax. No ERP.";
+	name = "Sauna"
+	},
+/obj/structure/fans/tiny,
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction/layer1{
+	dir = 1
+	},
+/turf/open/floor/wood,
 /area/crew_quarters/fitness)
 "mzb" = (
 /obj/effect/landmark/start/shaft_miner,
@@ -23509,7 +23540,6 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 8
 	},
@@ -23520,7 +23550,9 @@
 	dir = 4;
 	id = "garbage"
 	},
-/obj/structure/disposalpipe/trunk,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "mHY" = (
@@ -23949,12 +23981,9 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "mUw" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/brown,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "mUy" = (
@@ -24877,6 +24906,9 @@
 /obj/machinery/camera{
 	c_tag = "Custodial Quarters"
 	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/janitor)
 "nsu" = (
@@ -25015,11 +25047,10 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/crew_quarters/cryopod)
 "nxE" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/quartermaster/storage)
+/obj/machinery/light/floor/fakeday,
+/obj/structure/sink/well,
+/turf/open/floor/plating/ice/smooth,
+/area/icemoon/surface/outdoors)
 "nxJ" = (
 /obj/structure/sink{
 	dir = 8;
@@ -25531,6 +25562,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "nJN" = (
@@ -26272,7 +26304,7 @@
 /area/crew_quarters/bar)
 "oiu" = (
 /obj/structure/reagent_dispensers/water_cooler,
-/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/trimline/green/filled/corner,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "oiw" = (
@@ -26795,7 +26827,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/structure/closet/wardrobe/miner,
+/obj/structure/table,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
 "ovT" = (
@@ -27100,6 +27132,9 @@
 /area/engine/engineering)
 "oDl" = (
 /obj/effect/landmark/blobstart,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/science/server)
 "oDv" = (
@@ -27202,6 +27237,9 @@
 	},
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
@@ -27363,9 +27401,6 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "oJU" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -27659,11 +27694,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "oSj" = (
-/obj/structure/disposalpipe/junction/yjunction{
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
@@ -27796,7 +27831,8 @@
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "oWN" = (
-/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/structure/table/glass,
+/obj/structure/bedsheetbin/towel,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "oWS" = (
@@ -27845,14 +27881,11 @@
 	},
 /area/ai_monitored/turret_protected/ai)
 "oXf" = (
-/obj/machinery/atmospherics/pipe/manifold{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/server)
@@ -28061,11 +28094,6 @@
 	pixel_x = -8;
 	pixel_y = -25;
 	req_access_txt = "12"
-	},
-/obj/machinery/conveyor_switch/oneway{
-	dir = 8;
-	id = "garbage";
-	name = "disposal conveyor"
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
@@ -28329,7 +28357,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "piR" = (
@@ -28397,9 +28424,6 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "pkH" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/noticeboard{
 	pixel_y = 32
 	},
@@ -28415,6 +28439,9 @@
 /obj/effect/landmark/start/depsec/supply,
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
+	},
+/obj/structure/disposalpipe/junction/flip{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
@@ -29006,7 +29033,6 @@
 /turf/open/floor/wood,
 /area/crew_quarters/fitness)
 "pCY" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -29717,6 +29743,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "pWQ" = (
@@ -29955,6 +29982,9 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "qax" = (
@@ -30089,11 +30119,10 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "qet" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk,
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/machinery/vending/pdavendor,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "qey" = (
@@ -30255,14 +30284,12 @@
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "qhT" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/light/floor/fakeday,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/hallway/secondary/entry)
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors)
 "qhY" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
@@ -30304,14 +30331,12 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "qjk" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
+/obj/machinery/light/floor/fakeday,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plating,
-/area/hallway/secondary/entry)
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors)
 "qjw" = (
 /obj/machinery/light{
 	dir = 4
@@ -30441,7 +30466,7 @@
 /obj/machinery/shower{
 	dir = 4
 	},
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/showroomfloor/shower,
 /area/security/prison)
 "qmZ" = (
 /obj/effect/turf_decal/stripes/line{
@@ -31046,6 +31071,9 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 10
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "qHA" = (
@@ -31053,8 +31081,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "qIu" = (
-/turf/closed/mineral/random/snow/no_caves,
-/area/icemoon/surface/outdoors)
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "qIv" = (
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/bar)
@@ -31139,6 +31170,9 @@
 /area/science/robotics/lab)
 "qJB" = (
 /obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "qJV" = (
@@ -31355,6 +31389,10 @@
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "qOf" = (
@@ -31402,12 +31440,11 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "qOS" = (
-/obj/structure/chair/sofa/corp{
-	dir = 8;
-	pixel_x = 7
+/obj/machinery/light/small{
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer1{
-	dir = 10
+	dir = 4
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/fitness)
@@ -31747,6 +31784,7 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "qZg" = (
@@ -32147,7 +32185,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "rkD" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -32835,9 +32876,8 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "rDj" = (
-/turf/open/floor/plasteel/yellowsiding{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "rEe" = (
 /obj/machinery/pipedispenser,
@@ -33029,6 +33069,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/start/security_officer,
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "rJD" = (
@@ -33506,6 +33547,9 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "rWt" = (
@@ -33670,7 +33714,7 @@
 	desc = "A dumb hen, kept in the Brig to boost Prisoner morale... Mostly to make more mushroom wine.";
 	name = "Broiler"
 	},
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/showroomfloor/shower,
 /area/security/prison)
 "sbt" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
@@ -34400,9 +34444,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/open/floor/plasteel/yellowsiding{
-	dir = 8
-	},
+/turf/open/floor/plasteel/grimy,
 /area/crew_quarters/fitness)
 "sst" = (
 /obj/effect/landmark/event_spawn,
@@ -34545,11 +34587,11 @@
 /turf/closed/wall,
 /area/maintenance/starboard/aft)
 "swu" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/heater{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "swy" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -34924,9 +34966,6 @@
 /turf/open/floor/wood,
 /area/hallway/primary/aft)
 "sHm" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
@@ -35443,15 +35482,15 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "sWf" = (
-/obj/machinery/atmospherics/pipe/simple{
-	dir = 9
-	},
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -24
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/server)
@@ -35603,7 +35642,6 @@
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/maintenance/starboard/aft)
 "tad" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -35816,15 +35854,7 @@
 /area/science/robotics/mechbay)
 "tgF" = (
 /obj/vehicle/ridden/atv/snowmobile,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "tgL" = (
@@ -36212,9 +36242,9 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "tsf" = (
-/obj/machinery/space_heater,
+/obj/structure/trash_pile,
 /turf/open/floor/plating,
-/area/icemoon/surface/outdoors)
+/area/maintenance/starboard/aft)
 "tsl" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -36240,7 +36270,6 @@
 	},
 /obj/item/storage/book/bible,
 /obj/item/soulstone/anybody/chaplain,
-/obj/item/organ/heart,
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
 "tsO" = (
@@ -36363,14 +36392,12 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "twb" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/wood/normal{
+	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plating,
-/area/quartermaster/storage)
+/turf/open/floor/wood,
+/area/maintenance/bar)
 "tws" = (
 /obj/machinery/computer/prisoner/management{
 	dir = 8
@@ -36478,7 +36505,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/mineral/equipment_vendor,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
 "tzr" = (
@@ -37337,14 +37363,9 @@
 	},
 /area/hallway/secondary/exit/departure_lounge)
 "tTP" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/obj/item/chair/wood,
+/turf/open/floor/wood,
+/area/maintenance/bar)
 "tTY" = (
 /obj/effect/turf_decal/vg_decals/atmos/air,
 /obj/machinery/light/small{
@@ -37687,9 +37708,6 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "udK" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -37699,6 +37717,9 @@
 	},
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 5
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
@@ -38279,7 +38300,6 @@
 /area/crew_quarters/abandoned_gambling_den)
 "uuo" = (
 /obj/machinery/airalarm/directional/east,
-/obj/machinery/space_heater,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "uuA" = (
@@ -38658,6 +38678,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "uDR" = (
@@ -38953,6 +38974,7 @@
 	req_access_txt = "50"
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "uLk" = (
@@ -39742,6 +39764,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "viq" = (
@@ -39833,6 +39858,9 @@
 /obj/structure/punching_bag,
 /obj/machinery/airalarm{
 	pixel_y = 23
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/janitor)
@@ -39978,11 +40006,8 @@
 /turf/open/floor/plasteel,
 /area/medical/sleeper)
 "vnp" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors/unexplored/rivers/no_monsters)
 "vnV" = (
 /obj/item/kirbyplants/photosynthetic,
 /obj/item/radio/intercom{
@@ -41259,9 +41284,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "wat" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -41272,7 +41294,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "wax" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -41387,9 +41408,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "wdH" = (
-/obj/structure/disposalpipe/segment,
-/turf/closed/wall/r_wall,
-/area/quartermaster/qm)
+/obj/effect/spawner/blocker,
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "wes" = (
 /obj/machinery/button/door{
 	id = "LockerShitter2";
@@ -41448,14 +41470,10 @@
 /turf/open/floor/plasteel/white,
 /area/maintenance/starboard/aft)
 "wga" = (
-/obj/vehicle/ridden/atv/snowmobile,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/vehicle/ridden/atv/snowmobile{
 	dir = 1
 	},
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "wgj" = (
@@ -42461,10 +42479,10 @@
 /turf/open/floor/carpet,
 /area/hallway/primary/aft)
 "wIY" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 9
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "wJq" = (
@@ -42583,6 +42601,10 @@
 /obj/machinery/space_heater,
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
+	},
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable{
+	icon_state = "0-8"
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
@@ -42709,15 +42731,9 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
 "wRw" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/maintenance{
-	name = "Cargo Bay Maintenance";
-	req_access_txt = "31"
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
-/area/quartermaster/storage)
+/area/maintenance/starboard/aft)
 "wRI" = (
 /obj/effect/turf_decal/stripes,
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_toxmix{
@@ -43435,11 +43451,6 @@
 /turf/open/floor/plasteel,
 /area/bridge)
 "xiU" = (
-/obj/structure/closet/crate/secure/weapon{
-	desc = "A secure clothing crate.";
-	name = "formal uniform crate";
-	req_access = "3"
-	},
 /obj/machinery/airalarm{
 	dir = 4;
 	pixel_x = -22
@@ -43452,6 +43463,16 @@
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
+	},
+/obj/structure/closet/crate{
+	desc = "A rectangular steel crate designated for carrying a fair amount of sandbags in the inevitable case of martial law.";
+	name = "Sandbag Crate"
+	},
+/obj/item/stack/sheet/mineral/sandbags{
+	amount = 50
+	},
+/obj/item/stack/sheet/mineral/sandbags{
+	amount = 50
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -43503,9 +43524,10 @@
 /turf/open/floor/plating,
 /area/crew_quarters/abandoned_gambling_den)
 "xlo" = (
-/turf/open/floor/plasteel/yellowsiding/corner{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
 	},
+/turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "xlx" = (
 /obj/machinery/status_display/evac{
@@ -43758,10 +43780,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -44576,8 +44595,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
@@ -45384,9 +45403,9 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "yhF" = (
-/obj/machinery/computer/security/telescreen/engine{
+/obj/machinery/airalarm{
 	dir = 8;
-	pixel_x = 30
+	pixel_x = 23
 	},
 /turf/open/floor/carpet/orange,
 /area/engine/engineering)
@@ -45627,9 +45646,9 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 jsJ
 pxz
 gOS
@@ -45884,9 +45903,9 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -46129,21 +46148,21 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -46258,11 +46277,11 @@ pxz
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -46384,24 +46403,24 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 uSY
 jsJ
@@ -46511,21 +46530,21 @@ cyH
 jsJ
 cyH
 jsJ
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 uSY
 jsJ
 jsJ
@@ -46640,25 +46659,25 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -46766,27 +46785,27 @@ uSY
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -46872,6 +46891,41 @@ jsJ
 kgx
 jsJ
 jsJ
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+kSg
+kSg
+kSg
+kSg
+kSg
+kSg
+kSg
 kSg
 rMm
 rMm
@@ -46882,41 +46936,6 @@ rMm
 rMm
 rMm
 rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rLU
-rLU
-rLU
-kSg
-kSg
-kSg
-kSg
-kSg
-kSg
-kSg
-kSg
-rLU
-rLU
-rLU
-rMm
-rMm
-rMm
-rLU
-rLU
-rLU
 jsJ
 jsJ
 tXu
@@ -47129,6 +47148,42 @@ jsJ
 jsJ
 jsJ
 rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+kSg
+kSg
+kSg
+kSg
+kSg
+kSg
+kSg
+kSg
+kSg
+kSg
 kSg
 rMm
 rMm
@@ -47139,42 +47194,6 @@ rMm
 rMm
 rMm
 rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-kSg
-kSg
-kSg
-kSg
-kSg
-kSg
-kSg
-kSg
-kSg
-kSg
-kSg
-rLU
-rLU
-rLU
-rLU
-rMm
-rMm
-rLU
-rLU
-rLU
 jsJ
 jsJ
 jsJ
@@ -47386,8 +47405,6 @@ jsJ
 kgx
 jsJ
 rMm
-kSg
-kSg
 rMm
 rMm
 rMm
@@ -47411,16 +47428,11 @@ rMm
 rMm
 rMm
 rMm
-kSg
-kSg
-kSg
+rMm
+rMm
 kSg
 kSg
 kSg
-rLU
-rLU
-rLU
-rLU
 kSg
 kSg
 kSg
@@ -47428,10 +47440,17 @@ rLU
 rLU
 rLU
 rLU
-rLU
-rLU
-rLU
-rLU
+kSg
+kSg
+kSg
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 uSY
@@ -47469,11 +47488,11 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -47644,15 +47663,15 @@ jsJ
 jsJ
 rMm
 rMm
-kSg
-kSg
-kSg
-kSg
-kSg
-kSg
-kSg
-kSg
-kSg
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -47682,11 +47701,11 @@ rLU
 kSg
 kSg
 kSg
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -47725,15 +47744,15 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -47909,13 +47928,13 @@ rMm
 rMm
 rMm
 rMm
-kSg
-kSg
-kSg
-kSg
-kSg
-kSg
-kSg
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -47941,8 +47960,8 @@ srK
 kSg
 kSg
 kSg
-rLU
-rLU
+rMm
+rMm
 kSg
 jsJ
 jsJ
@@ -47981,27 +48000,27 @@ jsJ
 kgx
 jsJ
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -48172,10 +48191,10 @@ rMm
 rMm
 rMm
 rMm
-kSg
-kSg
-kSg
-kSg
+rMm
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -48238,31 +48257,31 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -48432,10 +48451,10 @@ rMm
 rMm
 rMm
 rMm
-kSg
-kSg
-kSg
-kSg
+rMm
+rMm
+rMm
+rMm
 rMm
 rMm
 kSg
@@ -48494,9 +48513,6 @@ jsJ
 jsJ
 uSY
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -48505,24 +48521,27 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -48692,8 +48711,8 @@ rMm
 rMm
 rMm
 rMm
-kSg
-kSg
+rMm
+rMm
 kSg
 kSg
 kSg
@@ -48750,9 +48769,6 @@ jsJ
 jsJ
 kgx
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -48773,15 +48789,18 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -48985,31 +49004,28 @@ piz
 gzo
 gzo
 gzo
-sdw
+fiM
 gzo
 gzo
-sdw
-gzo
-gzo
-sdw
-gzo
-gzo
-piz
-gzo
-gzo
-sdw
+fiM
 gzo
 gzo
 sdw
 gzo
 gzo
 piz
+gzo
+gzo
+fiM
+gzo
+gzo
+fiM
+gzo
+gzo
+piz
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -49034,14 +49050,17 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -49264,9 +49283,6 @@ gzo
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -49294,16 +49310,19 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -49520,10 +49539,6 @@ kSg
 gzo
 jsJ
 jsJ
-rLU
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -49553,14 +49568,18 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -49752,7 +49771,7 @@ jsJ
 jsJ
 jsJ
 jsJ
-sdw
+fiM
 kSg
 kSg
 kSg
@@ -49774,13 +49793,9 @@ kSg
 kSg
 kSg
 kSg
-sdw
+fiM
 jsJ
 jsJ
-rLU
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -49813,11 +49828,15 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
 eXj
@@ -50034,10 +50053,6 @@ kSg
 gzo
 jsJ
 jsJ
-rLU
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -50070,9 +50085,13 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
 eXj
@@ -50291,10 +50310,6 @@ kSg
 gzo
 jsJ
 jsJ
-rLU
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -50327,9 +50342,13 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
 kSg
@@ -50523,7 +50542,7 @@ srK
 srK
 srK
 jsJ
-sdw
+fiM
 kSg
 kSg
 kSg
@@ -50545,13 +50564,9 @@ kSg
 kSg
 kSg
 kSg
-sdw
+fiM
 jsJ
 jsJ
-rLU
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -50584,9 +50599,13 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
 kSg
@@ -50805,10 +50824,6 @@ kSg
 gzo
 jsJ
 jsJ
-rLU
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -50841,9 +50856,13 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
 kSg
@@ -51063,9 +51082,6 @@ gzo
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -51097,9 +51113,12 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 eXj
 kSg
@@ -51278,7 +51297,7 @@ mcL
 fsY
 wIY
 gwA
-uJE
+fcl
 nGV
 vUF
 srl
@@ -51294,7 +51313,7 @@ nGV
 jZU
 srK
 jsJ
-sdw
+fiM
 kSg
 kSg
 kSg
@@ -51316,13 +51335,10 @@ kSg
 kSg
 kSg
 kSg
-sdw
+fiM
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -51354,9 +51370,12 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
 rMm
@@ -51527,7 +51546,7 @@ rLU
 rLU
 rLU
 mLE
-ahW
+dFw
 qza
 qWl
 iDz
@@ -51577,9 +51596,6 @@ gzo
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -51611,9 +51627,12 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
 rMm
@@ -51834,9 +51853,6 @@ gzo
 jsJ
 kgx
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -51867,9 +51883,12 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 eXj
 kSg
@@ -52069,7 +52088,7 @@ piz
 gzo
 gzo
 gzo
-sdw
+fiM
 gzo
 gzo
 dwP
@@ -52092,9 +52111,6 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -52124,9 +52140,12 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
 kSg
@@ -52349,9 +52368,6 @@ jsJ
 tXu
 jsJ
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -52381,9 +52397,12 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
 rMm
@@ -52607,9 +52626,6 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -52630,17 +52646,20 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 eXj
 kSg
 rMm
@@ -52865,9 +52884,6 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -52885,18 +52901,21 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
 kSg
@@ -53122,9 +53141,6 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -53141,17 +53157,20 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -53379,17 +53398,6 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
-rMm
-rMm
-rMm
-rMm
-rLU
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -53398,15 +53406,26 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -53636,17 +53655,6 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
-rMm
-rMm
-rMm
-rLU
-rLU
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
@@ -53655,8 +53663,19 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -53892,28 +53911,28 @@ ahd
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
-rMm
-rMm
-rMm
-rMm
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -54149,28 +54168,28 @@ ahd
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
-rMm
-rMm
-rMm
-rLU
-rLU
-kSg
-kSg
-rLU
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -54358,7 +54377,7 @@ rvq
 rvq
 rvq
 iUa
-dFw
+rvq
 gKa
 fFH
 lMG
@@ -54406,28 +54425,28 @@ ahd
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-jsJ
-jsJ
-jsJ
-jsJ
-jsJ
-rLU
-rLU
-rLU
 rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -54664,26 +54683,26 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-jsJ
-jsJ
-jsJ
-jsJ
-jsJ
-kSg
-rLU
-rLU
 rMm
 rMm
 rMm
 rMm
-rLU
-rLU
+rMm
+rMm
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 jsJ
 jsJ
@@ -54922,10 +54941,10 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
 kSg
 bCe
 jsJ
@@ -54933,14 +54952,14 @@ jsJ
 jsJ
 bCe
 jsJ
-rLU
-rLU
-rLU
-rLU
 rMm
 rMm
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 jsJ
 jsJ
@@ -55127,7 +55146,7 @@ kSg
 nuJ
 mUy
 mUB
-lMe
+rvq
 rvq
 rvq
 gKa
@@ -55181,23 +55200,23 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-jsJ
-jsJ
-jsJ
-jsJ
-jsJ
-jsJ
-jsJ
-jsJ
-kSg
-kSg
-rLU
-rLU
 rMm
-rLU
-rLU
-rLU
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 kgx
 jsJ
@@ -55447,15 +55466,15 @@ kgx
 jsJ
 jsJ
 jsJ
-kSg
-kSg
-rLU
-rLU
-rLU
-rLU
-rLU
-kSg
-kSg
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 jsJ
 jsJ
@@ -55705,14 +55724,14 @@ jsJ
 jsJ
 jsJ
 jsJ
-kSg
-kSg
-kSg
-rLU
-rLU
-rLU
-kSg
-kSg
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 jsJ
 jsJ
@@ -55962,15 +55981,15 @@ jsJ
 jsJ
 kgx
 jsJ
-kSg
-kSg
-kSg
-rLU
-kSg
-kSg
-kSg
-kSg
-kSg
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -56219,15 +56238,15 @@ kgx
 jsJ
 jsJ
 jsJ
-kSg
-kSg
-kSg
-kSg
-kSg
-rLU
-rLU
-kSg
-kSg
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
 jsJ
@@ -56475,16 +56494,16 @@ jsJ
 jsJ
 jsJ
 jsJ
-kSg
-kSg
-kSg
-kSg
-rLU
-rLU
-rLU
-rLU
-rLU
-kSg
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 kgx
@@ -56732,16 +56751,16 @@ jsJ
 nSm
 jsJ
 jsJ
-kSg
-kSg
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -56989,16 +57008,16 @@ kgx
 jsJ
 jsJ
 kgx
-kSg
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -57245,17 +57264,17 @@ jsJ
 jsJ
 jsJ
 jsJ
-kSg
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -57284,7 +57303,7 @@ kgx
 bNT
 jsJ
 jsJ
-sfb
+nxE
 ayN
 sfb
 jsJ
@@ -57502,17 +57521,17 @@ kgx
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -57542,7 +57561,7 @@ cyH
 jsJ
 jsJ
 sfb
-fZk
+sfb
 sfb
 sfb
 jsJ
@@ -57759,17 +57778,17 @@ jsJ
 jsJ
 kgx
 jsJ
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -58016,18 +58035,18 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 cyH
@@ -58273,20 +58292,20 @@ kgx
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-qIu
-qIu
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+beO
+beO
 kSg
 jsJ
 jsJ
@@ -58530,21 +58549,21 @@ cyH
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-kSg
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+vnp
 kgx
 jsJ
 jsJ
@@ -58788,20 +58807,20 @@ jsJ
 kgx
 jsJ
 jsJ
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -59042,24 +59061,24 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 cyH
 jsJ
 jsJ
@@ -59088,7 +59107,7 @@ rMm
 rMm
 rMm
 rMm
-jrH
+rMm
 rMm
 rMm
 rMm
@@ -59298,28 +59317,28 @@ jsJ
 cyH
 jsJ
 jsJ
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 kgx
 cyH
@@ -59345,9 +59364,6 @@ rMm
 rMm
 rMm
 rMm
-jrH
-jrH
-kSg
 rMm
 rMm
 rMm
@@ -59376,7 +59392,10 @@ rMm
 rMm
 rMm
 rMm
-rLU
+rMm
+rMm
+rMm
+rMm
 ioQ
 ioQ
 ioQ
@@ -59554,30 +59573,30 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 pxz
 jsJ
 jsJ
@@ -59603,10 +59622,6 @@ rMm
 rMm
 rMm
 rMm
-kSg
-kSg
-kSg
-kSg
 rMm
 rMm
 rMm
@@ -59631,9 +59646,13 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 ioQ
 ioQ
@@ -59811,30 +59830,30 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -59862,11 +59881,6 @@ rMm
 rMm
 rMm
 rMm
-kSg
-kSg
-eXj
-kSg
-kSg
 rMm
 rMm
 rMm
@@ -59888,9 +59902,14 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 ioQ
 ioQ
@@ -60067,31 +60086,31 @@ rLU
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -60121,10 +60140,6 @@ rMm
 rMm
 rMm
 rMm
-kSg
-kSg
-kSg
-kSg
 rMm
 rMm
 rMm
@@ -60144,9 +60159,13 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 ioQ
@@ -60324,30 +60343,30 @@ rLU
 pxz
 jsJ
 jsJ
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 cyH
 jsJ
 jsJ
@@ -60380,12 +60399,6 @@ rMm
 rMm
 rMm
 rMm
-eXj
-kSg
-kSg
-eXj
-kSg
-kSg
 rMm
 rMm
 rMm
@@ -60401,9 +60414,15 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 ioQ
@@ -60581,30 +60600,30 @@ cyH
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -60638,12 +60657,6 @@ rMm
 rMm
 rMm
 rMm
-kSg
-kSg
-kSg
-kSg
-jrH
-jrH
 rMm
 rMm
 rMm
@@ -60658,9 +60671,15 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 ioQ
@@ -60839,29 +60858,29 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kgx
 jsJ
 jsJ
@@ -60900,7 +60919,6 @@ rMm
 rMm
 rMm
 rMm
-jrH
 rMm
 rMm
 rMm
@@ -60915,9 +60933,10 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 ioQ
@@ -61096,36 +61115,36 @@ kSg
 kgx
 jsJ
 jsJ
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 rLU
 rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-kSg
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
-jsJ
-kgx
 jsJ
 jsJ
 kgx
+jsJ
+jsJ
+kgx
 rMm
 rMm
 rMm
@@ -61157,7 +61176,6 @@ rMm
 rMm
 rMm
 rMm
-kSg
 rMm
 rMm
 rMm
@@ -61171,9 +61189,10 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -61354,8 +61373,8 @@ jsJ
 jsJ
 ujh
 jsJ
-rLU
-rLU
+rMm
+rMm
 rLU
 rLU
 rLU
@@ -61372,15 +61391,15 @@ hoF
 hoF
 hoF
 hoF
-rLU
-rLU
-rLU
-rLU
-rLU
-kSg
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
-kSg
+jsJ
+jsJ
 rMm
 rMm
 rMm
@@ -61414,9 +61433,6 @@ rMm
 rMm
 rMm
 rMm
-kSg
-kSg
-kSg
 rMm
 rMm
 rMm
@@ -61428,9 +61444,12 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 tXu
 jsJ
@@ -61629,50 +61648,13 @@ oRh
 hIp
 piR
 hoF
-rLU
-rLU
-rLU
-rLU
-rLU
-kSg
-kSg
-kSg
 rMm
 rMm
 rMm
 rMm
 rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-kSg
+jsJ
+jsJ
 kSg
 kSg
 rMm
@@ -61684,9 +61666,46 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -61886,13 +61905,15 @@ nSd
 jse
 oiJ
 hoF
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
-xlg
+kSg
 kSg
 rMm
 rMm
@@ -61930,8 +61951,6 @@ rMm
 rMm
 rMm
 rMm
-eXj
-kSg
 rMm
 rMm
 rMm
@@ -61941,9 +61960,9 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -62143,41 +62162,6 @@ jhm
 lus
 yis
 hoF
-rLU
-rLU
-rLU
-rLU
-eXj
-kSg
-kSg
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
 rMm
 rMm
 rMm
@@ -62188,19 +62172,54 @@ rMm
 rMm
 rMm
 kSg
-kSg
-kSg
-kSg
-kSg
 rMm
 rMm
 rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 kgx
@@ -62400,45 +62419,6 @@ nSd
 tJR
 nSd
 hoF
-rLU
-rLU
-rLU
-rLU
-kSg
-kSg
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
 rMm
 rMm
 rMm
@@ -62449,15 +62429,54 @@ rMm
 rMm
 rMm
 kSg
+kSg
 rMm
 rMm
 rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -62657,45 +62676,6 @@ nSd
 kRZ
 ryK
 hoF
-rLU
-rLU
-rLU
-kSg
-kSg
-kSg
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
 rMm
 rMm
 rMm
@@ -62706,15 +62686,54 @@ rMm
 rMm
 rMm
 kSg
+kSg
 rMm
 rMm
 rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 tXu
 jsJ
 jsJ
@@ -62914,45 +62933,6 @@ cyI
 xCI
 taq
 hoF
-rLU
-rLU
-rLU
-kSg
-kSg
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
 rMm
 rMm
 rMm
@@ -62963,14 +62943,53 @@ rMm
 rMm
 rMm
 kSg
+kSg
 rMm
 rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -63171,11 +63190,17 @@ cyI
 jse
 lus
 hoF
-rLU
-rLU
-lDG
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
-kSg
 rMm
 rMm
 rMm
@@ -63219,15 +63244,9 @@ rMm
 rMm
 rMm
 rMm
-eXj
 rMm
 rMm
 rMm
-rMm
-rMm
-rLU
-rLU
-rLU
 cyH
 jsJ
 jsJ
@@ -63428,43 +63447,6 @@ cyI
 jse
 tJR
 hoF
-rLU
-rLU
-kSg
-kSg
-eXj
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
 rMm
 rMm
 rMm
@@ -63482,9 +63464,46 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 kgx
@@ -63685,41 +63704,6 @@ cyI
 jse
 kRZ
 hoF
-rLU
-rLU
-kSg
-kSg
-kSg
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
 rMm
 rMm
 rMm
@@ -63732,15 +63716,50 @@ rMm
 rMm
 rMm
 kSg
-kSg
 rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -63939,44 +63958,9 @@ aTI
 pbf
 cyI
 peb
-jse
+twb
 tuT
 hoF
-rLU
-rLU
-kSg
-kSg
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
 rMm
 rMm
 rMm
@@ -63993,11 +63977,46 @@ kSg
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -64195,14 +64214,24 @@ hoF
 ifI
 kaP
 jse
-ecF
+nSd
 nCM
-fCG
+nSd
 hoF
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
+kSg
 rMm
 rMm
 rMm
@@ -64245,16 +64274,6 @@ rMm
 rMm
 rMm
 rMm
-jrH
-jrH
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
 jsJ
 jsJ
 gna
@@ -64453,12 +64472,22 @@ aKn
 jse
 jse
 mIh
-nSd
+tTP
 poN
 hoF
-rLU
-rLU
-xlg
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 rMm
 rMm
@@ -64493,16 +64522,6 @@ rMm
 rMm
 rMm
 rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-jrH
 jsJ
 jsJ
 jsJ
@@ -64713,21 +64732,21 @@ hoF
 jgd
 hoF
 hoF
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
-kSg
-kSg
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
 rMm
 rMm
 rMm
@@ -64969,24 +64988,24 @@ lDG
 kSg
 kSg
 kSg
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
 kSg
-kSg
-kSg
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
 rMm
 rMm
 rMm
@@ -65243,8 +65262,8 @@ rMm
 rMm
 rMm
 rMm
-rMm
-rMm
+kSg
+kSg
 rMm
 rMm
 rMm
@@ -65398,7 +65417,7 @@ cyH
 jsJ
 jsJ
 jsJ
-uUy
+jsJ
 jsJ
 jsJ
 jsJ
@@ -65500,8 +65519,8 @@ rMm
 rMm
 rMm
 rMm
-rMm
-rMm
+kSg
+kSg
 rMm
 rMm
 rMm
@@ -65533,13 +65552,13 @@ jsJ
 cyH
 jsJ
 jsJ
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -65723,9 +65742,9 @@ jsJ
 kgv
 rLU
 rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 hoF
 hoF
 hoF
@@ -65757,8 +65776,8 @@ rMm
 rMm
 rMm
 rMm
-rMm
-rMm
+kSg
+kSg
 rMm
 rMm
 rMm
@@ -65787,18 +65806,18 @@ jsJ
 tXu
 jsJ
 jsJ
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -65979,10 +65998,10 @@ cXC
 jrH
 cXC
 cXC
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
 hoF
 biv
 nSd
@@ -66014,9 +66033,9 @@ rMm
 rMm
 rMm
 rMm
-rMm
-rMm
-rMm
+kSg
+kSg
+kSg
 rMm
 rMm
 rMm
@@ -66041,22 +66060,22 @@ jsJ
 kgx
 jsJ
 cyH
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -66234,12 +66253,12 @@ rLU
 rLU
 kSg
 kSg
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 hoF
 uXU
 cih
@@ -66256,24 +66275,24 @@ kSg
 kSg
 xlg
 kSg
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
-rMm
+jsJ
+jsJ
+jsJ
 rMm
 rMm
 rMm
@@ -66311,10 +66330,10 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -66491,12 +66510,12 @@ kSg
 kSg
 kSg
 kSg
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 hoF
 hoF
 hoF
@@ -66513,7 +66532,6 @@ kSg
 kSg
 kSg
 kSg
-kSg
 rMm
 rMm
 rMm
@@ -66527,11 +66545,12 @@ rMm
 rMm
 rMm
 rMm
-rMm
-rMm
-rMm
-rMm
-rMm
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
+jsJ
 jsJ
 jsJ
 jsJ
@@ -66569,9 +66588,9 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -66746,18 +66765,18 @@ kSg
 kSg
 kSg
 kSg
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 lDG
 kSg
 kSg
@@ -66769,7 +66788,7 @@ kSg
 kSg
 kSg
 kSg
-kSg
+rMm
 rMm
 rMm
 rMm
@@ -66827,9 +66846,9 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -67001,19 +67020,19 @@ kSg
 kSg
 kSg
 kSg
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 hoF
 hoF
 fML
@@ -67024,8 +67043,8 @@ hoF
 fML
 hoF
 hoF
-kSg
-kSg
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -67085,10 +67104,10 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -67257,20 +67276,20 @@ dwo
 kSg
 kSg
 kSg
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 hoF
 tuO
 jse
@@ -67281,8 +67300,8 @@ hoF
 jse
 jse
 hoF
-eXj
-kSg
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -67343,11 +67362,11 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
 jsJ
 jsJ
 jsJ
@@ -67457,7 +67476,7 @@ rMm
 rMm
 jsJ
 jsJ
-jsJ
+aaz
 jsJ
 uSN
 qfL
@@ -67514,35 +67533,35 @@ dwo
 kSg
 kSg
 kSg
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 hoF
 oGh
 jse
 hoF
 kSg
-rLU
+rMm
 hoF
 cEB
 vZP
 hoF
+rMm
+rMm
+rMm
+rMm
 kSg
-kSg
-rMm
-rMm
-kSg
 jsJ
 jsJ
 jsJ
@@ -67601,12 +67620,12 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 rMm
 jsJ
 jsJ
@@ -67772,32 +67791,32 @@ kSg
 xlg
 kSg
 kSg
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 hoF
 hoF
 hoF
 hoF
-rLU
-rLU
+rMm
+rMm
 hoF
 hoF
 hoF
 hoF
-kSg
-jrH
-jrH
+rMm
+rMm
+rMm
 kSg
 kSg
 kSg
@@ -67860,9 +67879,9 @@ rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 jsJ
@@ -68029,34 +68048,34 @@ kSg
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-kSg
-kSg
 rMm
-jrH
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+kSg
 eXj
-rMm
+kSg
 rMm
 rMm
 rMm
@@ -68288,32 +68307,32 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 eXj
 kSg
 rMm
 rMm
-rMm
-rMm
-rMm
+kSg
+kSg
+kSg
 rMm
 rMm
 rMm
@@ -68546,30 +68565,30 @@ jsJ
 kgx
 jsJ
 jsJ
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-kSg
-kSg
-kSg
-kSg
-kSg
-kSg
 rMm
 rMm
 rMm
 rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+kSg
+kSg
+kSg
+kSg
+kSg
+kSg
+kSg
+kSg
+kSg
+kSg
 rMm
 rMm
 rMm
@@ -68805,15 +68824,15 @@ jsJ
 jsJ
 cyH
 jsJ
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
 kSg
@@ -68823,9 +68842,9 @@ kSg
 kSg
 kSg
 eXj
-rMm
-rMm
-rMm
+kSg
+kSg
+kSg
 rMm
 rMm
 rMm
@@ -69063,10 +69082,10 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
 kSg
 eXj
 kSg
@@ -69081,7 +69100,7 @@ xyr
 xyr
 kSg
 kSg
-rMm
+kSg
 rMm
 rMm
 rMm
@@ -71663,21 +71682,21 @@ fzW
 fYi
 fYi
 knp
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -71928,13 +71947,13 @@ oLx
 oLx
 oLx
 oLx
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -72193,8 +72212,8 @@ oLx
 oLx
 oLx
 oLx
-rLU
-rLU
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -72452,7 +72471,7 @@ oLx
 oLx
 oLx
 oLx
-rLU
+rMm
 rMm
 rMm
 rMm
@@ -72710,7 +72729,7 @@ sya
 oLx
 oLx
 oLx
-rLU
+rMm
 rMm
 rMm
 rMm
@@ -72968,7 +72987,7 @@ sya
 oLx
 oLx
 oLx
-rLU
+rMm
 rMm
 rMm
 rMm
@@ -73226,7 +73245,7 @@ sya
 oLx
 oLx
 oLx
-rLU
+rMm
 rMm
 rMm
 rMm
@@ -73484,7 +73503,7 @@ sya
 oLx
 oLx
 oLx
-rLU
+rMm
 rMm
 rMm
 rMm
@@ -74706,7 +74725,7 @@ jsJ
 kSg
 pLE
 tgF
-tTP
+iHn
 wga
 pLE
 bIb
@@ -75221,7 +75240,7 @@ oqk
 pLE
 uhX
 gFu
-iHn
+lkk
 pLE
 bBJ
 omn
@@ -76249,7 +76268,7 @@ hXj
 pLE
 sar
 iHn
-hrP
+lMe
 pLE
 bBJ
 tYo
@@ -76762,8 +76781,8 @@ kSg
 xBg
 pLE
 jZr
-jZr
-jZr
+iHn
+hrP
 pLE
 bBJ
 tYo
@@ -77082,7 +77101,7 @@ sya
 sya
 oLx
 oLx
-rLU
+rMm
 rMm
 rMm
 rMm
@@ -77338,9 +77357,9 @@ sya
 sya
 oLx
 oLx
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -77595,12 +77614,12 @@ viN
 viN
 viN
 viN
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -77855,11 +77874,11 @@ gOO
 beu
 uea
 uea
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -78115,9 +78134,9 @@ dfd
 uea
 uea
 uea
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -78374,8 +78393,8 @@ viN
 uea
 uea
 uea
-rLU
-rLU
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -78555,7 +78574,7 @@ rLU
 kSg
 kSg
 kSg
-kSg
+xBg
 kSg
 rLU
 sws
@@ -78632,8 +78651,8 @@ viN
 cOA
 uea
 uea
-rLU
-rLU
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -78799,7 +78818,7 @@ rLU
 rLU
 rLU
 tXu
-jsJ
+kSg
 kSg
 kSg
 kSg
@@ -78808,8 +78827,8 @@ rLU
 rLU
 rLU
 rLU
-jsJ
-jsJ
+kSg
+kSg
 kSg
 kSg
 kSg
@@ -78889,8 +78908,8 @@ yiI
 mMj
 uea
 uea
-rLU
-rLU
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -79056,7 +79075,7 @@ quB
 jsJ
 jsJ
 jsJ
-jsJ
+kSg
 kSg
 kSg
 hCt
@@ -79065,9 +79084,9 @@ rLU
 rLU
 rLU
 rLU
-jsJ
-jsJ
-kgx
+kSg
+kSg
+kSg
 kSg
 rLU
 rLU
@@ -79146,8 +79165,8 @@ viN
 cOA
 uea
 uea
-rLU
-rLU
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -79313,7 +79332,7 @@ quB
 quB
 jsJ
 jsJ
-jsJ
+kSg
 kSg
 tTD
 kSg
@@ -79322,10 +79341,10 @@ kSg
 rLU
 rLU
 kSg
-jsJ
-jsJ
-jsJ
-jsJ
+kSg
+kSg
+kSg
+kSg
 rLU
 rLU
 fem
@@ -79402,8 +79421,8 @@ viN
 izv
 uea
 uea
-rLU
-rLU
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -79570,8 +79589,8 @@ jsJ
 rLU
 rLU
 jsJ
-cyH
-jsJ
+xlg
+kSg
 kSg
 kSg
 kSg
@@ -79579,9 +79598,9 @@ jrH
 jrH
 kSg
 kSg
-jsJ
-jsJ
-jsJ
+kSg
+kSg
+kSg
 rLU
 rLU
 rLU
@@ -79649,17 +79668,17 @@ sya
 sya
 oLx
 oLx
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 uea
 uea
 uea
-rLU
-rLU
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -79827,8 +79846,8 @@ jsJ
 rLU
 rLU
 rLU
-jsJ
-jsJ
+kSg
+kSg
 rLU
 rLU
 rLU
@@ -79836,9 +79855,9 @@ jrH
 kSg
 kSg
 kSg
-jsJ
-jsJ
-pxz
+kSg
+kSg
+jnH
 rLU
 rLU
 sPD
@@ -79906,16 +79925,16 @@ sya
 sya
 oLx
 oLx
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -80084,7 +80103,7 @@ jsJ
 rLU
 rLU
 rLU
-jsJ
+kSg
 tXu
 rLU
 rLU
@@ -80092,10 +80111,10 @@ rLU
 rLU
 rLU
 kSg
-jsJ
-jsJ
-jsJ
-jsJ
+kSg
+kSg
+kSg
+kSg
 rLU
 rLU
 sPD
@@ -80163,15 +80182,15 @@ sya
 sya
 oLx
 oLx
-rLU
-rLU
 rMm
 rMm
 rMm
 rMm
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -80349,10 +80368,10 @@ rLU
 rLU
 rLU
 rLU
-jsJ
-jsJ
-jsJ
-jsJ
+kSg
+kSg
+kSg
+kSg
 rLU
 rLU
 sPD
@@ -80420,7 +80439,7 @@ sya
 sya
 oLx
 oLx
-rLU
+rMm
 rMm
 rMm
 rMm
@@ -80607,9 +80626,9 @@ rLU
 rLU
 rLU
 rLU
-jsJ
-jsJ
-jsJ
+kSg
+kSg
+kSg
 rLU
 rLU
 rLU
@@ -80677,7 +80696,7 @@ sya
 sya
 oLx
 oLx
-rLU
+rMm
 rMm
 rMm
 rMm
@@ -80864,9 +80883,9 @@ rLU
 rLU
 rLU
 rLU
-jsJ
-jsJ
-jsJ
+kSg
+kSg
+kSg
 rLU
 rLU
 rLU
@@ -80934,7 +80953,7 @@ sya
 sya
 oLx
 oLx
-rLU
+rMm
 rMm
 rMm
 rMm
@@ -81121,9 +81140,9 @@ rLU
 rLU
 rLU
 jsJ
-jsJ
-jsJ
-jsJ
+kSg
+kSg
+kSg
 rLU
 rLU
 rLU
@@ -81191,7 +81210,7 @@ sya
 sya
 oLx
 oLx
-rLU
+rMm
 rMm
 rMm
 rMm
@@ -81378,9 +81397,9 @@ jsJ
 jsJ
 jsJ
 jsJ
-jsJ
-jsJ
-jsJ
+kSg
+kSg
+kSg
 rLU
 rLU
 rLU
@@ -81448,7 +81467,7 @@ sya
 sya
 oLx
 oLx
-rLU
+rMm
 rMm
 rMm
 rMm
@@ -81636,8 +81655,8 @@ jsJ
 jsJ
 jsJ
 jsJ
-jsJ
-jsJ
+kSg
+kSg
 rLU
 rLU
 rLU
@@ -81705,7 +81724,7 @@ sya
 sya
 oLx
 oLx
-rLU
+rMm
 rMm
 rMm
 rMm
@@ -81894,7 +81913,7 @@ jsJ
 jsJ
 jsJ
 kgx
-jsJ
+kSg
 rLU
 rLU
 rLU
@@ -81962,7 +81981,7 @@ sya
 sya
 oLx
 oLx
-rLU
+rMm
 rMm
 rMm
 rMm
@@ -82219,7 +82238,7 @@ sya
 sya
 oLx
 oLx
-rLU
+rMm
 rMm
 rMm
 rMm
@@ -82476,7 +82495,7 @@ sya
 sya
 oLx
 oLx
-rLU
+rMm
 rMm
 rMm
 rMm
@@ -82733,7 +82752,7 @@ sya
 oLx
 oLx
 oLx
-rLU
+rMm
 rMm
 rMm
 rMm
@@ -82989,8 +83008,8 @@ oLx
 oLx
 oLx
 oLx
-rLU
-rLU
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -83244,9 +83263,9 @@ sya
 sya
 oLx
 oLx
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -83387,20 +83406,20 @@ kSg
 rMm
 rMm
 rMm
-uSY
-jsJ
+rLU
+rLU
 rMm
-ake
-ake
-ake
-ake
-ake
-ake
-ake
-ake
-ake
-ake
-ake
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 ake
 qxJ
 qxJ
@@ -83500,10 +83519,10 @@ gzo
 sya
 sya
 oLx
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -83645,19 +83664,19 @@ jrH
 jsJ
 jsJ
 kgx
-aFi
-jsJ
+rLU
+rLU
 ake
-bMv
-caE
-czz
 ake
-dcz
-swu
-enA
-kDw
-kDw
-kDw
+ake
+ake
+ake
+ake
+ake
+ake
+ake
+ake
+ake
 ake
 hnO
 vKz
@@ -83757,9 +83776,9 @@ gzo
 sya
 oLx
 oLx
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -83903,18 +83922,18 @@ jsJ
 jsJ
 uUy
 jsJ
-jsJ
+rLU
 ake
 bOk
-iDf
+bMv
 dDJ
-eEe
+ake
 oWN
 gmO
 hsJ
-cyW
-cyW
-cyW
+kDw
+kDw
+kDw
 ake
 dTO
 aSI
@@ -84013,9 +84032,9 @@ fYi
 fYi
 knp
 oLx
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -84163,14 +84182,14 @@ jsJ
 jsJ
 ake
 qOS
-bWa
+iDf
 dPt
 myU
 fVQ
 gAA
 hxx
-hYt
-hYt
+cyW
+cyW
 geG
 ake
 xKN
@@ -84270,8 +84289,8 @@ wXm
 upq
 knp
 oLx
-rLU
-rLU
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -84419,10 +84438,10 @@ jsJ
 tXu
 jsJ
 ake
-ake
-ake
-ake
-ake
+aKX
+bWa
+czz
+dcz
 fWv
 rDj
 xlo
@@ -84526,9 +84545,9 @@ ioN
 mhv
 mhv
 knp
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -84675,14 +84694,14 @@ kgx
 gna
 jsJ
 jsJ
-jsJ
-uCb
-xbG
-xbG
+ake
+ake
+ake
+ake
+ake
+ecF
+enA
 ePH
-xbG
-xbG
-nGH
 kDw
 gtR
 kDw
@@ -84783,9 +84802,9 @@ ioN
 gys
 gys
 knp
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -84934,11 +84953,11 @@ jsJ
 jsJ
 jsJ
 uCb
-cdq
+xbG
 xbG
 cdq
 xbG
-cdq
+xbG
 nGH
 eVF
 uhY
@@ -84972,11 +84991,11 @@ bse
 bse
 aCS
 bse
-bse
+hyx
 rll
 rll
 rll
-jsJ
+ioG
 jsJ
 cXC
 sDA
@@ -85040,9 +85059,9 @@ ioN
 kSg
 kSg
 nOK
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -85191,12 +85210,12 @@ jsJ
 jsJ
 jsJ
 uCb
+caE
 xbG
+caE
 xbG
-xbG
-xbG
-xbG
-aKX
+caE
+nGH
 eWs
 sii
 kfr
@@ -85229,11 +85248,11 @@ faG
 oMG
 aCS
 oRH
-bse
+hYt
 oQM
 evZ
 uyb
-jsJ
+iGL
 jsJ
 cXC
 eCO
@@ -85297,9 +85316,9 @@ rLU
 kSg
 kSg
 kSg
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -85447,13 +85466,13 @@ jsJ
 jsJ
 jsJ
 jsJ
-ake
-cuv
+uCb
+xbG
+xbG
+xbG
+xbG
 xbG
 eTE
-xbG
-eTE
-nGH
 vDC
 ake
 ake
@@ -85490,11 +85509,11 @@ dIj
 prj
 rll
 rll
-jsJ
+jOi
 jsJ
 cXC
-cXC
-tsf
+kZf
+kgv
 kgv
 vIt
 fkY
@@ -85553,9 +85572,9 @@ sws
 kSg
 kSg
 kSg
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -85707,7 +85726,7 @@ jsJ
 ake
 cxs
 xbG
-xbG
+ioq
 xbG
 ioq
 nGH
@@ -85749,7 +85768,7 @@ rLU
 kSg
 jsJ
 jsJ
-rLU
+cXC
 cXC
 tSV
 kgv
@@ -85810,9 +85829,9 @@ sws
 kSg
 kSg
 kSg
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -85961,12 +85980,12 @@ jsJ
 jsJ
 jsJ
 jsJ
-uCb
+ake
+chL
 xbG
 xbG
 xbG
-xbG
-xbG
+cFL
 nGH
 aqI
 aws
@@ -86037,7 +86056,7 @@ ptE
 jki
 jki
 sFo
-jki
+tsf
 scn
 sfq
 wAQ
@@ -86067,9 +86086,9 @@ sws
 kSg
 kSg
 kSg
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -86219,10 +86238,10 @@ kgx
 jsJ
 jsJ
 uCb
-hyx
-ioq
 xbG
-hyx
+xbG
+xbG
+xbG
 xbG
 nGH
 hKK
@@ -86310,7 +86329,7 @@ scn
 scn
 scn
 jki
-scb
+wdH
 sws
 sws
 sws
@@ -86324,9 +86343,9 @@ kSg
 kSg
 kSg
 kSg
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -86476,10 +86495,10 @@ jsJ
 jsJ
 jsJ
 uCb
+cuv
+cFL
 xbG
-xbG
-xbG
-xbG
+cuv
 xbG
 nGH
 blU
@@ -86567,10 +86586,11 @@ jki
 bPu
 gWH
 jki
-jki
+wRw
 wOn
 jFX
 eOM
+rAX
 kSg
 kSg
 kSg
@@ -86578,11 +86598,10 @@ kSg
 kSg
 kSg
 kSg
-kSg
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -86732,12 +86751,12 @@ uSY
 jsJ
 jsJ
 jsJ
-ake
-cFL
-imQ
+uCb
+xbG
+xbG
 srN
 fkI
-imQ
+xbG
 dxG
 rZK
 ake
@@ -86828,17 +86847,17 @@ sws
 sws
 sws
 sws
+jhC
 kSg
 kSg
 kSg
 kSg
-kSg
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -87056,7 +87075,7 @@ sws
 rPM
 ulA
 wFk
-fcl
+mpU
 fbq
 mpU
 mjv
@@ -87088,14 +87107,14 @@ kSg
 kSg
 kSg
 kSg
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -87313,7 +87332,7 @@ rLU
 rPM
 odX
 dBJ
-fiM
+dBJ
 fYw
 mpU
 lOb
@@ -87344,12 +87363,12 @@ kSg
 kSg
 kSg
 kSg
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -87510,8 +87529,8 @@ jNq
 mHS
 aqn
 piL
-hEP
-ffq
+oVT
+jvx
 tIk
 qxJ
 qxJ
@@ -87570,8 +87589,8 @@ rLU
 rPM
 lxN
 mpU
-rkD
 mpU
+rkD
 mpU
 kxP
 kxP
@@ -87599,11 +87618,11 @@ kSg
 kSg
 kSg
 kSg
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -87852,13 +87871,13 @@ kSg
 kSg
 kSg
 kSg
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -88022,7 +88041,7 @@ jsJ
 jsJ
 jNq
 dzh
-lkk
+dzh
 iuv
 oVT
 swU
@@ -88085,7 +88104,7 @@ rPM
 oDQ
 xUS
 mpU
-mpU
+swu
 mpU
 vtF
 rPM
@@ -88105,16 +88124,16 @@ kSg
 kSg
 kSg
 kSg
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -88360,16 +88379,16 @@ jsJ
 jsJ
 jsJ
 kSg
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -88536,7 +88555,7 @@ jsJ
 jsJ
 jNq
 pLJ
-dzh
+esd
 pcK
 oVT
 jvx
@@ -88615,14 +88634,14 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -88793,7 +88812,7 @@ jsJ
 cyH
 jNq
 dzh
-dzh
+eEe
 xUe
 oVT
 jvx
@@ -88830,7 +88849,7 @@ lhd
 dez
 roF
 vvz
-ips
+imQ
 ips
 rQl
 dIj
@@ -88870,12 +88889,12 @@ ioQ
 ioQ
 jsJ
 jsJ
-rLU
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -89050,7 +89069,7 @@ jsJ
 jsJ
 jNq
 dzh
-dzh
+iuv
 iuv
 oVT
 jvx
@@ -89126,11 +89145,11 @@ rLU
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -89307,7 +89326,7 @@ jsJ
 jsJ
 jNq
 dzh
-gRM
+jNq
 iuv
 oVT
 jvx
@@ -89382,10 +89401,10 @@ rLU
 rLU
 jsJ
 jsJ
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -89638,9 +89657,9 @@ rLU
 rLU
 xTt
 jsJ
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -89895,8 +89914,8 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -90137,7 +90156,7 @@ rLU
 rLU
 rPM
 khl
-mpU
+qIu
 mpU
 mpU
 djW
@@ -90151,8 +90170,8 @@ jsJ
 jsJ
 kgx
 jsJ
-rLU
-rLU
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -90406,9 +90425,9 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -90662,10 +90681,10 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -90918,10 +90937,10 @@ jsJ
 jsJ
 kgx
 jsJ
-rLU
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -91163,9 +91182,9 @@ jsJ
 jsJ
 kgx
 xTt
-jsJ
-jsJ
-jsJ
+qhT
+qjk
+jOi
 jsJ
 jsJ
 jsJ
@@ -91175,9 +91194,9 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -91431,9 +91450,9 @@ gzo
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -91688,9 +91707,9 @@ gzo
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -91945,9 +91964,9 @@ gzo
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -92202,9 +92221,9 @@ vPr
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -92405,7 +92424,7 @@ sEs
 dha
 iKl
 jNy
-esd
+sus
 sus
 sus
 sus
@@ -92458,9 +92477,9 @@ jsJ
 gzo
 jsJ
 jsJ
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -92715,9 +92734,9 @@ jsJ
 gzo
 jsJ
 jsJ
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -92973,9 +92992,9 @@ gzo
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -93230,9 +93249,9 @@ gzo
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -93487,9 +93506,9 @@ gzo
 jsJ
 tXu
 jsJ
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -93713,13 +93732,13 @@ jge
 mmw
 jsJ
 cyH
-osn
+xBg
 uea
 uea
 uea
 uea
 uea
-osn
+xBg
 jsJ
 jsJ
 jsJ
@@ -93744,9 +93763,9 @@ gzo
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -94001,9 +94020,9 @@ gzo
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -94240,9 +94259,9 @@ bCe
 jsJ
 jsJ
 jsJ
+nxE
 sfb
 sfb
-fZk
 sfb
 sfb
 jsJ
@@ -94258,9 +94277,9 @@ gzo
 jsJ
 jsJ
 jsJ
-rLU
-rLU
-rLU
+rMm
+rMm
+rMm
 rMm
 rMm
 rMm
@@ -95250,7 +95269,7 @@ kAR
 pTD
 tWF
 qet
-vnp
+jTy
 jTy
 lyb
 jsJ
@@ -95507,7 +95526,7 @@ kAR
 xVh
 tWF
 pKO
-ioG
+jTy
 lbG
 lyb
 lyb
@@ -95764,7 +95783,7 @@ kAR
 kwK
 tWF
 lDd
-ioG
+jTy
 oOc
 gKM
 yhp
@@ -96021,7 +96040,7 @@ kAR
 kKF
 tWF
 aZI
-ioG
+jTy
 oOc
 gKM
 yhp
@@ -96278,7 +96297,7 @@ cqT
 iZe
 tWF
 uyG
-ioG
+jTy
 nfn
 lyb
 lyb
@@ -96535,7 +96554,7 @@ tWF
 tWF
 tWF
 vWa
-ioG
+jTy
 jTy
 lyb
 jsJ
@@ -97039,7 +97058,7 @@ neu
 bse
 bse
 cof
-iWH
+ffq
 lUR
 vYV
 vYV
@@ -97052,15 +97071,15 @@ vYV
 keu
 jTy
 efk
-efk
-efk
-osn
+rLU
+rLU
+xBg
 jsJ
 jsJ
 jsJ
 jsJ
 jsJ
-osn
+xBg
 rLU
 rLU
 rLU
@@ -97297,20 +97316,20 @@ qNt
 qNt
 qNt
 wat
-auf
+idr
 tad
 wax
 pCY
 tad
 tad
-tad
+fCG
 idr
 mUw
 aYE
 frx
-kZf
-qjk
 efk
+rLU
+rLU
 rLU
 uSY
 jsJ
@@ -97566,8 +97585,8 @@ uHl
 uHl
 uHl
 uHl
-qhT
-efk
+rLU
+rLU
 rLU
 jsJ
 jsJ
@@ -97823,8 +97842,8 @@ sjl
 imn
 rwz
 uHl
-qhT
-efk
+rLU
+rLU
 rLU
 jsJ
 kgx
@@ -98080,8 +98099,8 @@ ouA
 leK
 pLN
 uHl
-qhT
-efk
+rLU
+rLU
 rLU
 jsJ
 jsJ
@@ -98336,9 +98355,9 @@ kna
 cVx
 bWy
 jzD
-wdH
-aaz
-efk
+uHl
+rLU
+rLU
 rLU
 jsJ
 jsJ
@@ -98594,8 +98613,8 @@ faD
 fYV
 oHw
 uHl
-jOi
-efk
+rLU
+rLU
 rLU
 jsJ
 jsJ
@@ -98851,8 +98870,8 @@ ktE
 qat
 lko
 uHl
-jOi
-efk
+rLU
+rLU
 rLU
 jsJ
 jsJ
@@ -99108,8 +99127,8 @@ kna
 hjV
 kna
 uHl
-jOi
-efk
+rLU
+rLU
 rLU
 jsJ
 jsJ
@@ -99364,9 +99383,9 @@ fFp
 qYN
 lBa
 iZd
-wRw
-twb
-efk
+xtU
+rLU
+rLU
 rLU
 rLU
 jsJ
@@ -99619,11 +99638,11 @@ dKb
 kxq
 ruj
 ruj
-dzm
+fZk
 gvV
 xtU
-nxE
-efk
+rLU
+rLU
 rLU
 rLU
 jsJ
@@ -99876,11 +99895,11 @@ dSC
 eEz
 dzm
 dzm
-dzm
+fZk
 jEk
 xtU
-nxE
-chL
+rLU
+rLU
 rLU
 rLU
 jsJ
@@ -100135,9 +100154,9 @@ sze
 esb
 wMY
 vqV
-xtU
-iGL
-chL
+gRM
+rLU
+rLU
 rLU
 kgx
 jsJ
@@ -100391,10 +100410,10 @@ uaw
 uaw
 uaw
 xtU
-xtU
-xtU
-chL
-chL
+gRM
+gRM
+rLU
+rLU
 rLU
 jsJ
 jsJ

--- a/_maps/map_files/FridgeStation/FridgeStation.dmm
+++ b/_maps/map_files/FridgeStation/FridgeStation.dmm
@@ -1,10 +1,9 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "aae" = (
-/obj/structure/reagent_dispensers/water_cooler,
-/turf/open/floor/wood{
-	icon_state = "wood-broken6"
-	},
-/area/hallway/secondary/exit/departure_lounge)
+/obj/machinery/light/floor/fakeday,
+/obj/structure/closet/lasertag/blue,
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors)
 "aah" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -25,11 +24,11 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "aaT" = (
-/obj/structure/disposalpipe/junction{
-	dir = 2
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
-/turf/open/floor/plasteel,
-/area/hydroponics)
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/security/execution/education)
 "aaU" = (
 /obj/machinery/door/airlock/command{
 	name = "Head of Security's Office";
@@ -190,6 +189,9 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
+/obj/effect/turf_decal/loading_area{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "agQ" = (
@@ -230,11 +232,11 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "ahK" = (
-/obj/machinery/atmospherics/pipe/simple/violet/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 2
+	},
+/obj/machinery/atmospherics/pipe/simple/violet/visible{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
@@ -336,6 +338,16 @@
 	req_access_txt = "5"
 	},
 /obj/effect/mapping_helpers/airlock/unres,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "ajl" = (
@@ -353,11 +365,10 @@
 /area/ai_monitored/storage/eva)
 "ajy" = (
 /obj/structure/cable{
-	icon_state = "2-4"
+	icon_state = "4-8"
 	},
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/maintenance/fore)
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/security/execution/education)
 "ajJ" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -370,7 +381,6 @@
 /area/crew_quarters/locker)
 "ajQ" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /obj/machinery/camera{
 	c_tag = "Engineering Secure Storage";
 	dir = 4
@@ -578,6 +588,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
 /turf/open/floor/wood,
 /area/medical/psych)
 "asp" = (
@@ -591,15 +604,22 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/psych)
 "asr" = (
-/obj/structure/table,
-/obj/machinery/chem_dispenser/drinks/beer{
-	dir = 4
-	},
 /obj/machinery/light{
 	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"asH" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/disposalpipe/junction/flip{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "asS" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -671,6 +691,9 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "auB" = (
@@ -711,12 +734,11 @@
 /turf/open/floor/plating/smooth/grass,
 /area/engine/break_room)
 "avT" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/open/floor/engine,
-/area/engine/engineering)
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors)
 "awa" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -773,9 +795,6 @@
 /turf/open/floor/plating,
 /area/icemoon/surface/outdoors)
 "awF" = (
-/obj/item/kirbyplants{
-	icon_state = "plant-20"
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
@@ -786,6 +805,9 @@
 	c_tag = "Medbay South";
 	dir = 5;
 	network = list("ss13","medbay")
+	},
+/obj/item/kirbyplants{
+	icon_state = "plant-20"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
@@ -852,8 +874,20 @@
 	pixel_y = -7
 	},
 /obj/item/clothing/glasses/welding,
+/obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/plasteel/white,
 /area/science/lab)
+"axC" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio3";
+	name = "containment blast door"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/science/xenobiology)
 "axE" = (
 /obj/structure/table,
 /turf/open/floor/plasteel,
@@ -970,17 +1004,18 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "aAS" = (
-/obj/structure/kitchenspike,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8
-	},
-/obj/item/radio/intercom{
-	pixel_y = 25
-	},
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/open/floor/plasteel/freezer,
+/obj/machinery/door/window/southleft{
+	name = "Kitchen Delivery";
+	req_access_txt = "28"
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
 "aAT" = (
 /obj/machinery/light{
@@ -994,8 +1029,10 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "aAW" = (
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/engine/engineering)
 "aBi" = (
@@ -1165,11 +1202,34 @@
 /obj/item/kitchen/rollingpin,
 /turf/open/floor/plating,
 /area/hallway/secondary/service)
+"aIb" = (
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/obj/machinery/suit_storage_unit/standard_unit,
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "aId" = (
 /obj/structure/table/wood,
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = 24
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
+	pixel_x = 6;
+	pixel_y = 27
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
+	pixel_x = -4;
+	pixel_y = 27
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
+	pixel_x = -4;
+	pixel_y = 21
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
+	pixel_x = 6;
+	pixel_y = 21
 	},
 /turf/open/floor/wood,
 /area/bridge/meeting_room)
@@ -1362,11 +1422,21 @@
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "aMR" = (
-/obj/machinery/vending/wallmed{
-	pixel_y = 28
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/brig)
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/light/floor/fakeday,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors)
 "aNy" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -1391,14 +1461,12 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
 "aOg" = (
-/obj/structure/fans/tiny,
-/obj/structure/mineral_door/woodrustic,
-/turf/open/floor/wood,
-/area/icemoon/surface/outdoors)
-"aOk" = (
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/security/execution/education)
+"aOk" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
@@ -1408,10 +1476,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/green,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
 /turf/open/floor/plasteel/white,
 /area/maintenance/starboard/aft)
 "aOB" = (
@@ -1460,6 +1530,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"aPy" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/loading_area{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "aPC" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -1601,13 +1680,6 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plasteel,
 /area/storage/primary)
-"aVe" = (
-/obj/structure/window/reinforced,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/gateway)
 "aVl" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -1638,8 +1710,8 @@
 /area/crew_quarters/dorms)
 "aVX" = (
 /obj/structure/window/reinforced,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/gateway)
@@ -1694,9 +1766,6 @@
 /turf/open/floor/plasteel/dark,
 /area/gateway)
 "aXB" = (
-/obj/structure/chair/office/dark{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -1821,9 +1890,9 @@
 /area/maintenance/starboard/fore)
 "bbC" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
+	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/closed/wall,
 /area/maintenance/port)
 "bbX" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1835,14 +1904,6 @@
 /obj/structure/ore_box,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
-"bce" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/chair/comfy/beige,
-/obj/effect/landmark/start/assistant,
-/turf/open/floor/wood,
-/area/hallway/secondary/exit/departure_lounge)
 "bcf" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 8
@@ -1925,6 +1986,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"beh" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/machinery/light/small,
+/turf/open/floor/plating,
+/area/science/xenobiology)
 "bes" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -2054,9 +2121,15 @@
 /turf/closed/wall,
 /area/science/research)
 "bgE" = (
-/obj/structure/table,
-/obj/item/stack/rods/fifty,
-/obj/effect/spawner/lootdrop/maintenance,
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/port)
 "bgM" = (
@@ -2263,6 +2336,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
+"bli" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "bll" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -2430,6 +2512,7 @@
 	dir = 4;
 	pixel_x = 12
 	},
+/obj/structure/reagent_dispensers/watertank/high,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "boS" = (
@@ -2443,31 +2526,20 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue,
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_y = 32
+/obj/machinery/computer/security/telescreen/vault{
+	dir = 4;
+	pixel_x = -30
 	},
-/obj/item/book/manual/wiki/security_space_law,
 /turf/open/floor/plasteel/dark,
 /area/blueshield)
 "boY" = (
-/obj/structure/sign/poster/official/no_erp{
-	pixel_y = 32
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
-/obj/structure/chair/sofa/corp{
-	dir = 4;
-	pixel_x = -7
-	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer1{
-	dir = 6
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/fitness)
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/security/execution/education)
 "bpE" = (
 /obj/machinery/space_heater,
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -2477,9 +2549,13 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/trimline/green/filled/corner,
+/obj/machinery/power/apc/auto_name/north,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
 /turf/open/floor/plasteel/white,
-/area/maintenance/starboard/aft)
+/area/science/mixing)
 "bqa" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -2606,12 +2682,9 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "but" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/cleanable/oil{
-	icon_state = "floor5"
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/area/maintenance/fore)
 "buI" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/machinery/light/small{
@@ -2719,7 +2792,6 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel,
 /area/bridge)
 "bzU" = (
@@ -2847,13 +2919,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"bEB" = (
-/obj/item/reagent_containers/food/snacks/beans,
-/obj/structure/window{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "bEG" = (
 /obj/effect/landmark/start/botanist,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
@@ -2873,13 +2938,6 @@
 /turf/open/floor/plasteel/dark,
 /area/security/warden)
 "bEY" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
 	},
@@ -2892,14 +2950,11 @@
 	},
 /area/ai_monitored/turret_protected/ai)
 "bFe" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer1{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/fitness)
+/obj/structure/grille/broken,
+/obj/effect/decal/cleanable/glass,
+/obj/structure/barricade/wooden/snowed,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "bFJ" = (
 /obj/structure/closet/secure_closet/bar{
 	pixel_x = -3;
@@ -2926,7 +2981,10 @@
 	dir = 8
 	},
 /obj/structure/table,
-/obj/machinery/reagentgrinder,
+/obj/machinery/reagentgrinder{
+	pixel_x = -7;
+	pixel_y = 5
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bGq" = (
@@ -2990,9 +3048,9 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bHe" = (
-/obj/structure/table,
 /obj/machinery/recharger,
 /obj/effect/turf_decal/trimline/red/filled/line,
+/obj/structure/table/reinforced,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "bHo" = (
@@ -3032,6 +3090,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
@@ -3110,11 +3171,10 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
 "bJU" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 4
+/obj/structure/reagent_dispensers/water_cooler,
+/turf/open/floor/wood{
+	icon_state = "wood-broken6"
 	},
-/obj/machinery/disposal/bin,
-/turf/open/floor/wood,
 /area/hallway/secondary/exit/departure_lounge)
 "bKa" = (
 /obj/machinery/atmospherics/pipe/simple/dark/visible{
@@ -3130,6 +3190,12 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"bKw" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/tcommsat/server)
 "bKB" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -3217,9 +3283,6 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "bMl" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
@@ -3229,15 +3292,27 @@
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
 "bMv" = (
+/obj/structure/sign/poster/official/no_erp{
+	pixel_y = 32
+	},
 /obj/structure/chair/sofa/corp{
-	dir = 8;
-	pixel_x = 7
+	dir = 4;
+	pixel_x = -7
 	},
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer1{
-	dir = 10
+	dir = 6
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/fitness)
+"bMF" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "bMU" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
@@ -3275,17 +3350,30 @@
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors)
 "bOk" = (
-/turf/closed/wall,
-/area/security/execution/education)
-"bOp" = (
 /obj/machinery/light/small{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer1{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/fitness)
+"bOp" = (
+/obj/machinery/door/airlock/external{
+	name = "External Access";
+	req_access_txt = "7"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/science/mixing)
 "bPg" = (
 /obj/machinery/ore_silo,
 /obj/effect/turf_decal/bot_white/left,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 6
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
 "bPu" = (
@@ -3401,6 +3489,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "bRD" = (
@@ -3422,11 +3511,13 @@
 /turf/closed/wall/r_wall,
 /area/security/execution/education)
 "bSg" = (
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = 20
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
 	},
-/turf/open/floor/engine,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "bSr" = (
 /obj/structure/cable{
@@ -3448,19 +3539,15 @@
 /turf/open/floor/plasteel,
 /area/janitor)
 "bTk" = (
-/obj/structure/chair/sofa/corp{
-	dir = 4;
-	pixel_x = -7
-	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer1,
-/turf/open/floor/wood,
-/area/crew_quarters/fitness)
+/obj/structure/chair/stool,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "bTp" = (
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/area/icemoon/surface/outdoors)
 "bTr" = (
 /obj/structure/table,
 /obj/item/clothing/gloves/color/yellow{
@@ -3498,6 +3585,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"bUg" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "misclab";
+	name = "test chamber blast door"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/science/xenobiology)
 "bUt" = (
 /turf/open/floor/plasteel/yellowsiding/corner,
 /area/crew_quarters/dorms)
@@ -3546,15 +3648,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
-"bVo" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/oil{
-	icon_state = "floor6"
-	},
-/turf/open/floor/plating,
-/area/maintenance/fore)
 "bVt" = (
 /obj/item/target,
 /obj/structure/window/reinforced{
@@ -3574,8 +3667,12 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "bWa" = (
-/obj/structure/weightmachine/stacklifter,
-/turf/open/floor/plasteel/grimy,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer1,
+/obj/structure/chair/sofa/corp{
+	dir = 8;
+	pixel_x = 7
+	},
+/turf/open/floor/wood,
 /area/crew_quarters/fitness)
 "bWd" = (
 /obj/structure/rack,
@@ -3794,11 +3891,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "caE" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer1,
 /obj/structure/chair/sofa/corp{
-	dir = 8;
-	pixel_x = 7
+	dir = 4;
+	pixel_x = -7
 	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer1,
 /turf/open/floor/wood,
 /area/crew_quarters/fitness)
 "caH" = (
@@ -3836,10 +3933,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -3858,13 +3955,10 @@
 /obj/structure/sign/nanotrasen{
 	pixel_x = 32
 	},
-/obj/item/paper_bin{
-	pixel_y = 6
-	},
-/obj/item/pen,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
+/obj/machinery/photocopier/faxmachine,
 /turf/open/floor/plasteel,
 /area/bridge)
 "ccc" = (
@@ -3907,6 +4001,16 @@
 	name = "Cargo Bay";
 	req_access_txt = "31"
 	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "cda" = (
@@ -3914,11 +4018,9 @@
 /turf/open/floor/carpet,
 /area/medical/psych)
 "cdq" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/security/execution/education)
+/obj/structure/weightmachine/stacklifter,
+/turf/open/floor/plasteel/grimy,
+/area/crew_quarters/fitness)
 "cdw" = (
 /obj/structure/punching_bag,
 /turf/open/floor/wood,
@@ -3940,9 +4042,6 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"ces" = (
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat/hallway)
 "ceH" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -4362,6 +4461,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/hallway)
 "cqT" = (
@@ -4499,18 +4599,15 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "cuv" = (
-/obj/structure/chair/sofa/corp{
-	dir = 4;
-	pixel_x = -7
+/obj/structure/weightmachine/weightlifter,
+/obj/machinery/camera{
+	c_tag = "Fitness Room";
+	desc = "It may or may not be recording you for muscle worship films."
 	},
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = -32
+	pixel_y = 25
 	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer1{
-	dir = 5
-	},
-/turf/open/floor/wood,
+/turf/open/floor/plasteel/grimy,
 /area/crew_quarters/fitness)
 "cuB" = (
 /obj/machinery/door/airlock/external{
@@ -4526,7 +4623,6 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
 "cvO" = (
-/obj/structure/table/wood,
 /obj/item/reagent_containers/food/condiment/saltshaker{
 	pixel_x = -3;
 	pixel_y = 9
@@ -4535,6 +4631,9 @@
 	dir = 1;
 	pixel_x = 3;
 	pixel_y = 9
+	},
+/obj/structure/chair/sofa/right{
+	dir = 4
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
@@ -4617,20 +4716,26 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"cxk" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "cxp" = (
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -24
 	},
 /obj/machinery/light,
-/obj/structure/closet/lasertag/red,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "cxs" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/manifold/layer1{
+/obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/wood,
+/turf/open/floor/plasteel/grimy,
 /area/crew_quarters/fitness)
 "cxX" = (
 /obj/structure/reagent_dispensers/fueltank,
@@ -4689,13 +4794,16 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
 "czz" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer1{
-	dir = 9
-	},
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos,
 /obj/structure/chair/sofa/corp{
-	dir = 8;
-	pixel_x = 7
+	dir = 4;
+	pixel_x = -7
+	},
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = -32
+	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer1{
+	dir = 5
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/fitness)
@@ -4814,10 +4922,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark/telecomms,
@@ -4841,6 +4946,9 @@
 /obj/effect/landmark/start/security_officer,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/brig)
@@ -4883,15 +4991,10 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "cFL" = (
-/obj/machinery/door/airlock/public/glass{
-	desc = "A great place to relax. No ERP.";
-	name = "Sauna"
+/obj/item/kirbyplants/random,
+/turf/open/floor/plasteel/yellowsiding{
+	dir = 8
 	},
-/obj/structure/fans/tiny,
-/obj/machinery/atmospherics/pipe/heat_exchanging/junction/layer1{
-	dir = 1
-	},
-/turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/fitness)
 "cFU" = (
 /obj/structure/beebox,
@@ -4941,9 +5044,6 @@
 /area/science/misc_lab)
 "cHw" = (
 /obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -4989,11 +5089,8 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "cIR" = (
-/obj/structure/table,
-/obj/machinery/chem_dispenser/drinks{
-	dir = 4
-	},
-/turf/open/floor/light/colour_cycle,
+/obj/item/toy/lumosplush/light,
+/turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cJq" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -5168,11 +5265,10 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "cOk" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/light/small{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet/firecloset{
+	anchored = 1
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cOA" = (
@@ -5180,9 +5276,9 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
 "cOJ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall,
-/area/crew_quarters/fitness)
+/obj/structure/bonfire,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "cPO" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plasteel,
@@ -5337,6 +5433,9 @@
 /area/crew_quarters/heads/hos)
 "cUj" = (
 /obj/machinery/telecomms/receiver/preset_left,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
 "cUt" = (
@@ -5394,9 +5493,6 @@
 	pixel_y = 3
 	},
 /obj/effect/turf_decal/tile/yellow,
-/obj/machinery/status_display/evac{
-	pixel_x = -32
-	},
 /obj/item/storage/box/beakers{
 	pixel_x = -3;
 	pixel_y = 7
@@ -5463,6 +5559,9 @@
 /area/icemoon/surface/outdoors)
 "cXv" = (
 /obj/machinery/telecomms/processor/preset_four,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
 "cXw" = (
@@ -5474,10 +5573,6 @@
 "cXC" = (
 /turf/closed/wall,
 /area/icemoon/surface/outdoors)
-"cXH" = (
-/obj/machinery/light,
-/turf/open/floor/engine,
-/area/science/xenobiology)
 "cYm" = (
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
@@ -5490,11 +5585,14 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "cYM" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 8
 	},
-/turf/closed/wall,
-/area/maintenance/port)
+/obj/effect/turf_decal/bot{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/medical/virology)
 "cYP" = (
 /obj/machinery/light{
 	dir = 1
@@ -5520,10 +5618,6 @@
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "cZu" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
@@ -5536,6 +5630,9 @@
 /mob/living/simple_animal/pet/roro/roboticsroro{
 	desc = "A little robot designed for cuteness. Submit to the Borg.";
 	name = "Borg"
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
@@ -5556,6 +5653,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
@@ -5628,10 +5728,10 @@
 /area/maintenance/starboard)
 "daK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 9
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
+	dir = 4
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -5671,8 +5771,8 @@
 	},
 /area/ai_monitored/turret_protected/ai_upload)
 "dbN" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
+/obj/effect/turf_decal/loading_area{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
@@ -5699,9 +5799,8 @@
 /turf/open/floor/plating,
 /area/crew_quarters/abandoned_gambling_den)
 "dcz" = (
-/obj/machinery/atmospherics/components/binary/valve{
-	name = "Steam Valve"
-	},
+/obj/structure/table/glass,
+/obj/structure/bedsheetbin/towel,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "dcD" = (
@@ -5786,12 +5885,7 @@
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat/hallway)
 "dez" = (
-/obj/machinery/power/apc{
-	areastring = "/area/chapel/office";
-	name = "Chapel Office APC";
-	pixel_y = -24
-	},
-/obj/structure/cable,
+/obj/item/kirbyplants/random,
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
 "deA" = (
@@ -5835,8 +5929,11 @@
 	name = "Prisoner Transfer Centre";
 	req_access_txt = "63;4"
 	},
-/obj/structure/fans/tiny,
 /obj/machinery/door/firedoor,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
 /area/security/execution/education)
 "dfF" = (
@@ -5855,12 +5952,6 @@
 /turf/open/floor/plasteel,
 /area/janitor)
 "dfT" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/effect/decal/cleanable/blood/old,
 /obj/machinery/firealarm{
 	dir = 1;
@@ -5936,9 +6027,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/wood,
 /area/medical/psych)
 "dha" = (
@@ -5957,6 +6046,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
+"dhD" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Xenobiology Maintenance";
+	req_access_txt = "55"
+	},
+/turf/open/floor/plating,
+/area/science/xenobiology)
 "dhG" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plasteel,
@@ -6000,8 +6096,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/light/small{
+	dir = 8
+	},
 /turf/open/floor/plating,
-/area/maintenance/starboard)
+/area/chapel/office)
 "diy" = (
 /turf/closed/wall/r_wall,
 /area/crew_quarters/heads/hos)
@@ -6105,6 +6204,9 @@
 	id_tag = "innerbrig";
 	name = "Brig";
 	req_access_txt = "63"
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -6240,6 +6342,7 @@
 	dir = 1
 	},
 /obj/item/kirbyplants/random,
+/obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/hallway)
 "dqb" = (
@@ -6323,6 +6426,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/port)
+"dsp" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/wood,
+/area/engine/engineering)
 "dsy" = (
 /obj/structure/closet/crate/freezer/surplus_limbs,
 /obj/effect/turf_decal/tile/blue{
@@ -6356,35 +6465,25 @@
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors)
 "dtl" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/command{
-	name = "Maintenance Access";
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/window/eastright{
+	dir = 1;
+	name = "Bridge Delivery";
 	req_access_txt = "19"
 	},
-/obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=1";
-	dir = 1;
-	freq = 1400;
-	location = "Bridge"
-	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel,
 /area/bridge)
 "dtn" = (
-/obj/structure/weightmachine/weightlifter,
-/obj/machinery/light{
-	dir = 1
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-4"
 	},
-/obj/machinery/camera{
-	c_tag = "Fitness Room";
-	desc = "It may or may not be recording you for muscle worship films."
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "blueshutter";
+	name = "Perma Blueshield Shutter"
 	},
-/obj/item/radio/intercom{
-	pixel_y = 25
-	},
-/turf/open/floor/plasteel/grimy,
-/area/crew_quarters/fitness)
+/turf/open/floor/plating,
+/area/blueshield)
 "dtx" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "telecap";
@@ -6406,6 +6505,7 @@
 /area/bridge)
 "dtW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "dtY" = (
@@ -6467,8 +6567,22 @@
 	dir = 4
 	},
 /obj/machinery/photocopier,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 9
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"duO" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio4";
+	name = "containment blast door"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/science/xenobiology)
 "dvk" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -6479,9 +6593,6 @@
 /turf/open/floor/plasteel/dark/corner,
 /area/hallway/primary/starboard)
 "dvm" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/structure/disposalpipe/broken,
 /turf/open/floor/plating,
 /area/maintenance/fore)
@@ -6498,14 +6609,25 @@
 /area/medical/virology)
 "dvG" = (
 /obj/machinery/telecomms/server/presets/security,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
 "dwb" = (
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "0-2"
 	},
-/turf/open/floor/circuit/telecomms/mainframe,
-/area/tcommsat/server)
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "blueshutter";
+	name = "Perma Blueshield Shutter"
+	},
+/turf/open/floor/plating,
+/area/blueshield)
 "dwi" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -6647,7 +6769,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "dBf" = (
-/obj/machinery/atmospherics/pipe/simple/violet/hidden{
+/obj/machinery/atmospherics/pipe/simple/violet/visible{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -6699,17 +6821,11 @@
 /turf/open/floor/plasteel/white,
 /area/maintenance/starboard/aft)
 "dDJ" = (
-/obj/machinery/door/airlock/research{
-	name = "Research Division Maintenance";
-	req_access_txt = "47"
+/obj/machinery/atmospherics/pipe/heat_exchanging/manifold/layer1{
+	dir = 1
 	},
-/obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=2";
-	freq = 1400;
-	location = "Research Division"
-	},
-/turf/open/floor/plating,
-/area/science/research)
+/turf/open/floor/wood,
+/area/crew_quarters/fitness)
 "dDO" = (
 /obj/effect/landmark/start/assistant,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -6753,6 +6869,9 @@
 /obj/structure/table/wood,
 /obj/item/paper_bin,
 /obj/item/pen,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/medical/psych)
 "dEH" = (
@@ -6787,10 +6906,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "dEW" = (
-/obj/structure/table/reinforced,
 /obj/machinery/airalarm{
 	pixel_y = 23
 	},
+/obj/structure/table/reinforced,
 /obj/item/paper_bin{
 	pixel_x = -2;
 	pixel_y = 5
@@ -6813,9 +6932,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/white,
 /area/science/storage)
@@ -6823,10 +6939,16 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "dFt" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -6872,7 +6994,6 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "dGv" = (
-/obj/structure/reagent_dispensers/water_cooler,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
@@ -6883,6 +7004,11 @@
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_y = 20
+	},
+/obj/structure/window/reinforced,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
@@ -6899,6 +7025,9 @@
 	dir = 10
 	},
 /obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/dark,
 /area/blueshield)
 "dHc" = (
@@ -7029,9 +7158,12 @@
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
 "dIY" = (
-/obj/effect/decal/remains/human,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
+/obj/machinery/hydroponics/soil,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/grass,
+/area/chapel/office)
 "dJs" = (
 /obj/structure/window/reinforced{
 	dir = 4;
@@ -7201,6 +7333,9 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
 "dNW" = (
@@ -7301,11 +7436,16 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "dPt" = (
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer1{
+	dir = 9
 	},
-/turf/open/floor/light/colour_cycle,
-/area/maintenance/starboard/aft)
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos,
+/obj/structure/chair/sofa/corp{
+	dir = 8;
+	pixel_x = 7
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/fitness)
 "dPC" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -7322,12 +7462,18 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "dQb" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible,
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "2-4"
 	},
-/turf/open/floor/plasteel/white,
-/area/science/mixing)
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating,
+/area/security/brig)
 "dQn" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -7356,14 +7502,15 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "dQZ" = (
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "0-8"
 	},
-/obj/machinery/light{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
-/area/maintenance/fore)
+/area/security/brig)
 "dRp" = (
 /obj/machinery/door/poddoor{
 	id = "Secure Storage";
@@ -7387,14 +7534,14 @@
 	id = "xenobio6";
 	name = "containment blast door"
 	},
-/obj/machinery/atmospherics/pipe/simple/violet/hidden{
+/obj/machinery/atmospherics/pipe/simple/violet/visible{
 	dir = 4
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "dRN" = (
-/obj/structure/reagent_dispensers/keg/mead,
 /obj/structure/spider/stickyweb/genetic,
+/obj/structure/trash_pile,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "dRV" = (
@@ -7432,6 +7579,15 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
+"dUf" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 2
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/science/lab)
 "dUk" = (
 /obj/machinery/light{
 	dir = 4
@@ -7508,11 +7664,19 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
+	},
 /turf/open/floor/plasteel/white,
 /area/science/storage)
 "dVL" = (
 /obj/machinery/telecomms/server/presets/engineering,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
 "dVR" = (
@@ -7527,12 +7691,23 @@
 /area/bridge)
 "dVW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "dWc" = (
 /obj/structure/chair/stool,
 /turf/open/floor/wood,
 /area/crew_quarters/fitness)
+"dWL" = (
+/obj/machinery/disposal/bin,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/disposalpipe/trunk,
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "dXC" = (
 /obj/machinery/hydroponics/soil,
 /turf/open/floor/grass,
@@ -7542,6 +7717,7 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc/auto_name/east,
+/obj/effect/turf_decal/loading_area,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "dXI" = (
@@ -7556,23 +7732,12 @@
 /obj/structure/flora/rock,
 /turf/open/floor/grass,
 /area/bridge)
-"dYk" = (
-/obj/machinery/atmospherics/pipe/simple/violet/hidden,
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
 "dYF" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
-"dYZ" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/disposalpipe/junction/flip{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
 "dZa" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -7599,6 +7764,16 @@
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"dZA" = (
+/obj/structure/table,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/glasses/science,
+/obj/item/clothing/glasses/science,
+/obj/item/clothing/glasses/science,
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "eaP" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -7620,13 +7795,16 @@
 /turf/open/floor/plating,
 /area/crew_quarters/abandoned_gambling_den)
 "eby" = (
-/obj/structure/disposalpipe/segment,
 /obj/effect/spawner/structure/window,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/medical/sleeper)
 "ebD" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "ebF" = (
@@ -7642,12 +7820,12 @@
 "ebT" = (
 /obj/structure/table/glass,
 /obj/item/paper/fluff/fridgestation/nt,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 9
+	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "eca" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/fore)
@@ -7704,6 +7882,7 @@
 	c_tag = "Cargo Office";
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "ede" = (
@@ -7858,9 +8037,6 @@
 /turf/closed/wall,
 /area/hallway/secondary/entry)
 "efs" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
@@ -7986,6 +8162,9 @@
 /obj/item/clothing/glasses/science{
 	pixel_y = 8
 	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "elC" = (
@@ -8086,6 +8265,16 @@
 	id = "permalock";
 	name = "Perma Lockdown Shutter"
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "end" = (
@@ -8123,8 +8312,12 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "enA" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
+/obj/machinery/portable_atmospherics/canister/water_vapor,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
@@ -8135,8 +8328,10 @@
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "enH" = (
-/obj/item/toy/lumosplush/light,
-/turf/open/floor/light/colour_cycle,
+/obj/machinery/atmospherics/components/binary/valve{
+	dir = 4
+	},
+/turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "enU" = (
 /obj/structure/chair{
@@ -8202,7 +8397,6 @@
 /turf/open/floor/wood,
 /area/hallway/primary/aft)
 "epI" = (
-/obj/effect/turf_decal/tile/blue,
 /obj/structure/table,
 /obj/item/assembly/prox_sensor{
 	pixel_x = -8;
@@ -8219,16 +8413,21 @@
 	pixel_x = -4;
 	pixel_y = 1
 	},
-/obj/item/assembly/flash,
-/obj/item/assembly/flash{
+/obj/item/assembly/flash/handheld{
+	pixel_x = -8
+	},
+/obj/item/assembly/flash/handheld{
+	pixel_x = -4
+	},
+/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash/handheld{
+	pixel_x = 4
+	},
+/obj/item/assembly/flash/handheld{
 	pixel_x = 8
 	},
-/obj/item/assembly/flash{
-	pixel_x = -6
-	},
-/obj/item/assembly/flash{
-	pixel_x = 5
-	},
+/obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
 "epS" = (
@@ -8296,9 +8495,6 @@
 /area/hallway/primary/central)
 "erj" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
@@ -8363,6 +8559,9 @@
 /obj/item/clothing/suit/hooded/wintercoat/cargo,
 /obj/item/clothing/suit/hooded/wintercoat/cargo,
 /obj/item/clothing/suit/hooded/wintercoat/cargo,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "esd" = (
@@ -8576,6 +8775,9 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "exl" = (
@@ -8637,6 +8839,9 @@
 /obj/structure/table,
 /obj/machinery/newscaster{
 	pixel_y = 32
+	},
+/obj/structure/sign/poster/contraband/billyh2{
+	pixel_x = -32
 	},
 /turf/open/floor/plasteel,
 /area/janitor)
@@ -8757,6 +8962,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/holopad,
 /turf/open/floor/plasteel,
 /area/science/lab)
 "eCB" = (
@@ -8769,12 +8975,9 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/bridge)
 "eCO" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/light/small,
+/obj/effect/decal/remains/human,
 /turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/area/icemoon/surface/outdoors)
 "eCU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 9
@@ -8844,11 +9047,16 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "eEe" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+/obj/machinery/door/airlock/public/glass{
+	desc = "A great place to relax. No ERP.";
+	name = "Sauna"
+	},
+/obj/structure/fans/tiny,
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction/layer1{
 	dir = 1
 	},
-/turf/open/floor/plasteel/white,
-/area/science/lab)
+/turf/open/floor/wood,
+/area/crew_quarters/fitness)
 "eEz" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -8859,17 +9067,14 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/security{
-	name = "maint access";
-	req_access_txt = "2"
+/obj/machinery/door/window/eastright{
+	base_state = "left";
+	icon_state = "left";
+	name = "Security Delivery";
+	req_access_txt = "1"
 	},
-/obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=4";
-	dir = 4;
-	freq = 1400;
-	location = "Security"
-	},
-/turf/open/floor/plating,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/maintenance/fore)
 "eEJ" = (
 /obj/effect/turf_decal/tile/blue{
@@ -9072,9 +9277,6 @@
 /obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 1
-	},
 /obj/machinery/light,
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
@@ -9134,9 +9336,6 @@
 "eLD" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/white,
@@ -9207,10 +9406,8 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 9
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/white,
 /area/science/storage)
 "eOM" = (
@@ -9219,6 +9416,9 @@
 	req_access_txt = "13;7"
 	},
 /obj/structure/fans/tiny,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "ePb" = (
@@ -9260,12 +9460,12 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "ePH" = (
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -22
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
 	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
+/turf/open/floor/plasteel/grimy,
+/area/crew_quarters/fitness)
 "ePN" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -9384,16 +9584,8 @@
 /turf/open/floor/carpet/orange,
 /area/engine/engineering)
 "eTE" = (
-/obj/structure/closet/secure_closet/personal{
-	anchored = 1
-	},
-/obj/structure/window/reinforced/tinted{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/obj/structure/weightmachine/weightlifter,
+/turf/open/floor/plasteel/grimy,
 /area/crew_quarters/fitness)
 "eTL" = (
 /obj/machinery/light{
@@ -9437,18 +9629,13 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "eUS" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/window/eastleft{
+	dir = 8;
+	name = "Medical Delivery";
+	req_access_txt = "5"
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/medical/sleeper)
 "eVd" = (
 /obj/machinery/computer/security{
@@ -9502,7 +9689,6 @@
 /obj/machinery/door/airlock/external{
 	name = "Escape Airlock"
 	},
-/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/security/checkpoint/auxiliary)
 "eXd" = (
@@ -9565,6 +9751,15 @@
 	},
 /turf/open/floor/grass,
 /area/bridge)
+"fan" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "faD" = (
 /obj/machinery/computer/card/minor/qm,
 /obj/effect/turf_decal/trimline/brown/filled/line{
@@ -9593,9 +9788,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "fbq" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
@@ -9613,11 +9805,11 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
-/obj/structure/disposalpipe/junction/flip{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
@@ -9946,11 +10138,11 @@
 /turf/open/floor/wood,
 /area/icemoon/surface/outdoors)
 "fkV" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 9
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
@@ -9995,6 +10187,7 @@
 	pixel_x = 17;
 	pixel_y = 9
 	},
+/obj/item/paper/fluff/fridgestation/nt,
 /turf/open/floor/carpet,
 /area/bridge/meeting_room)
 "flx" = (
@@ -10056,6 +10249,10 @@
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"fnG" = (
+/obj/structure/table,
+/turf/open/floor/plating,
+/area/science/xenobiology)
 "fnY" = (
 /obj/structure/chair{
 	dir = 8
@@ -10097,25 +10294,6 @@
 /obj/item/clothing/shoes/winterboots/ice_boots,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
-"fps" = (
-/obj/machinery/door/window/northleft{
-	base_state = "right";
-	icon_state = "right";
-	name = "Containment Pen";
-	req_access_txt = "55"
-	},
-/obj/machinery/door/window/northleft{
-	dir = 2;
-	name = "Containment Pen";
-	req_access_txt = "55"
-	},
-/obj/machinery/atmospherics/pipe/simple/violet/hidden,
-/obj/machinery/door/poddoor/preopen{
-	id = "misclab";
-	name = "test chamber blast door"
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
 "fpK" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/plasteel,
@@ -10212,6 +10390,9 @@
 /obj/machinery/computer/cargo{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 9
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "fsE" = (
@@ -10261,6 +10442,9 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "fte" = (
@@ -10290,11 +10474,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"fuc" = (
-/turf/open/floor/wood{
-	icon_state = "wood-broken4"
-	},
-/area/hallway/secondary/exit/departure_lounge)
 "fuh" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/mechanical{
@@ -10450,9 +10629,17 @@
 /turf/open/floor/plasteel,
 /area/gateway)
 "fBu" = (
-/obj/machinery/light,
+/obj/structure/closet/secure_closet/security/sec,
+/obj/effect/turf_decal/bot,
+/obj/item/clothing/suit/hooded/wintercoat/security,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/dark,
-/area/crew_quarters/fitness)
+/area/security/brig)
 "fCq" = (
 /turf/closed/wall,
 /area/tcommsat/computer)
@@ -10506,12 +10693,11 @@
 /turf/open/floor/wood,
 /area/medical/psych)
 "fDn" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
 	},
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/structure/barricade/wooden/crude,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "fDq" = (
@@ -10522,6 +10708,7 @@
 /area/maintenance/starboard)
 "fDu" = (
 /obj/machinery/space_heater,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/hallway)
 "fDV" = (
@@ -10551,6 +10738,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "fFH" = (
@@ -10639,11 +10829,11 @@
 /turf/open/floor/plating,
 /area/engine/atmos)
 "fIX" = (
-/obj/item/kirbyplants/random,
-/turf/open/floor/plasteel/yellowsiding{
-	dir = 8
+/obj/machinery/vending/wallmed{
+	pixel_y = 28
 	},
-/area/crew_quarters/fitness)
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "fIZ" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -10844,6 +11034,17 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"fOp" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio1";
+	name = "containment blast door"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/science/xenobiology)
 "fOw" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -10892,10 +11093,32 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 2
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "fPp" = (
 /obj/machinery/gateway/centerstation,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/gateway)
 "fPs" = (
@@ -10913,9 +11136,6 @@
 /area/icemoon/surface/outdoors)
 "fPR" = (
 /obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -10925,7 +11145,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/maintenance/starboard)
+/area/chapel/office)
 "fQb" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	name = "Gas to Chamber"
@@ -10973,13 +11193,6 @@
 "fRc" = (
 /turf/open/floor/carpet,
 /area/medical/psych)
-"fRi" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/maintenance/fore)
 "fRv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -11012,16 +11225,6 @@
 /obj/machinery/disposal/bin,
 /turf/open/floor/plasteel,
 /area/janitor)
-"fSJ" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/space_heater,
-/turf/open/floor/plating,
-/area/maintenance/fore)
 "fTp" = (
 /obj/machinery/status_display/supply,
 /turf/closed/wall/r_wall,
@@ -11066,12 +11269,14 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
@@ -11106,11 +11311,11 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
 "fVQ" = (
-/obj/machinery/door/morgue{
-	name = "Confession Booth"
+/obj/machinery/atmospherics/components/binary/valve{
+	name = "Steam Valve"
 	},
-/turf/open/floor/plasteel/dark,
-/area/chapel/main)
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
 "fVV" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "telecap";
@@ -11122,13 +11327,9 @@
 /turf/open/floor/plasteel,
 /area/teleporter)
 "fWf" = (
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/power/apc/auto_name/east,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "fWh" = (
@@ -11151,11 +11352,13 @@
 /turf/open/floor/plating,
 /area/crew_quarters/abandoned_gambling_den)
 "fWv" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/structure/sign/poster/contraband/billyh{
+	pixel_y = 32
 	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
+/turf/open/floor/plasteel/yellowsiding{
+	dir = 4
+	},
+/area/crew_quarters/fitness)
 "fWw" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -11214,10 +11417,8 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "fXe" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/west,
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/bridge)
 "fXi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
@@ -11264,9 +11465,6 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/engine/atmos)
 "fYw" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 9
 	},
@@ -11445,12 +11643,7 @@
 	name = "Station Intercom (General)";
 	pixel_y = -32
 	},
-/obj/structure/closet/secure_closet/personal{
-	anchored = 1
-	},
-/obj/structure/window/reinforced/tinted{
-	dir = 1
-	},
+/obj/structure/chair/stool,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/fitness)
 "geQ" = (
@@ -11547,6 +11740,9 @@
 	dir = 9
 	},
 /obj/effect/landmark/start/depsec/supply,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "ggo" = (
@@ -11563,6 +11759,9 @@
 	c_tag = "Gateway";
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
 /turf/open/floor/plasteel/dark,
 /area/gateway)
 "ggO" = (
@@ -11571,7 +11770,7 @@
 	},
 /obj/machinery/power/apc/auto_name/north,
 /turf/open/floor/plating,
-/area/crew_quarters/fitness)
+/area/maintenance/starboard/fore)
 "ggU" = (
 /obj/machinery/power/apc{
 	areastring = "/area/teleporter";
@@ -11730,13 +11929,13 @@
 /area/ai_monitored/turret_protected/aisat/service)
 "gmk" = (
 /obj/structure/cable{
-	icon_state = "0-4"
+	icon_state = "1-2"
 	},
-/obj/machinery/power/terminal{
-	dir = 1
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
 	},
-/turf/open/floor/circuit/telecomms/mainframe,
-/area/tcommsat/server)
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "gmm" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -11774,10 +11973,11 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "gmO" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/spider/stickyweb/genetic,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
 "gna" = (
 /obj/structure/flora/grass/both,
 /obj/machinery/light/floor/fakeday,
@@ -11837,12 +12037,11 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "gnW" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
+/obj/machinery/camera{
+	c_tag = "Departures Lounge";
+	dir = 1
 	},
-/turf/open/floor/carpet{
-	icon_state = "carpetsymbol"
-	},
+/turf/open/floor/wood,
 /area/hallway/secondary/exit/departure_lounge)
 "goe" = (
 /obj/structure/window/reinforced{
@@ -12012,9 +12211,6 @@
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "gte" = (
-/obj/machinery/computer/security/telescreen/vault{
-	pixel_y = 30
-	},
 /obj/structure/chair/office/dark{
 	dir = 8
 	},
@@ -12026,6 +12222,9 @@
 	pixel_x = 32
 	},
 /obj/effect/landmark/start/blueshield,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/dark,
 /area/blueshield)
 "gtN" = (
@@ -12116,6 +12315,7 @@
 	},
 /obj/item/pen,
 /obj/item/storage/firstaid/regular,
+/obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "gwh" = (
@@ -12268,12 +12468,14 @@
 	},
 /turf/open/floor/carpet,
 /area/chapel/main)
-"gAA" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
+"gAy" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/visible,
 /turf/open/floor/plating,
-/area/maintenance/port)
+/area/maintenance/starboard/aft)
+"gAA" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
 "gAC" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -12316,8 +12518,8 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "gCn" = (
-/obj/effect/spawner/structure/window,
 /obj/structure/flora/ausbushes/brflowers,
+/obj/structure/window/fulltile,
 /turf/open/floor/grass,
 /area/hallway/secondary/exit/departure_lounge)
 "gCq" = (
@@ -12333,11 +12535,13 @@
 /turf/open/floor/carpet,
 /area/chapel/main)
 "gCC" = (
-/obj/machinery/camera{
-	c_tag = "Xenobiology Test Chamber";
-	network = list("xeno","rd")
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
 	},
-/turf/open/floor/engine,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "gCM" = (
 /obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
@@ -12367,6 +12571,9 @@
 /obj/machinery/airalarm{
 	dir = 4;
 	pixel_x = -23
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
@@ -12493,6 +12700,9 @@
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 1
 	},
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "gHp" = (
@@ -12523,12 +12733,6 @@
 "gJp" = (
 /obj/structure/cable{
 	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
@@ -12830,17 +13034,25 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
-"gRM" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+"gRG" = (
+/obj/machinery/atmospherics/components/binary/valve/on{
+	dir = 4;
+	name = "Miasma Scrubber Vent"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
+"gRM" = (
+/obj/effect/turf_decal/delivery,
+/obj/structure/window/reinforced{
+	dir = 1
 	},
 /turf/open/floor/plating,
-/area/maintenance/port)
+/area/maintenance/disposal)
 "gRV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -12919,9 +13131,15 @@
 /turf/open/floor/wood,
 /area/library)
 "gTv" = (
-/obj/machinery/atmospherics/pipe/simple/violet/hidden,
 /obj/structure/disposalpipe/segment{
 	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/violet/visible,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
@@ -12973,6 +13191,9 @@
 /obj/machinery/computer/cargo,
 /obj/machinery/newscaster{
 	pixel_y = 32
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
@@ -13218,14 +13439,18 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -22
+	},
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
 "haf" = (
 /obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
 	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/loading_area{
+	dir = 1
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/bridge)
@@ -13308,15 +13533,13 @@
 /area/maintenance/starboard/fore)
 "hdn" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "hdR" = (
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/hallway)
 "hec" = (
@@ -13371,6 +13594,9 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/brig)
 "hfB" = (
@@ -13514,9 +13740,6 @@
 /obj/item/kirbyplants{
 	icon_state = "plant-08"
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4
-	},
 /obj/machinery/vending/wallmed{
 	pixel_x = -28
 	},
@@ -13582,7 +13805,9 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/wood,
+/turf/open/floor/wood{
+	icon_state = "wood-broken5"
+	},
 /area/hallway/secondary/exit/departure_lounge)
 "hlA" = (
 /obj/structure/window/reinforced{
@@ -13623,9 +13848,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"hmR" = (
-/turf/closed/wall/r_wall,
-/area/maintenance/fore)
 "hnj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 6
@@ -13795,7 +14017,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "hry" = (
-/obj/machinery/atmospherics/pipe/simple/violet/hidden{
+/obj/machinery/atmospherics/pipe/simple/violet/visible{
 	dir = 4
 	},
 /turf/closed/wall,
@@ -13846,16 +14068,18 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "hsJ" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plasteel,
-/area/crew_quarters/locker)
+/area/crew_quarters/fitness)
 "hsX" = (
 /obj/structure/table/wood,
+/obj/machinery/button/door{
+	id = "heads_meeting";
+	name = "Security Shutters";
+	pixel_x = -16;
+	pixel_y = 1;
+	plane = -4
+	},
 /turf/open/floor/carpet,
 /area/bridge/meeting_room)
 "hts" = (
@@ -13990,12 +14214,11 @@
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
 "hxx" = (
-/obj/structure/cable{
-	icon_state = "0-8"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
 	},
-/obj/machinery/power/smes,
-/turf/open/floor/plating,
-/area/maintenance/port)
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
 "hxB" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 6
@@ -14029,6 +14252,7 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/structure/trash_pile,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "hyz" = (
@@ -14153,13 +14377,17 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hydroponics)
+"hBQ" = (
+/obj/machinery/hydroponics/constructable,
+/obj/structure/spider/stickyweb/genetic,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "hCj" = (
 /obj/structure/table,
+/obj/effect/turf_decal/trimline/green/filled/line,
 /obj/machinery/microwave{
-	pixel_x = -3;
 	pixel_y = 6
 	},
-/obj/effect/turf_decal/trimline/green/filled/line,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "hCt" = (
@@ -14167,9 +14395,6 @@
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors)
 "hCP" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/effect/turf_decal/arrows{
 	pixel_x = -11
 	},
@@ -14193,6 +14418,9 @@
 /area/hallway/primary/central)
 "hDi" = (
 /obj/machinery/telecomms/processor/preset_three,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 9
+	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
 "hDs" = (
@@ -14321,9 +14549,9 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "hHA" = (
-/obj/machinery/atmospherics/pipe/simple/violet/hidden,
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/violet/visible,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
@@ -14353,6 +14581,12 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/dorms)
+"hIp" = (
+/obj/structure/chair/wood/normal{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/bar)
 "hIu" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -14616,6 +14850,9 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/structure/disposalpipe/junction/yjunction{
+	dir = 8
+	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "hPh" = (
@@ -14695,12 +14932,13 @@
 /area/crew_quarters/heads/hop)
 "hQt" = (
 /obj/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/gateway)
 "hQx" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 1
-	},
+/obj/effect/turf_decal/trimline/purple/filled/corner,
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "hQA" = (
@@ -14781,11 +15019,13 @@
 /turf/open/floor/plasteel,
 /area/bridge)
 "hSZ" = (
-/obj/effect/decal/cleanable/glitter/pink,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/obj/effect/spawner/lootdrop/two_percent_xeno_egg_spawner,
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "hTx" = (
-/obj/structure/closet/firecloset,
+/obj/structure/closet/firecloset{
+	anchored = 1
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
@@ -14860,6 +15100,9 @@
 	pixel_y = 5
 	},
 /obj/item/pen/fourcolor,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
 "hVj" = (
@@ -14896,6 +15139,7 @@
 /area/icemoon/surface/outdoors)
 "hVM" = (
 /obj/machinery/holopad,
+/obj/effect/turf_decal/trimline/blue/line,
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "hVV" = (
@@ -14994,18 +15238,12 @@
 /area/hallway/primary/aft)
 "hXI" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
-	icon_state = "2-4"
+	icon_state = "0-8"
 	},
 /obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
@@ -15030,19 +15268,9 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "hYt" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Hydroponics";
-	req_access_txt = "35"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=4";
-	dir = 4;
-	freq = 1400;
-	location = "Hydroponics"
-	},
-/turf/open/floor/plating,
-/area/hydroponics)
+/obj/structure/chair/stool,
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/fitness)
 "hYA" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -15061,10 +15289,16 @@
 /area/tcommsat/computer)
 "hYD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "hYR" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -15097,6 +15331,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 10
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
 "hYX" = (
@@ -15245,9 +15480,13 @@
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/icemoon/surface/outdoors)
 "ieY" = (
-/obj/machinery/light,
-/turf/open/floor/plating,
-/area/maintenance/port)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/brig)
 "ifb" = (
 /obj/structure/table,
 /obj/item/storage/box/bodybags,
@@ -15303,9 +15542,6 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "igz" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12;22"
 	},
@@ -15416,9 +15652,12 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hop)
 "iks" = (
-/obj/structure/trash_pile,
-/turf/open/floor/plasteel,
-/area/maintenance/port)
+/obj/machinery/door/airlock/maintenance{
+	name = "Kitchen Maintenance";
+	req_access_txt = "28"
+	},
+/turf/open/floor/plasteel/freezer,
+/area/crew_quarters/kitchen)
 "ikL" = (
 /obj/item/ammo_casing/energy/plasmagun/rifle,
 /obj/item/ammo_casing/energy/plasmagun/rifle{
@@ -15429,14 +15668,11 @@
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors)
 "ikW" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -15448,7 +15684,7 @@
 /area/security/detectives_office)
 "ils" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 6
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
@@ -15473,10 +15709,8 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 5
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "imn" = (
@@ -15516,6 +15750,9 @@
 	icon_state = "1-2"
 	},
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
 "iof" = (
@@ -15560,33 +15797,17 @@
 /turf/open/openspace/icemoon,
 /area/icemoon/surface/outdoors)
 "ioU" = (
-/obj/machinery/door/airlock{
-	name = "Kitchen cold room";
-	req_access_txt = "28"
-	},
-/obj/machinery/door/firedoor,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=2";
-	freq = 1400;
-	location = "Kitchen"
-	},
-/turf/open/floor/plasteel/freezer,
+/turf/closed/wall,
 /area/crew_quarters/kitchen)
 "ips" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
+/turf/open/floor/grass,
+/area/chapel/office)
 "ipF" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/structure/disposalpipe/broken{
 	dir = 1
 	},
@@ -15611,6 +15832,9 @@
 /area/science/xenobiology)
 "iqf" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
 /turf/open/floor/plating,
 /area/blueshield)
 "iqM" = (
@@ -15657,6 +15881,9 @@
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = -24
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/hallway)
@@ -15743,15 +15970,26 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "ivz" = (
-/obj/structure/disposalpipe/segment,
-/turf/closed/wall/r_wall,
-/area/science/circuit)
-"ivA" = (
-/obj/structure/chair/comfy/brown{
-	dir = 8
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=2";
+	freq = 1400;
+	location = "Kitchen"
 	},
-/turf/open/floor/wood,
-/area/icemoon/surface/outdoors)
+/obj/structure/plasticflaps/opaque,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/crew_quarters/kitchen)
+"ivA" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "ivB" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
@@ -15849,7 +16087,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/mob/living/simple_animal/bot/medbot,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "iAn" = (
@@ -15881,7 +16118,7 @@
 	id = "xenobio3";
 	name = "containment blast door"
 	},
-/obj/machinery/atmospherics/pipe/simple/violet/hidden{
+/obj/machinery/atmospherics/pipe/simple/violet/visible{
 	dir = 4
 	},
 /turf/open/floor/engine,
@@ -15907,6 +16144,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"iAG" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/tcommsat/server)
 "iAJ" = (
 /obj/machinery/power/apc/highcap/five_k{
 	areastring = "/area/medical/virology";
@@ -15939,11 +16185,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "iBp" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/closet/firecloset/full,
-/turf/open/floor/plating,
+/turf/closed/mineral/random/snow/more_caves,
 /area/maintenance/fore)
 "iBX" = (
 /obj/structure/closet/crate/rcd,
@@ -16020,10 +16262,23 @@
 /obj/item/wrench/medical,
 /turf/open/floor/plasteel,
 /area/medical/sleeper)
+"iDJ" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "EngiSci Plaza East";
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "iDM" = (
 /obj/machinery/space_heater,
 /obj/effect/turf_decal/stripes/line{
-	dir = 5
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
@@ -16121,6 +16376,9 @@
 /area/crew_quarters/toilet)
 "iGt" = (
 /obj/machinery/telecomms/processor/preset_two,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 6
+	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
 "iGD" = (
@@ -16298,7 +16556,10 @@
 /area/maintenance/starboard/fore)
 "iKy" = (
 /obj/structure/table/wood,
-/obj/item/flashlight/lamp,
+/obj/item/flashlight/lamp{
+	pixel_x = -4;
+	pixel_y = 11
+	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
@@ -16309,6 +16570,14 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
+	},
+/obj/machinery/button/door{
+	id = "blueshutter";
+	name = "Permabrig Bluesheild button";
+	pixel_x = -7;
+	pixel_y = -3;
+	plane = -4;
+	req_access_txt = "2;63;71"
 	},
 /turf/open/floor/plasteel/dark,
 /area/blueshield)
@@ -16383,9 +16652,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
@@ -16425,14 +16691,17 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "iNU" = (
-/obj/structure/table,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/metal/fifty{
-	pixel_x = -3;
-	pixel_y = -7
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/open/floor/plating,
-/area/maintenance/port)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/bridge)
 "iNY" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -16728,6 +16997,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 10
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "iZe" = (
@@ -16750,7 +17022,18 @@
 	req_access_txt = "12"
 	},
 /turf/open/floor/plating,
-/area/crew_quarters/fitness)
+/area/maintenance/starboard/fore)
+"jaa" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio2";
+	name = "containment blast door"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/science/xenobiology)
 "jak" = (
 /obj/structure/disposalpipe/junction{
 	dir = 4
@@ -16761,11 +17044,14 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "jaR" = (
-/obj/effect/landmark/start/assistant,
-/turf/open/floor/plasteel/yellowsiding{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/area/crew_quarters/fitness)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/bridge)
 "jbw" = (
 /obj/structure/rack,
 /obj/item/aiModule/core/full/asimov,
@@ -16833,7 +17119,7 @@
 	id = "xenobio4";
 	name = "containment blast door"
 	},
-/obj/machinery/atmospherics/pipe/simple/violet/hidden{
+/obj/machinery/atmospherics/pipe/simple/violet/visible{
 	dir = 4
 	},
 /turf/open/floor/engine,
@@ -16848,6 +17134,17 @@
 /obj/vehicle/ridden/atv/snowmobile,
 /turf/open/floor/plating,
 /area/icemoon/surface/outdoors)
+"jga" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio7";
+	name = "containment blast door"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/science/xenobiology)
 "jgd" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/fans/tiny,
@@ -16889,9 +17186,11 @@
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
 "jgW" = (
-/turf/open/floor/wood{
-	icon_state = "wood-broken5"
+/obj/structure/disposalpipe/trunk{
+	dir = 4
 	},
+/obj/machinery/disposal/bin,
+/turf/open/floor/wood,
 /area/hallway/secondary/exit/departure_lounge)
 "jgX" = (
 /obj/structure/disposalpipe/segment{
@@ -16987,13 +17286,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
+"jiz" = (
+/obj/structure/falsewall/reinforced,
+/turf/open/floor/plating,
+/area/science/xenobiology)
 "jiH" = (
-/obj/machinery/suit_storage_unit/rd,
-/obj/machinery/firealarm{
-	pixel_y = 24
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/plasteel/white,
-/area/science/mixing)
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "jiV" = (
 /obj/machinery/status_display/evac{
 	pixel_y = 32
@@ -17011,11 +17318,9 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "jjt" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plating,
-/area/maintenance/fore)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/turf/open/floor/plasteel/dark,
+/area/gateway)
 "jki" = (
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
@@ -17051,21 +17356,9 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "jkV" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on{
-	dir = 8
-	},
-/obj/effect/turf_decal/bot{
-	dir = 1
-	},
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/medical/virology)
-"jlf" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/turf/open/floor/plasteel/dark,
+/area/gateway)
 "jll" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -17121,13 +17414,15 @@
 /turf/open/floor/plating,
 /area/icemoon/surface/outdoors)
 "jmu" = (
-/obj/structure/rack,
 /obj/machinery/button/door{
 	id = "stationawaygate";
 	name = "Gateway Access Shutter Control";
 	pixel_x = -1;
 	pixel_y = -24;
 	req_access_txt = "31"
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/gateway)
@@ -17140,6 +17435,9 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "jmR" = (
@@ -17172,17 +17470,13 @@
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
 "jnB" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/port)
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "jnC" = (
 /obj/machinery/power/apc{
 	areastring = "/area/tcommsat/computer";
@@ -17193,6 +17487,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 10
 	},
+/obj/structure/filingcabinet/chestdrawer,
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "jnD" = (
@@ -17242,6 +17537,9 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "joe" = (
@@ -17284,9 +17582,6 @@
 	name = "Research Division Access";
 	req_access_txt = "47"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
@@ -17304,11 +17599,8 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "jpv" = (
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
+/obj/machinery/power/terminal{
+	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -17552,6 +17844,9 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "juj" = (
@@ -17590,6 +17885,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -17650,6 +17948,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"jwY" = (
+/obj/structure/chair/stool,
+/turf/open/floor/plating,
+/area/science/xenobiology)
 "jxe" = (
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Power Storage";
@@ -17727,6 +18029,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
+/obj/item/kirbyplants/random,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "jzq" = (
@@ -17795,6 +18098,9 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "jAV" = (
@@ -17809,6 +18115,7 @@
 /area/engine/engineering)
 "jBh" = (
 /obj/machinery/light,
+/obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "jCM" = (
@@ -17816,13 +18123,14 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "jCZ" = (
-/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/hallway)
 "jDz" = (
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel/dark,
 /area/gateway)
 "jDQ" = (
@@ -17846,6 +18154,7 @@
 "jEk" = (
 /obj/machinery/autolathe,
 /obj/machinery/light,
+/obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "jEJ" = (
@@ -17993,7 +18302,9 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "jJt" = (
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "jJz" = (
@@ -18084,9 +18395,14 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "jNf" = (
-/obj/item/kirbyplants/random,
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "jNo" = (
 /obj/structure/chair/stool,
 /obj/effect/landmark/loneopspawn,
@@ -18113,6 +18429,9 @@
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
 	},
+/obj/effect/turf_decal/loading_area{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "jNR" = (
@@ -18138,6 +18457,11 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
+/obj/machinery/button/door{
+	id = "heads_meeting";
+	name = "Security Shutters";
+	pixel_x = -24
+	},
 /turf/open/floor/wood,
 /area/bridge/meeting_room)
 "jQm" = (
@@ -18146,6 +18470,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
+"jRr" = (
+/obj/structure/table,
+/obj/machinery/chem_dispenser/drinks/beer,
+/turf/open/floor/plating,
+/area/science/xenobiology)
 "jRA" = (
 /obj/structure/table/glass,
 /obj/item/radio/intercom{
@@ -18422,13 +18751,21 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "kbL" = (
-/obj/structure/reagent_dispensers/watertank,
-/obj/structure/spider/stickyweb/genetic,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "kcD" = (
 /obj/structure/closet/crate/goldcrate,
 /obj/effect/turf_decal/bot_white/right,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 10
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
 "kcH" = (
@@ -18506,16 +18843,13 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "kev" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
 /obj/machinery/power/apc/auto_name/north,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
 /turf/open/floor/plating,
 /area/security/execution/education)
 "keV" = (
@@ -18634,9 +18968,9 @@
 /area/security/brig)
 "khl" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -27
+	pixel_y = 30
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/white,
 /area/science/mixing)
 "khm" = (
 /obj/structure/cable{
@@ -18654,6 +18988,17 @@
 /obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
+"khD" = (
+/obj/structure/table/reinforced,
+/obj/machinery/computer/security/telescreen{
+	dir = 1;
+	name = "Test Chamber Monitor";
+	network = list("xeno");
+	pixel_y = 2;
+	plane = -4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "khF" = (
 /obj/machinery/vending/wardrobe/chap_wardrobe,
 /turf/open/floor/plasteel/grimy,
@@ -18714,6 +19059,13 @@
 /obj/structure/closet/crate/rcd,
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
+"kjo" = (
+/obj/machinery/camera{
+	c_tag = "Xenobiology Test Chamber";
+	network = list("xeno","rd")
+	},
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "kjp" = (
 /obj/item/chair/stool,
 /obj/item/clothing/gloves/color/fyellow/old,
@@ -18741,12 +19093,12 @@
 /turf/open/floor/carpet/orange,
 /area/engine/engineering)
 "klX" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Garden"
+/obj/machinery/door/airlock/maintenance{
+	name = "Garden Maintenance";
+	req_access_txt = "12"
 	},
-/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
-/area/hydroponics/garden)
+/area/maintenance/starboard/fore)
 "kmA" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
@@ -18891,6 +19243,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
+"krL" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/maintenance/port)
 "krU" = (
 /obj/machinery/door/airlock,
 /turf/open/floor/plating,
@@ -18953,6 +19312,9 @@
 "ktD" = (
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
@@ -19062,6 +19424,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"kxb" = (
+/obj/structure/disposalpipe/broken{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "kxg" = (
 /obj/machinery/camera{
 	c_tag = "Hydroponics"
@@ -19071,7 +19439,6 @@
 	departmentType = 2;
 	pixel_y = 30
 	},
-/obj/structure/reagent_dispensers/watertank/high,
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
 	},
@@ -19200,6 +19567,12 @@
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"kAA" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/ai_upload)
 "kAE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
@@ -19254,6 +19627,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
 "kCb" = (
@@ -19309,8 +19683,8 @@
 /turf/open/floor/plating/smooth/grass,
 /area/engine/break_room)
 "kDl" = (
-/obj/effect/spawner/structure/window,
 /obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/window/fulltile,
 /turf/open/floor/grass,
 /area/hallway/secondary/exit/departure_lounge)
 "kDw" = (
@@ -19385,6 +19759,13 @@
 /area/bridge)
 "kED" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 8
+	},
+/obj/structure/table,
+/obj/machinery/smartfridge/disks{
+	pixel_y = 2
+	},
+/obj/machinery/light{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -19497,8 +19878,9 @@
 /area/maintenance/port)
 "kJh" = (
 /obj/structure/disposalpipe/segment,
+/obj/structure/grille,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+	dir = 10
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
@@ -19596,6 +19978,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/medical/sleeper)
+"kOc" = (
+/obj/structure/table/reinforced,
+/obj/machinery/button/door{
+	id = "misclab";
+	name = "Test Chamber Blast Doors";
+	plane = -4;
+	req_access_txt = "55"
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "kOw" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -19652,6 +20044,9 @@
 /obj/effect/landmark/start/station_engineer,
 /obj/structure/cable{
 	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/carpet/orange,
 /area/engine/engineering)
@@ -19743,10 +20138,9 @@
 /turf/open/floor/wood,
 /area/maintenance/bar)
 "kSe" = (
-/obj/effect/decal/cleanable/glitter/pink,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/light/colour_cycle,
-/area/maintenance/starboard/aft)
+/obj/machinery/light,
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "kSg" = (
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors)
@@ -19901,6 +20295,16 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "kXp" = (
@@ -20195,6 +20599,9 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
 	},
+/obj/structure/chair/sofa/right{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "lgj" = (
@@ -20239,6 +20646,9 @@
 /area/icemoon/surface/outdoors)
 "lhB" = (
 /obj/machinery/telecomms/broadcaster/preset_left,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
 "lhG" = (
@@ -20266,8 +20676,15 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
+"lis" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "lit" = (
 /obj/machinery/sleeper{
 	dir = 8
@@ -20299,14 +20716,9 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
 "lju" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/layer_manifold{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/plasteel/dark,
+/area/gateway)
 "ljG" = (
 /obj/machinery/light{
 	dir = 1
@@ -20426,8 +20838,6 @@
 /area/engine/atmos)
 "lnw" = (
 /obj/structure/rack,
-/obj/structure/bedsheetbin/color,
-/obj/structure/table,
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = 24
@@ -20456,13 +20866,13 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "lnF" = (
-/obj/machinery/atmospherics/pipe/manifold/green/visible{
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/turf/open/floor/engine,
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/turf/open/floor/plating,
 /area/engine/engineering)
 "lnU" = (
 /obj/structure/disposalpipe/segment{
@@ -20523,7 +20933,7 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "loT" = (
-/obj/effect/spawner/structure/window/reinforced,
+/obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/storage/primary)
 "lpr" = (
@@ -20546,15 +20956,13 @@
 	id = "xenobio2";
 	name = "containment blast door"
 	},
-/obj/machinery/atmospherics/pipe/simple/violet/hidden{
+/obj/machinery/atmospherics/pipe/simple/violet/visible{
 	dir = 4
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "lpP" = (
-/obj/structure/chair/comfy/brown{
-	dir = 8
-	},
+/obj/structure/table/wood,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "lpR" = (
@@ -20578,11 +20986,11 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "lqo" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/window/reinforced{
+	dir = 8
 	},
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/bridge)
 "lqs" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/cardboard,
@@ -20627,6 +21035,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/morgue)
+"lre" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/science/robotics/lab)
 "lrl" = (
 /obj/machinery/button/door{
 	id = "qm_warehouse";
@@ -20788,11 +21202,15 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "luG" = (
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=1";
+	dir = 1;
+	freq = 1400;
+	location = "Bridge"
 	},
-/turf/open/floor/plating/asteroid/snow/icemoon,
-/area/maintenance/fore)
+/obj/structure/plasticflaps/opaque,
+/turf/open/floor/plating,
+/area/bridge)
 "luM" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -20805,13 +21223,20 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "luQ" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
@@ -20827,6 +21252,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "lvm" = (
@@ -20883,12 +21309,18 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
 /turf/open/floor/wood{
 	icon_state = "wood-broken5"
 	},
 /area/engine/engineering)
 "lwz" = (
 /obj/machinery/light,
+/obj/structure/chair/sofa/left{
+	dir = 8
+	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "lwB" = (
@@ -20932,7 +21364,7 @@
 	},
 /obj/effect/landmark/start/station_engineer,
 /obj/structure/cable{
-	icon_state = "1-4"
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -20968,12 +21400,19 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
 "lyT" = (
-/obj/machinery/light,
-/obj/structure/chair/comfy/beige{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/open/floor/wood,
-/area/hallway/secondary/exit/departure_lounge)
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=4";
+	dir = 4;
+	freq = 1400;
+	location = "Security"
+	},
+/obj/structure/plasticflaps/opaque,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/maintenance/fore)
 "lzW" = (
 /obj/machinery/airalarm{
 	pixel_y = 23
@@ -21000,9 +21439,6 @@
 /turf/open/floor/plating,
 /area/crew_quarters/abandoned_gambling_den)
 "lAy" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/holopad,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
@@ -21027,6 +21463,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
 	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "lBB" = (
@@ -21036,11 +21475,17 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "lBM" = (
-/obj/structure/chair/comfy/beige{
-	dir = 1
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/structure/table/reinforced,
+/obj/item/roller,
+/obj/item/roller{
+	pixel_y = 5
 	},
-/turf/open/floor/wood,
-/area/hallway/secondary/exit/departure_lounge)
+/obj/item/roller{
+	pixel_y = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "lBT" = (
 /obj/machinery/vending/games,
 /obj/machinery/camera{
@@ -21050,10 +21495,12 @@
 /turf/open/floor/wood,
 /area/library)
 "lCa" = (
-/obj/machinery/power/apc/auto_name/east,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/hydroponics)
+/obj/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/gateway)
 "lCA" = (
 /obj/structure/chair/comfy/black,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -21099,13 +21546,17 @@
 "lDq" = (
 /obj/machinery/light,
 /obj/item/kirbyplants/random,
+/obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "lDF" = (
-/obj/machinery/light{
-	dir = 8
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
 	},
-/turf/open/floor/engine,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "lDG" = (
 /obj/item/flashlight/lantern,
@@ -21151,9 +21602,8 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "lEw" = (
-/obj/item/toy/lumosplush/vera,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/turf/closed/wall/r_wall,
+/area/maintenance/fore)
 "lEC" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -21246,13 +21696,9 @@
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors)
 "lFT" = (
-/obj/machinery/airalarm{
-	pixel_y = 23
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
-/obj/structure/closet/secure_closet/freezer/fridge,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "lGd" = (
@@ -21269,11 +21715,13 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/toilet)
 "lGz" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 1
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
-/turf/open/floor/engine,
-/area/engine/engineering)
+/turf/open/floor/plating,
+/area/security/brig)
 "lGK" = (
 /obj/machinery/light/floor/fakeday,
 /obj/structure/flora/grass/both,
@@ -21317,6 +21765,10 @@
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "blueshutter";
+	name = "Perma Blueshield Shutter"
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
@@ -21367,10 +21819,8 @@
 /area/crew_quarters/bar)
 "lKZ" = (
 /obj/machinery/light,
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
+/obj/structure/table/glass,
+/obj/item/reagent_containers/food/snacks/grown/harebell,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "lLe" = (
@@ -21391,6 +21841,9 @@
 	},
 /obj/structure/window/reinforced{
 	dir = 1
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
@@ -21509,6 +21962,12 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/plating,
 /area/maintenance/port)
+"lPf" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "lPw" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -21623,6 +22082,10 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
+"lSo" = (
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "lSs" = (
 /obj/machinery/computer/crew{
 	dir = 4
@@ -21642,6 +22105,9 @@
 /obj/item/reagent_containers/food/snacks/meat/slab/monkey,
 /obj/item/reagent_containers/food/snacks/meat/slab/monkey,
 /obj/item/reagent_containers/food/snacks/meat/slab/monkey,
+/obj/machinery/airalarm{
+	pixel_y = 23
+	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "lSS" = (
@@ -21653,6 +22119,7 @@
 	name = "Toxins Launch Room";
 	req_access_txt = "7"
 	},
+/obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "lTr" = (
@@ -21761,6 +22228,10 @@
 /area/crew_quarters/bar)
 "lVZ" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "heads_meeting";
+	name = "privacy shutters"
+	},
 /turf/open/floor/plating,
 /area/bridge/meeting_room)
 "lWn" = (
@@ -21934,7 +22405,7 @@
 	broadcasting = 1;
 	frequency = 1480;
 	name = "Confessional Intercom";
-	pixel_x = -29
+	pixel_y = -32
 	},
 /obj/machinery/light/small,
 /turf/open/floor/plasteel/dark,
@@ -22008,15 +22479,29 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"mbU" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "misclab";
+	name = "test chamber blast door"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/science/xenobiology)
 "mbZ" = (
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = -24
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/locker)
 "mcj" = (
 /obj/effect/turf_decal/stripes/line,
@@ -22035,14 +22520,12 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "mcv" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/door/airlock/maintenance{
+	name = "Kitchen Maintenance";
+	req_access_txt = "28"
 	},
 /turf/open/floor/plating,
-/area/maintenance/fore)
+/area/crew_quarters/kitchen)
 "mcC" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
@@ -22092,6 +22575,9 @@
 	req_access_txt = "2"
 	},
 /obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/security/execution/education)
 "mdJ" = (
@@ -22101,6 +22587,18 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/engine,
 /area/engine/engineering)
+"mdK" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "mep" = (
 /obj/machinery/quantumpad{
 	map_pad_id = "toxenoarch";
@@ -22220,10 +22718,9 @@
 /turf/open/floor/wood,
 /area/library)
 "mif" = (
-/obj/effect/decal/cleanable/glitter/pink,
-/obj/effect/decal/cleanable/glass,
+/obj/structure/trash_pile,
 /turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/area/bridge)
 "mit" = (
 /obj/structure/barricade/wooden/crude,
 /turf/open/floor/plating,
@@ -22287,6 +22784,10 @@
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = -24
+	},
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
@@ -22365,9 +22866,8 @@
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
 "mlS" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/hydroponics)
 "mlW" = (
@@ -22448,9 +22948,6 @@
 	dir = 8;
 	name = "west facing firelock"
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
@@ -22463,15 +22960,25 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "mqz" = (
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "mqB" = (
-/obj/structure/weightmachine/weightlifter,
-/turf/open/floor/plasteel/grimy,
-/area/crew_quarters/fitness)
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel,
+/area/gateway)
 "mrm" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -22549,18 +23056,17 @@
 /area/hallway/primary/central)
 "mss" = (
 /obj/machinery/washing_machine,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/locker)
 "msL" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 10
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -22596,11 +23102,12 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "mtL" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/spider/stickyweb/genetic,
+/obj/machinery/door/airlock/command{
+	name = "Maintenance Access";
+	req_access_txt = "19"
+	},
 /turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/area/bridge)
 "mtP" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -22612,11 +23119,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/science/lab)
@@ -22692,6 +23199,7 @@
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "myc" = (
+/obj/effect/turf_decal/trimline/blue/corner,
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "myA" = (
@@ -22715,17 +23223,8 @@
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat/hallway)
 "myU" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
-	},
-/obj/structure/closet/secure_closet/personal{
-	anchored = 1
-	},
-/obj/structure/window/reinforced/tinted,
-/turf/open/floor/plasteel/dark,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/closed/wall,
 /area/crew_quarters/fitness)
 "mzb" = (
 /obj/effect/landmark/start/shaft_miner,
@@ -22912,7 +23411,7 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "mFk" = (
 /obj/effect/turf_decal/stripes/line{
@@ -23177,8 +23676,8 @@
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
 "mMP" = (
-/obj/effect/spawner/structure/window,
 /obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/window/fulltile,
 /turf/open/floor/grass,
 /area/hallway/secondary/exit/departure_lounge)
 "mNq" = (
@@ -23246,6 +23745,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet,
 /area/security/detectives_office)
+"mOr" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/tcommsat/server)
 "mOS" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
@@ -23396,6 +23901,7 @@
 /area/maintenance/port)
 "mTy" = (
 /obj/machinery/telecomms/server/presets/service,
+/obj/effect/turf_decal/trimline/neutral/filled/line,
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
 "mTB" = (
@@ -23422,6 +23928,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
 	},
+/mob/living/simple_animal/bot/medbot,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "mUb" = (
@@ -23516,9 +24023,12 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "mVD" = (
-/obj/machinery/vending/wardrobe/science_wardrobe,
-/turf/open/floor/plasteel/white,
-/area/science/lab)
+/obj/machinery/door/airlock/maintenance{
+	name = "Security Maintenance";
+	req_access_txt = "1"
+	},
+/turf/open/floor/plating,
+/area/security/brig)
 "mVF" = (
 /turf/closed/wall,
 /area/hydroponics)
@@ -23650,15 +24160,19 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8
-	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hop)
 "nat" = (
 /obj/effect/turf_decal/trimline/green/filled/corner,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"nav" = (
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = 20
+	},
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "naZ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -23757,29 +24271,23 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/item/paper/fluff/fridgestation/nt,
+/obj/item/reagent_containers/food/drinks/bottle/vodka/badminka{
+	pixel_x = 5;
+	pixel_y = 14
+	},
+/obj/item/reagent_containers/food/drinks/bottle/gin{
+	pixel_x = -4;
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/food/drinks/bottle/whiskey{
+	pixel_y = 7
+	},
 /turf/open/floor/wood,
 /area/bridge/meeting_room)
 "nfE" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Server Room";
-	req_access_txt = "61"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/structure/fans/tiny,
-/turf/open/floor/plasteel/dark,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
 /area/tcommsat/computer)
 "nfF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
@@ -23854,7 +24362,6 @@
 /turf/open/floor/grass,
 /area/bridge)
 "nhC" = (
-/obj/item/kirbyplants/random,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
@@ -24080,9 +24587,6 @@
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "nmL" = (
@@ -24129,11 +24633,16 @@
 /turf/open/floor/plating,
 /area/quartermaster/miningdock)
 "nof" = (
-/obj/structure/chair/comfy/brown{
-	dir = 8
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=4";
+	dir = 4;
+	freq = 1400;
+	location = "Hydroponics"
 	},
-/turf/open/floor/carpet,
-/area/crew_quarters/bar)
+/obj/structure/plasticflaps/opaque,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "nos" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/plasteel,
@@ -24155,6 +24664,7 @@
 /obj/item/clothing/under/rank/captain,
 /obj/item/door_remote/captain,
 /obj/item/book/manual/wiki/security_space_law,
+/obj/item/reagent_containers/food/drinks/flask/gold,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "noT" = (
@@ -24273,6 +24783,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
+"nrm" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "nrw" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -24285,6 +24804,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
 "nrS" = (
@@ -24605,11 +25125,15 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
 	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "nAd" = (
 /obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "nAi" = (
@@ -24643,6 +25167,12 @@
 	},
 /turf/open/floor/carpet,
 /area/hallway/primary/aft)
+"nBd" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/aisat/hallway)
 "nBk" = (
 /obj/machinery/vending/tool,
 /turf/open/floor/plating,
@@ -24653,6 +25183,13 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/miningdock)
+"nBL" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "nCi" = (
 /obj/structure/bed,
 /obj/effect/landmark/loneopspawn,
@@ -24664,7 +25201,17 @@
 	c_tag = "Chief Engineer's Equipment";
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "nCs" = (
 /obj/machinery/conveyor{
@@ -24809,18 +25356,9 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "nGt" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/external{
-	name = "External Access";
-	req_access_txt = "13"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/security/execution/education)
+/obj/effect/turf_decal/trimline/blue/line,
+/turf/open/floor/plasteel,
+/area/ai_monitored/storage/eva)
 "nGu" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -24866,6 +25404,9 @@
 /area/medical/medbay/central)
 "nHf" = (
 /obj/machinery/telecomms/bus/preset_one,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 10
+	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
 "nHg" = (
@@ -24888,10 +25429,11 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "nHH" = (
-/obj/structure/table/glass,
-/obj/structure/bedsheetbin/towel,
+/obj/effect/turf_decal/trimline/blue/corner{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
+/area/ai_monitored/storage/eva)
 "nHL" = (
 /obj/machinery/computer/upload/ai,
 /obj/machinery/light{
@@ -24922,12 +25464,17 @@
 	pixel_y = 3
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/brig)
 "nIC" = (
-/obj/structure/falsewall/reinforced,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/obj/structure/chair/sofa/left{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "nIK" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -24965,7 +25512,13 @@
 "nJK" = (
 /obj/machinery/washing_machine,
 /obj/machinery/light,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/locker)
 "nJM" = (
 /obj/machinery/door/airlock/maintenance{
@@ -24999,9 +25552,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
 	},
@@ -25025,13 +25575,24 @@
 /turf/open/floor/plating,
 /area/engine/atmos)
 "nMa" = (
-/obj/structure/disposalpipe/segment,
-/turf/closed/wall/r_wall,
-/area/science/research)
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = -3;
+	pixel_y = 9
+	},
+/obj/item/reagent_containers/food/condiment/peppermill{
+	dir = 1;
+	pixel_x = 3;
+	pixel_y = 9
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "nMs" = (
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
+/obj/structure/chair/sofa/right{
+	dir = 8
+	},
+/turf/open/floor/carpet,
+/area/crew_quarters/bar)
 "nMI" = (
 /obj/structure/window/plasma/reinforced{
 	dir = 8
@@ -25116,9 +25677,6 @@
 /area/medical/medbay/central)
 "nOw" = (
 /obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
 /obj/machinery/light{
 	dir = 1
 	},
@@ -25128,6 +25686,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
+/obj/structure/disposalpipe/trunk,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
 "nOK" = (
@@ -25496,17 +26055,18 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "oaN" = (
-/obj/structure/window/reinforced{
-	dir = 1
+/turf/open/floor/carpet{
+	icon_state = "carpetsymbol"
 	},
-/obj/structure/chair/comfy/beige,
-/turf/open/floor/wood,
 /area/hallway/secondary/exit/departure_lounge)
 "obH" = (
 /obj/structure/filingcabinet,
 /obj/effect/turf_decal/bot_white/left,
 /obj/machinery/light{
 	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
@@ -25522,7 +26082,7 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "odA" = (
-/obj/machinery/atmospherics/pipe/simple/violet/hidden{
+/obj/machinery/atmospherics/pipe/simple/violet/visible{
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
@@ -25567,6 +26127,9 @@
 /obj/machinery/airalarm{
 	dir = 4;
 	pixel_x = -23
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
@@ -25656,6 +26219,17 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/hor)
+"ohd" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "misclab";
+	name = "test chamber blast door"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/science/xenobiology)
 "ohq" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -25729,19 +26303,24 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "ojG" = (
-/obj/structure/closet/firecloset/full,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"ojI" = (
-/obj/structure/disposalpipe/segment{
+/obj/structure/chair/sofa/left{
 	dir = 4
 	},
-/obj/effect/turf_decal/arrows{
-	dir = 8;
-	pixel_y = 10
+/turf/open/floor/carpet,
+/area/crew_quarters/bar)
+"ojI" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = -3;
+	pixel_y = 9
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/obj/item/reagent_containers/food/condiment/peppermill{
+	dir = 1;
+	pixel_x = 3;
+	pixel_y = 9
+	},
+/turf/open/floor/carpet,
+/area/crew_quarters/bar)
 "ojK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -25817,9 +26396,6 @@
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "okT" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
@@ -25829,11 +26405,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
@@ -25854,10 +26427,12 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "olL" = (
-/turf/open/floor/plasteel/chapel{
-	dir = 8
+/obj/machinery/door/airlock/maintenance{
+	name = "Hydroponics Maintenance";
+	req_access_txt = "35"
 	},
-/area/chapel/main)
+/turf/open/floor/plating,
+/area/hydroponics)
 "omm" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/mix_output,
 /turf/open/floor/engine/airless,
@@ -25983,7 +26558,7 @@
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "ooJ" = (
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -26049,7 +26624,10 @@
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors)
 "opO" = (
-/obj/structure/table,
+/obj/machinery/atmospherics/components/unary/tank/air{
+	dir = 4
+	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "oqc" = (
@@ -26082,16 +26660,11 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "oqR" = (
-/obj/machinery/camera{
-	c_tag = "Aft Starboard Generator";
+/obj/effect/turf_decal/trimline/blue/corner{
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/power/port_gen/pacman,
-/turf/open/floor/plating,
-/area/maintenance/port)
+/turf/open/floor/plasteel,
+/area/ai_monitored/storage/eva)
 "orf" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin{
@@ -26127,9 +26700,11 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "osk" = (
-/obj/structure/reagent_dispensers/beerkeg,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/ai_monitored/storage/eva)
 "osl" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -26143,7 +26718,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "osn" = (
 /obj/item/stack/marker_beacon{
@@ -26359,6 +26934,10 @@
 	c_tag = "Kitchen Cold Room"
 	},
 /obj/structure/closet/secure_closet/freezer/fridge,
+/obj/item/radio/intercom{
+	pixel_y = 25
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "ozX" = (
@@ -26511,6 +27090,12 @@
 	freq = 1400;
 	location = "Engineering"
 	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "oDl" = (
@@ -26572,9 +27157,6 @@
 /turf/open/floor/plasteel,
 /area/teleporter)
 "oEF" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
@@ -26603,6 +27185,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating,
 /area/security/execution/education)
 "oFs" = (
@@ -26614,6 +27199,9 @@
 "oFC" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
@@ -26740,9 +27328,11 @@
 /turf/open/floor/plasteel/dark,
 /area/security/checkpoint/auxiliary)
 "oIM" = (
-/obj/structure/closet/emcloset,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/obj/effect/turf_decal/trimline/blue/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/ai_monitored/storage/eva)
 "oJt" = (
 /obj/machinery/camera{
 	c_tag = "Starboard West"
@@ -26763,17 +27353,15 @@
 /turf/open/floor/plating,
 /area/crew_quarters/abandoned_gambling_den)
 "oJv" = (
-/obj/machinery/power/terminal{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/light/small{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/light/small,
 /turf/open/floor/plating,
-/area/maintenance/port)
+/area/maintenance/fore)
 "oJU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -26833,17 +27421,15 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
 "oLO" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
+/area/hallway/secondary/exit/departure_lounge)
+"oMh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/hydroponics/constructable,
+/obj/structure/spider/stickyweb/genetic,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "oMp" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/open/floor/plasteel/white,
@@ -26890,7 +27476,17 @@
 /area/science/misc_lab)
 "oNy" = (
 /obj/machinery/suit_storage_unit/ce,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "oOc" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
@@ -26944,7 +27540,9 @@
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
 "oOW" = (
-/obj/structure/closet/firecloset,
+/obj/structure/closet/firecloset{
+	anchored = 1
+	},
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -27044,6 +27642,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "oRh" = (
+/obj/structure/table/wood,
 /turf/open/floor/plating,
 /area/maintenance/bar)
 "oRv" = (
@@ -27197,6 +27796,7 @@
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "oWN" = (
+/obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "oWS" = (
@@ -27319,6 +27919,9 @@
 "oZQ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
@@ -27475,10 +28078,11 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "pds" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "pdA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -27596,11 +28200,13 @@
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
 "pgg" = (
-/obj/structure/chair/comfy/brown{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/disposalpipe/junction/flip{
 	dir = 1
 	},
-/turf/open/floor/wood,
-/area/icemoon/surface/outdoors)
+/turf/open/floor/carpet,
+/area/chapel/main)
 "pgp" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -27695,13 +28301,12 @@
 /turf/closed/wall/r_wall,
 /area/icemoon/surface/outdoors)
 "piH" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
 	},
-/turf/open/floor/plasteel/white,
-/area/science/mixing)
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "piJ" = (
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -27717,6 +28322,7 @@
 	red_alert_access = 1;
 	req_access_txt = "5"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "piL" = (
@@ -27807,6 +28413,9 @@
 	dir = 1
 	},
 /obj/effect/landmark/start/depsec/supply,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "pkS" = (
@@ -27908,10 +28517,10 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/structure/chair/comfy/beige{
+	dir = 8
 	},
-/obj/structure/table/wood,
+/obj/effect/landmark/start/assistant,
 /turf/open/floor/wood,
 /area/hallway/secondary/exit/departure_lounge)
 "pol" = (
@@ -27961,11 +28570,10 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "poL" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/bed/roller,
 /obj/effect/turf_decal/trimline/red/filled/line,
+/obj/structure/closet/firecloset{
+	anchored = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "poN" = (
@@ -28004,7 +28612,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/cable{
-	icon_state = "2-4"
+	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
@@ -28014,6 +28622,12 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/science/storage)
 "pqE" = (
@@ -28048,14 +28662,23 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
 "pse" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "1-4"
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
+"psm" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/maintenance/port)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/science/robotics/lab)
 "psB" = (
 /obj/machinery/shower{
 	dir = 8;
@@ -28065,6 +28688,7 @@
 	dir = 1
 	},
 /obj/item/soap/deluxe,
+/obj/item/bikehorn/rubberducky,
 /turf/open/floor/mineral/gold,
 /area/crew_quarters/heads/captain)
 "psD" = (
@@ -28115,6 +28739,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"ptS" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "pub" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -28234,6 +28867,9 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
 	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "pzJ" = (
@@ -28332,7 +28968,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/landmark/start/assistant,
 /turf/open/floor/wood,
 /area/hallway/secondary/exit/departure_lounge)
 "pCh" = (
@@ -28387,6 +29022,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/obj/effect/turf_decal/trimline/blue/line,
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "pDz" = (
@@ -28489,6 +29125,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -28713,11 +29352,11 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "pLT" = (
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
-/turf/open/floor/circuit/telecomms/mainframe,
-/area/tcommsat/server)
+/turf/open/floor/plasteel,
+/area/crew_quarters/locker)
 "pLX" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -28822,12 +29461,14 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "pON" = (
-/obj/structure/rack,
-/obj/item/clothing/head/cowboyhat/black,
-/obj/item/clothing/head/foilhat,
-/obj/item/clothing/head/hardhat,
-/obj/item/clothing/head/russobluecamohat,
-/obj/item/clothing/head/that,
+/obj/machinery/camera{
+	c_tag = "Aft Starboard Generator";
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/port_gen/pacman,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "pPP" = (
@@ -28855,20 +29496,14 @@
 /turf/open/floor/carpet,
 /area/chapel/main)
 "pPT" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
+/obj/structure/chair/stool{
+	pixel_y = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/white,
-/area/science/lab)
+/turf/open/floor/plasteel,
+/area/crew_quarters/locker)
 "pPX" = (
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
@@ -28920,6 +29555,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"pQV" = (
+/obj/effect/turf_decal/trimline/purple/filled/line,
+/turf/open/floor/plasteel/white,
+/area/science/lab)
 "pRn" = (
 /obj/machinery/door/airlock/hatch{
 	id_tag = null;
@@ -29016,9 +29655,6 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 5
-	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
 "pTq" = (
@@ -29053,7 +29689,7 @@
 /turf/open/floor/wood,
 /area/library)
 "pVO" = (
-/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating,
 /area/chapel/main)
 "pVZ" = (
@@ -29115,12 +29751,12 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "pXf" = (
-/obj/structure/rack,
-/obj/item/stack/sheet/mineral/plasma{
-	amount = 10
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/maintenance/port)
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/carpet,
+/area/chapel/main)
 "pXr" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/red{
@@ -29191,6 +29827,9 @@
 /area/chapel/office)
 "pXJ" = (
 /obj/machinery/telecomms/receiver/preset_right,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
 "pXM" = (
@@ -29390,6 +30029,13 @@
 /obj/machinery/light/floor/fakeday,
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors)
+"qcV" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/structure/disposaloutlet,
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "qdc" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -29479,6 +30125,9 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/auto_name/north,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
 "qfL" = (
@@ -29500,6 +30149,9 @@
 "qga" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 6
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
@@ -29546,6 +30198,10 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
 	},
+/obj/structure/chair/stool{
+	desc = "The most important people get the best seating.";
+	name = "Blueshield stool"
+	},
 /turf/open/floor/wood,
 /area/bridge/meeting_room)
 "qhi" = (
@@ -29581,7 +30237,7 @@
 	id = "xenobio5";
 	name = "containment blast door"
 	},
-/obj/machinery/atmospherics/pipe/simple/violet/hidden{
+/obj/machinery/atmospherics/pipe/simple/violet/visible{
 	dir = 4
 	},
 /turf/open/floor/engine,
@@ -29618,11 +30274,14 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8
-	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
@@ -29639,10 +30298,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -29660,6 +30316,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/gateway)
 "qjS" = (
@@ -29704,12 +30361,10 @@
 /area/crew_quarters/heads/cmo)
 "qkG" = (
 /obj/effect/landmark/start/cook,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "qkH" = (
@@ -29904,10 +30559,10 @@
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
 "qqq" = (
-/obj/machinery/ntnet_relay,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/power/smes{
+	charge = 5e+006
 	},
+/obj/structure/cable,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "qqN" = (
@@ -29930,6 +30585,17 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"qrF" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio6";
+	name = "containment blast door"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/science/xenobiology)
 "qrG" = (
 /turf/open/floor/plasteel/freezer,
 /area/chapel/office)
@@ -29975,18 +30641,19 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
 "qsS" = (
-/obj/machinery/camera{
-	c_tag = "Departures Lounge";
-	dir = 1
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
 	},
-/turf/open/floor/wood,
-/area/hallway/secondary/exit/departure_lounge)
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/locker)
 "qtk" = (
 /obj/machinery/camera{
 	c_tag = "Dorms West";
 	dir = 1
 	},
-/obj/structure/closet/lasertag/blue,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "qts" = (
@@ -30012,6 +30679,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
+/obj/structure/grille,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "qtV" = (
@@ -30095,11 +30763,11 @@
 	dir = 8
 	},
 /obj/machinery/disposal/bin,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -31
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
@@ -30111,10 +30779,10 @@
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "qwM" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
+/obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/wood,
 /area/engine/engineering)
 "qxc" = (
@@ -30145,24 +30813,18 @@
 /turf/closed/wall,
 /area/crew_quarters/dorms)
 "qxY" = (
-/obj/structure/table/glass,
-/obj/item/reagent_containers/food/snacks/grown/harebell,
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -31
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "qye" = (
-/obj/structure/table,
-/obj/machinery/smartfridge/disks{
-	pixel_y = 2
+/obj/machinery/door/window/eastleft{
+	name = "Hydroponics Delivery";
+	req_access_txt = "35"
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 30
-	},
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 9
-	},
+/obj/effect/turf_decal/delivery,
+/obj/structure/window/reinforced,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "qyX" = (
@@ -30381,14 +31043,11 @@
 	},
 /area/hallway/secondary/exit/departure_lounge)
 "qHa" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 10
 	},
 /turf/open/floor/plasteel,
-/area/crew_quarters/locker)
+/area/quartermaster/storage)
 "qHA" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/plasteel,
@@ -30409,6 +31068,9 @@
 	},
 /obj/machinery/light{
 	dir = 1
+	},
+/obj/machinery/status_display/evac{
+	pixel_y = 32
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
@@ -30476,11 +31138,9 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "qJB" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/fitness)
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "qJV" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4;
@@ -30503,6 +31163,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "qJW" = (
@@ -30511,6 +31172,7 @@
 /obj/item/disk/design_disk,
 /obj/item/disk/tech_disk,
 /obj/item/disk/tech_disk,
+/obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "qJX" = (
@@ -30540,10 +31202,13 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "qKi" = (
-/obj/machinery/atmospherics/pipe/simple/violet/hidden{
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/violet/visible{
 	dir = 6
 	},
-/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "qKK" = (
@@ -30620,7 +31285,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "qNc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
@@ -30666,6 +31331,9 @@
 	name = "Station Intercom (General)";
 	pixel_y = 20
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/carpet/orange,
 /area/engine/engineering)
 "qNU" = (
@@ -30679,9 +31347,16 @@
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "qNZ" = (
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/plating,
-/area/maintenance/port)
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "qOf" = (
 /obj/machinery/door/airlock{
 	name = "Unisex Restrooms"
@@ -30702,7 +31377,6 @@
 /obj/machinery/door/airlock/external{
 	name = "Escape Airlock"
 	},
-/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
 "qOQ" = (
@@ -30710,6 +31384,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -30725,11 +31402,14 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "qOS" = (
-/obj/structure/closet/secure_closet/personal{
-	anchored = 1
+/obj/structure/chair/sofa/corp{
+	dir = 8;
+	pixel_x = 7
 	},
-/obj/structure/window/reinforced/tinted,
-/turf/open/floor/plasteel/dark,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer1{
+	dir = 10
+	},
+/turf/open/floor/wood,
 /area/crew_quarters/fitness)
 "qOW" = (
 /obj/machinery/suit_storage_unit/atmos,
@@ -30752,12 +31432,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "qPt" = (
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/door/morgue{
+	name = "Confession Booth"
 	},
-/obj/effect/decal/cleanable/oil,
-/turf/open/floor/plating,
-/area/maintenance/fore)
+/turf/open/floor/plasteel/dark,
+/area/chapel/main)
 "qPB" = (
 /obj/machinery/door/window/northleft{
 	desc = "Don't release him.";
@@ -30867,6 +31546,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
 /turf/open/floor/plasteel/dark,
 /area/blueshield)
 "qTd" = (
@@ -30895,7 +31577,6 @@
 "qTx" = (
 /obj/structure/table,
 /obj/item/flashlight/lamp,
-/obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plating,
 /area/security/execution/education)
 "qTF" = (
@@ -30925,6 +31606,9 @@
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -31015,10 +31699,9 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
 "qWF" = (
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
 "qXc" = (
@@ -31056,11 +31739,16 @@
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors)
 "qYN" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/heater{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
+/area/quartermaster/storage)
 "qZg" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -31143,10 +31831,14 @@
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "rcg" = (
-/obj/structure/bed/roller,
-/obj/effect/turf_decal/trimline/red/filled/line,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/power/apc/auto_name/west,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/chapel/office)
 "rci" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -31159,8 +31851,18 @@
 	},
 /obj/structure/closet/l3closet/security,
 /obj/effect/turf_decal/trimline/red/filled/line,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
+"rcy" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "rcJ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -31210,6 +31912,7 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "rde" = (
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "rdk" = (
@@ -31263,19 +31966,19 @@
 /obj/machinery/vending/hydronutrients,
 /turf/open/floor/plasteel/dark,
 /area/hydroponics)
-"rfl" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+"rfa" = (
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/engine,
+/area/science/xenobiology)
+"rfl" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
 "rfS" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -31283,13 +31986,12 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "rgg" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "misclab";
-	name = "test chamber blast door"
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
-/area/science/xenobiology)
+/area/chapel/office)
 "rgh" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -31496,18 +32198,10 @@
 /turf/open/floor/plasteel,
 /area/bridge)
 "rmb" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/external{
-	name = "External Access";
-	req_access_txt = "13"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/security/execution/education)
+/obj/effect/turf_decal/bot,
+/obj/machinery/holopad,
+/turf/open/floor/plasteel,
+/area/storage/primary)
 "rmF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -31590,9 +32284,9 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "roF" = (
-/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/area/chapel/office)
 "roK" = (
 /obj/machinery/airalarm{
 	pixel_y = 23
@@ -31671,15 +32365,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"rrb" = (
-/obj/structure/window{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "rrs" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -31762,12 +32447,12 @@
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "rth" = (
-/obj/structure/table/wood,
-/obj/item/flashlight/lantern{
-	pixel_y = 5
+/obj/machinery/door/airlock/public/glass{
+	name = "Chapel Garden";
+	req_access_txt = "22"
 	},
-/turf/open/floor/wood,
-/area/icemoon/surface/outdoors)
+/turf/open/floor/plasteel/dark,
+/area/chapel/office)
 "rtx" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -31879,12 +32564,12 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "rwk" = (
-/obj/machinery/camera{
-	c_tag = "EngiSci Plaza East";
-	dir = 8
+/obj/structure/sink{
+	pixel_y = 28
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plasteel/dark,
+/area/chapel/office)
 "rwz" = (
 /obj/structure/table,
 /obj/machinery/photocopier/faxmachine,
@@ -31986,9 +32671,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
@@ -31996,7 +32678,7 @@
 	dir = 4
 	},
 /obj/structure/cable{
-	icon_state = "2-8"
+	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -32011,9 +32693,12 @@
 /turf/open/floor/plating,
 /area/hydroponics)
 "rzb" = (
-/obj/machinery/space_heater,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
+/obj/machinery/hydroponics/soil,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/grass,
+/area/chapel/office)
 "rzg" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -32069,6 +32754,7 @@
 /area/hallway/secondary/exit/departure_lounge)
 "rAH" = (
 /obj/machinery/telecomms/server/presets/science,
+/obj/effect/turf_decal/trimline/neutral/filled/line,
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
 "rAJ" = (
@@ -32197,6 +32883,10 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
+/obj/structure/reagent_dispensers/peppertank{
+	pixel_x = -30
+	},
+/obj/item/book/manual/wiki/security_space_law,
 /turf/open/floor/plasteel/dark,
 /area/blueshield)
 "rFm" = (
@@ -32381,7 +33071,9 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "rKE" = (
-/obj/structure/chair/stool,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "rKF" = (
@@ -32546,7 +33238,24 @@
 /turf/open/floor/grass,
 /area/bridge)
 "rOc" = (
-/obj/structure/closet/firecloset/full,
+/obj/structure/closet/emcloset{
+	name = "External Supply Closet"
+	},
+/obj/item/pickaxe,
+/obj/item/pickaxe,
+/obj/item/pickaxe,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/shoes/winterboots,
+/obj/item/clothing/shoes/winterboots,
+/obj/item/clothing/shoes/winterboots,
+/obj/item/clothing/suit/hooded/wintercoat,
+/obj/item/clothing/suit/hooded/wintercoat,
+/obj/item/clothing/suit/hooded/wintercoat,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -32580,6 +33289,9 @@
 /obj/machinery/camera{
 	c_tag = "Central Hallway Plaza"
 	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "rPy" = (
@@ -32598,14 +33310,9 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "rPI" = (
-/obj/machinery/door/airlock/external{
-	name = "External Access";
-	req_access_txt = "13;7"
+/obj/machinery/light/small{
+	dir = 1
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/science/mixing)
 "rPM" = (
@@ -32615,15 +33322,13 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/chapel/office)
-"rQl" = (
-/obj/structure/table,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/glass/fifty{
-	pixel_x = 3;
-	pixel_y = 3
-	},
+"rQb" = (
 /turf/open/floor/plating,
-/area/maintenance/port)
+/area/science/xenobiology)
+"rQl" = (
+/obj/machinery/hydroponics/soil,
+/turf/open/floor/grass,
+/area/chapel/office)
 "rQm" = (
 /obj/structure/table,
 /obj/structure/extinguisher_cabinet{
@@ -32736,6 +33441,7 @@
 	name = "Station Intercom (General)";
 	pixel_x = -30
 	},
+/obj/machinery/holopad,
 /turf/open/floor/wood,
 /area/bridge/meeting_room)
 "rVH" = (
@@ -32789,14 +33495,17 @@
 	},
 /area/ai_monitored/turret_protected/ai)
 "rWq" = (
-/obj/machinery/space_heater,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit/departure_lounge)
+/obj/machinery/droneDispenser/preloaded,
+/turf/open/floor/plating,
+/area/maintenance/port)
 "rWr" = (
 /obj/structure/chair/office/dark{
 	dir = 1
 	},
 /obj/effect/landmark/start/cargo_technician,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "rWt" = (
@@ -33000,6 +33709,13 @@
 	},
 /turf/open/floor/wood,
 /area/bridge/meeting_room)
+"scM" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/meter,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "sdg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -33032,11 +33748,10 @@
 /turf/open/floor/mineral/titanium/yellow,
 /area/icemoon/surface/outdoors)
 "sep" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
+/obj/machinery/hydroponics/soil,
+/obj/machinery/light,
+/turf/open/floor/grass,
+/area/chapel/office)
 "set" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -33232,6 +33947,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/teleporter)
+"shU" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "sid" = (
 /obj/effect/turf_decal/vg_decals/atmos/nitrogen,
 /obj/machinery/light/small{
@@ -33466,6 +34187,17 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"snB" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/science/storage)
 "snI" = (
 /obj/machinery/flasher{
 	id = "Cell 2";
@@ -33501,6 +34233,9 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/brig)
 "soq" = (
@@ -33512,6 +34247,7 @@
 	dir = 1;
 	network = list("vault")
 	},
+/obj/effect/turf_decal/trimline/neutral/filled/line,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
 "soF" = (
@@ -33544,6 +34280,11 @@
 	icon_state = "carpetsymbol"
 	},
 /area/hallway/secondary/exit/departure_lounge)
+"spc" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/engine/engineering)
 "spj" = (
 /obj/effect/landmark/start/botanist,
 /turf/open/floor/plasteel,
@@ -33616,6 +34357,9 @@
 /area/ai_monitored/storage/eva)
 "sqN" = (
 /obj/machinery/telecomms/bus/preset_three,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
 "sqO" = (
@@ -33644,12 +34388,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 6
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -33665,8 +34405,9 @@
 	},
 /area/crew_quarters/fitness)
 "sst" = (
-/turf/open/floor/light/colour_cycle,
-/area/maintenance/starboard/aft)
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plasteel,
+/area/maintenance/port)
 "ssL" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -33804,13 +34545,12 @@
 /turf/closed/wall,
 /area/maintenance/starboard/aft)
 "swu" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/components/unary/thermomachine/heater{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "swy" = (
-/obj/structure/disposalpipe/junction{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -33822,13 +34562,15 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/structure/disposalpipe/junction{
+	dir = 1
+	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "swE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
 	},
-/obj/machinery/light/floor/fakeday,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
 "swL" = (
@@ -33886,6 +34628,9 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "sxE" = (
@@ -33939,6 +34684,9 @@
 /area/security/brig)
 "sze" = (
 /obj/machinery/vending/wardrobe/cargo_wardrobe,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "szx" = (
@@ -33962,6 +34710,7 @@
 /area/science/research)
 "szC" = (
 /obj/effect/landmark/start/assistant,
+/obj/machinery/light,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/fitness)
 "szF" = (
@@ -33984,10 +34733,11 @@
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors)
 "sAx" = (
-/obj/machinery/hydroponics/constructable,
-/obj/structure/spider/stickyweb/genetic,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
 /turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/area/icemoon/surface/outdoors)
 "sAS" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -34015,12 +34765,24 @@
 	dir = 8;
 	network = list("aiupload")
 	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "sBM" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/port)
+"sBZ" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio5";
+	name = "containment blast door"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/science/xenobiology)
 "sCk" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/camera{
@@ -34047,9 +34809,6 @@
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "sCD" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
@@ -34059,15 +34818,14 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "sCW" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/window{
+	dir = 8
 	},
-/obj/machinery/door/airlock/security{
-	name = "persuasion room";
-	req_access_txt = "2"
+/obj/machinery/atmospherics/components/unary/vent_scrubber{
+	dir = 8
 	},
 /turf/open/floor/plating,
-/area/security/execution/education)
+/area/icemoon/surface/outdoors)
 "sDk" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
@@ -34081,15 +34839,9 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "sDA" = (
-/obj/machinery/door/airlock/external{
-	name = "External Access";
-	req_access_txt = "7"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
+/obj/item/reagent_containers/food/snacks/beans,
 /turf/open/floor/plating,
-/area/science/mixing)
+/area/icemoon/surface/outdoors)
 "sDP" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -34113,7 +34865,7 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "sFo" = (
-/obj/machinery/atmospherics/pipe/simple/violet/hidden{
+/obj/machinery/atmospherics/pipe/simple/violet/visible{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -34124,8 +34876,11 @@
 /turf/open/floor/plating,
 /area/medical/virology)
 "sFZ" = (
-/obj/machinery/atmospherics/pipe/manifold/violet/hidden{
+/obj/machinery/atmospherics/pipe/manifold/violet/visible{
 	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
@@ -34153,7 +34908,7 @@
 /area/ai_monitored/storage/eva)
 "sGB" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/reagent_dispensers/fueltank,
+/obj/structure/closet/firecloset/full,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "sHj" = (
@@ -34438,11 +35193,8 @@
 /area/medical/sleeper)
 "sPD" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/turf/closed/mineral/random/snow/more_caves,
+/area/icemoon/surface/outdoors)
 "sPF" = (
 /obj/machinery/door/airlock/medical{
 	name = "Morgue";
@@ -34532,6 +35284,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "sRv" = (
@@ -34542,9 +35297,14 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "sRD" = (
-/obj/effect/decal/cleanable/glass,
-/turf/open/floor/light/colour_cycle,
-/area/maintenance/starboard/aft)
+/obj/structure/table,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty{
+	pixel_x = -3;
+	pixel_y = -7
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/port)
 "sRJ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -34593,11 +35353,11 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/bar)
 "sSy" = (
-/obj/machinery/atmospherics/pipe/simple/violet/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/violet/visible{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
@@ -34669,7 +35429,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "sVx" = (
 /obj/structure/disposalpipe/segment{
@@ -34709,6 +35469,16 @@
 	req_access_txt = "63"
 	},
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "sXw" = (
@@ -34724,14 +35494,13 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "sYd" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Starboard Quarter Emergency Generator";
-	req_access_txt = "10"
+/obj/structure/table,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty{
+	pixel_x = 3;
+	pixel_y = 3
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel,
 /area/maintenance/port)
 "sYD" = (
 /obj/structure/chair/comfy/brown{
@@ -34776,8 +35545,13 @@
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
 "sZu" = (
-/obj/machinery/droneDispenser/preloaded,
-/turf/open/floor/plating,
+/obj/structure/rack,
+/obj/item/clothing/head/cowboyhat/black,
+/obj/item/clothing/head/foilhat,
+/obj/item/clothing/head/hardhat,
+/obj/item/clothing/head/russobluecamohat,
+/obj/item/clothing/head/that,
+/turf/open/floor/plasteel,
 /area/maintenance/port)
 "sZL" = (
 /obj/structure/table/reinforced,
@@ -34816,12 +35590,11 @@
 /turf/open/floor/plasteel/dark,
 /area/security/warden)
 "sZY" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/structure/closet/firecloset/full,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/decal/remains/human,
+/mob/living/carbon/monkey,
 /turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/area/icemoon/surface/outdoors)
 "tab" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 8
@@ -34897,8 +35670,8 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "tds" = (
-/obj/effect/decal/cleanable/glitter/pink,
-/turf/open/floor/light/colour_cycle,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "tdD" = (
 /obj/effect/turf_decal/tile/blue{
@@ -34934,7 +35707,6 @@
 	pixel_y = -22
 	},
 /obj/machinery/light,
-/obj/structure/filingcabinet/chestdrawer,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
 	},
@@ -34952,6 +35724,9 @@
 /area/engine/break_room)
 "teD" = (
 /obj/structure/reagent_dispensers/keg/quintuple_sec,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
 "teN" = (
@@ -34962,7 +35737,6 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/holopad,
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "teT" = (
@@ -35073,6 +35847,10 @@
 	poster_item_desc = "This poster promotes obesity, it also promotes giving the Chef a reason to keep their job."
 	},
 /obj/machinery/vending/wardrobe/chef_wardrobe,
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -22
+	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "thw" = (
@@ -35241,8 +36019,8 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "tmo" = (
-/obj/structure/chair/comfy/brown{
-	dir = 4
+/obj/structure/chair/sofa/left{
+	dir = 8
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
@@ -35358,11 +36136,12 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "tpt" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
+/obj/machinery/door/window/northright{
+	dir = 8;
+	name = "brap chamber door"
 	},
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/icemoon/surface/outdoors)
 "tpT" = (
 /obj/structure/table/wood,
 /obj/machinery/reagentgrinder,
@@ -35433,9 +36212,8 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "tsf" = (
-/obj/effect/spawner/lootdrop/bedsheet,
-/obj/structure/bed,
-/turf/open/floor/wood,
+/obj/machinery/space_heater,
+/turf/open/floor/plating,
 /area/icemoon/surface/outdoors)
 "tsl" = (
 /obj/structure/chair,
@@ -35501,16 +36279,10 @@
 /area/engine/engineering)
 "ttZ" = (
 /obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/light{
-	dir = 8
+	icon_state = "1-4"
 	},
 /turf/open/floor/plating/asteroid/snow/icemoon,
-/area/maintenance/fore)
+/area/icemoon/surface/outdoors)
 "tug" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -35627,6 +36399,9 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/hallway)
 "twX" = (
@@ -35688,15 +36463,12 @@
 /obj/structure/disposalpipe/junction/flip{
 	dir = 2
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "tzk" = (
@@ -35751,6 +36523,9 @@
 "tAy" = (
 /obj/structure/cable{
 	icon_state = "2-4"
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
@@ -35885,6 +36660,9 @@
 	dir = 4;
 	pixel_x = -23
 	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/hallway)
 "tFv" = (
@@ -36006,6 +36784,16 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "tIk" = (
@@ -36066,16 +36854,6 @@
 	},
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
-"tKQ" = (
-/obj/machinery/door/window/northright{
-	dir = 8;
-	name = "brap chamber door"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "tKS" = (
 /obj/machinery/gibber,
 /turf/open/floor/plasteel/freezer,
@@ -36148,6 +36926,17 @@
 /obj/effect/landmark/xmastree,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"tMi" = (
+/obj/machinery/door/airlock/external{
+	name = "External Access";
+	req_access_txt = "13;7"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/science/mixing)
 "tMC" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -36158,6 +36947,9 @@
 	pixel_x = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/dark,
 /area/blueshield)
 "tMF" = (
@@ -36217,6 +37009,9 @@
 	pixel_y = 24;
 	req_access_txt = "31"
 	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "tND" = (
@@ -36264,6 +37059,16 @@
 	id = "permalock";
 	name = "Perma Lockdown Shutter"
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "tOh" = (
@@ -36279,6 +37084,9 @@
 	},
 /obj/machinery/light{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/dark,
 /area/blueshield)
@@ -36311,7 +37119,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/light/small,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
 /turf/open/floor/plating,
 /area/maintenance/port)
 "tPI" = (
@@ -36398,13 +37208,13 @@
 /obj/structure/sign/warning/nosmoking{
 	pixel_y = 32
 	},
-/obj/structure/reagent_dispensers/water_cooler,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/disposal/bin,
 /turf/open/floor/wood,
 /area/engine/engineering)
 "tRB" = (
@@ -36480,10 +37290,9 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "tSV" = (
-/obj/structure/chair/stool,
-/obj/effect/decal/cleanable/glitter/pink,
+/obj/structure/trash_pile,
 /turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/area/icemoon/surface/outdoors)
 "tTa" = (
 /obj/machinery/light{
 	dir = 8
@@ -36495,6 +37304,9 @@
 /obj/item/tank/internals/nitrogen/belt/full,
 /obj/structure/cable{
 	icon_state = "2-4"
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
@@ -36517,16 +37329,13 @@
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors)
 "tTG" = (
-/obj/machinery/hydroponics/constructable,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/turf/open/floor/wood,
+/area/hallway/secondary/exit/departure_lounge)
 "tTJ" = (
-/obj/machinery/portable_atmospherics/canister/water_vapor,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
+/turf/open/floor/wood{
+	icon_state = "wood-broken4"
 	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
+/area/hallway/secondary/exit/departure_lounge)
 "tTP" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -36571,14 +37380,18 @@
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
 	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 30
+	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "tUL" = (
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/turf/open/floor/plating,
-/area/maintenance/fore)
+/obj/structure/chair/comfy/beige,
+/turf/open/floor/wood,
+/area/hallway/secondary/exit/departure_lounge)
 "tVc" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -36611,6 +37424,9 @@
 /area/science/circuit)
 "tVt" = (
 /obj/machinery/telecomms/bus/preset_two,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
 "tVO" = (
@@ -36881,6 +37697,9 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 8
 	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 5
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "udS" = (
@@ -36984,6 +37803,9 @@
 /area/tcommsat/computer)
 "uhx" = (
 /obj/effect/turf_decal/bot_white/left,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
 "uhy" = (
@@ -36995,6 +37817,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "uhU" = (
@@ -37037,6 +37860,9 @@
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
@@ -37096,6 +37922,9 @@
 	pixel_y = 30;
 	receive_ore_updates = 1
 	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "ujP" = (
@@ -37132,6 +37961,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "ukH" = (
@@ -37181,9 +38011,6 @@
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/mechbay)
 "ulK" = (
-/obj/machinery/atmospherics/pipe/simple/violet/hidden{
-	dir = 4
-	},
 /obj/machinery/door/window/northleft{
 	base_state = "right";
 	dir = 8;
@@ -37191,15 +38018,21 @@
 	name = "Containment Pen";
 	req_access_txt = "55"
 	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/violet/visible{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "umj" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/turf/open/floor/carpet{
-	icon_state = "carpetsymbol"
-	},
+/obj/structure/chair/comfy/beige,
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/wood,
 /area/hallway/secondary/exit/departure_lounge)
 "umY" = (
 /turf/open/floor/engine,
@@ -37332,6 +38165,9 @@
 	name = "Station Intercom (General)";
 	pixel_x = -28
 	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/hallway)
 "urO" = (
@@ -37363,10 +38199,29 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
 "usI" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
+/obj/machinery/door/window/northleft{
+	base_state = "right";
+	icon_state = "right";
+	name = "Containment Pen";
+	req_access_txt = "55"
 	},
-/turf/open/floor/engine,
+/obj/machinery/door/window/northleft{
+	dir = 2;
+	name = "Containment Pen";
+	req_access_txt = "55"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "misclab";
+	name = "test chamber blast door"
+	},
+/obj/machinery/atmospherics/pipe/simple/violet/visible,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "utc" = (
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
@@ -37433,6 +38288,9 @@
 /area/maintenance/starboard/fore)
 "uuD" = (
 /obj/machinery/door/firedoor/heavy,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "uvn" = (
@@ -37515,6 +38373,7 @@
 	dir = 4;
 	pixel_x = -22
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel/dark,
 /area/gateway)
 "uwU" = (
@@ -37546,6 +38405,7 @@
 	},
 /obj/item/stock_parts/cell/high/plus,
 /obj/item/stock_parts/cell/high/plus,
+/obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "uxO" = (
@@ -37687,7 +38547,13 @@
 "uBO" = (
 /obj/structure/table,
 /obj/structure/bedsheetbin/color,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/locker)
 "uCb" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -37722,6 +38588,9 @@
 "uCA" = (
 /obj/structure/closet/crate/silvercrate,
 /obj/effect/turf_decal/bot_white/right,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
 "uCN" = (
@@ -37729,6 +38598,12 @@
 /obj/machinery/photocopier/faxmachine,
 /obj/machinery/airalarm{
 	pixel_y = 23
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
@@ -37792,7 +38667,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/obj/structure/disposalpipe/segment,
 /obj/machinery/camera{
 	c_tag = "Research Division Access"
 	},
@@ -37827,8 +38701,11 @@
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat/hallway)
 "uEG" = (
-/obj/machinery/atmospherics/pipe/simple/violet/hidden,
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/violet/visible,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "uEP" = (
@@ -37974,10 +38851,11 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "uIe" = (
-/obj/structure/grille,
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/structure/table,
+/obj/item/stack/rods/fifty,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "uIi" = (
@@ -38025,6 +38903,12 @@
 /obj/item/phone{
 	pixel_x = 10;
 	pixel_y = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
@@ -38110,9 +38994,6 @@
 	},
 /area/ai_monitored/turret_protected/ai)
 "uLT" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
@@ -38190,16 +39071,20 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "uNU" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/table/wood,
+/turf/open/floor/wood,
+/area/hallway/secondary/exit/departure_lounge)
 "uOn" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/neutral/filled/line,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
 "uOs" = (
@@ -38216,7 +39101,6 @@
 	pixel_x = -3;
 	pixel_y = 3
 	},
-/obj/machinery/light/floor/fakeday,
 /turf/open/floor/plating,
 /area/icemoon/surface/outdoors)
 "uOY" = (
@@ -38386,15 +39270,9 @@
 	},
 /area/ai_monitored/turret_protected/aisat/hallway)
 "uUk" = (
-/obj/machinery/button/door{
-	id = "misclab";
-	name = "Test Chamber Blast Doors";
-	pixel_x = -26;
-	pixel_y = -26;
-	req_access_txt = "55"
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/closed/wall,
+/area/maintenance/port)
 "uUn" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/aisat/service)
@@ -38404,21 +39282,29 @@
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors)
 "uUN" = (
-/obj/machinery/light{
-	dir = 4
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
 	},
-/turf/open/floor/engine,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "uVl" = (
 /obj/machinery/plate_chute/outputchute{
 	pixel_y = 25
 	},
 /obj/effect/turf_decal/loading_area,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "uVm" = (
-/obj/structure/sign/warning/electricshock,
-/turf/closed/wall/r_wall,
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/turf/open/floor/plating,
 /area/maintenance/port)
 "uWm" = (
 /obj/structure/cable{
@@ -38444,9 +39330,6 @@
 /turf/open/floor/wood,
 /area/maintenance/bar)
 "uWA" = (
-/obj/structure/disposalpipe/junction{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -38458,6 +39341,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "2-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
@@ -38508,6 +39394,11 @@
 /obj/item/flashlight/lantern,
 /turf/open/floor/plating,
 /area/icemoon/surface/outdoors)
+"uZh" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/wood/normal,
+/turf/open/floor/wood,
+/area/maintenance/bar)
 "uZt" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
@@ -38609,6 +39500,7 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc/auto_name/east,
+/obj/structure/table,
 /turf/open/floor/plasteel,
 /area/gateway)
 "vdt" = (
@@ -38630,6 +39522,9 @@
 	},
 /obj/machinery/light{
 	dir = 8
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
@@ -38653,6 +39548,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
+"vex" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/aisat/hallway)
 "veE" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/machinery/atmospherics/components/binary/pump{
@@ -38744,6 +39645,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -38854,8 +39758,19 @@
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "vis" = (
-/obj/machinery/atmospherics/pipe/simple/violet/hidden,
-/turf/open/floor/engine,
+/obj/machinery/atmospherics/components/binary/valve/on{
+	name = "Containment Pen Scrubber"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "viH" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
@@ -38894,7 +39809,7 @@
 /obj/machinery/power/emitter/anchored{
 	dir = 1
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "vjO" = (
 /obj/structure/cable{
@@ -38931,18 +39846,13 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "vkk" = (
-/obj/effect/spawner/lootdrop/two_percent_xeno_egg_spawner,
+/obj/machinery/atmospherics/pipe/simple/violet/visible,
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "vkl" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 9
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 2
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/turf/open/floor/plating,
+/area/icemoon/surface/outdoors)
 "vkH" = (
 /obj/structure/table/wood,
 /obj/item/book/manual/wiki/security_space_law,
@@ -38960,6 +39870,7 @@
 	dir = 4;
 	network = list("tcomms")
 	},
+/obj/machinery/ntnet_relay,
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
 "vkW" = (
@@ -39178,6 +40089,9 @@
 	dir = 1;
 	pixel_y = -24
 	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 6
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "vqY" = (
@@ -39219,6 +40133,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"vsj" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/tcommsat/server)
 "vsk" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -39293,13 +40213,18 @@
 	},
 /area/icemoon/surface/outdoors)
 "vvz" = (
+/turf/open/floor/plasteel/dark,
+/area/chapel/office)
+"vvT" = (
+/obj/structure/window{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber{
+	dir = 8
+	},
 /obj/item/reagent_containers/food/snacks/beans,
 /turf/open/floor/plating,
-/area/maintenance/starboard)
-"vvT" = (
-/obj/structure/falsewall,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
+/area/icemoon/surface/outdoors)
 "vwb" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -39321,10 +40246,10 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/structure/chair/comfy/beige{
-	dir = 8
+/obj/item/kirbyplants/random,
+/turf/open/floor/wood{
+	icon_state = "wood-broken7"
 	},
-/turf/open/floor/wood,
 /area/hallway/secondary/exit/departure_lounge)
 "vwD" = (
 /turf/open/floor/wood,
@@ -39337,9 +40262,9 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "vxg" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/structure/closet/firecloset/full,
 /turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
+/area/hallway/secondary/exit/departure_lounge)
 "vxh" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -39372,14 +40297,9 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "vyw" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/item/kirbyplants/random,
-/turf/open/floor/wood{
-	icon_state = "wood-broken7"
-	},
-/area/hallway/secondary/exit/departure_lounge)
+/obj/structure/disposalpipe/broken,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "vyy" = (
 /obj/effect/decal/remains/human,
 /obj/item/clothing/head/helmet/space/syndicate{
@@ -39458,7 +40378,6 @@
 /area/quartermaster/office)
 "vAf" = (
 /obj/item/stack/cable_coil/cut,
-/obj/machinery/light/floor/fakeday,
 /turf/open/floor/plating,
 /area/icemoon/surface/outdoors)
 "vAt" = (
@@ -39652,17 +40571,34 @@
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "vGH" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/structure/cable{
 	icon_state = "1-4"
 	},
-/turf/open/floor/plating,
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Server Room";
+	req_access_txt = "61"
+	},
+/obj/structure/fans/tiny,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel/dark,
 /area/tcommsat/computer)
 "vGK" = (
 /obj/effect/turf_decal/tile/purple{
@@ -39678,6 +40614,10 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -31
 	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 10
+	},
+/obj/machinery/vending/wardrobe/science_wardrobe,
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "vHY" = (
@@ -39812,11 +40752,12 @@
 /turf/open/floor/plating,
 /area/science/mixing)
 "vMT" = (
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/plasteel/chapel{
-	dir = 1
+/obj/machinery/light{
+	dir = 4
 	},
-/area/chapel/main)
+/obj/machinery/space_heater,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
 "vMX" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
@@ -39828,6 +40769,20 @@
 /obj/machinery/light/small,
 /turf/open/floor/plating,
 /area/medical/sleeper)
+"vNc" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "misclab";
+	name = "test chamber blast door"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/science/xenobiology)
 "vNq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -39844,9 +40799,11 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "vOz" = (
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
@@ -39988,6 +40945,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
+"vSf" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/aisat/hallway)
 "vSg" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
@@ -40014,13 +40977,16 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "vTm" = (
-/obj/machinery/atmospherics/pipe/simple/violet/hidden{
-	dir = 4
-	},
 /obj/machinery/door/window/northleft{
 	dir = 4;
 	name = "Containment Pen";
 	req_access_txt = "55"
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/violet/visible{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
@@ -40157,6 +41123,9 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "vXG" = (
@@ -40248,15 +41217,16 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "vZg" = (
-/mob/living/simple_animal/cockroach{
-	has_penis = 1;
-	health = 1000;
-	name = "cumroach";
-	wound_bonus = 0
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=1";
+	dir = 1;
+	freq = 1400;
+	location = "Medbay"
 	},
-/obj/effect/decal/cleanable/glitter/pink,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/obj/structure/plasticflaps/opaque,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/medical/sleeper)
 "vZv" = (
 /turf/closed/wall,
 /area/medical/psych)
@@ -40348,9 +41318,11 @@
 /turf/open/floor/plasteel/dark/side,
 /area/hallway/primary/starboard)
 "wbF" = (
-/obj/effect/decal/remains/human,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "wbQ" = (
 /obj/structure/flora/ausbushes/stalkybush,
 /obj/machinery/light/small{
@@ -40383,6 +41355,9 @@
 /area/medical/sleeper)
 "wcO" = (
 /obj/machinery/telecomms/bus/preset_four,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 5
+	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
 "wcZ" = (
@@ -40467,7 +41442,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -40506,6 +41481,7 @@
 	dir = 1;
 	pixel_y = -24
 	},
+/obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "wgS" = (
@@ -40680,8 +41656,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"wlE" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/robotics/lab)
 "wlU" = (
-/obj/machinery/atmospherics/pipe/manifold4w/violet/hidden,
+/obj/machinery/atmospherics/pipe/manifold4w/violet/visible,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "wlV" = (
@@ -40707,11 +41699,24 @@
 /obj/item/statuebust,
 /turf/open/floor/grass,
 /area/hallway/secondary/exit/departure_lounge)
+"wnw" = (
+/obj/structure/plasticflaps/opaque,
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=2";
+	freq = 1400;
+	location = "Engineering"
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=2";
+	freq = 1400;
+	location = "Atmospherics"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "wnJ" = (
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
 "wnU" = (
@@ -40768,15 +41773,15 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
 "woI" = (
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -22
+/obj/machinery/light/small,
+/obj/structure/disposalpipe/segment{
+	dir = 5
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
+/turf/open/floor/plating,
+/area/maintenance/port)
 "wpc" = (
 /obj/structure/table/glass,
 /obj/machinery/light/small{
@@ -40887,14 +41892,11 @@
 /turf/open/floor/carpet,
 /area/science/robotics/lab)
 "wsM" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/light{
-	dir = 8
+/obj/effect/decal/cleanable/oil{
+	icon_state = "floor5"
 	},
 /turf/open/floor/plating,
-/area/maintenance/fore)
+/area/maintenance/starboard/aft)
 "wsR" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -40949,9 +41951,15 @@
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "wuI" = (
-/obj/item/toy/lumosplush/duke,
-/turf/open/floor/light/colour_cycle,
-/area/maintenance/starboard/aft)
+/obj/machinery/door/airlock/engineering{
+	name = "Starboard Quarter Emergency Generator";
+	req_access_txt = "10"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "wvq" = (
 /obj/structure/sign/poster/official/hydro_ad{
 	pixel_y = 32
@@ -41008,9 +42016,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -41018,6 +42023,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -41054,6 +42062,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "wxG" = (
@@ -41069,11 +42078,9 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "wxV" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/obj/structure/sign/warning/electricshock,
+/turf/closed/wall/r_wall,
+/area/maintenance/port)
 "wxZ" = (
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
@@ -41119,7 +42126,7 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/bridge)
 "wAm" = (
-/obj/machinery/atmospherics/pipe/simple/violet/hidden{
+/obj/machinery/atmospherics/pipe/simple/violet/visible{
 	dir = 4
 	},
 /turf/open/floor/engine,
@@ -41346,9 +42353,8 @@
 	dir = 9
 	},
 /obj/machinery/power/apc/auto_name/south,
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
@@ -41510,6 +42516,16 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/genetics)
+"wKK" = (
+/obj/structure/window/reinforced,
+/obj/machinery/door/window/southleft{
+	dir = 4;
+	name = "Engineering Delivery";
+	req_access_txt = "10"
+	},
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "wLD" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -41529,6 +42545,12 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/plasteel,
 /area/bridge)
+"wLE" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/aisat/hallway)
 "wLN" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -41540,11 +42562,14 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal/incinerator)
 "wMz" = (
-/obj/structure/reagent_dispensers/water_cooler,
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 9
+/obj/machinery/door/window/eastright{
+	base_state = "left";
+	icon_state = "left";
+	name = "Research Division Delivery";
+	req_access_txt = "47"
 	},
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/science/research)
 "wMV" = (
 /obj/item/chair/wood,
@@ -41556,6 +42581,9 @@
 /area/maintenance/starboard/aft)
 "wMY" = (
 /obj/machinery/space_heater,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "wNs" = (
@@ -41597,6 +42625,7 @@
 	name = "External Access";
 	req_access_txt = "13;7"
 	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "wOE" = (
@@ -41650,6 +42679,11 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"wQk" = (
+/obj/structure/table,
+/obj/machinery/chem_dispenser/drinks,
+/turf/open/floor/plating,
+/area/science/xenobiology)
 "wQy" = (
 /obj/machinery/smartfridge/chemistry/preloaded,
 /turf/closed/wall/r_wall,
@@ -41695,7 +42729,9 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/structure/closet/firecloset,
+/obj/structure/closet/firecloset{
+	anchored = 1
+	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "wSr" = (
@@ -41738,11 +42774,11 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 6
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/science/lab)
@@ -41770,12 +42806,10 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "wUd" = (
@@ -41915,17 +42949,22 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "wYp" = (
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating,
 /area/engine/engineering)
 "wYr" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/engine_waste{
 	dir = 4
 	},
-/obj/machinery/light/floor/fakeday,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
 "wYw" = (
@@ -42005,8 +43044,9 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
 "xbb" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
+/obj/structure/rack,
+/obj/item/stack/sheet/mineral/plasma{
+	amount = 10
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
@@ -42209,6 +43249,9 @@
 "xeq" = (
 /obj/structure/chair/stool,
 /obj/effect/landmark/start/scientist,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "xeE" = (
@@ -42236,6 +43279,11 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
+"xfA" = (
+/obj/machinery/shieldwallgen/xenobiologyaccess,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/science/xenobiology)
 "xfH" = (
 /obj/machinery/chem_master/condimaster{
 	name = "HoochMaster 2000"
@@ -42257,9 +43305,12 @@
 /turf/open/floor/wood,
 /area/library)
 "xgr" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/carpet,
-/area/chapel/main)
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/smes,
+/turf/open/floor/plating,
+/area/maintenance/port)
 "xgy" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable{
@@ -42332,6 +43383,9 @@
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
@@ -42407,6 +43461,9 @@
 /area/maintenance/fore)
 "xkc" = (
 /obj/machinery/telecomms/broadcaster/preset_right,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
 "xkr" = (
@@ -42425,17 +43482,14 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/icemoon/surface/outdoors)
 "xlb" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /obj/machinery/airalarm{
 	pixel_y = 26
 	},
 /obj/structure/cable{
 	icon_state = "2-4"
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -42454,17 +43508,11 @@
 	},
 /area/crew_quarters/fitness)
 "xlx" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/machinery/status_display/evac{
 	pixel_y = 32
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -42535,6 +43583,9 @@
 	pixel_y = 3
 	},
 /obj/item/clothing/glasses/welding,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 6
+	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "xnX" = (
@@ -42550,12 +43601,12 @@
 /turf/open/floor/plasteel,
 /area/bridge)
 "xos" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on{
-	dir = 4
-	},
-/mob/living/carbon/monkey,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
+/obj/structure/table/glass,
+/obj/item/seeds/plump,
+/obj/item/seeds/reishi,
+/obj/item/cultivator,
+/turf/open/floor/plasteel/dark,
+/area/chapel/office)
 "xov" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -42613,7 +43664,6 @@
 	name = "Station Intercom (General)";
 	pixel_x = -30
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
 "xqU" = (
@@ -42687,6 +43737,9 @@
 /area/maintenance/port)
 "xtP" = (
 /obj/machinery/telecomms/processor/preset_one,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
 "xtU" = (
@@ -42721,13 +43774,20 @@
 	},
 /area/crew_quarters/heads/captain)
 "xuD" = (
-/obj/effect/decal/remains/human,
-/turf/open/floor/light/colour_cycle,
-/area/maintenance/starboard/aft)
+/obj/structure/disposalpipe/segment,
+/obj/structure/grille,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "xuH" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
@@ -42747,11 +43807,11 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "xuW" = (
-/obj/structure/disposalpipe/junction{
-	dir = 1
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
 	},
 /turf/open/floor/carpet,
 /area/chapel/main)
@@ -42835,6 +43895,9 @@
 /obj/structure/safe,
 /obj/item/gun/ballistic/revolver/nagant,
 /obj/effect/turf_decal/bot_white/left,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
 "xyn" = (
@@ -42929,7 +43992,7 @@
 	id = "xenobio1";
 	name = "containment blast door"
 	},
-/obj/machinery/atmospherics/pipe/simple/violet/hidden{
+/obj/machinery/atmospherics/pipe/simple/violet/visible{
 	dir = 4
 	},
 /turf/open/floor/engine,
@@ -42988,11 +44051,10 @@
 /turf/open/floor/engine,
 /area/engine/supermatter)
 "xBy" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/bed/roller,
 /obj/effect/turf_decal/trimline/red/filled/line,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "xBO" = (
@@ -43009,8 +44071,11 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/grimy,
-/area/chapel/office)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "xCa" = (
 /obj/machinery/atmospherics/components/binary/pump/on,
 /obj/machinery/light/small{
@@ -43029,9 +44094,8 @@
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
 "xCb" = (
-/obj/effect/decal/cleanable/glitter/pink,
 /obj/machinery/light,
-/turf/open/floor/light/colour_cycle,
+/turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "xCI" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -43141,12 +44205,6 @@
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "xEP" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/blood/gibs/human/body,
 /obj/item/melee/baseball_bat,
 /turf/open/floor/plating,
@@ -43161,7 +44219,7 @@
 	id = "xenobio7";
 	name = "containment blast door"
 	},
-/obj/machinery/atmospherics/pipe/simple/violet/hidden{
+/obj/machinery/atmospherics/pipe/simple/violet/visible{
 	dir = 4
 	},
 /turf/open/floor/engine,
@@ -43317,9 +44375,6 @@
 /turf/open/floor/plasteel,
 /area/teleporter)
 "xIP" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
@@ -43453,7 +44508,6 @@
 /turf/open/floor/carpet,
 /area/bridge/meeting_room)
 "xMh" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible,
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/purple{
 	dir = 2
@@ -43527,10 +44581,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"xOc" = (
+/obj/structure/closet/emcloset,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "xOd" = (
-/turf/open/floor/carpet{
-	icon_state = "carpetsymbol"
+/obj/structure/chair/comfy/beige{
+	dir = 1
 	},
+/turf/open/floor/wood,
 /area/hallway/secondary/exit/departure_lounge)
 "xOq" = (
 /obj/machinery/portable_atmospherics/pump,
@@ -43548,9 +44607,6 @@
 /area/crew_quarters/locker)
 "xOB" = (
 /obj/machinery/door/firedoor/heavy,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
@@ -43573,14 +44629,15 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "xPb" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=4";
+	freq = 1400;
+	location = "Research Division"
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/science/storage)
+/obj/effect/turf_decal/bot,
+/obj/structure/plasticflaps/opaque,
+/turf/open/floor/plasteel,
+/area/science/research)
 "xPk" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
@@ -44123,10 +45180,10 @@
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "ybI" = (
-/obj/effect/turf_decal/tile/purple{
+/obj/structure/tank_dispenser/plasma,
+/obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 8
 	},
-/obj/structure/tank_dispenser/plasma,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "ycv" = (
@@ -44212,12 +45269,14 @@
 /turf/open/floor/plasteel,
 /area/bridge)
 "yem" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
-/obj/effect/decal/remains/human,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
+/obj/structure/table/glass,
+/obj/item/seeds/harebell,
+/obj/item/seeds/poppy,
+/obj/item/seeds/tea,
+/obj/item/seeds/sunflower,
+/obj/item/storage/bag/plants/portaseeder,
+/turf/open/floor/plasteel/dark,
+/area/chapel/office)
 "yeu" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/stripes/line,
@@ -44286,14 +45345,17 @@
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
 "ygL" = (
-/obj/machinery/jukebox/disco{
-	anchored = 1;
-	req_access = null;
-	req_one_access = null
+/obj/structure/chair{
+	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "ygW" = (
 /obj/structure/chair/stool{
 	pixel_y = 8
@@ -44427,6 +45489,9 @@
 /obj/machinery/firealarm{
 	pixel_y = 29
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
 "ykl" = (
@@ -44436,6 +45501,10 @@
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
+	},
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -22
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -44964,7 +46033,7 @@ jsJ
 jsJ
 jsJ
 jsJ
-ctd
+tXu
 jsJ
 jsJ
 jsJ
@@ -45732,7 +46801,7 @@ jsJ
 jsJ
 jsJ
 jsJ
-ctd
+tXu
 jsJ
 jsJ
 jsJ
@@ -46255,7 +47324,7 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
@@ -46504,19 +47573,19 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
 jsJ
-ctd
+tXu
 jsJ
 jsJ
 jsJ
 jsJ
 jsJ
 jsJ
-ctd
+tXu
 jsJ
 jsJ
 jsJ
@@ -47546,7 +48615,7 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
@@ -47629,9 +48698,9 @@ kSg
 kSg
 kSg
 srK
-wsM
-vjO
-vjO
+cMk
+cMk
+cMk
 dvm
 eca
 eca
@@ -47641,10 +48710,10 @@ eca
 eca
 hCP
 ipF
-dQZ
-vjO
+cMk
+cMk
 nmK
-jjt
+cMk
 xjf
 srK
 rLU
@@ -47795,7 +48864,7 @@ jsJ
 jsJ
 jsJ
 jsJ
-ctd
+tXu
 jsJ
 jsJ
 jsJ
@@ -47901,7 +48970,7 @@ iJl
 iJl
 iJl
 iJl
-vUF
+cMk
 xjf
 srK
 rLU
@@ -48141,9 +49210,9 @@ rMm
 rMm
 kSg
 kSg
-kSg
 srK
-vUF
+srK
+cMk
 diy
 pBy
 wFg
@@ -48158,7 +49227,7 @@ gzG
 gzG
 fMq
 iJl
-vUF
+cMk
 jqz
 srK
 srK
@@ -48398,9 +49467,9 @@ rMm
 rMm
 kSg
 kSg
-kSg
 srK
-vUF
+cMk
+cMk
 diy
 kFK
 qvG
@@ -48415,7 +49484,7 @@ pEA
 pEA
 ocm
 iJl
-vUF
+cMk
 qri
 nin
 cMk
@@ -48570,7 +49639,7 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
@@ -48578,7 +49647,7 @@ jsJ
 jsJ
 jsJ
 jsJ
-ctd
+tXu
 jsJ
 jsJ
 jsJ
@@ -48655,9 +49724,9 @@ rMm
 rMm
 kSg
 kSg
-kSg
 srK
-vUF
+cMk
+bTk
 diy
 mIA
 uIF
@@ -48672,7 +49741,7 @@ sSo
 sAS
 fLT
 iJl
-vUF
+cMk
 jxf
 srK
 srK
@@ -48912,9 +49981,9 @@ rMm
 rMm
 kSg
 kSg
-kSg
-srK
-vUF
+but
+cMk
+cOJ
 diy
 bGv
 fgZ
@@ -48929,7 +49998,7 @@ vwb
 qoT
 ovi
 iJl
-vUF
+cMk
 xjf
 srK
 rLU
@@ -49169,9 +50238,9 @@ rMm
 rMm
 kSg
 kSg
-kSg
-srK
-vUF
+bFe
+bTk
+cMk
 diy
 hlb
 nVs
@@ -49186,7 +50255,7 @@ jcZ
 wYT
 lnY
 iJl
-vUF
+cMk
 xjf
 srK
 rLU
@@ -49342,10 +50411,10 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
-ctd
+tXu
 jsJ
 jsJ
 jsJ
@@ -49426,9 +50495,9 @@ rMm
 rMm
 rMm
 kSg
-kSg
 srK
-vUF
+srK
+cMk
 diy
 oyS
 rEF
@@ -49443,7 +50512,7 @@ iJl
 iJl
 iJl
 iJl
-vUF
+cMk
 cMk
 srK
 srK
@@ -49683,9 +50752,9 @@ rMm
 rMm
 rMm
 kSg
-kSg
+rLU
 srK
-vUF
+srK
 diy
 cUe
 oMP
@@ -49700,7 +50769,7 @@ iJl
 srl
 xjf
 xjf
-vUF
+cMk
 tCC
 cMk
 cMk
@@ -49940,9 +51009,9 @@ rMm
 rMm
 rMm
 kSg
-kSg
-srK
-vUF
+rLU
+rLU
+rLU
 diy
 szx
 aaU
@@ -50125,7 +51194,7 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 cXC
@@ -50197,9 +51266,9 @@ rMm
 rMm
 rMm
 kSg
-kSg
-srK
-vUF
+rLU
+rLU
+rLU
 mLE
 jWI
 sxE
@@ -50212,10 +51281,10 @@ gwA
 uJE
 nGV
 vUF
-cMk
+srl
 nGV
 nGV
-nGV
+mVD
 nGV
 nGV
 nGV
@@ -50454,9 +51523,9 @@ rMm
 rMm
 rMm
 kSg
-kSg
-srK
-vUF
+rLU
+rLU
+rLU
 mLE
 ahW
 qza
@@ -50472,7 +51541,7 @@ vUF
 xjf
 nGV
 tQl
-woI
+awe
 ykl
 rjk
 pXu
@@ -50636,7 +51705,7 @@ rMm
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 pxz
@@ -50709,11 +51778,11 @@ rMm
 rMm
 rMm
 rMm
-rMm
 kSg
 kSg
-srK
-vUF
+rLU
+rLU
+rLU
 mLE
 rjs
 xHY
@@ -50725,7 +51794,7 @@ fFH
 gFn
 iLK
 nGV
-mcv
+vUF
 xjf
 nGV
 rnr
@@ -50966,11 +52035,11 @@ rMm
 rMm
 rMm
 rMm
-rMm
 kSg
-kSg
-srK
-vUF
+rLU
+rLU
+rLU
+rLU
 mLE
 hqZ
 tzQ
@@ -50983,7 +52052,7 @@ gFn
 uJE
 nGV
 vUF
-xjf
+cMk
 nGV
 vcA
 uHf
@@ -51223,11 +52292,11 @@ rMm
 rMm
 rMm
 rMm
-rMm
 kSg
-kSg
-srK
-vUF
+rLU
+rLU
+rLU
+rLU
 mLE
 yiC
 sZL
@@ -51480,11 +52549,11 @@ rMm
 rMm
 rMm
 rMm
-rMm
 kSg
-kSg
-srK
-vUF
+rLU
+rLU
+rLU
+rLU
 mLE
 ahW
 mxN
@@ -51496,8 +52565,8 @@ nfI
 gNq
 kho
 nGV
-vUF
-srl
+lyT
+lEw
 nGV
 hlk
 vZe
@@ -51668,7 +52737,7 @@ jsJ
 jsJ
 jsJ
 jsJ
-bCe
+kgx
 jsJ
 rNe
 kgv
@@ -51737,11 +52806,11 @@ rMm
 rMm
 rMm
 rMm
-rMm
 kSg
-kSg
-srK
-vUF
+rLU
+rLU
+rLU
+rLU
 mLE
 blN
 eVd
@@ -51791,8 +52860,8 @@ ahd
 ahd
 ahd
 ahd
-ahd
 hZT
+jsJ
 jsJ
 jsJ
 jsJ
@@ -51994,11 +53063,11 @@ rMm
 rMm
 rMm
 rMm
-rMm
 kSg
 rLU
-srK
-vUF
+rLU
+rLU
+rLU
 mLE
 mLE
 mLE
@@ -52044,12 +53113,12 @@ rzR
 fcM
 fcM
 rMP
-jII
+tTG
 hlt
 jgW
 bJU
-aae
 ahd
+jsJ
 jsJ
 jsJ
 jsJ
@@ -52251,11 +53320,11 @@ rMm
 rMm
 rMm
 rMm
-rMm
 kSg
 rLU
-srK
-vUF
+rLU
+rLU
+rLU
 nGV
 xck
 lcL
@@ -52278,7 +53347,7 @@ pVZ
 pVZ
 pVZ
 nGV
-qPt
+tCC
 jZU
 srK
 wyi
@@ -52301,12 +53370,12 @@ jII
 jII
 jII
 jII
-jII
-fuc
-umj
+tTJ
+oaN
+soT
 gnW
-qsS
 ahd
+jsJ
 jsJ
 jsJ
 jsJ
@@ -52508,11 +53577,11 @@ rMm
 rMm
 rMm
 rMm
-rMm
+kSg
 kSg
 rLU
-srK
-vUF
+rLU
+rLU
 nGV
 kjQ
 rvq
@@ -52536,7 +53605,7 @@ afS
 kgV
 nGV
 xjf
-jZU
+oJv
 srK
 wyi
 jII
@@ -52558,12 +53627,12 @@ rBQ
 jII
 dqk
 jII
-jII
+tUL
 oaN
 soT
 xOd
-lyT
 ahd
+jsJ
 jsJ
 jsJ
 jsJ
@@ -52768,8 +53837,8 @@ rMm
 kSg
 kSg
 kSg
-srK
-vUF
+rLU
+rLU
 nGV
 nGV
 nGV
@@ -52815,14 +53884,14 @@ rHa
 uGd
 xZj
 jII
-jII
-bce
+umj
+oaN
 soT
 xOd
-lBM
 ahd
 jsJ
 jsJ
+jsJ
 rLU
 rLU
 rLU
@@ -52951,7 +54020,7 @@ rMm
 rMm
 rMm
 jsJ
-bCe
+kgx
 jsJ
 jsJ
 jsJ
@@ -53025,8 +54094,8 @@ rMm
 kSg
 kSg
 kSg
-srK
-vUF
+kSg
+rLU
 nGV
 heB
 iix
@@ -53072,12 +54141,12 @@ rLF
 jII
 uBs
 jII
-jII
+uNU
 pnZ
 pBU
 vwy
-vyw
 ahd
+jsJ
 jsJ
 jsJ
 rLU
@@ -53282,10 +54351,10 @@ rMm
 kSg
 kSg
 kSg
-srK
-vUF
-nGV
-aMR
+kSg
+kSg
+oZy
+rvq
 rvq
 rvq
 iUa
@@ -53330,11 +54399,11 @@ jII
 ffg
 jII
 jII
-jII
+vxg
 rOc
 nNt
-nNt
 ahd
+jsJ
 jsJ
 jsJ
 rLU
@@ -53538,20 +54607,20 @@ rMm
 rMm
 kSg
 kSg
-rLU
-hmR
-vUF
-nGV
-mUy
+kSg
+kSg
+kSg
+dQb
+fBu
 cEs
 nIn
 sop
-aQZ
+ieY
 hfb
-wEf
-rkn
-fUp
-jKJ
+ivA
+jiH
+jnB
+uvO
 xYP
 nGV
 jsJ
@@ -53590,8 +54659,8 @@ wbl
 wbl
 xQM
 jII
-jII
 ahd
+jsJ
 jsJ
 jsJ
 jsJ
@@ -53795,10 +54864,10 @@ rMm
 rMm
 kSg
 kSg
-rLU
-hmR
-vUF
-nGV
+kSg
+kSg
+kSg
+dQZ
 nvQ
 elH
 xeE
@@ -53846,13 +54915,13 @@ fEE
 vXg
 jII
 sSB
-cas
-rWq
+vMT
 ahd
 jsJ
 jsJ
 jsJ
 jsJ
+jsJ
 rLU
 rLU
 rLU
@@ -53863,7 +54932,7 @@ jsJ
 jsJ
 jsJ
 bCe
-kSg
+jsJ
 rLU
 rLU
 rLU
@@ -54052,10 +55121,10 @@ rMm
 rMm
 kSg
 kSg
-rLU
-hmR
-vUF
-nGV
+kSg
+kSg
+kSg
+nuJ
 mUy
 mUB
 lMe
@@ -54066,7 +55135,7 @@ fFH
 lMG
 vZe
 jKJ
-nGO
+lBM
 nGV
 jsJ
 jsJ
@@ -54080,12 +55149,12 @@ nUn
 gBm
 vgz
 gBm
-ahd
-ahd
-ahd
-ahd
-ahd
-ahd
+oLO
+oLO
+oLO
+oLO
+oLO
+oLO
 hZT
 dzo
 eiq
@@ -54105,7 +55174,7 @@ hZT
 fbE
 hZT
 dwo
-dwo
+rLU
 rLU
 jsJ
 jsJ
@@ -54120,7 +55189,7 @@ jsJ
 jsJ
 jsJ
 jsJ
-kSg
+jsJ
 kSg
 kSg
 rLU
@@ -54309,9 +55378,9 @@ rMm
 rMm
 kSg
 kSg
-hmR
-hmR
-fDn
+kSg
+rLU
+rLU
 nGV
 nwv
 rvq
@@ -54324,7 +55393,7 @@ wEj
 aQh
 uvO
 bHe
-nGV
+oZy
 cyH
 jsJ
 jsJ
@@ -54337,7 +55406,7 @@ nUn
 tNv
 nkn
 tNv
-ahd
+oLO
 awq
 gyf
 sno
@@ -54361,8 +55430,8 @@ tYG
 dwo
 dNL
 qCT
-pak
 dwo
+rLU
 rLU
 rLU
 rLU
@@ -54377,7 +55446,7 @@ jsJ
 kgx
 jsJ
 jsJ
-kSg
+jsJ
 kSg
 kSg
 rLU
@@ -54565,10 +55634,10 @@ rLU
 rLU
 nSm
 kSg
+kSg
 rLU
-hmR
-ajy
-tUL
+rLU
+rLU
 nGV
 caH
 gKa
@@ -54579,9 +55648,9 @@ nGV
 wJq
 lMG
 kxG
-jKJ
+jNf
 rck
-nGV
+lGz
 jsJ
 jsJ
 jsJ
@@ -54594,7 +55663,7 @@ nUn
 nuG
 nkn
 tNv
-ahd
+oLO
 uhd
 pGZ
 wnc
@@ -54617,12 +55686,12 @@ kIP
 kIP
 dwo
 hLE
-kIP
 pak
-hWW
-hWW
-hWW
-hWW
+dwo
+rLU
+rLU
+rLU
+rLU
 rLU
 jsJ
 jsJ
@@ -54634,8 +55703,8 @@ jsJ
 jsJ
 jsJ
 jsJ
-kSg
-kSg
+jsJ
+jsJ
 kSg
 kSg
 kSg
@@ -54823,9 +55892,9 @@ rLU
 kSg
 kSg
 rLU
-hmR
-fRi
-cMk
+rLU
+iBp
+iBp
 nGV
 nUQ
 pUi
@@ -54851,7 +55920,7 @@ nUn
 tNv
 nkn
 tNv
-ahd
+oLO
 rol
 upQ
 ddx
@@ -54874,12 +55943,12 @@ uMY
 kIP
 dwo
 hLE
-kIP
-ieY
-hWW
-pXf
-oqR
-hWW
+pak
+dwo
+rLU
+rLU
+rLU
+rLU
 rLU
 jsJ
 jsJ
@@ -54892,7 +55961,7 @@ jsJ
 jsJ
 jsJ
 kgx
-kSg
+jsJ
 kSg
 kSg
 kSg
@@ -54929,7 +55998,7 @@ cdw
 mXA
 oWE
 rNe
-kgx
+jsJ
 jsJ
 jsJ
 vXT
@@ -55080,9 +56149,9 @@ piz
 kSg
 piz
 piz
-hmR
-fRi
-cMk
+iBp
+iBp
+iBp
 nGV
 jgS
 rvq
@@ -55119,7 +56188,7 @@ teN
 gJc
 xMK
 xMK
-xMK
+rmb
 grO
 xMK
 xMK
@@ -55130,13 +56199,13 @@ dwo
 dwo
 kIP
 mit
-jnB
-niE
-niE
-sYd
-jll
-cMs
-hWW
+hLE
+pak
+dwo
+rLU
+rLU
+rLU
+rLU
 rLU
 rLU
 jsJ
@@ -55148,8 +56217,8 @@ jsJ
 jsJ
 kgx
 jsJ
-kSg
-kSg
+jsJ
+jsJ
 kSg
 kSg
 kSg
@@ -55336,10 +56405,10 @@ cWJ
 kEY
 cWJ
 cWJ
-fPg
-hmR
+bRT
 iBp
-cMk
+iBp
+iBp
 nGV
 eJr
 ukD
@@ -55374,7 +56443,7 @@ xwH
 vCS
 dGh
 gJc
-enE
+gJc
 gJc
 gJc
 gJc
@@ -55388,12 +56457,12 @@ kDE
 uYU
 dwo
 hLE
-kIP
-kIP
-uVm
-hxx
-oJv
-hWW
+pak
+dwo
+rLU
+rLU
+rLU
+rLU
 rLU
 rLU
 jsJ
@@ -55405,7 +56474,7 @@ jsJ
 jsJ
 jsJ
 jsJ
-kSg
+jsJ
 kSg
 kSg
 kSg
@@ -55594,9 +56663,9 @@ cWJ
 cWJ
 cWJ
 fPg
-hmR
-fSJ
-cMk
+iBp
+iBp
+iBp
 nGV
 fkr
 nVO
@@ -55608,8 +56677,8 @@ tpg
 wvC
 vZe
 jKJ
-rcg
-nGV
+nGO
+oZy
 jsJ
 jsJ
 jsJ
@@ -55644,13 +56713,13 @@ uYU
 hkz
 eIS
 dwo
-wgj
-nnG
-pse
-hWW
-hWW
-hWW
-hWW
+hLE
+kIP
+dwo
+rLU
+rLU
+rLU
+rLU
 rLU
 rLU
 jsJ
@@ -55661,8 +56730,8 @@ jsJ
 kgx
 jsJ
 nSm
-kSg
-kSg
+jsJ
+jsJ
 kSg
 kSg
 rLU
@@ -55851,9 +56920,9 @@ dpj
 ayy
 cWJ
 cWJ
-hmR
-bVo
-cMk
+iBp
+iBp
+iBp
 nGV
 vpq
 vau
@@ -55864,9 +56933,9 @@ gKa
 tsl
 lMG
 vZe
-jKJ
+jNf
 xBy
-nGV
+lGz
 jsJ
 jsJ
 jsJ
@@ -55901,13 +56970,13 @@ kDE
 eIS
 kDE
 dwo
-pak
-kIP
 hLE
+kIP
 dwo
-sZu
-rQl
 dwo
+rLU
+rLU
+rLU
 rLU
 rLU
 rLU
@@ -55918,7 +56987,7 @@ jsJ
 jsJ
 kgx
 jsJ
-kSg
+jsJ
 kgx
 kSg
 rLU
@@ -56109,7 +57178,7 @@ dpj
 cWJ
 cWJ
 bRT
-sCW
+bRT
 bRT
 bRT
 nGV
@@ -56158,13 +57227,13 @@ dwo
 dwo
 dwo
 dwo
-pak
-kIP
 hLE
-dwo
 kIP
-kIP
+xOZ
 dwo
+rLU
+rLU
+rLU
 rLU
 rLU
 rLU
@@ -56175,7 +57244,7 @@ jsJ
 jsJ
 jsJ
 jsJ
-kSg
+jsJ
 kSg
 rLU
 rLU
@@ -56409,19 +57478,19 @@ fiW
 rpR
 rjU
 ibS
-tYG
+rWq
 kIP
 tFU
-vpA
-iks
+sRD
 dwo
 pak
-kIP
 hLE
-dwo
 kIP
-qNZ
-dwo
+kIP
+hWW
+hWW
+hWW
+hWW
 rLU
 rLU
 jsJ
@@ -56432,7 +57501,7 @@ jsJ
 kgx
 jsJ
 jsJ
-kSg
+jsJ
 rLU
 rLU
 rLU
@@ -56620,8 +57689,8 @@ bZM
 bZM
 bZM
 dpj
-cWJ
-nvx
+aaT
+cHw
 dfD
 oFa
 cHw
@@ -56669,16 +57738,16 @@ ibS
 oTq
 vpA
 vpA
-vpA
-tFU
-dwo
+sYd
+uUk
 pak
-kIP
-hLE
+wgj
+nnG
+woI
+hWW
 xbb
-kIP
 pON
-dwo
+hWW
 rLU
 jsJ
 cyH
@@ -56689,7 +57758,7 @@ jsJ
 jsJ
 jsJ
 kgx
-kSg
+jsJ
 rLU
 rLU
 rLU
@@ -56877,7 +57946,7 @@ dpj
 dpj
 dpj
 ayy
-cWJ
+ajy
 nvx
 bRT
 kyq
@@ -56924,18 +57993,18 @@ mzi
 mzi
 ibS
 uIe
-vpA
+sst
 vpA
 tFU
-vpA
+uVm
 kIP
 kIP
 kIP
 tPs
-dwo
-kIP
-iNU
-dwo
+wuI
+jll
+cMs
+hWW
 rLU
 jsJ
 jsJ
@@ -57129,12 +58198,12 @@ rLU
 rLU
 rLU
 cWJ
-cWJ
-cWJ
-cWJ
-cWJ
-cWJ
-cWJ
+aaT
+aOg
+aOg
+aOg
+aOg
+boY
 rLU
 bRT
 qTx
@@ -57148,7 +58217,7 @@ fwh
 sCm
 pIR
 xlx
-fWv
+igV
 vfU
 msL
 oZy
@@ -57183,16 +58252,16 @@ ibS
 pak
 tFU
 tFU
-vpA
-kIP
+sZu
+dwo
 kIP
 kIP
 dwo
 hLE
-dwo
-qpl
+wxV
+xgr
 bgE
-dwo
+hWW
 rLU
 jsJ
 jsJ
@@ -57386,7 +58455,7 @@ rLU
 rLU
 rLU
 cWJ
-cWJ
+ajy
 cWJ
 cBB
 cWJ
@@ -57395,7 +58464,7 @@ rLU
 rLU
 bRT
 bRT
-rmb
+bRT
 pIR
 toD
 jiu
@@ -57446,10 +58515,10 @@ cJI
 tvk
 tvk
 hLE
-dwo
-dwo
-dwo
-dwo
+hWW
+hWW
+hWW
+hWW
 rLU
 jsJ
 jsJ
@@ -57643,7 +58712,7 @@ rLU
 piz
 piz
 piz
-kSg
+avT
 piz
 piz
 rLU
@@ -57651,8 +58720,8 @@ rLU
 rLU
 rLU
 rLU
-bOk
-cdq
+rLU
+rLU
 pIR
 toD
 jiu
@@ -57663,7 +58732,7 @@ toD
 pIR
 ikW
 etD
-vZe
+kbL
 srI
 sXs
 oGz
@@ -57900,16 +58969,16 @@ cXC
 kSg
 kSg
 kSg
+avT
 kSg
-kSg
 cXC
 cXC
 cXC
 rLU
 rLU
 rLU
-bOk
-nGt
+rLU
+rLU
 pIR
 opC
 jiu
@@ -58157,7 +59226,7 @@ xIt
 xIt
 xIt
 xIt
-xIt
+aMR
 xIt
 xIt
 xIt
@@ -58166,9 +59235,9 @@ xIt
 bkg
 bkg
 ttZ
-luG
+rLU
 pIR
-jiu
+fIX
 jiu
 hMq
 beY
@@ -58186,7 +59255,7 @@ ibn
 jVQ
 myc
 oZQ
-myc
+oqR
 bud
 ibn
 rTU
@@ -58955,9 +60024,9 @@ eHQ
 eHQ
 eHQ
 jVQ
-myc
+nGt
 tvs
-myc
+osk
 pYr
 adY
 rss
@@ -59197,13 +60266,13 @@ pIR
 pIR
 tTa
 cZZ
-xeG
+gmk
 sRd
 pIR
 sbo
 qmK
 pIR
-baZ
+jjt
 jDz
 uwR
 ggH
@@ -59212,9 +60281,9 @@ jSJ
 rKp
 eHQ
 dKv
-myc
+nHH
 bHG
-myc
+oIM
 nlI
 ibn
 cDJ
@@ -59720,10 +60789,10 @@ pIR
 gUK
 bfL
 nAi
-aVe
+hQt
 fBd
 gUD
-tLG
+mqB
 hnZ
 juU
 bsQ
@@ -60014,7 +61083,7 @@ tvk
 tvk
 dGv
 eUS
-tvk
+vZg
 wgj
 dFG
 nnG
@@ -60491,7 +61560,7 @@ pIR
 baZ
 baZ
 baZ
-hQt
+aVX
 pdF
 seX
 jmu
@@ -60555,9 +61624,9 @@ rLU
 rLU
 hoF
 fgT
-jse
+uZh
 oRh
-oRh
+hIp
 piR
 hoF
 rLU
@@ -60745,10 +61814,10 @@ pIR
 pIR
 pIR
 pIR
-baZ
+jkV
 qjw
-baZ
-hQt
+lju
+lCa
 okh
 vdr
 lnw
@@ -61567,7 +62636,7 @@ hLS
 dwo
 kgv
 kgv
-awA
+kgv
 mkt
 awA
 szI
@@ -62081,7 +63150,7 @@ hLE
 dwo
 kgv
 dKq
-awA
+kgv
 cyH
 awA
 doz
@@ -62278,7 +63347,7 @@ gzo
 gzo
 azx
 lAG
-eSO
+dtn
 boS
 iKy
 rjb
@@ -62338,7 +63407,7 @@ mtg
 irb
 npG
 lbb
-jsJ
+kSg
 uOy
 uGB
 jsJ
@@ -62535,7 +63604,7 @@ gzo
 gzo
 gzo
 lAG
-eSO
+dwb
 gte
 tOh
 tMC
@@ -62596,7 +63665,7 @@ dwo
 kgv
 kHm
 kgv
-awA
+kgv
 iAo
 jsJ
 quB
@@ -63108,8 +64177,8 @@ khY
 hLE
 dwo
 kgv
-jsJ
-jsJ
+kSg
+kSg
 kgv
 jsJ
 rLU
@@ -63364,9 +64433,9 @@ mwR
 khY
 hLE
 dwo
-jsJ
-jsJ
-gna
+kSg
+kSg
+fZF
 kgv
 cXC
 rLU
@@ -63621,9 +64690,9 @@ lMa
 khY
 hLE
 dwo
-cyH
+xlg
 kgv
-jsJ
+kSg
 rLU
 cXC
 rLU
@@ -64136,7 +65205,7 @@ khY
 hLE
 dwo
 kgv
-jsJ
+kSg
 rLU
 rLU
 rLU
@@ -64386,7 +65455,7 @@ kww
 gMa
 qtG
 kJh
-tBs
+xuD
 lfg
 tBs
 tBs
@@ -64642,11 +65711,11 @@ fQy
 fWr
 uqh
 uyV
-gRM
 niE
+xBR
 niE
-niE
-niE
+krL
+krL
 hyy
 dwo
 kgv
@@ -64899,12 +65968,12 @@ cWQ
 fOY
 uqh
 hLE
-gAA
+dwo
 bbC
-pak
-pak
-pak
-tYG
+dwo
+dwo
+dwo
+dwo
 dwo
 cXC
 jrH
@@ -65158,11 +66227,11 @@ uqh
 hLE
 dwo
 cYM
-dwo
-dwo
-dwo
-dwo
-dwo
+rLU
+rLU
+rLU
+rLU
+rLU
 kSg
 kSg
 rLU
@@ -65370,7 +66439,7 @@ gpx
 oiS
 oiS
 oiS
-pIT
+iNU
 jmS
 nlQ
 pDz
@@ -65414,8 +66483,8 @@ dzS
 uqh
 hLE
 dwo
-jkV
-rLU
+kSg
+kSg
 rLU
 rLU
 kSg
@@ -65627,7 +66696,7 @@ daf
 ltA
 rls
 oiS
-pIT
+jaR
 aYM
 nlQ
 dVb
@@ -66412,7 +67481,7 @@ uaG
 uaG
 uaG
 czn
-hZo
+czn
 max
 bYC
 giB
@@ -66658,18 +67727,18 @@ eCB
 cLh
 haf
 dtl
-nUv
-nUv
+luG
 fXe
-adb
-adb
-adb
-adb
-adb
-adb
-adb
-rDh
-tpt
+fXe
+fXe
+mtL
+uea
+uea
+uea
+uea
+uea
+uea
+uea
 uea
 cab
 vcQ
@@ -66916,17 +67985,17 @@ fHB
 ePn
 uSN
 lqo
-lIq
-wYw
-gSB
-dod
-dHX
-dHX
-dHX
-dHX
-dHX
-dHX
-dHX
+fXe
+fXe
+mif
+uSN
+kSg
+rLU
+rLU
+rLU
+kSg
+kSg
+kSg
 uea
 cab
 vcQ
@@ -67172,16 +68241,16 @@ kKA
 wpc
 nkK
 uSN
-dHX
-dHX
-dHX
-dHX
-dHX
-dHX
+uSN
+uSN
+uSN
+uSN
+uSN
 rLU
 rLU
 rLU
-jsJ
+rLU
+rLU
 uSY
 kSg
 uea
@@ -67438,7 +68507,7 @@ rLU
 rLU
 rLU
 rLU
-jsJ
+rLU
 bCe
 kSg
 uea
@@ -68247,7 +69316,7 @@ jsJ
 jsJ
 jsJ
 jsJ
-jsJ
+kgx
 jsJ
 jsJ
 jsJ
@@ -69285,7 +70354,7 @@ dpU
 isX
 urz
 tFr
-ces
+nBd
 hYR
 xdd
 vbW
@@ -69797,9 +70866,9 @@ eGG
 awd
 xAb
 wxr
-ces
+vex
 twD
-ces
+wLE
 qOQ
 xdd
 rNE
@@ -70054,7 +71123,7 @@ soq
 fXk
 jCZ
 kPi
-ces
+vSf
 uUn
 uUn
 gmj
@@ -70311,7 +71380,7 @@ bPg
 fXk
 hdR
 kPi
-ces
+vSf
 uUn
 nyq
 nIe
@@ -70566,9 +71635,9 @@ fXk
 fXk
 fXk
 fXk
-ces
+jCZ
 kPi
-ces
+vSf
 uUn
 oSB
 uSl
@@ -70825,7 +71894,7 @@ agQ
 mpt
 fDu
 kPi
-ces
+vSf
 uUn
 uSl
 uSl
@@ -71082,7 +72151,7 @@ agQ
 mpt
 cqQ
 kPi
-ces
+vSf
 uUn
 ewZ
 qdX
@@ -71354,10 +72423,10 @@ mpt
 hMF
 blE
 blE
-blE
+iAG
 qqq
 jpv
-gmk
+drD
 drD
 drD
 dqs
@@ -71611,16 +72680,16 @@ nXG
 cUj
 xtP
 nHf
-drD
+vsj
 rfl
 cDK
-dwb
+drD
 hDi
 sqN
 pXJ
 fzW
-gzo
-gzo
+uea
+uea
 sya
 sya
 sya
@@ -71853,7 +72922,7 @@ ibn
 pIW
 uhD
 bzW
-rde
+kAA
 pWc
 ugL
 mAi
@@ -71868,17 +72937,17 @@ nXG
 roK
 pcy
 rAH
-drD
-gXb
+mOr
+bKw
 ppB
-pLT
+drD
 dvG
 hKo
 gXb
 fzW
 wYr
-gzo
-gzo
+uea
+uea
 gzo
 gzo
 gzo
@@ -72110,7 +73179,7 @@ ibn
 xmc
 rde
 dbo
-rde
+kAA
 xKf
 ugL
 oku
@@ -72134,7 +73203,7 @@ fzW
 fzW
 fzW
 swE
-gzo
+uea
 gzo
 gzo
 gzo
@@ -72624,7 +73693,7 @@ ibn
 jbw
 rde
 dON
-rde
+kAA
 etu
 ugL
 sRL
@@ -73138,7 +74207,7 @@ ibn
 pbu
 sBG
 dbo
-rde
+kAA
 pbu
 ugL
 xiI
@@ -73686,8 +74755,8 @@ jrG
 veF
 hPY
 sVv
-wfb
-avT
+sHs
+lba
 pTA
 xDw
 bbb
@@ -73944,7 +75013,7 @@ ahM
 hPY
 sVv
 lnF
-avT
+lba
 hNu
 iuu
 bbb
@@ -74431,9 +75500,9 @@ iHn
 tYo
 rHk
 hNu
-giM
+nfi
 oDj
-giM
+spc
 hNu
 hNu
 hNu
@@ -74687,8 +75756,8 @@ pCw
 vCu
 hcc
 vme
-hNu
-cJq
+wnw
+wKK
 nCt
 wpN
 hNu
@@ -74945,7 +76014,7 @@ iHn
 iHn
 mtl
 mda
-cJq
+aPy
 nCt
 wpN
 hNu
@@ -74971,8 +76040,8 @@ nFy
 nFy
 hPY
 fHR
-sHs
-lba
+wfb
+rcy
 pTA
 iuu
 bbb
@@ -75228,8 +76297,8 @@ gzX
 hvO
 mBx
 yld
-sHs
-lba
+wfb
+rcy
 hNu
 xDw
 nrY
@@ -75703,8 +76772,8 @@ eTL
 iHn
 iHn
 iHn
-rwk
-eTL
+iHn
+iDJ
 oUj
 cnB
 geQ
@@ -75960,7 +77029,7 @@ xWi
 aVY
 aVY
 aVY
-xWi
+dUf
 xWi
 lAl
 ybx
@@ -76218,7 +77287,7 @@ lcN
 iXr
 lcN
 xWi
-mVD
+xWi
 lAl
 vyS
 wgJ
@@ -76485,19 +77554,19 @@ iRZ
 lAl
 whd
 lxk
-wJu
+nrm
 wYp
-cJq
+fan
 ryB
-uNU
+wpN
 aAW
 qwM
 lww
-jXF
-jXF
-wpN
+dsp
+dsp
+nBL
 qTI
-cJq
+fan
 pFC
 dEK
 dSc
@@ -76732,7 +77801,7 @@ elv
 kqk
 uWm
 kqk
-kqk
+pQV
 lAl
 cjk
 uvD
@@ -76988,7 +78057,7 @@ xWi
 owI
 ihn
 wSX
-eEe
+kqk
 wgK
 lAl
 xoE
@@ -77484,11 +78553,11 @@ rLU
 rLU
 rLU
 kSg
-jsJ
-jsJ
-sws
-sws
-sws
+kSg
+kSg
+kSg
+kSg
+rLU
 sws
 sws
 sws
@@ -77741,17 +78810,17 @@ rLU
 rLU
 jsJ
 jsJ
-jsJ
-jsJ
+kSg
+kSg
+kSg
+rLU
+rLU
 sws
-sZY
-but
-pqX
 cOk
-pqX
-pqX
-pqX
-nMa
+wsM
+jki
+jki
+vIt
 uDR
 wxb
 hTx
@@ -77999,15 +79068,15 @@ rLU
 jsJ
 jsJ
 kgx
-jsJ
-sws
-bTp
+kSg
+rLU
+rLU
 sKY
 sKY
 sKY
 sKY
 sKY
-vIt
+xPb
 vIt
 bgD
 exc
@@ -78257,22 +79326,22 @@ jsJ
 jsJ
 jsJ
 jsJ
-sws
-bTp
+rLU
+rLU
 fem
 sYY
 lOX
 pxY
 sKY
 wMz
-kXp
+ygL
 kXp
 uim
 vEB
 xWi
 ebD
 jJt
-pPT
+ilv
 qJW
 pmV
 jDQ
@@ -78288,7 +79357,7 @@ qse
 qUI
 ajQ
 daK
-lGz
+xKh
 trX
 knp
 lmy
@@ -78513,9 +79582,9 @@ kSg
 jsJ
 jsJ
 jsJ
-kSg
-sws
-ojI
+rLU
+rLU
+rLU
 sKY
 iIs
 oYw
@@ -78524,7 +79593,7 @@ naZ
 baI
 gFh
 jCM
-oLO
+iVB
 uvn
 xWi
 nll
@@ -78534,7 +79603,7 @@ nll
 pmV
 uds
 xqf
-xqf
+lre
 ruA
 xqf
 aDR
@@ -78544,8 +79613,8 @@ oDl
 lud
 qUI
 oCb
-xKh
-trX
+bli
+cxk
 trX
 knp
 urp
@@ -78770,9 +79839,9 @@ kSg
 jsJ
 jsJ
 pxz
-kSg
-sws
-jlf
+rLU
+rLU
+sPD
 sKY
 qpd
 tGq
@@ -78781,17 +79850,17 @@ naZ
 fZj
 gFh
 gFh
-oLO
+iVB
 wPO
 pHB
 fZj
-gFh
+shU
 uLT
 lDX
 pHP
 enz
 qJy
-qJy
+psm
 qqi
 qJy
 eLa
@@ -79028,9 +80097,9 @@ jsJ
 jsJ
 jsJ
 rLU
-sws
-dYZ
-ivz
+rLU
+sPD
+sKY
 nOw
 hYT
 nrw
@@ -79042,13 +80111,13 @@ hPc
 lvh
 lvh
 lvh
-lvh
+asH
 swy
 bWu
 wVi
 veY
 veY
-veY
+wlE
 vXe
 qMg
 tOC
@@ -79285,7 +80354,7 @@ jsJ
 jsJ
 jsJ
 rLU
-sws
+rLU
 sPD
 sKY
 kVH
@@ -79542,8 +80611,8 @@ jsJ
 jsJ
 jsJ
 rLU
-sws
-bTp
+rLU
+rLU
 sKY
 rbj
 eXD
@@ -79799,8 +80868,8 @@ jsJ
 jsJ
 jsJ
 rLU
-sws
-bTp
+rLU
+rLU
 sKY
 jlC
 nsc
@@ -80056,8 +81125,8 @@ jsJ
 jsJ
 jsJ
 rLU
-sws
-bTp
+rLU
+rLU
 sKY
 sKY
 sKY
@@ -80313,8 +81382,8 @@ jsJ
 jsJ
 jsJ
 rLU
-sws
-bTp
+rLU
+rLU
 kjd
 ovY
 sIZ
@@ -80570,8 +81639,8 @@ jsJ
 jsJ
 jsJ
 rLU
-sws
-bTp
+rLU
+rLU
 kjd
 daQ
 nlM
@@ -80827,8 +81896,8 @@ jsJ
 kgx
 jsJ
 rLU
-sws
-bTp
+rLU
+rLU
 kjd
 wkc
 lIi
@@ -81084,8 +82153,8 @@ jsJ
 jsJ
 rLU
 rLU
-sws
-bTp
+rLU
+rLU
 kjd
 qJs
 hpE
@@ -81341,8 +82410,8 @@ jsJ
 jsJ
 rLU
 rLU
-sws
-bTp
+rLU
+rLU
 kjd
 qak
 eDg
@@ -81362,7 +82431,7 @@ bvC
 dLG
 eLD
 oVI
-xPb
+oVI
 oOk
 bvC
 jmp
@@ -81556,7 +82625,7 @@ rMm
 rMm
 rMm
 rMm
-rLU
+rMm
 rLU
 rLU
 jsJ
@@ -81598,8 +82667,8 @@ pxz
 jsJ
 rLU
 rLU
-sws
-jlf
+rLU
+sPD
 kjd
 fVl
 cwG
@@ -81807,15 +82876,15 @@ rMm
 rMm
 rMm
 rMm
-ake
-ake
-ake
-ake
-ake
-ake
-ake
-ake
-ake
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rLU
 rLU
 rLU
 jsJ
@@ -81855,8 +82924,8 @@ jsJ
 rLU
 rLU
 rLU
-sws
-jlf
+rLU
+sPD
 kjd
 vmT
 tlR
@@ -81899,17 +82968,17 @@ wDg
 xUu
 sfq
 scn
-rLU
-rLU
-rLU
-rLU
-rLU
+wQk
+rQb
+rQb
+jwY
+jwY
 ioN
-sst
+jki
 asr
 cIR
+jki
 opO
-iBb
 opO
 ioN
 gzo
@@ -82064,15 +83133,15 @@ rMm
 rMm
 rMm
 rMm
-ake
-boY
-bTk
-cuv
-ake
-nHH
-qYN
-tTJ
-ake
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 rLU
 rLU
 rLU
@@ -82112,8 +83181,8 @@ jsJ
 rLU
 rLU
 rLU
-sws
-jlf
+rLU
+sPD
 kjd
 ePb
 fWL
@@ -82132,7 +83201,7 @@ kbB
 bvC
 hGd
 hGd
-ppH
+snB
 mrs
 mrs
 bvC
@@ -82156,18 +83225,18 @@ wDg
 gcx
 sfq
 scn
-rLU
-rLU
-rLU
-rLU
-rLU
-nIC
+jRr
+rQb
+rQb
+fnG
+beh
+ioN
 tds
-hSZ
-tds
-tSV
+jki
+jki
+jki
 rKE
-opO
+gAy
 ioN
 gzo
 gzo
@@ -82322,13 +83391,13 @@ uSY
 jsJ
 rMm
 ake
-bFe
-iDf
-cxs
-cFL
-nMs
-sep
-vxg
+ake
+ake
+ake
+ake
+ake
+ake
+ake
 ake
 ake
 ake
@@ -82369,8 +83438,8 @@ rLU
 rLU
 rLU
 rLU
-sws
-bTp
+rLU
+rLU
 vIt
 cIz
 oNo
@@ -82414,17 +83483,17 @@ wAm
 sfq
 scn
 scn
+jiz
 scn
 scn
 scn
 scn
 scn
-xuD
-tds
-sst
+scn
+scn
+scn
 jki
-hSZ
-iBb
+scM
 ioN
 gzo
 gzo
@@ -82582,11 +83651,11 @@ ake
 bMv
 caE
 czz
-cOJ
+ake
 dcz
 swu
 enA
-eTE
+kDw
 kDw
 kDw
 ake
@@ -82597,7 +83666,7 @@ qxJ
 mqz
 mqz
 mqz
-jNf
+mqz
 aGj
 ake
 wEg
@@ -82625,10 +83694,10 @@ jsJ
 rLU
 rLU
 rLU
-rLU
-sws
-ojI
-dDJ
+cXC
+cXC
+cXC
+vIt
 ngu
 ogj
 qwq
@@ -82660,28 +83729,28 @@ scn
 wXv
 viH
 scn
-hza
+fOp
 xAk
 hza
-sjy
+jaa
 lpB
 sjy
-xcJ
+axC
 iAy
 xcJ
 scn
 lDF
+bMF
+xfA
+scn
+rfa
 sfq
 sfq
 sfq
 sfq
 scn
-sRD
-wbF
-hSZ
-vZg
-sst
-rKE
+jki
+uSo
 ioN
 gzo
 gzo
@@ -82836,16 +83905,16 @@ uUy
 jsJ
 jsJ
 ake
-ake
-ake
-ake
-ake
+bOk
+iDf
+dDJ
+eEe
 oWN
-oWN
-oWN
+gmO
+hsJ
 cyW
 cyW
-fBu
+cyW
 ake
 dTO
 aSI
@@ -82881,9 +83950,9 @@ jsJ
 jsJ
 rLU
 rLU
-rLU
-rLU
-sws
+cXC
+cXC
+kgv
 eCO
 vIt
 seM
@@ -82928,16 +83997,16 @@ vTm
 sxz
 scn
 gCC
+kOc
+mbU
+scn
+kjo
 sfq
 sfq
 sfq
 sfq
 scn
-sst
-wuI
-wbF
-sst
-tds
+jki
 enH
 ioN
 fYi
@@ -83092,16 +84161,16 @@ cyH
 jsJ
 jsJ
 jsJ
-uCb
+ake
 qOS
-qOS
-qOS
+bWa
+dPt
 myU
-oWN
-oWN
-oWN
-kDw
-kDw
+fVQ
+gAA
+hxx
+hYt
+hYt
 geG
 ake
 xKN
@@ -83138,9 +84207,9 @@ jsJ
 jsJ
 rLU
 rLU
-rLU
-rLU
-sws
+cXC
+eCO
+kgv
 bTp
 vIt
 jyX
@@ -83182,19 +84251,19 @@ sSy
 odD
 odD
 sSy
-uUk
-rgg
+odD
+odD
+icn
+khD
+vNc
+sfq
 sfq
 sfq
 sfq
 sfq
 sfq
 scn
-dPt
-ygL
-mif
-sst
-tds
+jki
 xCb
 ioN
 wXm
@@ -83349,12 +84418,12 @@ jsJ
 jsJ
 tXu
 jsJ
-uCb
-rDj
-rDj
-jaR
-rDj
-rDj
+ake
+ake
+ake
+ake
+ake
+fWv
 rDj
 xlo
 cyW
@@ -83395,10 +84464,10 @@ jsJ
 jsJ
 jsJ
 rLU
-rLU
-rLU
-sws
-bTp
+cXC
+sAx
+sZY
+vkl
 vIt
 vIt
 jUC
@@ -83430,29 +84499,29 @@ gTv
 uEG
 hHA
 sFZ
-dYk
-dYk
+hHA
+hHA
 wlU
-dYk
-dYk
+hHA
+hHA
 wlU
-dYk
-dYk
+hHA
+hHA
 wlU
-dYk
-fps
+hHA
+hHA
 vis
-vis
+hHA
 usI
 vkk
-cXH
-scn
+vkk
+vkk
 wbF
 hSZ
 kSe
-hSZ
-sst
-tds
+scn
+jki
+jki
 ioN
 mhv
 mhv
@@ -83606,11 +84675,11 @@ kgx
 gna
 jsJ
 jsJ
+jsJ
 uCb
 xbG
 xbG
-xbG
-xbG
+ePH
 xbG
 xbG
 nGH
@@ -83652,10 +84721,10 @@ jsJ
 jsJ
 jsJ
 rLU
-rLU
-rLU
-sws
-bTp
+cXC
+sCW
+tpt
+vvT
 vIt
 xcc
 uXg
@@ -83669,7 +84738,7 @@ nqV
 ujP
 snL
 ngu
-wPF
+mdK
 gFh
 gFh
 gFh
@@ -83685,9 +84754,6 @@ icn
 dBf
 ils
 xMh
-vkl
-ahK
-fMs
 fMs
 ahK
 fMs
@@ -83697,19 +84763,22 @@ fMs
 fMs
 ahK
 fMs
-rgg
+fMs
+ahK
+fMs
+fMs
+icn
+dWL
+bUg
+qcV
 sfq
 sfq
 sfq
 sfq
 sfq
 scn
-sws
-roF
-scb
-sws
-sws
-sws
+jki
+jki
 ioN
 gys
 gys
@@ -83863,13 +84932,13 @@ rMm
 jsJ
 jsJ
 jsJ
+jsJ
 uCb
-bWa
+cdq
 xbG
-bWa
+cdq
 xbG
-bWa
-xbG
+cdq
 nGH
 eVF
 uhY
@@ -83909,10 +84978,10 @@ rll
 rll
 jsJ
 jsJ
-rLU
-rLU
-sws
-bTp
+cXC
+sDA
+kgv
+eCO
 vIt
 uXg
 lOu
@@ -83956,18 +85025,18 @@ ulK
 jAU
 scn
 bSg
+dZA
+ohd
+scn
+nav
 sfq
 sfq
 sfq
 sfq
 scn
-sAx
-jki
-jki
-kbL
+gWH
 sws
-rLU
-rLU
+ioN
 kSg
 kSg
 nOK
@@ -84120,8 +85189,8 @@ rMm
 kgx
 jsJ
 jsJ
+jsJ
 uCb
-xbG
 xbG
 xbG
 xbG
@@ -84166,10 +85235,10 @@ evZ
 uyb
 jsJ
 jsJ
-rLU
-rLU
-sws
-bTp
+cXC
+eCO
+kgv
+sDA
 vIt
 uyB
 taE
@@ -84196,34 +85265,34 @@ lzW
 iKz
 iKz
 icn
-dBf
+gRG
 yiF
 scn
-dXI
+duO
 jeg
 dXI
-bmJ
+sBZ
 qhv
 bmJ
-kUo
+qrF
 dRw
 kUo
-cgx
+jga
 xGc
 cgx
 scn
 uUN
+ptS
+xfA
+scn
+lPf
 sfq
 sfq
 sfq
 sfq
 scn
-sAx
-bbX
-tZM
-mtL
+jki
 sws
-rLU
 rLU
 kSg
 kSg
@@ -84377,13 +85446,13 @@ rMm
 jsJ
 jsJ
 jsJ
+jsJ
 ake
-dtn
+cuv
 xbG
-mqB
+eTE
 xbG
-mqB
-xbG
+eTE
 nGH
 vDC
 ake
@@ -84423,10 +85492,10 @@ rll
 rll
 jsJ
 jsJ
-rLU
-rLU
-sws
-bTp
+cXC
+cXC
+tsf
+kgv
 vIt
 fkY
 uXg
@@ -84469,18 +85538,18 @@ rMt
 wAm
 sfq
 scn
+dhD
 scn
 scn
 scn
 scn
 scn
 scn
-sAx
-lEw
-gmO
-tTG
+scn
+scn
+scn
+jki
 sws
-rLU
 kSg
 kSg
 kSg
@@ -84634,9 +85703,9 @@ rMm
 tXu
 cyH
 jsJ
-uCb
-xbG
-xbG
+jsJ
+ake
+cxs
 xbG
 xbG
 xbG
@@ -84681,9 +85750,9 @@ kSg
 jsJ
 jsJ
 rLU
-rLU
-sws
-bTp
+cXC
+tSV
+kgv
 vIt
 vIt
 vIt
@@ -84726,18 +85795,18 @@ wDg
 chD
 sfq
 scn
-ojG
-oIM
+jki
+jki
 sGB
-jki
-jki
+srF
+lis
 sws
 iBb
-cNQ
+oMh
+hBQ
+tZM
 jki
-pds
 sws
-rLU
 kSg
 kSg
 kSg
@@ -84891,8 +85960,8 @@ jsJ
 jsJ
 jsJ
 jsJ
+jsJ
 uCb
-xbG
 xbG
 xbG
 xbG
@@ -84922,12 +85991,12 @@ ccc
 wbv
 pPR
 mPT
-mPT
+pgg
 psU
 xuW
-xgr
-xgr
-kLp
+gCs
+gCs
+uCr
 lKZ
 dIj
 wNs
@@ -84938,23 +86007,23 @@ rLU
 jsJ
 jsJ
 jsJ
-rLU
-sws
-wxV
+cXC
+cXC
+kgv
+cJX
+vyw
+pqX
 sMF
-pqX
-pqX
-pqX
 pqX
 pqX
 pqX
 vXX
 sMF
-pqX
-pqX
-pqX
-pqX
-lju
+kxb
+jki
+jki
+jki
+stX
 oBc
 jki
 jki
@@ -84991,10 +86060,10 @@ jki
 scb
 yjB
 cNQ
-bbX
-sAx
+cNQ
+yjB
 sws
-rLU
+sws
 kSg
 kSg
 kSg
@@ -85148,8 +86217,8 @@ jsJ
 jsJ
 kgx
 jsJ
+jsJ
 uCb
-xbG
 hyx
 ioq
 xbG
@@ -85190,15 +86259,15 @@ dIj
 otL
 dIj
 dIj
-rLU
+dIj
 rLU
 jsJ
 cyH
 jsJ
 rLU
+cXC
+cXC
 sws
-oIM
-ojG
 sws
 sws
 cJX
@@ -85213,9 +86282,9 @@ tZM
 jki
 uSo
 jki
-jki
+xOc
 hiz
-ioN
+rPM
 bpP
 aOk
 wfm
@@ -85405,8 +86474,8 @@ jsJ
 jsJ
 jsJ
 jsJ
+jsJ
 uCb
-xbG
 xbG
 xbG
 xbG
@@ -85446,16 +86515,16 @@ qxY
 dIj
 qrG
 luX
+luX
 dIj
 rLU
+jsJ
+jsJ
+jsJ
+jsJ
 rLU
-jsJ
-jsJ
-jsJ
-jsJ
-sws
-sws
-sws
+rLU
+rLU
 sws
 hmp
 ugq
@@ -85482,7 +86551,7 @@ azV
 sws
 sws
 hry
-scb
+jki
 tZM
 jki
 jki
@@ -85662,9 +86731,9 @@ jsJ
 uSY
 jsJ
 jsJ
-uCb
-fIX
-imQ
+jsJ
+ake
+cFL
 imQ
 srN
 fkI
@@ -85699,12 +86768,12 @@ gAp
 pxS
 lFd
 jdP
-jdP
+qPt
 dIj
 pEM
 luX
+luX
 dIj
-rLU
 rLU
 rLU
 jsJ
@@ -85919,17 +86988,17 @@ kgx
 jsJ
 jsJ
 jsJ
+jsJ
 ake
 uCb
 uCb
-uCb
 ake
 ake
 ake
 ake
 ake
 ake
-qJB
+tlW
 qxJ
 dTO
 aSI
@@ -85953,15 +87022,15 @@ uNj
 nNp
 gCs
 gAp
-vMT
-olL
-fVQ
+uNj
+nNp
+jdP
 may
 dIj
 rci
-luX
+qrG
+qrG
 dIj
-rLU
 rLU
 rLU
 jsJ
@@ -86209,7 +87278,7 @@ pVO
 pxS
 vEj
 gCs
-gAp
+pXf
 pxS
 vEj
 jdP
@@ -86217,8 +87286,8 @@ tcU
 dIj
 pXI
 luX
+luX
 dIj
-rLU
 rLU
 rLU
 rLU
@@ -86474,8 +87543,8 @@ mNT
 dIj
 qrG
 luX
+luX
 dIj
-rLU
 rLU
 rLU
 rLU
@@ -86502,7 +87571,7 @@ rPM
 lxN
 mpU
 rkD
-piH
+mpU
 mpU
 kxP
 kxP
@@ -86732,10 +87801,10 @@ dIj
 otL
 dIj
 dIj
-mmw
-mmw
-mmw
-rLU
+dIj
+dIj
+dIj
+dIj
 rLU
 rLU
 jsJ
@@ -86991,9 +88060,9 @@ gZO
 dIj
 xos
 dIY
-mmw
-mmw
-rLU
+rQl
+dIj
+dIj
 rLU
 jsJ
 jsJ
@@ -87016,7 +88085,7 @@ rPM
 oDQ
 xUS
 mpU
-piH
+mpU
 mpU
 vtF
 rPM
@@ -87245,12 +88314,12 @@ ufZ
 tsJ
 lhd
 bpE
-dIj
+roF
 yem
 ips
-bEB
-mmw
-rLU
+ips
+rQl
+dIj
 rLU
 rLU
 jsJ
@@ -87273,7 +88342,7 @@ rPM
 xBO
 exJ
 cqH
-dQb
+oMp
 oMp
 hGC
 rML
@@ -87502,12 +88571,12 @@ pPP
 uHs
 iOa
 nhC
+rth
+vvz
+vvz
+ips
+sep
 dIj
-rrb
-tKQ
-dIY
-mmw
-rLU
 rLU
 rLU
 jsJ
@@ -87530,7 +88599,7 @@ rPM
 hxH
 mpU
 mpU
-piH
+mpU
 mpU
 mpU
 cbY
@@ -87756,15 +88825,15 @@ uCr
 uCr
 taI
 bMl
-xBR
-xBR
+lhd
+lhd
 dez
-dIj
+roF
 vvz
-gUu
-gUu
-mmw
-rLU
+ips
+ips
+rQl
+dIj
 rLU
 rLU
 jsJ
@@ -87787,7 +88856,7 @@ rPM
 kcS
 exJ
 cqH
-dQb
+oMp
 oMp
 oeN
 rML
@@ -88017,11 +89086,11 @@ frd
 cwp
 khF
 dIj
-apE
-gUu
-vvz
-mmw
-rLU
+rwk
+rzb
+rQl
+dIj
+dIj
 rLU
 rLU
 jsJ
@@ -88238,7 +89307,7 @@ jsJ
 jsJ
 jNq
 dzh
-jNq
+gRM
 iuv
 oVT
 jvx
@@ -88268,16 +89337,16 @@ lIV
 gUu
 gUu
 gUu
-mmw
+dIj
 igz
-mmw
-mmw
-mmw
-mmw
-mmw
-gUu
-rzb
-mmw
+dIj
+dIj
+dIj
+dIj
+dIj
+dIj
+dIj
+dIj
 rLU
 rLU
 rLU
@@ -88527,14 +89596,14 @@ qcA
 wvN
 dip
 fPR
-pHu
-pHu
-pHu
+rcg
+rgg
+rgg
 eBr
 mmw
-vvT
-mmw
-mmw
+rLU
+rLU
+rLU
 rLU
 rLU
 rLU
@@ -88543,8 +89612,6 @@ jsJ
 jsJ
 jsJ
 jsJ
-rLU
-rLU
 rLU
 rLU
 rLU
@@ -88555,8 +89622,10 @@ rLU
 rLU
 rLU
 rPM
+rPM
+rPM
 dEW
-mpU
+lSo
 oEn
 qyX
 vMN
@@ -88789,8 +89858,8 @@ skT
 skT
 ylT
 mmw
-gUu
-apE
+mmw
+mmw
 mmw
 rLU
 rLU
@@ -88810,9 +89879,9 @@ rLU
 rLU
 rLU
 rPM
-rPM
-rPM
-jiH
+aIb
+mpU
+mpU
 mpU
 oEn
 gAC
@@ -89068,7 +90137,7 @@ rLU
 rLU
 rPM
 khl
-sDA
+mpU
 mpU
 mpU
 djW
@@ -89304,7 +90373,7 @@ skT
 ylT
 mmw
 gUu
-gUu
+apE
 mmw
 rLU
 rLU
@@ -89837,9 +90906,9 @@ jsJ
 jsJ
 jsJ
 jsJ
-jsJ
-jsJ
-jsJ
+rPM
+tMi
+rPM
 jsJ
 jsJ
 jsJ
@@ -90310,7 +91379,7 @@ cxX
 ydv
 adb
 ydv
-adb
+ydv
 mQT
 mQT
 tIk
@@ -90530,7 +91599,7 @@ rMm
 rMm
 rMm
 rMm
-jsJ
+aae
 gzo
 cUt
 gzo
@@ -90566,8 +91635,8 @@ nUv
 nUv
 nUv
 mlS
-mlS
-lCa
+adb
+adb
 rDh
 adb
 ruT
@@ -90818,13 +91887,13 @@ dqb
 aem
 gkB
 gkB
+mcv
 gkB
 gkB
-gkB
+nof
 mVF
-mVF
-hYt
-mVF
+tIk
+olL
 mVF
 mVF
 mVF
@@ -91075,7 +92144,7 @@ vZb
 bXZ
 gkB
 thb
-ePH
+sEs
 gZn
 gkB
 qye
@@ -91338,7 +92407,7 @@ iKl
 jNy
 esd
 sus
-aaT
+sus
 sus
 mTF
 ilF
@@ -92864,7 +93933,7 @@ kSg
 kSg
 tIk
 pYO
-osk
+adb
 dRN
 tIk
 xzc
@@ -93122,10 +94191,10 @@ kSg
 tIk
 adb
 adb
-fzy
+tIk
 tIk
 xzc
-gkB
+iks
 lFT
 lCC
 tKS
@@ -93379,8 +94448,8 @@ kSg
 tIk
 uuA
 pYO
-tIk
-tIk
+adb
+adb
 vfL
 ioU
 wTT
@@ -93406,7 +94475,7 @@ kAR
 bHv
 kAR
 kAR
-kAR
+qsS
 uBO
 tWF
 cPO
@@ -93636,10 +94705,10 @@ kSg
 tIk
 dod
 adb
-krU
+tIk
 jnJ
 lRF
-gkB
+ivz
 aAS
 dXG
 wwG
@@ -93649,8 +94718,8 @@ ohM
 hkE
 tLk
 eRe
-tmo
 jsQ
+nIC
 lfW
 ree
 pOL
@@ -93663,7 +94732,7 @@ cpw
 ime
 dVW
 vXN
-kAR
+qsS
 nJK
 tWF
 gEX
@@ -93906,9 +94975,9 @@ ohM
 jlz
 hKY
 jsQ
-cvO
 jsQ
-jsQ
+nMa
+lpP
 ree
 bse
 tfO
@@ -93917,8 +94986,8 @@ pxO
 bEz
 tWF
 cqi
-hsJ
-kAR
+bHv
+pLT
 qCq
 mJz
 lsk
@@ -94163,8 +95232,8 @@ ohM
 wkD
 hKY
 jsQ
-nof
 tQg
+nMs
 tmo
 ree
 aXM
@@ -94174,8 +95243,8 @@ pxO
 voG
 tWF
 nmP
-qHa
-aEq
+bHv
+pPT
 kTd
 kAR
 pTD
@@ -94421,7 +95490,7 @@ wkD
 dKk
 jsQ
 tQg
-tQg
+ojG
 cvO
 ree
 bse
@@ -94678,7 +95747,7 @@ wkQ
 hKY
 lKS
 tQg
-tQg
+ojI
 lpP
 ree
 hDW
@@ -94935,7 +96004,7 @@ bkf
 tjN
 bBK
 tQg
-tQg
+nMs
 lwz
 lLX
 tfO
@@ -96748,7 +97817,7 @@ tqb
 eMO
 nzc
 jEb
-dzm
+qHa
 uHl
 sjl
 imn
@@ -97001,11 +98070,11 @@ uLa
 rWr
 ecV
 iIc
+piH
 dzm
 dzm
 dzm
-dzm
-dzm
+qJB
 kna
 ouA
 leK
@@ -97262,7 +98331,7 @@ pzE
 ruj
 dzm
 ruj
-dzm
+qJB
 kna
 cVx
 bWy
@@ -97519,7 +98588,7 @@ uVl
 ruj
 dzm
 ruj
-dzm
+qJB
 kna
 faD
 fYV
@@ -97772,11 +98841,11 @@ iIc
 hEF
 ccS
 rZX
-dzm
+piH
 ruj
 kxq
 ruj
-dzm
+qJB
 fTp
 ktE
 qat
@@ -98029,7 +99098,7 @@ xtU
 duB
 qiS
 dFk
-dzm
+pse
 ruj
 pId
 ruj
@@ -98290,9 +99359,9 @@ uDQ
 uDQ
 cwK
 uDQ
-uDQ
+qNZ
 fFp
-uDQ
+qYN
 lBa
 iZd
 wRw
@@ -99055,7 +100124,7 @@ tbM
 tbM
 xtU
 gUt
-dzm
+pds
 hIu
 cre
 dkw
@@ -101607,7 +102676,7 @@ rMm
 rMm
 rMm
 rMm
-jsJ
+kSg
 jsJ
 gzo
 gzo
@@ -101864,8 +102933,8 @@ rMm
 rMm
 rMm
 kSg
-jsJ
-gzo
+kSg
+uea
 gzo
 gzo
 gzo
@@ -102112,18 +103181,18 @@ rMm
 rMm
 rMm
 rMm
-rNe
-rNe
-rNe
-rNe
-rNe
+rMm
+rMm
+rMm
+rMm
+rMm
 rMm
 rMm
 kSg
 kSg
-jsJ
-gzo
-gzo
+kSg
+uea
+uea
 rLU
 rLU
 rLU
@@ -102369,18 +103438,18 @@ rMm
 rMm
 rMm
 rMm
-rNe
-rth
-pgg
-oXJ
-rNe
-nSm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
-kSg
-gzo
-gzo
-gzo
+uea
+uea
+uea
 rLU
 rLU
 rLU
@@ -102626,18 +103695,18 @@ rMm
 rMm
 rMm
 rMm
-rNe
-ivA
-blZ
-blZ
-aOg
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
-kSg
-tTD
 kSg
 uea
 uea
-gzo
+uea
 rLU
 rLU
 rLU
@@ -102883,12 +103952,12 @@ rMm
 rMm
 rMm
 rMm
-rNe
-tsf
-blZ
-koh
-rNe
-kSg
+rMm
+rMm
+rMm
+rMm
+rMm
+rMm
 kSg
 kSg
 kSg
@@ -103140,11 +104209,11 @@ rMm
 rMm
 rMm
 rMm
-rNe
-rNe
-rNe
-rNe
-rNe
+rMm
+rMm
+rMm
+rMm
+rMm
 rMm
 kSg
 kSg
@@ -103403,7 +104472,7 @@ rMm
 rMm
 rMm
 rMm
-lDG
+kSg
 kSg
 kSg
 dMQ

--- a/_maps/map_files/FridgeStation/IcemoonUnderground_Fridge_Above.dmm
+++ b/_maps/map_files/FridgeStation/IcemoonUnderground_Fridge_Above.dmm
@@ -1,12 +1,5 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "af" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8
-	},
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 11
-	},
 /obj/machinery/light/small{
 	dir = 4
 	},
@@ -145,9 +138,6 @@
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/mine/production)
 "dA" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
 /turf/open/floor/plasteel/showroomfloor/shower,
 /area/mine/living_quarters)
 "dH" = (
@@ -184,7 +174,7 @@
 /turf/closed/wall,
 /area/mine/maintenance)
 "eS" = (
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -246,6 +236,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/mine/maintenance)
 "gO" = (
@@ -290,6 +283,17 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
 "ih" = (
@@ -428,7 +432,7 @@
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
 "lQ" = (
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -702,6 +706,7 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
 "tz" = (
@@ -727,6 +732,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/mine/production)
 "tE" = (
@@ -915,6 +921,7 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/mine/production)
 "wL" = (
@@ -1008,12 +1015,6 @@
 /obj/machinery/door/airlock{
 	desc = "Eighteen naked Miners in the showers at Fridgestation. Big, hard games waiting to get powered. Eighteen naked Miners wanting to be fucked. Miners in the showers at Fridgestation. On their knees sucking megafauna cocks. Fridgestation really rocks!";
 	name = "Mining Showers"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
@@ -1128,8 +1129,20 @@
 /turf/open/floor/plating,
 /area/mine/living_quarters)
 "AU" = (
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/mine/production)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
 "Br" = (
 /obj/machinery/light,
 /turf/open/floor/plating/asteroid/basalt,
@@ -1362,6 +1375,7 @@
 /area/mine/living_quarters)
 "Gj" = (
 /obj/structure/closet/wardrobe/miner,
+/obj/effect/turf_decal/trimline/green/filled/corner,
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
 "Gk" = (
@@ -1396,6 +1410,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
 "GL" = (
@@ -1448,12 +1463,6 @@
 /turf/open/floor/plating,
 /area/mine/living_quarters)
 "HN" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/mine/living_quarters)
 "Ie" = (
@@ -1553,6 +1562,16 @@
 /area/mine/living_quarters)
 "JI" = (
 /turf/closed/wall,
+/area/mine/living_quarters)
+"JL" = (
+/obj/machinery/light,
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/green/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/mine/living_quarters)
 "JM" = (
 /turf/open/floor/plating,
@@ -1758,6 +1777,7 @@
 /area/icemoon/surface/outdoors)
 "Ob" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner,
+/obj/structure/closet/wardrobe/miner,
 /turf/open/floor/plasteel,
 /area/mine/production)
 "Od" = (
@@ -1881,11 +1901,11 @@
 /turf/open/floor/plasteel/white,
 /area/mine/production)
 "Rk" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
@@ -1959,6 +1979,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/mine/production)
 "Tp" = (
@@ -1983,6 +2004,7 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
 "TA" = (
@@ -2299,10 +2321,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -56923,8 +56942,8 @@ MF
 Ek
 JI
 Gj
-tK
-yp
+AU
+JL
 JI
 LE
 LE
@@ -57448,7 +57467,7 @@ mU
 PS
 de
 mU
-AU
+Ig
 Ng
 xI
 uh
@@ -57705,7 +57724,7 @@ EI
 RB
 gZ
 Nq
-AU
+Ig
 xI
 xI
 uh
@@ -57962,7 +57981,7 @@ FT
 oT
 xq
 FT
-AU
+Ig
 xI
 xI
 xI
@@ -60515,9 +60534,9 @@ uh
 uh
 uh
 fI
-AU
-AU
-AU
+Ig
+Ig
+Ig
 fI
 uh
 uh

--- a/_maps/map_files/FridgeStation/IcemoonUnderground_Fridge_Above.dmm
+++ b/_maps/map_files/FridgeStation/IcemoonUnderground_Fridge_Above.dmm
@@ -160,6 +160,10 @@
 	},
 /turf/open/floor/wood,
 /area/maintenance/starboard/fore)
+"dY" = (
+/obj/machinery/light/floor/fakeday,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/surface/outdoors)
 "eu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
@@ -2175,6 +2179,11 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/mine/production)
+"Vu" = (
+/obj/machinery/light/floor/fakeday,
+/obj/structure/closet/lasertag/red,
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors)
 "VB" = (
 /obj/machinery/door/airlock/research{
 	name = "Xenoarchaeology";
@@ -30274,9 +30283,9 @@ hl
 hl
 hl
 hl
-Ig
-Ig
-Ig
+dY
+dY
+dY
 hl
 hl
 hl
@@ -30531,10 +30540,10 @@ hl
 hl
 hl
 hl
-Ig
-Ig
-Ig
-Ig
+dY
+dY
+dY
+dY
 hl
 hl
 hl
@@ -30791,8 +30800,8 @@ hl
 hl
 hl
 xI
-Ig
-Ig
+dY
+dY
 hl
 hl
 hl
@@ -31048,8 +31057,8 @@ hl
 hl
 hl
 Ng
-Ig
-Ig
+dY
+dY
 hl
 hl
 hl
@@ -31305,7 +31314,7 @@ hl
 hl
 hl
 xI
-Ig
+dY
 hl
 hl
 hl
@@ -32076,7 +32085,7 @@ hl
 hl
 hl
 xI
-Ig
+dY
 hl
 hl
 hl
@@ -32333,7 +32342,7 @@ hl
 hl
 hl
 xI
-Ig
+dY
 hl
 hl
 hl
@@ -33104,7 +33113,7 @@ hl
 hl
 xI
 xI
-Ig
+dY
 hl
 hl
 hl
@@ -33361,8 +33370,8 @@ hl
 xI
 Uc
 xI
-Ig
-Ig
+dY
+dY
 hl
 hl
 hl
@@ -33618,8 +33627,8 @@ xI
 Ng
 xI
 xI
-Ig
-Ig
+dY
+dY
 hl
 hl
 hl
@@ -33872,10 +33881,10 @@ hl
 hl
 hl
 xI
-Ig
-Ig
-Ig
-Ig
+dY
+dY
+dY
+dY
 hl
 hl
 hl
@@ -34129,9 +34138,9 @@ hl
 hl
 hl
 xI
-Ig
-Ig
-Ig
+dY
+dY
+dY
 hl
 hl
 hl
@@ -35928,7 +35937,7 @@ hl
 hl
 hl
 xI
-Ig
+dY
 hl
 hl
 hl
@@ -36185,7 +36194,7 @@ hl
 hl
 hl
 xI
-Ig
+dY
 hl
 hl
 hl
@@ -36442,8 +36451,8 @@ hl
 hl
 hl
 xI
-Ig
-Ig
+dY
+dY
 hl
 hl
 hl
@@ -36699,8 +36708,8 @@ hl
 hl
 hl
 Ng
-Ig
-Ig
+dY
+dY
 hl
 hl
 hl
@@ -36956,8 +36965,8 @@ hl
 hl
 hl
 xI
-Ig
-Ig
+dY
+dY
 hl
 hl
 hl
@@ -37213,8 +37222,8 @@ hl
 hl
 hl
 xI
-Ig
-Ig
+dY
+dY
 hl
 hl
 hl
@@ -37470,8 +37479,8 @@ hl
 hl
 hl
 xI
-Ig
-Ig
+dY
+dY
 hl
 hl
 hl
@@ -37727,8 +37736,8 @@ hl
 hl
 hl
 xI
-Ig
-Ig
+dY
+dY
 hl
 hl
 hl
@@ -37984,8 +37993,8 @@ hl
 hl
 hl
 xI
-Ig
-Ig
+dY
+dY
 hl
 hl
 hl
@@ -38241,8 +38250,8 @@ hl
 hl
 hl
 xI
-Ig
-Ig
+dY
+dY
 hl
 hl
 hl
@@ -38498,8 +38507,8 @@ hl
 hl
 Ng
 xI
-Ig
-Ig
+dY
+dY
 hl
 hl
 hl
@@ -38755,8 +38764,8 @@ hl
 hl
 hl
 nM
-Ig
-Ig
+dY
+dY
 hl
 hl
 hl
@@ -39010,9 +39019,9 @@ hl
 hl
 hl
 hl
-Ig
-Ig
-Ig
+dY
+dY
+dY
 hl
 hl
 hl
@@ -49688,7 +49697,7 @@ uh
 hl
 hl
 uh
-np
+Vu
 uh
 hl
 hl

--- a/_maps/map_files/FridgeStation/IcemoonUnderground_Fridge_Above.dmm
+++ b/_maps/map_files/FridgeStation/IcemoonUnderground_Fridge_Above.dmm
@@ -19,10 +19,10 @@
 	pixel_y = -23
 	},
 /obj/machinery/recharge_station,
-/obj/effect/turf_decal/tile/purple{
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 1
 	},
-/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/mine/production)
 "av" = (
@@ -35,10 +35,10 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
+/obj/structure/closet/emcloset,
+/obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 8
 	},
-/obj/structure/closet/emcloset,
 /turf/open/floor/plasteel,
 /area/mine/production)
 "aW" = (
@@ -128,8 +128,14 @@
 /turf/open/floor/plasteel,
 /area/mine/production)
 "de" = (
-/obj/effect/turf_decal/tile/purple,
 /obj/structure/closet/emcloset,
+/obj/effect/turf_decal/trimline/purple/filled/corner,
+/turf/open/floor/plasteel,
+/area/mine/production)
+"di" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/mine/production)
 "dq" = (
@@ -254,13 +260,10 @@
 /turf/open/floor/circuit,
 /area/mine/maintenance)
 "gZ" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/plasteel,
 /area/mine/production)
 "he" = (
@@ -294,14 +297,11 @@
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
 "iq" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/mine/production)
@@ -328,19 +328,13 @@
 /obj/item/gps/mining,
 /obj/item/gps/mining,
 /obj/item/gps/mining,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/mine/production)
 "ja" = (
-/obj/effect/turf_decal/tile/brown{
+/obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -379,10 +373,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
 "lg" = (
@@ -448,6 +439,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/plasteel,
 /area/mine/production)
 "mi" = (
@@ -459,26 +451,19 @@
 /area/icemoon/surface/outdoors)
 "mt" = (
 /obj/machinery/suit_storage_unit/mining,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
 /obj/machinery/airalarm{
 	dir = 8;
 	pixel_x = 24
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/mine/production)
 "mF" = (
 /obj/machinery/suit_storage_unit/mining,
-/obj/effect/turf_decal/tile/brown{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/mine/production)
@@ -495,15 +480,12 @@
 "ni" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
+/obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
 "nj" = (
 /obj/structure/closet/emcloset,
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -550,7 +532,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -643,10 +625,7 @@
 	pixel_x = -2;
 	pixel_y = -1
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -716,6 +695,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
 "tz" = (
@@ -869,12 +851,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
@@ -883,6 +859,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/mine/production)
@@ -922,6 +901,16 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/mine/production)
 "wL" = (
@@ -956,7 +945,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 30
 	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -992,7 +981,7 @@
 /area/mine/production)
 "yp" = (
 /obj/machinery/light,
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -1090,12 +1079,11 @@
 /turf/open/floor/plating,
 /area/mine/production)
 "At" = (
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/mine/production)
@@ -1115,6 +1103,16 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown,
 /turf/open/floor/plasteel,
 /area/mine/production)
 "AM" = (
@@ -1181,8 +1179,8 @@
 /obj/machinery/shower{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/purple,
 /obj/structure/ore_box,
+/obj/effect/turf_decal/trimline/purple/filled/corner,
 /turf/open/floor/plasteel,
 /area/mine/production)
 "Do" = (
@@ -1290,6 +1288,7 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/plasteel,
 /area/mine/production)
 "EQ" = (
@@ -1331,18 +1330,6 @@
 	c_tag = "Processing Area Room";
 	dir = 8;
 	network = list("mine")
-	},
-/turf/open/floor/plasteel,
-/area/mine/production)
-"FP" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/mine/production)
@@ -1389,7 +1376,7 @@
 /turf/open/floor/plating,
 /area/mine/living_quarters)
 "Gs" = (
-/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/trimline/purple/filled/corner,
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
 "Gy" = (
@@ -1514,7 +1501,7 @@
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors)
 "IK" = (
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -1604,11 +1591,8 @@
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
 "KS" = (
-/obj/effect/turf_decal/tile/brown{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/mine/production)
@@ -1618,8 +1602,11 @@
 /obj/item/stack/packageWrap,
 /obj/item/stack/packageWrap,
 /obj/item/hand_labeler,
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 8
+	},
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/mine/production)
@@ -1656,6 +1643,16 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown,
 /turf/open/floor/plasteel,
 /area/mine/production)
 "LU" = (
@@ -1663,11 +1660,11 @@
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors)
 "Mf" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/mine/production)
@@ -1738,6 +1735,16 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/mine/production)
 "NX" = (
@@ -1745,12 +1752,16 @@
 /obj/machinery/light/floor,
 /turf/open/floor/plating,
 /area/icemoon/surface/outdoors)
+"Ob" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner,
+/turf/open/floor/plasteel,
+/area/mine/production)
 "Od" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
 /obj/machinery/computer/mech_bay_power_console{
 	dir = 1
+	},
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/mine/production)
@@ -1819,10 +1830,10 @@
 /turf/open/floor/plasteel/white,
 /area/mine/production)
 "PS" = (
-/obj/effect/turf_decal/tile/purple{
+/obj/structure/ore_box,
+/obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 4
 	},
-/obj/structure/ore_box,
 /turf/open/floor/plasteel,
 /area/mine/production)
 "Qf" = (
@@ -1831,10 +1842,7 @@
 	},
 /area/maintenance/starboard/fore)
 "Qo" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
+/obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
 "QA" = (
@@ -1882,23 +1890,17 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/security/execution/education)
 "Rs" = (
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/mine/production)
 "RB" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/mine/production)
@@ -1974,6 +1976,9 @@
 	name = "Xenoarchaeology";
 	req_access_txt = "47"
 	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
 "TA" = (
@@ -1996,6 +2001,9 @@
 /turf/open/floor/circuit,
 /area/mine/maintenance)
 "TG" = (
+/obj/effect/turf_decal/stripes/red/corner{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/security/execution/education)
 "TH" = (
@@ -2004,7 +2012,7 @@
 /area/mine/living_quarters)
 "TN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -2089,6 +2097,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/mine/production)
 "Ur" = (
@@ -2103,8 +2114,7 @@
 /obj/machinery/light_switch{
 	pixel_x = 27
 	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -2131,7 +2141,7 @@
 /turf/open/floor/plasteel,
 /area/mine/production)
 "UX" = (
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -2165,6 +2175,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/mine/production)
+"VB" = (
+/obj/machinery/door/airlock/research{
+	name = "Xenoarchaeology";
+	req_access_txt = "47"
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
 "VD" = (
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
@@ -2205,7 +2225,7 @@
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
 "Wj" = (
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -2216,7 +2236,7 @@
 /area/mine/production)
 "Wr" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
 "Wx" = (
@@ -2224,11 +2244,8 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
@@ -2309,7 +2326,10 @@
 /area/mine/maintenance)
 "YT" = (
 /obj/structure/tank_dispenser/oxygen,
-/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/trimline/purple/filled/corner,
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/mine/production)
 "YV" = (
@@ -57156,7 +57176,7 @@ MQ
 JI
 JI
 MQ
-Tw
+VB
 MQ
 JI
 Mp
@@ -57669,7 +57689,7 @@ qm
 tc
 TB
 mh
-FP
+RB
 TB
 TB
 EI
@@ -57916,9 +57936,9 @@ TV
 tY
 Ae
 jk
-Va
+Ob
 Ui
-Va
+di
 Zq
 Va
 Va
@@ -59974,7 +59994,7 @@ uh
 Mp
 Di
 At
-Va
+di
 lt
 lt
 Mp

--- a/_maps/map_files/FridgeStation/IcemoonUnderground_Fridge_Below.dmm
+++ b/_maps/map_files/FridgeStation/IcemoonUnderground_Fridge_Below.dmm
@@ -18,7 +18,8 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
-/obj/structure/ore_box,
+/obj/item/clothing/shoes/winterboots/ice_boots,
+/obj/structure/closet/secure_closet/miner,
 /turf/open/floor/plasteel,
 /area/mine/eva)
 "cf" = (
@@ -94,8 +95,7 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
-/obj/structure/closet/secure_closet/miner,
-/obj/item/clothing/shoes/winterboots/ice_boots,
+/obj/structure/ore_box,
 /turf/open/floor/plasteel,
 /area/mine/eva)
 "oj" = (
@@ -214,6 +214,8 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
+/obj/structure/closet/secure_closet/miner,
+/obj/item/clothing/shoes/winterboots/ice_boots,
 /turf/open/floor/plasteel,
 /area/mine/eva)
 "Dh" = (
@@ -251,19 +253,12 @@
 	dir = 8
 	},
 /obj/machinery/light/small,
+/obj/structure/closet/secure_closet/miner,
+/obj/item/clothing/shoes/winterboots/ice_boots,
 /turf/open/floor/plasteel,
 /area/mine/eva)
 "ID" = (
 /obj/structure/ore_box,
-/turf/open/floor/plasteel,
-/area/mine/eva)
-"IH" = (
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/structure/closet/secure_closet/miner,
-/obj/item/clothing/shoes/winterboots/ice_boots,
 /turf/open/floor/plasteel,
 /area/mine/eva)
 "JM" = (
@@ -18855,7 +18850,7 @@ yT
 oj
 oj
 oj
-oj
+cV
 KI
 oj
 OQ
@@ -58819,8 +58814,8 @@ xp
 oj
 AD
 ne
-IH
-IH
+SB
+SB
 cb
 KK
 oj

--- a/_maps/map_files/FridgeStation/IcemoonUnderground_Fridge_Below.dmm
+++ b/_maps/map_files/FridgeStation/IcemoonUnderground_Fridge_Below.dmm
@@ -204,7 +204,6 @@
 /area/mine/eva)
 "AX" = (
 /obj/effect/decal/remains/plasma,
-/obj/structure/railing,
 /turf/open/lava/plasma/ice_moon,
 /area/icemoon/underground/explored)
 "Br" = (
@@ -36521,7 +36520,7 @@ OQ
 OQ
 OQ
 OQ
-AX
+hr
 JM
 OX
 gk
@@ -37032,7 +37031,7 @@ zN
 SI
 OQ
 OQ
-OQ
+AX
 OQ
 OQ
 hr

--- a/_maps/shuttles/arrival_fridge.dmm
+++ b/_maps/shuttles/arrival_fridge.dmm
@@ -63,6 +63,12 @@
 /obj/structure/table,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/arrival)
+"K" = (
+/obj/structure/shuttle/engine/propulsion/burst/left{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/shuttle/arrival)
 "L" = (
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/arrival)
@@ -94,11 +100,11 @@
 /obj/docking_port/mobile/arrivals{
 	name = "Snaxi Arrivals Shuttle"
 	},
-/obj/structure/shuttle/engine/propulsion/burst/right{
-	dir = 4
-	},
 /obj/docking_port/mobile/arrivals{
 	name = "Fridge Arrivals Shuttle"
+	},
+/obj/structure/shuttle/engine/propulsion/burst{
+	dir = 4
 	},
 /turf/open/floor/plating/airless,
 /area/shuttle/arrival)
@@ -219,8 +225,8 @@ L
 "}
 (12,1,1) = {"
 L
-Z
-Z
+K
+K
 W
 Z
 Z


### PR DESCRIPTION
## About The Pull Request

Big sweep of general fixes, rebalances, and otherwise changes to Fridge, mostly for the better in my eyes.

## Why It's Good For The Game

Gives Fridge abit more good shit, I wish more people would atleast give Icemoon a chance.

## Changelog
:cl:
add: Generators in the stead of Solars, emergency generators use plasma but are otherwise intended for emergencies or basic power supply (so atmosbois can hopefully one day make beeg functional atmos engines on Fridge)
add: Delivery areas for several (but not all) departments, Engineering and Atmos have stack receivers due to space limitations.
del: few redundant areas, maint has been shortened or otherwise made more interesting to explore
tweak: Exterior has been reduced abit for more ruin gen on the surface
tweak: plenty of floor decals now use the trimlines, I have a design idea where internal department areas have the trim and basic block decals are department exteriors and hallways.
add: Chapel garden in office, with a pet possum. Garden is across the hall, yes, but this is for basic stuff like flowers, reshi and plump helmets.
tweak: Holo is now closer to the station and Fitness room has been compressed abit, Fitness sauna is now the only one on station Zlevel.
tweak: reworked alot of airlocks to exterior, I was very liberal with tiny fans and now I believe cyclelink is much better looking and tiny fans should only be used extremely sparingly.
tweak: Drone room has been moves abit northward to use up that space by Surgery, it looks nice and decrepit.
add: proper containment cell in Xenobio, with proper shield generators. Scrubber pipes now have manual valves (on by default) incase any enterprising Xenobio bois wanna start being economical.
tweak: added a small manual valve (off by default) for unary main to Viro unary, just incase the place needs extra air.
add: couple new posters here and there, cause why not?
add: electrified windows in some security walls (because big featureless walls are nasty)
tweak: arrival shuttle redundant thruster fix, really doesn't do anything, however
add: Perma gets some shutters for lockdown
del: solitary, if a prisoner is that bad just take them into the persuasion room.
add: couple fine drinks to the Bridge conference room
add: BlueShield gets a stool in Conference rooms
add: Blueshield gets electrified shuttered windows overlooking the perma yard
tweak: Engi-Sci maint was squashed with the containment cell change, surprisingly better now imo
tweak: general changes around the station to some output/inputs (scrubbers and vents)
tweak: disposals parity here and there, now most run through departments
tweak: wild penguins are now atmos-immune, bad workaround but it's not really destructive
del: removed all the airless tiles (sorry for my stupidity)
tweak: wiring layout in several areas has been largely simplified or shortened
del: cargo maint tunnel, was just 1 wide and only there for the APC, APC moved to interior Cargo.
/:cl: