### PR TITLE
Boxstation Maint Bar Change

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation_Lumos.dmm
+++ b/_maps/map_files/BoxStation/BoxStation_Lumos.dmm
@@ -47510,6 +47510,13 @@
 /obj/machinery/meter,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
+"cmc" = (
+/obj/structure/table/wood/poker,
+/obj/item/toy/cards/deck{
+	pixel_y = 5
+	},
+/turf/open/floor/wood,
+/area/maintenance/bar)
 "cmd" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
@@ -53862,15 +53869,9 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "eDf" = (
-/obj/machinery/button/door{
-	id = "bardorm1";
-	name = "Dorm Bolt Control";
-	normaldoorcontrol = 1;
-	pixel_x = 25;
-	specialfunctions = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/maintenance/bar)
+/obj/machinery/vending/kink,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "eEe" = (
 /obj/machinery/door/airlock{
 	name = "Theatre Backstage";
@@ -57058,13 +57059,6 @@
 /turf/open/floor/circuit,
 /area/science/misc_lab)
 "kds" = (
-/obj/machinery/button/door{
-	id = "bardorm2";
-	name = "Dorm Bolt Control";
-	normaldoorcontrol = 1;
-	pixel_x = 25;
-	specialfunctions = 4
-	},
 /obj/structure/chair/sofa{
 	dir = 8
 	},
@@ -82675,7 +82669,7 @@ aaN
 alU
 amC
 alU
-aaN
+eDf
 atU
 alU
 atU
@@ -83278,7 +83272,7 @@ dKP
 gdQ
 dKQ
 jsw
-vDw
+lRY
 vDw
 dKP
 dKP
@@ -83536,7 +83530,7 @@ vDw
 mPd
 neL
 vDw
-vDw
+lRY
 nlJ
 oST
 evR
@@ -83793,7 +83787,7 @@ cjh
 vDw
 imH
 vDw
-vDw
+lRY
 dKP
 dKP
 dKP
@@ -84563,7 +84557,7 @@ foi
 oiu
 gGm
 mJz
-fry
+cmc
 lLR
 dKP
 gJi
@@ -86099,7 +86093,7 @@ bJf
 ccd
 dKP
 jmp
-eDf
+iqT
 dKP
 nqe
 kds

--- a/_maps/map_files/BoxStation/BoxStation_Lumos.dmm
+++ b/_maps/map_files/BoxStation/BoxStation_Lumos.dmm
@@ -11642,11 +11642,11 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "azn" = (
-/obj/machinery/light/small{
-	dir = 4;
-	light_color = "#d8b1b1"
+/obj/effect/decal/cleanable/cobweb,
+/obj/machinery/jukebox{
+	req_one_access = null
 	},
-/turf/open/floor/light/colour_cycle,
+/turf/open/floor/wood,
 /area/maintenance/bar)
 "azo" = (
 /obj/structure/cable{
@@ -46577,9 +46577,8 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
 "cjh" = (
-/obj/effect/decal/cleanable/generic,
-/obj/structure/closet/crate/bin,
-/turf/open/floor/plating,
+/obj/structure/chair/stool/bar,
+/turf/open/floor/wood,
 /area/maintenance/bar)
 "cji" = (
 /obj/structure/cable{
@@ -47033,11 +47032,9 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
 "ckv" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/structure/closet/crate/trashcart,
+/turf/open/floor/plasteel/dark,
+/area/maintenance/bar)
 "ckw" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -48745,12 +48742,9 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "cqL" = (
-/obj/machinery/door/airlock{
-	id_tag = "barbath";
-	name = "Restroom"
+/turf/open/floor/plating{
+	icon_state = "platingdmg2"
 	},
-/obj/structure/barricade/wooden/crude,
-/turf/open/floor/plating,
 /area/maintenance/bar)
 "cqM" = (
 /obj/structure/cable{
@@ -53194,9 +53188,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"doO" = (
-/turf/open/floor/carpet/black,
-/area/maintenance/bar)
 "dqb" = (
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/pool)
@@ -53321,10 +53312,9 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "dBH" = (
-/obj/structure/chair/stool/bar,
-/obj/effect/decal/cleanable/insectguts,
-/obj/structure/spider/stickyweb/genetic,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
 /area/maintenance/bar)
 "dCr" = (
 /obj/structure/pool/Rboard,
@@ -53381,17 +53371,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
-"dJY" = (
-/obj/structure/spider/stickyweb/genetic,
-/turf/open/floor/plasteel/stairs/medium,
-/area/maintenance/bar)
 "dKP" = (
 /turf/closed/wall,
 /area/maintenance/bar)
 "dKQ" = (
-/obj/structure/chair/stool,
-/obj/structure/spider/stickyweb/genetic,
-/turf/open/floor/plating,
+/obj/structure/table,
+/turf/open/floor/wood{
+	icon_state = "wood-broken6"
+	},
 /area/maintenance/bar)
 "dKV" = (
 /obj/effect/turf_decal/vg_decals/radiation,
@@ -53688,10 +53675,10 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "ejG" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/structure/chair/stool,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
 	},
-/turf/open/floor/plating,
 /area/maintenance/bar)
 "ekl" = (
 /obj/effect/turf_decal/stripes/line{
@@ -53706,9 +53693,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
-"elb" = (
-/turf/open/floor/light/colour_cycle,
-/area/maintenance/bar)
 "elf" = (
 /obj/structure/table/glass,
 /obj/machinery/reagentgrinder,
@@ -53885,7 +53869,7 @@
 	pixel_x = 25;
 	specialfunctions = 4
 	},
-/turf/open/floor/carpet/black,
+/turf/open/floor/plasteel/dark,
 /area/maintenance/bar)
 "eEe" = (
 /obj/machinery/door/airlock{
@@ -54098,11 +54082,9 @@
 	},
 /area/maintenance/starboard/fore)
 "ffd" = (
-/obj/structure/table/plasmaglass,
 /obj/machinery/chem_dispenser/drinks/beer,
-/obj/effect/decal/cleanable/cobweb,
-/obj/structure/spider/stickyweb/genetic,
-/turf/open/floor/plating,
+/obj/structure/table/glass,
+/turf/open/floor/wood,
 /area/maintenance/bar)
 "fgG" = (
 /obj/structure/table/wood,
@@ -54129,9 +54111,6 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
-"fjM" = (
-/turf/open/floor/plasteel/stairs/medium,
-/area/maintenance/bar)
 "fjS" = (
 /obj/structure/closet/radiation,
 /turf/open/floor/plasteel,
@@ -54160,14 +54139,8 @@
 /turf/open/floor/plasteel,
 /area/medical/cryo)
 "fmR" = (
-/obj/structure/bed,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/sign/poster/contraband/random{
-	pixel_y = 30
-	},
-/turf/open/floor/plating,
+/obj/structure/table/wood,
+/turf/open/floor/wood,
 /area/maintenance/bar)
 "fne" = (
 /obj/effect/landmark/start/mime,
@@ -54196,8 +54169,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
 "foi" = (
-/obj/effect/decal/cleanable/glass,
-/turf/open/floor/plating,
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/shaker,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
 /area/maintenance/bar)
 "fpl" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -54253,8 +54229,8 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "fry" = (
-/obj/effect/decal/cleanable/insectguts,
-/turf/open/floor/plating,
+/obj/structure/table/wood/poker,
+/turf/open/floor/wood,
 /area/maintenance/bar)
 "fsj" = (
 /obj/structure/table,
@@ -54350,9 +54326,10 @@
 /turf/open/pool,
 /area/crew_quarters/fitness/pool)
 "fzq" = (
-/obj/structure/chair/stool/bar,
-/obj/effect/decal/cleanable/ash,
-/turf/open/floor/plating,
+/obj/structure/window{
+	dir = 8
+	},
+/turf/open/floor/carpet/black,
 /area/maintenance/bar)
 "fzX" = (
 /turf/closed/wall/r_wall,
@@ -54450,10 +54427,12 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "fLE" = (
-/obj/structure/chair/stool/bar,
-/obj/effect/decal/cleanable/insectguts,
-/obj/effect/decal/cleanable/ash,
-/turf/open/floor/plating,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
 /area/maintenance/bar)
 "fLS" = (
 /obj/structure/cable{
@@ -54486,9 +54465,20 @@
 /turf/open/floor/wood,
 /area/medical/psych)
 "fPr" = (
-/obj/machinery/vending/autodrobe,
-/obj/structure/spider/stickyweb/genetic,
-/turf/open/floor/plating,
+/obj/structure/table/glass,
+/obj/item/reagent_containers/food/drinks/soda_cans/space_mountain_wind{
+	pixel_x = 4;
+	pixel_y = 9
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
+	pixel_x = 7;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
+	pixel_x = -5;
+	pixel_y = 12
+	},
+/turf/open/floor/carpet/black,
 /area/maintenance/bar)
 "fPy" = (
 /obj/effect/turf_decal/tile/red{
@@ -54604,13 +54594,10 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics/cloning)
 "gdQ" = (
-/obj/effect/decal/cleanable/blood,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/chair/stool,
-/obj/structure/spider/stickyweb/genetic,
-/turf/open/floor/plating,
+/obj/structure/table,
+/obj/item/storage/fancy/candle_box,
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/wood,
 /area/maintenance/bar)
 "geg" = (
 /obj/structure/disposalpipe/broken{
@@ -54752,10 +54739,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "gnI" = (
-/obj/machinery/door/airlock,
-/obj/structure/barricade/wooden/crude,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/effect/landmark/xeno_spawn,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/bar)
 "gok" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -54952,13 +54940,9 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
 "gGm" = (
-/obj/machinery/vending/snack/random,
-/obj/structure/spider/stickyweb/genetic,
-/obj/machinery/light/small{
-	dir = 4;
-	light_color = "#d8b1b1"
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
 	},
-/turf/open/floor/plating,
 /area/maintenance/bar)
 "gGw" = (
 /obj/structure/lattice,
@@ -55000,13 +54984,14 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "gLt" = (
-/obj/structure/table/plasmaglass,
 /obj/machinery/chem_dispenser/drinks,
-/obj/structure/spider/stickyweb/genetic,
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/open/floor/plating,
+/obj/structure/table/glass,
+/turf/open/floor/wood{
+	icon_state = "wood-broken6"
+	},
 /area/maintenance/bar)
 "gLH" = (
 /obj/machinery/door/airlock/external{
@@ -55151,18 +55136,9 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "gXE" = (
-/obj/structure/bed,
-/obj/item/bedsheet/blue,
-/obj/machinery/light/small{
-	dir = 1;
-	light_color = "#d8b1b1"
+/turf/open/floor/wood{
+	icon_state = "wood-broken7"
 	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
-"gYP" = (
-/obj/structure/chair/stool/bar,
-/obj/structure/spider/stickyweb/genetic,
-/turf/open/floor/plating,
 /area/maintenance/bar)
 "gZG" = (
 /obj/machinery/holopad,
@@ -55865,8 +55841,9 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "imH" = (
-/obj/structure/falsewall,
-/turf/open/floor/plating,
+/turf/open/floor/wood{
+	icon_state = "wood-broken3"
+	},
 /area/maintenance/bar)
 "iou" = (
 /obj/machinery/firealarm{
@@ -55898,12 +55875,7 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
 "iqT" = (
-/obj/machinery/door/airlock{
-	id_tag = "bardorm1";
-	name = "Room One"
-	},
-/obj/structure/barricade/wooden/crude,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/dark,
 /area/maintenance/bar)
 "iqU" = (
 /obj/machinery/door/airlock/external{
@@ -55963,9 +55935,10 @@
 /turf/open/floor/plasteel/dark,
 /area/blueshield)
 "iuE" = (
-/obj/effect/decal/cleanable/insectguts,
-/obj/structure/spider/stickyweb/genetic,
-/turf/open/floor/plasteel/stairs/medium,
+/obj/structure/chair/sofa/left{
+	dir = 1
+	},
+/turf/open/floor/carpet/black,
 /area/maintenance/bar)
 "iuJ" = (
 /obj/structure/cable{
@@ -55996,9 +55969,10 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/front_office)
 "iwm" = (
-/obj/machinery/vending/cola/random,
-/obj/structure/spider/stickyweb/genetic,
-/turf/open/floor/plating,
+/obj/structure/chair/sofa/corner{
+	dir = 8
+	},
+/turf/open/floor/carpet/black,
 /area/maintenance/bar)
 "iwX" = (
 /obj/structure/table/wood,
@@ -56013,12 +55987,10 @@
 /turf/open/floor/circuit/green,
 /area/security/prison)
 "iyz" = (
-/obj/structure/spider/stickyweb/genetic,
-/obj/machinery/jukebox/disco{
-	req_access = null;
-	req_one_access = null
+/obj/machinery/light/small{
+	dir = 4
 	},
-/turf/open/floor/light/colour_cycle,
+/turf/open/floor/wood,
 /area/maintenance/bar)
 "iyZ" = (
 /obj/structure/window,
@@ -56465,9 +56437,11 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "jmp" = (
-/obj/structure/bed,
-/obj/item/bedsheet/purple,
-/turf/open/floor/carpet/black,
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
+/obj/machinery/vending/cola/pwr_game,
+/turf/open/floor/plasteel/dark,
 /area/maintenance/bar)
 "jmy" = (
 /obj/structure/disposalpipe/segment{
@@ -56535,9 +56509,11 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/medical/medbay/lobby)
 "jsw" = (
-/obj/effect/decal/cleanable/generic,
-/obj/structure/chair/stool,
-/turf/open/floor/plating,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/table,
+/turf/open/floor/wood,
 /area/maintenance/bar)
 "jtV" = (
 /obj/machinery/chem_master/condimaster,
@@ -56580,8 +56556,10 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "jvS" = (
-/obj/machinery/light/small,
-/turf/open/floor/plating,
+/obj/structure/table/wood/poker,
+/turf/open/floor/wood{
+	icon_state = "wood-broken5"
+	},
 /area/maintenance/bar)
 "jxF" = (
 /obj/structure/grille,
@@ -56644,11 +56622,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"jDM" = (
-/obj/structure/spider/stickyweb/genetic,
-/obj/effect/decal/cleanable/glitter/pink,
-/turf/open/floor/plating,
-/area/maintenance/bar)
 "jDN" = (
 /obj/structure/table,
 /turf/open/floor/plasteel/cafeteria,
@@ -56852,9 +56825,11 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/pool)
 "jNn" = (
-/obj/structure/table,
-/obj/structure/spider/stickyweb/genetic,
-/turf/open/floor/plating,
+/obj/machinery/light/small,
+/obj/structure/chair/comfy/black{
+	dir = 1
+	},
+/turf/open/floor/wood,
 /area/maintenance/bar)
 "jNy" = (
 /obj/structure/lattice,
@@ -56983,7 +56958,6 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics)
 "jUb" = (
-/obj/structure/spider/stickyweb/genetic,
 /obj/machinery/vending/boozeomat,
 /turf/open/floor/plating,
 /area/maintenance/bar)
@@ -57053,7 +57027,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/structure/dresser,
+/obj/structure/chair/sofa/right,
 /turf/open/floor/carpet/black,
 /area/maintenance/bar)
 "kbp" = (
@@ -57066,7 +57040,7 @@
 /obj/structure/sign/poster/contraband/random{
 	pixel_x = -30
 	},
-/turf/open/floor/plating,
+/turf/open/floor/wood,
 /area/maintenance/bar)
 "kcO" = (
 /obj/structure/table/wood,
@@ -57090,6 +57064,9 @@
 	normaldoorcontrol = 1;
 	pixel_x = 25;
 	specialfunctions = 4
+	},
+/obj/structure/chair/sofa{
+	dir = 8
 	},
 /turf/open/floor/carpet/black,
 /area/maintenance/bar)
@@ -57770,10 +57747,6 @@
 /obj/item/chair,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"lxE" = (
-/obj/effect/spawner/lootdrop/crate_spawner,
-/turf/open/floor/plating,
-/area/maintenance/bar)
 "lyQ" = (
 /obj/structure/trash_pile,
 /turf/open/floor/carpet/purple,
@@ -57877,8 +57850,12 @@
 /turf/closed/wall,
 /area/security/brig)
 "lLR" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/obj/structure/chair/comfy/black{
+	dir = 1
+	},
+/turf/open/floor/wood{
+	icon_state = "wood-broken4"
+	},
 /area/maintenance/bar)
 "lMg" = (
 /turf/open/floor/circuit/telecomms,
@@ -57913,10 +57890,11 @@
 /turf/open/floor/plasteel/white,
 /area/science/explab)
 "lRY" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/structure/barricade/wooden{
+	max_integrity = 10;
+	obj_integrity = 10
 	},
-/turf/open/floor/plating,
+/turf/open/floor/wood,
 /area/maintenance/bar)
 "lUS" = (
 /obj/structure/table/wood/fancy/black,
@@ -58066,8 +58044,12 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/crew_quarters/toilet)
 "mmR" = (
-/obj/effect/spawner/lootdrop/keg,
-/turf/open/floor/plating,
+/obj/structure/chair/comfy/black{
+	dir = 1
+	},
+/turf/open/floor/wood{
+	icon_state = "wood-broken6"
+	},
 /area/maintenance/bar)
 "mnC" = (
 /obj/structure/target_stake,
@@ -58260,8 +58242,8 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "mJz" = (
-/obj/effect/decal/cleanable/generic,
-/turf/open/floor/plating,
+/obj/structure/chair/comfy/black,
+/turf/open/floor/wood,
 /area/maintenance/bar)
 "mKc" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible,
@@ -58314,8 +58296,8 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
 "mPd" = (
-/obj/effect/decal/cleanable/glitter/pink,
-/turf/open/floor/plating,
+/obj/structure/chair/stool,
+/turf/open/floor/wood,
 /area/maintenance/bar)
 "mPk" = (
 /obj/structure/bed,
@@ -58541,8 +58523,9 @@
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
 "neL" = (
-/obj/effect/landmark/blobstart,
-/turf/open/floor/plating,
+/turf/open/floor/wood{
+	icon_state = "wood-broken"
+	},
 /area/maintenance/bar)
 "nfZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -58633,12 +58616,10 @@
 /turf/open/floor/plasteel/dark,
 /area/maintenance/starboard/fore)
 "nqe" = (
-/obj/structure/bed,
 /obj/effect/decal/cleanable/cobweb{
 	icon_state = "cobweb2"
 	},
-/obj/effect/decal/cleanable/femcum,
-/obj/item/bedsheet/purple,
+/obj/structure/chair/sofa/corner,
 /turf/open/floor/carpet/black,
 /area/maintenance/bar)
 "nqz" = (
@@ -58776,8 +58757,7 @@
 /turf/closed/wall,
 /area/chapel/main)
 "nFP" = (
-/obj/structure/table,
-/obj/item/storage/fancy/candle_box,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/bar)
 "nGf" = (
@@ -58788,10 +58768,10 @@
 /turf/open/floor/plasteel/dark,
 /area/hydroponics)
 "nGn" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 11
+/obj/structure/toilet{
+	dir = 8
 	},
+/obj/effect/decal/cleanable/vomit/old,
 /turf/open/floor/plasteel/showroomfloor,
 /area/maintenance/bar)
 "nGt" = (
@@ -58810,13 +58790,13 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "nIB" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 3;
-	name = "3maintenance loot spawner"
+/obj/machinery/door/airlock{
+	id_tag = "barbath";
+	name = "Restroom"
 	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/structure/barricade/wooden/crude,
+/turf/open/floor/plasteel/showroomfloor,
+/area/maintenance/bar)
 "nLc" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -58824,7 +58804,6 @@
 /obj/structure/sign/poster/contraband/random{
 	pixel_x = -30
 	},
-/obj/structure/spider/stickyweb/genetic,
 /turf/open/floor/plating,
 /area/maintenance/bar)
 "nLu" = (
@@ -58868,8 +58847,10 @@
 /turf/open/floor/plating,
 /area/science/explab)
 "nNF" = (
-/obj/effect/landmark/xeno_spawn,
-/turf/open/floor/plating,
+/obj/structure/chair/comfy/black,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
 /area/maintenance/bar)
 "nQi" = (
 /obj/machinery/recharge_station,
@@ -58984,8 +58965,9 @@
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "nXT" = (
-/obj/structure/spider/stickyweb/genetic,
-/turf/open/floor/plating,
+/turf/open/floor/wood{
+	icon_state = "wood-broken4"
+	},
 /area/maintenance/bar)
 "nYe" = (
 /obj/structure/safe,
@@ -59105,8 +59087,16 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "odx" = (
-/obj/machinery/vending/kink,
-/turf/open/floor/plating,
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
+	},
+/obj/structure/mirror{
+	pixel_x = 28
+	},
+/obj/item/clothing/glasses/sunglasses/big,
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/showroomfloor,
 /area/maintenance/bar)
 "oem" = (
 /obj/structure/cable{
@@ -59150,7 +59140,9 @@
 /area/crew_quarters/fitness/pool)
 "oiu" = (
 /obj/structure/chair/stool/bar,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
 /area/maintenance/bar)
 "oiW" = (
 /obj/structure/cable{
@@ -59498,11 +59490,7 @@
 /turf/open/space,
 /area/space/nearstation)
 "oST" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/spider/stickyweb/genetic,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/stairs/medium,
 /area/maintenance/bar)
 "oTJ" = (
 /obj/item/radio/intercom{
@@ -60139,9 +60127,9 @@
 /area/security/brig)
 "qmg" = (
 /obj/machinery/light/small{
-	dir = 1
+	dir = 4
 	},
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plating,
 /area/maintenance/bar)
 "qmV" = (
 /obj/effect/turf_decal/tile/red{
@@ -60747,10 +60735,6 @@
 	},
 /turf/open/floor/carpet,
 /area/library)
-"rKI" = (
-/obj/effect/decal/cleanable/blood,
-/turf/open/floor/plating,
-/area/maintenance/bar)
 "rKO" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/tile/red{
@@ -61044,10 +61028,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"spa" = (
-/obj/effect/decal/cleanable/glitter/pink,
-/turf/open/floor/plasteel/stairs/medium,
-/area/maintenance/bar)
 "sqc" = (
 /obj/structure/table,
 /obj/machinery/recharger{
@@ -61381,7 +61361,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/decal/cleanable/oil/streak,
 /obj/machinery/door/airlock,
 /obj/structure/barricade/wooden/crude,
 /turf/open/floor/plating,
@@ -61817,16 +61796,6 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
 "tFc" = (
-/obj/effect/decal/cleanable/cobweb{
-	icon_state = "cobweb2"
-	},
-/obj/structure/sign/warning/fire{
-	desc = "A sign that states the labeled room's number.";
-	icon_state = "roomnum";
-	name = "Room Number 1";
-	pixel_x = 30;
-	pixel_y = -7
-	},
 /obj/machinery/power/apc{
 	areastring = "/area/storage/art";
 	dir = 1;
@@ -61836,7 +61805,6 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/structure/spider/stickyweb/genetic,
 /turf/open/floor/plating,
 /area/maintenance/bar)
 "tFr" = (
@@ -62119,12 +62087,8 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/pool)
 "ukM" = (
-/obj/machinery/shower{
-	dir = 8;
-	pixel_y = -4
-	},
-/obj/effect/decal/cleanable/semen,
-/turf/open/floor/plasteel/showroomfloor,
+/obj/structure/closet/emcloset,
+/turf/open/floor/plating,
 /area/maintenance/bar)
 "ulM" = (
 /obj/effect/turf_decal/loading_area{
@@ -62256,12 +62220,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "uuh" = (
-/obj/machinery/door/airlock{
-	id_tag = "bardorm2";
-	name = "Room Two"
-	},
-/obj/structure/barricade/wooden/crude,
-/turf/open/floor/plating,
+/turf/open/floor/carpet/black,
 /area/maintenance/bar)
 "uve" = (
 /obj/structure/table,
@@ -62508,9 +62467,14 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics/cloning)
 "uZJ" = (
-/obj/structure/table,
+/obj/structure/bed,
+/obj/item/bedsheet/blue,
+/obj/machinery/light/small{
+	dir = 1;
+	light_color = "#d8b1b1"
+	},
 /turf/open/floor/plating,
-/area/maintenance/port/aft)
+/area/maintenance/bar)
 "vaa" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
@@ -62666,8 +62630,8 @@
 /turf/open/floor/plasteel,
 /area/teleporter)
 "vkx" = (
-/obj/structure/spider/stickyweb/genetic,
-/turf/open/floor/light/colour_cycle,
+/obj/structure/chair,
+/turf/open/floor/plating,
 /area/maintenance/bar)
 "vnI" = (
 /obj/structure/disposalpipe/segment,
@@ -62718,17 +62682,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"vpH" = (
-/obj/structure/sign/warning/fire{
-	desc = "A sign that states the labeled room's number.";
-	dir = 1;
-	icon_state = "roomnum";
-	name = "Room Number 2";
-	pixel_x = 30;
-	pixel_y = -7
-	},
-/turf/open/floor/plating,
-/area/maintenance/bar)
 "vpY" = (
 /obj/structure/closet/lasertag/blue,
 /obj/item/clothing/under/misc/pj/blue,
@@ -62804,11 +62757,6 @@
 /turf/open/floor/wood,
 /area/library)
 "vuj" = (
-/obj/structure/toilet{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/vomit/old,
-/obj/item/clothing/glasses/sunglasses/big,
 /turf/open/floor/plasteel/showroomfloor,
 /area/maintenance/bar)
 "vvx" = (
@@ -62992,11 +62940,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "vDw" = (
-/obj/structure/sign/poster/contraband/random{
-	pixel_y = 30
-	},
-/obj/structure/spider/stickyweb/genetic,
-/turf/open/floor/plating,
+/turf/open/floor/wood,
 /area/maintenance/bar)
 "vDB" = (
 /obj/effect/turf_decal/stripes/line{
@@ -63225,9 +63169,8 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "waV" = (
-/obj/item/assembly/signaler,
-/obj/item/electropack/shockcollar,
-/turf/open/floor/plating,
+/obj/effect/spawner/lootdrop/keg,
+/turf/open/floor/wood,
 /area/maintenance/bar)
 "wbE" = (
 /obj/effect/turf_decal/tile/blue{
@@ -63407,8 +63350,11 @@
 /turf/open/floor/plating,
 /area/construction/mining/aux_base)
 "wpJ" = (
-/obj/effect/decal/cleanable/glass,
-/obj/structure/spider/stickyweb/genetic,
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 3;
+	name = "3maintenance loot spawner"
+	},
 /turf/open/floor/plating,
 /area/maintenance/bar)
 "wql" = (
@@ -63728,12 +63674,11 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/pool)
 "wXo" = (
-/obj/effect/decal/cleanable/cobweb,
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/structure/dresser,
-/turf/open/floor/carpet/black,
+/obj/machinery/vending/cigarette,
+/turf/open/floor/plasteel/dark,
 /area/maintenance/bar)
 "wYs" = (
 /obj/machinery/chem_master/condimaster{
@@ -63748,8 +63693,7 @@
 /turf/open/floor/plasteel,
 /area/security/processing)
 "wZG" = (
-/obj/effect/decal/cleanable/blood,
-/obj/structure/spider/stickyweb/genetic,
+/obj/structure/table,
 /turf/open/floor/plating,
 /area/maintenance/bar)
 "wZI" = (
@@ -64291,11 +64235,6 @@
 /obj/structure/closet/athletic_mixed,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/pool)
-"ybT" = (
-/obj/machinery/vending/clothing,
-/obj/structure/spider/stickyweb/genetic,
-/turf/open/floor/plating,
-/area/maintenance/bar)
 "ybX" = (
 /obj/structure/chair/office/light,
 /obj/structure/cable{
@@ -64384,8 +64323,10 @@
 /turf/open/floor/wood,
 /area/hallway/primary/central)
 "ykU" = (
-/obj/structure/table,
-/turf/open/floor/plating,
+/obj/structure/table/wood,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
 /area/maintenance/bar)
 
 (1,1,1) = {"
@@ -82818,19 +82759,19 @@ aaf
 aaa
 aaa
 aaa
-aaf
-dKP
-lLR
-lLR
-lLR
-dKP
-dKP
-dKP
-dKP
-dKP
-dKP
-dKP
-dKP
+gXs
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -83073,33 +83014,33 @@ aaa
 aaa
 aaf
 aaf
-dKP
-dKP
-gkf
+aaa
+aaa
+aaf
 dKP
 nFP
-ykU
-ykU
-evR
-dJY
-mPd
-elb
-ejG
-evR
-nXT
+nFP
+dKP
+nFP
+nFP
 dKP
 aaa
 aaa
 aaa
 aaa
 aaa
+dKP
+dKP
+nFP
+nFP
+nFP
 aaa
 aaa
-bCq
-bCq
-bLv
-bLv
-bLv
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -83330,33 +83271,33 @@ cfx
 aaa
 aaa
 aaf
+dKP
+dKP
 gkf
-fmR
-odx
 dKP
 gdQ
 dKQ
 jsw
-evR
-spa
-evR
-rKI
-evR
-mPd
-elb
+vDw
+vDw
 dKP
-bCq
-bCq
-bLv
-bLv
-bLv
-bCq
-bCq
-bCq
-ciT
-bHE
-nIB
-bLv
+dKP
+nFP
+nFP
+nFP
+dKP
+dKP
+ukM
+evR
+wpJ
+nFP
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -83586,34 +83527,34 @@ ciQ
 cfw
 aaa
 aaa
-aaa
+dKP
 gkf
-rKI
+waV
 waV
 dKP
 vDw
 mPd
 neL
-nXT
-fjM
-elb
-evR
-iyz
-evR
-nXT
+vDw
+vDw
 nlJ
-bHE
-ckv
-bHE
-bHE
-bHE
-ckv
-bHE
-gnI
-bHE
-cAQ
-uZJ
-bLv
+oST
+evR
+qmg
+evR
+evR
+nlJ
+evR
+vkx
+wZG
+nFP
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -83844,33 +83785,33 @@ cfw
 aaa
 aaa
 dKP
-dKP
+azn
 imH
-dKP
-dKP
+dBH
+fmR
 cjh
-lxE
-nXT
-nXT
-dJY
-evR
-nXT
-mPd
-vkx
-rKI
+vDw
+imH
+vDw
+vDw
 dKP
-bCq
-bCq
-bLv
-bLv
-bLv
-bCq
-bCq
-bCq
-gXE
-bHE
+dKP
+dKP
+dKP
+dKP
+dKP
+dKP
 uZJ
-bLv
+evR
+wZG
+nFP
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -84102,32 +84043,32 @@ aag
 aag
 gze
 ffd
-rKI
-nXT
+cqL
+dBH
 ykU
 oiu
-evR
-rKI
-mPd
-dJY
-evR
-evR
-azn
-evR
-evR
+vDw
+vDw
+vDw
+vDw
 dKP
 aaa
 aaa
+gXs
+aaa
+aaa
+dKP
+dKP
+nFP
+nFP
+nFP
 aaa
 aaa
 aaa
 aaa
 aaa
-bCq
-bCq
-bLv
-bLv
-bLv
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -84360,20 +84301,20 @@ bXv
 dKP
 gLt
 nXT
-nXT
+ejG
 ykU
 oiu
-evR
+gnI
 mJz
 jvS
-dKP
-dKP
-dKP
-dKP
-dKP
-dKP
+jNn
 dKP
 aaa
+aaa
+gXs
+aaa
+aaa
+gXs
 aaa
 aaa
 aaa
@@ -84617,20 +84558,20 @@ clA
 dKP
 jUb
 evR
-mmR
-ykU
-gYP
 evR
-evR
-fry
-fjM
-evR
-evR
+foi
 oiu
-dBH
-oST
+gGm
+mJz
+fry
+lLR
 dKP
-aaa
+gJi
+gXs
+gXs
+gXs
+gXs
+gXs
 aaa
 aaa
 aaa
@@ -84876,18 +84817,18 @@ dKP
 nlJ
 dKP
 dKP
-nXT
-jDM
+fLE
+dBH
 nNF
-evR
-dJY
-evR
-oiu
-jNn
-ykU
-fzq
-dKP
+fry
+mmR
+nFP
+gJi
 aaa
+gXs
+aaa
+aaa
+gXs
 aaa
 aaa
 aaa
@@ -85130,21 +85071,21 @@ lfJ
 lWq
 sNl
 nLc
-wZG
+evR
 kci
-nXT
-jDM
+lRY
+vDw
+gXE
 evR
+vDw
 evR
-evR
-iuE
-nXT
-fLE
-ykU
-ykU
-oiu
-dKP
+nFP
+gJi
 aaa
+gXs
+aaa
+aaa
+gXs
 aaa
 aaa
 aaa
@@ -85387,21 +85328,21 @@ bHE
 uvZ
 dKP
 tFc
-evR
+vDw
 lRY
-vpH
-rKI
-lRY
+vDw
+vDw
+vDw
+iyz
 evR
 evR
-dJY
-evR
-evR
-oiu
-oiu
-nXT
 dKP
-aaa
+gJi
+gXs
+gXs
+gXs
+gXs
+gXs
 aaa
 aaa
 aaa
@@ -85643,22 +85584,22 @@ bCq
 bCq
 cTF
 dKP
-dKP
+ckv
 iqT
 dKP
-dKP
+fzq
 uuh
+fzq
 dKP
-cqL
 dKP
-dKP
-foi
-foi
-foi
-wpJ
-fry
+nIB
 dKP
 aaa
+aaa
+gXs
+aaa
+aaa
+gXs
 aaa
 aaa
 aaa
@@ -85901,21 +85842,21 @@ ahY
 bHE
 dKP
 wXo
-doO
+iqT
 dKP
 kbi
-doO
+fPr
+iuE
 dKP
-qmg
+vuj
 vuj
 dKP
-iwm
-gGm
-ybT
-fPr
-dKP
-dKP
 aaa
+aaa
+gXs
+aaa
+aaa
+gXs
 aaa
 aaa
 aaa
@@ -86162,10 +86103,10 @@ eDf
 dKP
 nqe
 kds
+iwm
 dKP
-ukM
 nGn
-dKP
+odx
 btG
 gUu
 btG

--- a/_maps/map_files/BoxStation/BoxStation_Lumos.dmm
+++ b/_maps/map_files/BoxStation/BoxStation_Lumos.dmm
@@ -48749,9 +48749,11 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "cqL" = (
-/turf/open/floor/plating{
-	icon_state = "platingdmg2"
+/obj/effect/spawner/lootdrop/keg,
+/obj/machinery/light/small{
+	dir = 8
 	},
+/turf/open/floor/wood,
 /area/maintenance/bar)
 "cqM" = (
 /obj/structure/cable{
@@ -59484,7 +59486,10 @@
 /turf/open/space,
 /area/space/nearstation)
 "oST" = (
-/turf/open/floor/plasteel/stairs/medium,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating,
 /area/maintenance/bar)
 "oTJ" = (
 /obj/item/radio/intercom{
@@ -60120,9 +60125,7 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "qmg" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/maintenance/bar)
 "qmV" = (
@@ -62081,7 +62084,11 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/pool)
 "ukM" = (
-/obj/structure/closet/emcloset,
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 3;
+	name = "3maintenance loot spawner"
+	},
 /turf/open/floor/plating,
 /area/maintenance/bar)
 "ulM" = (
@@ -62461,12 +62468,7 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics/cloning)
 "uZJ" = (
-/obj/structure/bed,
-/obj/item/bedsheet/blue,
-/obj/machinery/light/small{
-	dir = 1;
-	light_color = "#d8b1b1"
-	},
+/obj/structure/table,
 /turf/open/floor/plating,
 /area/maintenance/bar)
 "vaa" = (
@@ -62624,7 +62626,12 @@
 /turf/open/floor/plasteel,
 /area/teleporter)
 "vkx" = (
-/obj/structure/chair,
+/obj/structure/bed,
+/obj/item/bedsheet/blue,
+/obj/machinery/light/small{
+	dir = 1;
+	light_color = "#d8b1b1"
+	},
 /turf/open/floor/plating,
 /area/maintenance/bar)
 "vnI" = (
@@ -63344,11 +63351,7 @@
 /turf/open/floor/plating,
 /area/construction/mining/aux_base)
 "wpJ" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 3;
-	name = "3maintenance loot spawner"
-	},
+/obj/structure/chair,
 /turf/open/floor/plating,
 /area/maintenance/bar)
 "wql" = (
@@ -63686,10 +63689,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
-"wZG" = (
-/obj/structure/table,
-/turf/open/floor/plating,
-/area/maintenance/bar)
 "wZI" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -83021,13 +83020,13 @@ dKP
 aaa
 aaa
 aaa
-aaa
-aaa
 dKP
 dKP
 nFP
 nFP
 nFP
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -83275,16 +83274,16 @@ jsw
 lRY
 vDw
 dKP
-dKP
 nFP
 nFP
 nFP
 dKP
-dKP
-ukM
+qmg
 evR
-wpJ
+ukM
 nFP
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -83523,7 +83522,7 @@ aaa
 aaa
 dKP
 gkf
-waV
+cqL
 waV
 dKP
 vDw
@@ -83532,16 +83531,16 @@ neL
 vDw
 lRY
 nlJ
+evR
 oST
-evR
-qmg
-evR
 evR
 nlJ
 evR
-vkx
-wZG
+wpJ
+uZJ
 nFP
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -83793,12 +83792,12 @@ dKP
 dKP
 dKP
 dKP
-dKP
-dKP
-uZJ
+vkx
 evR
-wZG
+uZJ
 nFP
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -84037,7 +84036,7 @@ aag
 aag
 gze
 ffd
-cqL
+gGm
 dBH
 ykU
 oiu
@@ -84049,13 +84048,13 @@ dKP
 aaa
 aaa
 gXs
-aaa
-aaa
 dKP
 dKP
 nFP
 nFP
 nFP
+aaa
+aaa
 aaa
 aaa
 aaa


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/26664829/102588820-a8d8f500-40d3-11eb-9651-7e2d3d2dee91.png)

## About The Pull Request

Yet another version of maint bar for Box, this area just can't catch a break

## Why It's Good For The Game

Revamps the place to feel alot more like a hidden dive bar, instead of a semi-broken disco that spiderman megacoomed in

## Changelog
:cl:
tweak: Changes Boxstation Maint Bar
/:cl: