### PR TITLE
makes a whole bunch of things glow

### DIFF
--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
@@ -14,6 +14,9 @@
 	welded = FALSE
 	level = 1
 	layer = GAS_SCRUBBER_LAYER
+	light_color = LIGHT_COLOR_LIGHT_CYAN
+	light_power = 0.3
+	light_range = 1.4
 
 	var/id_tag = null
 	var/pump_direction = RELEASING
@@ -55,32 +58,40 @@
 
 	if(welded)
 		icon_state = "vent_welded"
+		set_light(0)
 		return
 
 	if(!nodes[1] || !on || !is_operational())
 		if(icon_state == "vent_welded")
 			icon_state = "vent_off"
+			set_light(0)
 			return
 
 		if(pump_direction & RELEASING)
 			icon_state = "vent_out-off"
+			set_light(0)
 		else // pump_direction == SIPHONING
 			icon_state = "vent_in-off"
+			set_light(0)
 		return
 
 	if(icon_state == ("vent_out-off" || "vent_in-off" || "vent_off"))
 		if(pump_direction & RELEASING)
 			icon_state = "vent_out"
 			flick("vent_out-starting", src)
+			set_light(1.4, 0.3, LIGHT_COLOR_LIGHT_CYAN)
 		else // pump_direction == SIPHONING
 			icon_state = "vent_in"
 			flick("vent_in-starting", src)
+			set_light(1.4, 0.3, LIGHT_COLOR_RED)
 		return
 
 	if(pump_direction & RELEASING)
 		icon_state = "vent_out"
+		set_light(1.4, 0.3, LIGHT_COLOR_LIGHT_CYAN)
 	else // pump_direction == SIPHONING
 		icon_state = "vent_in"
+		set_light(1.4, 0.3, LIGHT_COLOR_RED)
 
 /obj/machinery/atmospherics/components/unary/vent_pump/process_atmos()
 	..()

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
@@ -12,6 +12,9 @@
 	welded = FALSE
 	level = 1
 	layer = GAS_SCRUBBER_LAYER
+	light_color = LIGHT_COLOR_LIGHT_CYAN
+	light_power = 0.3
+	light_range = 1.4
 
 	var/id_tag = null
 	var/scrubbing = SCRUBBING //0 = siphoning, 1 = scrubbing
@@ -73,19 +76,24 @@
 
 	if(welded)
 		icon_state = "scrub_welded"
+		set_light(0)
 		return
 
 	if(!nodes[1] || !on || !is_operational())
 		icon_state = "scrub_off"
+		set_light(0)
 		return
 
 	if(scrubbing & SCRUBBING)
 		if(widenet)
 			icon_state = "scrub_wide"
+			set_light(1.4, 0.5, LIGHT_COLOR_LIGHT_CYAN)
 		else
 			icon_state = "scrub_on"
+			set_light(1.4, 0.3, LIGHT_COLOR_LIGHT_CYAN)
 	else //scrubbing == SIPHONING
 		icon_state = "scrub_purge"
+		set_light(1.4, 0.5, LIGHT_COLOR_RED)
 
 /obj/machinery/atmospherics/components/unary/vent_scrubber/proc/set_frequency(new_frequency)
 	SSradio.remove_object(src, frequency)

--- a/code/modules/hydroponics/biogenerator.dm
+++ b/code/modules/hydroponics/biogenerator.dm
@@ -7,6 +7,9 @@
 	use_power = IDLE_POWER_USE
 	idle_power_usage = 40
 	circuit = /obj/item/circuitboard/machine/biogenerator
+	light_color = LIGHT_COLOR_LIGHT_CYAN
+	light_power = 0.4
+	light_range = 1.4
 	var/processing = FALSE
 	var/obj/item/reagent_containers/glass/beaker = null
 	var/points = 0

--- a/code/modules/hydroponics/seed_extractor.dm
+++ b/code/modules/hydroponics/seed_extractor.dm
@@ -46,6 +46,9 @@
 	icon_state = "sextractor"
 	density = TRUE
 	circuit = /obj/item/circuitboard/machine/seed_extractor
+	light_color = LIGHT_COLOR_LIGHT_CYAN
+	light_power = 0.4
+	light_range = 1.4
 	var/piles = list()
 	var/max_seeds = 1000
 	var/seed_multiplier = 1

--- a/code/modules/power/gravitygenerator.dm
+++ b/code/modules/power/gravitygenerator.dm
@@ -26,6 +26,7 @@ GLOBAL_LIST_EMPTY(gravity_generators) // We will keep track of this by adding ne
 	move_resist = INFINITY
 	use_power = NO_POWER_USE
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
+	light_color = LIGHT_COLOR_GREEN
 	var/sprite_number = 0
 
 /obj/machinery/gravity_generator/safe_throw_at()
@@ -331,6 +332,7 @@ GLOBAL_LIST_EMPTY(gravity_generators) // We will keep track of this by adding ne
 					overlay_state = "activating"
 				if(81 to 100)
 					overlay_state = "activated"
+			set_light(FLOOR(charge_count / 20, 0)) //glow increases depending on the charge
 
 			if(overlay_state != current_overlay)
 				if(middle)

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -78,6 +78,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 	flags_1 = PREVENT_CONTENTS_EXPLOSION_1
 	var/uid = 1
 	var/static/gl_uid = 1
+	light_color = LIGHT_COLOR_YELLOW
 	light_range = 4
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF | FREEZE_PROOF
 
@@ -399,10 +400,12 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 		if(gasmix_power_ratio > 0.8)
 			// with a perfect gas mix, make the power less based on heat
 			icon_state = "[base_icon_state]_glow"
+			set_light(l_color = LIGHT_COLOR_ORANGE)
 		else
 			// in normal mode, base the produced energy around the heat
 			temp_factor = 30
 			icon_state = base_icon_state
+			set_light(l_color = LIGHT_COLOR_YELLOW)
 
 		power = max( (removed.temperature * temp_factor / T0C) * gasmix_power_ratio + power, 0) //Total laser power plus an overload
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes the following machines glow: vents, scrubbers, grav gen, supermatter, biogenerator and seed extractor.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Botany machinery was missing a light but I reckon the other ones just look cool 😎 
The vents / scrubbers are pretty faint but I reckon it adds a nice touch, especially in areas when the lights go out. I don't think it has any real balance issues since they're fainter than the backup lights.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Vents, scrubbers, the grav gen, supermatter crystals, biogenerators and seed extractors now glow.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
