### PR TITLE
Box Station Lil Bitz

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation_Lumos.dmm
+++ b/_maps/map_files/BoxStation/BoxStation_Lumos.dmm
@@ -536,6 +536,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
 	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "abF" = (
@@ -939,15 +942,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
-"acC" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "acE" = (
 /obj/machinery/light{
 	dir = 1;
@@ -978,16 +972,6 @@
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"acH" = (
-/obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -1143,7 +1127,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/effect/turf_decal/bot,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "add" = (
@@ -1153,9 +1139,14 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
 	},
-/obj/effect/turf_decal/bot,
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -1175,12 +1166,14 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "adf" = (
-/obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/structure/chair/stool,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "adg" = (
@@ -1419,6 +1412,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -1691,6 +1687,9 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aek" = (
@@ -1827,12 +1826,14 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "aex" = (
-/obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /obj/structure/chair/stool,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aey" = (
@@ -2496,6 +2497,7 @@
 	name = "Command Tool Storage";
 	req_access_txt = "19"
 	},
+/obj/effect/turf_decal/lumos/tile/blue/fulltile,
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "afP" = (
@@ -2685,8 +2687,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/effect/turf_decal/bot,
 /obj/structure/chair/stool,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "agm" = (
@@ -2696,6 +2700,9 @@
 /obj/structure/table,
 /obj/item/stack/sheet/plasteel{
 	amount = 10
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
@@ -2734,8 +2741,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/obj/effect/turf_decal/bot,
 /obj/structure/chair/stool,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "agu" = (
@@ -2839,6 +2848,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -3581,7 +3593,7 @@
 	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/layer_manifold{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -3720,6 +3732,9 @@
 /obj/item/stack/sheet/metal/fifty,
 /obj/item/stack/sheet/rglass{
 	amount = 50
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
@@ -4283,6 +4298,9 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "ajA" = (
@@ -4328,6 +4346,9 @@
 /obj/effect/turf_decal/trimline/red/filled/corner,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "ajH" = (
@@ -4584,6 +4605,9 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "akh" = (
@@ -4741,6 +4765,9 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aku" = (
@@ -4834,6 +4861,9 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "akD" = (
@@ -4915,6 +4945,9 @@
 	dir = 10
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/preopen{
+	id = "permalock2"
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "akM" = (
@@ -4997,6 +5030,9 @@
 	light_color = "#c1caff"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "akU" = (
@@ -5182,6 +5218,9 @@
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 8
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "als" = (
@@ -5209,16 +5248,7 @@
 /area/security/brig)
 "alu" = (
 /obj/machinery/nuclearbomb/selfdestruct,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
 "alv" = (
@@ -5448,6 +5478,9 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "ama" = (
@@ -5470,6 +5503,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
@@ -5523,6 +5559,12 @@
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -5620,6 +5662,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/effect/turf_decal/bot_red,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "amv" = (
@@ -5804,6 +5847,9 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "amQ" = (
@@ -5902,11 +5948,11 @@
 	dir = 5
 	},
 /obj/machinery/portable_atmospherics/canister/air,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer1,
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "anc" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /turf/closed/wall,
@@ -6327,7 +6373,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/binary/pump/on{
+/obj/machinery/atmospherics/components/binary/pump/on/layer1{
 	dir = 8;
 	name = "Air Out"
 	},
@@ -6337,10 +6383,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+/obj/item/wrench,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/item/wrench,
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "aof" = (
@@ -7271,7 +7317,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/layer_manifold{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -7545,11 +7591,11 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
 /obj/structure/chair/stool{
 	pixel_y = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
@@ -8228,6 +8274,7 @@
 "asD" = (
 /obj/structure/table/wood,
 /mob/living/simple_animal/pet/fox/Renault,
+/obj/item/book/manual/wiki/security_space_law,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain)
 "asE" = (
@@ -8335,6 +8382,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
 "asX" = (
@@ -8342,6 +8390,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -8721,6 +8775,9 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "auk" = (
@@ -8955,12 +9012,14 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "auT" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
+/obj/structure/table/glass,
+/obj/item/hemostat,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "auU" = (
@@ -9003,11 +9062,10 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "auX" = (
+/obj/machinery/iv_drip,
 /obj/structure/mirror{
-	icon_state = "mirror_broke";
 	pixel_y = 28
 	},
-/obj/machinery/iv_drip,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "auY" = (
@@ -9118,14 +9176,14 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "avr" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
 	},
-/obj/machinery/camera{
-	c_tag = "Detective's Office"
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/grimy,
-/area/security/detectives_office)
+/turf/open/floor/plasteel,
+/area/security/prison)
 "avt" = (
 /obj/machinery/button/door{
 	id = "PoolShut";
@@ -9183,6 +9241,9 @@
 /area/crew_quarters/dorms)
 "avB" = (
 /obj/effect/spawner/structure/window,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
 /turf/open/floor/plating,
 /area/security/prison)
 "avC" = (
@@ -9590,6 +9651,9 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "awy" = (
@@ -9913,10 +9977,16 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "axg" = (
-/obj/structure/table/glass,
-/obj/item/storage/bag/trash,
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "axh" = (
 /obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 1
@@ -10083,6 +10153,13 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
 	},
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "axB" = (
@@ -10164,6 +10241,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
 "axL" = (
@@ -10181,10 +10261,12 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "axS" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
+/obj/effect/spawner/structure/window,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating,
+/area/security/prison)
 "axT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -10243,6 +10325,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -10308,6 +10393,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
@@ -10375,21 +10463,34 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "ayt" = (
-/obj/structure/table/glass,
-/obj/item/hemostat,
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "ayu" = (
-/obj/structure/table/glass,
-/obj/item/restraints/handcuffs/cable/zipties,
-/obj/item/reagent_containers/blood/random,
+/obj/item/shard,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "ayv" = (
 /obj/machinery/airalarm{
 	pixel_y = 23
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
 /area/ai_monitored/storage/eva)
 "ayw" = (
 /obj/structure/cable{
@@ -10503,7 +10604,9 @@
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
+	},
 /area/ai_monitored/storage/eva)
 "ayN" = (
 /obj/structure/rack,
@@ -10561,9 +10664,15 @@
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical{
 	pixel_x = -2;
-	pixel_y = -1
+	pixel_y = 7
 	},
-/obj/item/multitool,
+/obj/item/multitool{
+	pixel_x = 5
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "ayS" = (
@@ -10581,14 +10690,22 @@
 	dir = 1
 	},
 /obj/structure/table,
-/obj/item/assembly/signaler,
-/obj/item/assembly/signaler,
 /obj/item/stock_parts/cell/high/plus,
 /obj/item/pen{
 	desc = "Writes upside down!";
 	name = "astronaut pen";
-	pixel_x = 5;
-	pixel_y = 6
+	pixel_x = 13;
+	pixel_y = 2
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/obj/machinery/cell_charger{
+	pixel_x = -3;
+	pixel_y = 9
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
@@ -10621,6 +10738,12 @@
 /obj/item/storage/belt/utility,
 /obj/item/storage/belt/utility,
 /obj/item/clothing/head/welding,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "ayY" = (
@@ -10747,6 +10870,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "azk" = (
@@ -10756,9 +10882,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
@@ -10954,11 +11082,6 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"azI" = (
-/obj/structure/table/wood,
-/obj/item/instrument/eguitar,
-/turf/open/floor/wood,
-/area/crew_quarters/theatre)
 "azJ" = (
 /obj/effect/turf_decal/bot_white/right,
 /obj/effect/turf_decal/lumos/tile/neutral/fulltile,
@@ -11036,6 +11159,15 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "azS" = (
@@ -11055,6 +11187,12 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
@@ -11100,11 +11238,15 @@
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "azY" = (
-/obj/structure/table,
-/obj/item/radio/off,
-/obj/item/radio/off,
-/obj/item/assembly/prox_sensor,
-/obj/item/assembly/prox_sensor,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "azZ" = (
@@ -11187,9 +11329,6 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "aAj" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
 /obj/machinery/power/apc{
 	areastring = "/area/security/checkpoint/auxiliary";
 	name = "Security Checkpoint APC";
@@ -11266,21 +11405,17 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aAw" = (
-/obj/machinery/power/apc{
-	areastring = "/area/hydroponics/garden";
-	dir = 4;
-	name = "Garden APC";
-	pixel_x = 27;
-	pixel_y = 2
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
+/obj/structure/table/glass,
+/obj/item/restraints/handcuffs/cable/zipties,
+/obj/item/reagent_containers/blood/random,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aAx" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
 "aAy" = (
@@ -11583,17 +11718,28 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "aBl" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Security Maintenance";
-	req_access_txt = "1"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "aBm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
 "aBn" = (
@@ -11791,17 +11937,26 @@
 /turf/closed/wall,
 /area/security/checkpoint/auxiliary)
 "aBJ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/open/floor/carpet,
-/area/crew_quarters/theatre)
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
 "aBK" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
-/turf/open/floor/carpet,
-/area/crew_quarters/theatre)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "aBL" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Tool Storage Maintenance";
@@ -11858,57 +12013,41 @@
 	dir = 6
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/preopen{
+	id = "permalock2"
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aBT" = (
 /obj/machinery/computer/bank_machine,
 /obj/effect/turf_decal/bot_white,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
 "aBU" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
 	},
+/obj/structure/window,
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
 "aBV" = (
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 8
 	},
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
+	},
+/obj/machinery/door/window,
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
 "aBW" = (
 /obj/structure/filingcabinet,
 /obj/item/folder/documents,
 /obj/effect/turf_decal/bot_white,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
 "aBZ" = (
@@ -11965,9 +12104,8 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "aCh" = (
-/obj/machinery/vending/autodrobe,
 /turf/open/floor/plasteel/white/side{
-	dir = 4
+	dir = 1
 	},
 /area/crew_quarters/theatre)
 "aCi" = (
@@ -11979,6 +12117,10 @@
 /obj/machinery/camera{
 	c_tag = "EVA East";
 	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
@@ -12466,16 +12608,7 @@
 /area/ai_monitored/nuke_storage)
 "aDs" = (
 /obj/effect/turf_decal/bot_white/right,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
 "aDt" = (
@@ -12499,10 +12632,18 @@
 /turf/open/floor/plasteel/white,
 /area/security/prison)
 "aDv" = (
-/obj/structure/chair/stool,
-/obj/structure/window,
-/turf/open/floor/wood,
-/area/crew_quarters/theatre)
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/preopen{
+	id = "permalock2"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "aDw" = (
 /obj/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -12633,9 +12774,6 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/crew_quarters/toilet)
 "aDN" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
@@ -12644,6 +12782,9 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
@@ -13118,16 +13259,7 @@
 "aEN" = (
 /obj/effect/turf_decal/bot_white/right,
 /obj/structure/closet/crate/goldcrate,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
 "aEO" = (
@@ -13142,16 +13274,7 @@
 "aEP" = (
 /obj/effect/turf_decal/bot_white/left,
 /obj/structure/closet/crate/silvercrate,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
 "aEQ" = (
@@ -13310,6 +13433,9 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aFk" = (
@@ -13415,6 +13541,9 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aFF" = (
@@ -13624,25 +13753,16 @@
 /area/storage/primary)
 "aGa" = (
 /obj/machinery/light,
-/obj/effect/turf_decal/tile/neutral,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
 "aGb" = (
 /obj/effect/turf_decal/bot_white/right,
 /obj/machinery/ore_silo,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
 "aGc" = (
@@ -13655,21 +13775,15 @@
 	network = list("vault")
 	},
 /obj/machinery/light,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
 	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
 "aGd" = (
 /obj/structure/cable{
 	icon_state = "2-4"
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
@@ -13677,6 +13791,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 8
 	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
 "aGf" = (
@@ -13766,15 +13881,15 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "aGr" = (
-/obj/structure/chair/stool,
-/obj/effect/landmark/start/clown,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4
-	},
 /obj/effect/turf_decal/lumos/tile/blue/checker{
 	dir = 4
 	},
 /obj/effect/turf_decal/lumos/tile/red/checker,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
 "aGs" = (
@@ -13863,21 +13978,9 @@
 /area/maintenance/starboard/fore)
 "aGD" = (
 /obj/structure/table/wood,
-/obj/structure/mirror{
-	pixel_x = -28
-	},
-/obj/item/phone{
-	pixel_x = -3;
-	pixel_y = -1
-	},
-/obj/item/flashlight/lamp/bananalamp{
-	pixel_x = 4;
-	pixel_y = 15
-	},
-/obj/effect/turf_decal/lumos/tile/blue/checker{
-	dir = 4
-	},
-/obj/effect/turf_decal/lumos/tile/red/checker,
+/obj/item/instrument/piano_synth,
+/obj/item/instrument/guitar,
+/obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
 "aGE" = (
@@ -14386,11 +14489,18 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "aHI" = (
-/obj/effect/turf_decal/lumos/tile/blue/checker{
+/obj/machinery/door/airlock{
+	name = "Theatre Backstage";
+	req_access_txt = "46"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/white/side{
 	dir = 4
 	},
-/obj/effect/turf_decal/lumos/tile/red/checker,
-/turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
 "aHJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -14398,13 +14508,20 @@
 /turf/open/floor/plasteel,
 /area/gateway)
 "aHK" = (
-/obj/structure/closet/secure_closet/freezer/cream_pie,
-/obj/effect/turf_decal/lumos/tile/blue/checker{
-	dir = 4
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
 	},
-/obj/effect/turf_decal/lumos/tile/red/checker,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
-/area/crew_quarters/theatre)
+/area/security/prison)
 "aHL" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -14494,6 +14611,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
 "aHW" = (
@@ -14504,14 +14624,20 @@
 /area/bridge/meeting_room)
 "aHX" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Library"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "Library"
 	},
 /turf/open/floor/wood,
 /area/security/prison)
@@ -14938,20 +15064,20 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"aJe" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 5
+/turf/open/floor/plasteel,
+/area/security/prison)
+"aJe" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/open/floor/wood,
-/area/crew_quarters/theatre)
+/turf/open/floor/plasteel,
+/area/security/prison)
 "aJf" = (
 /obj/machinery/camera{
 	c_tag = "EVA South";
@@ -15161,9 +15287,12 @@
 /obj/item/clothing/under/suit/waiter,
 /obj/item/clothing/under/suit/waiter,
 /obj/item/clothing/under/suit/waiter,
-/obj/item/gun/ballistic/revolver/doublebarrel,
 /obj/item/storage/fancy/candle_box,
 /obj/item/storage/toolbox/mechanical,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/cable_coil,
+/obj/item/gun/ballistic/revolver/doublebarrel,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "aJF" = (
@@ -15240,6 +15369,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
@@ -15325,6 +15457,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
 "aJX" = (
@@ -15369,6 +15502,9 @@
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
@@ -15436,6 +15572,9 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/preopen{
+	id = "permalock2"
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aKi" = (
@@ -15451,10 +15590,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "aKk" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/half,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "aKl" = (
@@ -15532,28 +15668,19 @@
 /turf/open/floor/wood,
 /area/security/prison)
 "aKw" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/door/airlock/public/glass{
-	name = "Public Theatre"
+/obj/machinery/requests_console{
+	department = "Prison";
+	departmentType = 1;
+	pixel_y = 32
 	},
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/theatre)
+/turf/open/floor/plasteel,
+/area/security/prison)
 "aKx" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/trimline/red/filled/corner{
@@ -15563,6 +15690,12 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aKy" = (
@@ -15986,10 +16119,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/hallway/secondary/entry)
 "aLB" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/lumos/tile/neutral/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -16049,11 +16179,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "aLL" = (
-/obj/machinery/camera{
-	c_tag = "Port Hallway 2"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/port)
+/obj/effect/spawner/structure/window,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/prison)
 "aLN" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -16239,7 +16368,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aMo" = (
-/obj/item/soap,
 /obj/effect/landmark/xeno_spawn,
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/plasteel/showroomfloor/shower,
@@ -16257,6 +16385,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "aMr" = (
+/obj/structure/musician/piano,
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
 "aMs" = (
@@ -16302,6 +16431,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -16427,6 +16559,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
 "aML" = (
@@ -16467,9 +16602,6 @@
 /turf/open/floor/plasteel/white,
 /area/science/explab)
 "aMQ" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
 	},
@@ -16479,11 +16611,9 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "aMR" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
-/area/hallway/primary/port)
+/area/security/prison)
 "aMS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -16583,8 +16713,14 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "aNi" = (
-/turf/open/floor/goonplaque,
-/area/hallway/secondary/entry)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "aNj" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=CHW";
@@ -16674,6 +16810,10 @@
 /obj/item/reagent_containers/food/drinks/shaker,
 /obj/item/stack/spacecash/c100,
 /obj/item/stack/spacecash/c100,
+/obj/item/flashlight/lamp/green{
+	pixel_x = -8;
+	pixel_y = 16
+	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "aNv" = (
@@ -16735,11 +16875,9 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aND" = (
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/cable_coil,
-/obj/item/flashlight/lamp/green,
-/obj/structure/table/wood,
+/obj/machinery/chem_master/condimaster{
+	name = "HoochMaster 2000"
+	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "aNE" = (
@@ -16813,6 +16951,10 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
 	},
+/obj/machinery/airalarm/directional/north,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aNK" = (
@@ -16882,9 +17024,6 @@
 "aNT" = (
 /obj/structure/cable{
 	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -17153,9 +17292,14 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aOH" = (
-/obj/structure/window,
-/turf/open/floor/wood,
-/area/crew_quarters/theatre)
+/obj/machinery/button/door{
+	id = "permalock2";
+	name = "Perma Secure Airlock";
+	pixel_x = -26;
+	req_access_txt = "3"
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "aOI" = (
 /obj/structure/kitchenspike,
 /turf/open/floor/plasteel/showroomfloor,
@@ -17174,6 +17318,9 @@
 	icon = 'modular_skyrat/icons/obj/contraband.dmi';
 	icon_state = "poster2_legit";
 	pixel_y = 32
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -17278,11 +17425,14 @@
 /turf/open/floor/wood,
 /area/library)
 "aPc" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/button/door{
+	id = "permalock2";
+	name = "Perma Secure Airlock";
+	pixel_x = 26;
+	req_access_txt = "3"
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/port)
+/area/security/prison)
 "aPd" = (
 /obj/structure/bookcase/random/reference,
 /turf/open/floor/wood,
@@ -17298,13 +17448,6 @@
 /area/library)
 "aPh" = (
 /obj/machinery/light,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"aPi" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aPj" = (
@@ -17401,11 +17544,13 @@
 /area/maintenance/port)
 "aPC" = (
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/lumos/tile/blue/fulltile,
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "aPD" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/lumos/tile/blue/fulltile,
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "aPE" = (
@@ -17768,11 +17913,8 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "aQJ" = (
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/lumos/tile/neutral/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -17904,6 +18046,7 @@
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
 	},
+/obj/effect/turf_decal/trimline/green/filled/corner,
 /turf/open/floor/plasteel,
 /area/storage/art)
 "aQZ" = (
@@ -17916,9 +18059,16 @@
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/green/filled/corner{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/storage/art)
 "aRa" = (
+/obj/effect/turf_decal/trimline/green/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/green/filled/corner,
 /turf/open/floor/plasteel,
 /area/storage/art)
 "aRc" = (
@@ -17946,6 +18096,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/lumos/tile/yellow/fulltile,
 /turf/open/floor/plasteel,
 /area/storage/tools)
 "aRh" = (
@@ -17963,12 +18114,17 @@
 /area/bridge)
 "aRj" = (
 /obj/structure/table/reinforced,
-/obj/item/storage/secure/briefcase,
 /obj/item/storage/box/PDAs{
-	pixel_x = 4;
-	pixel_y = 4
+	pixel_x = 6;
+	pixel_y = 7
 	},
-/obj/item/storage/box/ids,
+/obj/item/storage/box/ids{
+	pixel_x = -8;
+	pixel_y = 7
+	},
+/obj/item/storage/secure/briefcase{
+	pixel_y = -9
+	},
 /turf/open/floor/plasteel,
 /area/bridge)
 "aRk" = (
@@ -18025,11 +18181,17 @@
 /area/bridge)
 "aRs" = (
 /obj/structure/table/reinforced,
-/obj/item/storage/toolbox/emergency,
-/obj/item/wrench,
-/obj/item/assembly/timer,
-/obj/item/assembly/signaler,
-/obj/item/assembly/signaler,
+/obj/item/storage/toolbox/mechanical{
+	pixel_y = 9
+	},
+/obj/item/assembly/signaler{
+	pixel_x = 4;
+	pixel_y = 8
+	},
+/obj/item/assembly/signaler{
+	pixel_x = -4;
+	pixel_y = 8
+	},
 /turf/open/floor/plasteel,
 /area/bridge)
 "aRt" = (
@@ -18348,6 +18510,12 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aSk" = (
@@ -18361,6 +18529,10 @@
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
 	},
+/obj/effect/turf_decal/trimline/green/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/green/filled/corner,
 /turf/open/floor/plasteel,
 /area/storage/art)
 "aSl" = (
@@ -18465,11 +18637,10 @@
 /area/bridge)
 "aSz" = (
 /obj/structure/table/reinforced,
-/obj/item/aicard,
-/obj/item/multitool,
 /obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 8
 	},
+/obj/item/storage/firstaid/regular,
 /turf/open/floor/plasteel,
 /area/bridge)
 "aSA" = (
@@ -18517,6 +18688,14 @@
 /area/bridge)
 "aSE" = (
 /obj/structure/table/reinforced,
+/obj/item/multitool{
+	pixel_x = 10;
+	pixel_y = 13
+	},
+/obj/item/aicard{
+	pixel_x = -4;
+	pixel_y = 16
+	},
 /obj/item/storage/fancy/donut_box,
 /turf/open/floor/plasteel,
 /area/bridge)
@@ -18529,11 +18708,8 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/crew_quarters/toilet)
 "aSG" = (
-/obj/machinery/requests_console{
-	department = "Prison";
-	departmentType = 1
-	},
-/turf/closed/wall,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/security/prison)
 "aSH" = (
 /obj/structure/window,
@@ -18657,12 +18833,10 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "aTa" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/preopen{
-	id = "permalock2"
+/turf/open/floor/wood{
+	icon_state = "wood-broken3"
 	},
-/turf/open/floor/plasteel,
-/area/security/prison)
+/area/crew_quarters/dorms)
 "aTb" = (
 /obj/machinery/newscaster{
 	pixel_y = 32
@@ -18724,17 +18898,14 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "aTp" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/preopen{
-	id = "permalock2"
+/obj/machinery/light/small{
+	dir = 4;
+	light_color = "#d8b1b1"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/cable{
-	icon_state = "1-2"
+/turf/open/floor/wood{
+	icon_state = "wood-broken6"
 	},
-/turf/open/floor/plasteel,
-/area/security/prison)
+/area/crew_quarters/dorms)
 "aTq" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Showers"
@@ -18798,10 +18969,6 @@
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
 	},
-/obj/structure/plasticflaps,
-/obj/machinery/conveyor/auto{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aTB" = (
@@ -18839,6 +19006,9 @@
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
 	},
+/obj/effect/turf_decal/trimline/green/filled/corner{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/storage/art)
 "aTF" = (
@@ -18848,12 +19018,21 @@
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/green/filled/corner{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/storage/art)
 "aTG" = (
 /obj/structure/table,
 /obj/item/storage/crayons,
 /obj/item/storage/crayons,
+/obj/effect/turf_decal/trimline/green/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/green/filled/corner{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/storage/art)
 "aTH" = (
@@ -18991,8 +19170,6 @@
 /turf/open/floor/plasteel,
 /area/bridge)
 "aUc" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/firstaid/regular,
 /obj/machinery/button/door{
 	id = "bridge blast";
 	name = "Bridge Blast Door Control";
@@ -19000,6 +19177,8 @@
 	pixel_y = 22;
 	req_access_txt = "19"
 	},
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk,
 /turf/open/floor/plasteel,
 /area/bridge)
 "aUd" = (
@@ -19022,12 +19201,10 @@
 /turf/open/floor/plasteel,
 /area/bridge)
 "aUf" = (
-/obj/structure/window/reinforced,
-/obj/machinery/conveyor/auto{
-	dir = 4
+/turf/open/floor/wood{
+	icon_state = "wood-broken5"
 	},
-/turf/open/floor/plasteel,
-/area/security/prison)
+/area/crew_quarters/dorms)
 "aUh" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/eastleft{
@@ -19062,14 +19239,13 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "aUq" = (
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/security/prison)
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "aUr" = (
 /obj/machinery/airalarm/directional/north,
-/obj/structure/chair{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aUs" = (
@@ -19147,13 +19323,12 @@
 /area/library)
 "aUC" = (
 /obj/machinery/camera{
-	c_tag = "Permabrig Iso Cell 1";
-	network = list("ss13","prison")
+	c_tag = "Permabrig Entrance";
+	dir = 8;
+	network = list("ss13","prison");
+	start_active = 1
 	},
-/obj/structure/bed,
-/turf/open/floor/mineral/titanium/white{
-	name = "secure isolation floor"
-	},
+/turf/open/floor/plasteel,
 /area/security/prison)
 "aUD" = (
 /obj/structure/table/wood,
@@ -19619,7 +19794,7 @@
 	name = "Food Orders";
 	pixel_y = 26
 	},
-/turf/open/floor/plasteel/cafeteria,
+/turf/open/floor/plating,
 /area/crew_quarters/kitchen)
 "aVB" = (
 /obj/structure/table,
@@ -19683,11 +19858,8 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "aVG" = (
-/obj/structure/table,
-/obj/item/clothing/suit/straight_jacket,
-/obj/item/clothing/suit/straight_jacket,
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -19737,11 +19909,12 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "aVP" = (
-/obj/structure/chair{
-	dir = 4
+/obj/effect/spawner/blocker,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/security/prison)
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "aVQ" = (
 /obj/structure/chair/comfy/black{
 	dir = 8
@@ -20022,13 +20195,10 @@
 /turf/open/floor/plasteel,
 /area/storage/tools)
 "aWE" = (
-/obj/machinery/computer/med_data,
 /obj/machinery/newscaster{
 	pixel_y = 32
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/machinery/computer/secure_data,
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
 "aWF" = (
@@ -20037,10 +20207,17 @@
 /turf/open/floor/plasteel,
 /area/storage/tools)
 "aWG" = (
-/obj/machinery/computer/secure_data,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/light_switch{
+	pixel_x = 4;
+	pixel_y = 24
 	},
+/obj/machinery/button/door{
+	id = "kanyewest";
+	name = "Privacy Shutters";
+	pixel_x = -4;
+	pixel_y = 24
+	},
+/obj/machinery/computer/med_data,
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
 "aWH" = (
@@ -20197,6 +20374,9 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
 /turf/open/floor/plasteel,
 /area/bridge)
 "aWZ" = (
@@ -20215,11 +20395,11 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/disposalpipe/junction{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/bridge)
 "aXb" = (
@@ -20470,10 +20650,13 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "aXK" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/firealarm{
+	pixel_y = 24
 	},
-/turf/closed/wall,
+/obj/machinery/camera{
+	c_tag = "Detective's Office"
+	},
+/turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
 "aXL" = (
 /turf/open/floor/carpet,
@@ -20493,12 +20676,8 @@
 /turf/open/floor/wood,
 /area/security/vacantoffice)
 "aXO" = (
-/obj/machinery/door/poddoor{
-	id = "soli2"
-	},
-/turf/open/floor/mineral/titanium/white{
-	name = "secure isolation floor"
-	},
+/obj/structure/table,
+/turf/open/floor/plasteel,
 /area/security/prison)
 "aXP" = (
 /obj/machinery/portable_atmospherics/canister/air,
@@ -20567,14 +20746,12 @@
 /turf/open/floor/carpet,
 /area/security/vacantoffice)
 "aYa" = (
-/obj/machinery/camera{
-	c_tag = "Permabrig Iso Cell 2";
-	network = list("ss13","prison")
+/obj/structure/table,
+/obj/item/storage/box/hug,
+/obj/item/razor{
+	pixel_x = -6
 	},
-/obj/structure/bed,
-/turf/open/floor/mineral/titanium/white{
-	name = "secure isolation floor"
-	},
+/turf/open/floor/plasteel,
 /area/security/prison)
 "aYc" = (
 /obj/structure/cable{
@@ -20622,22 +20799,17 @@
 /area/security/prison)
 "aYi" = (
 /obj/structure/closet/secure_closet/detective,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/item/storage/briefcase,
+/obj/item/camera/detective,
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
 "aYj" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/machinery/button/door{
-	id = "kanyewest";
-	name = "Privacy Shutters";
-	pixel_y = 24
-	},
 /obj/structure/rack,
-/obj/item/storage/briefcase,
+/obj/item/storage/box/evidence,
+/obj/item/hand_labeler{
+	pixel_x = 5
+	},
+/obj/item/taperecorder,
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
 "aYk" = (
@@ -20823,21 +20995,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aYH" = (
-/obj/machinery/door_timer{
-	id = "soli1";
-	name = "Solitary 1 door timer";
-	pixel_x = 31;
-	pixel_y = 36
+/obj/item/shard{
+	icon_state = "small"
 	},
-/obj/machinery/button/door{
-	id = "soli1";
-	name = "Solitary Cell 1";
-	pixel_x = 26;
-	pixel_y = 21;
-	req_access_txt = "3"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "aYI" = (
 /obj/machinery/conveyor/auto{
 	dir = 1
@@ -20954,18 +21116,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"aYZ" = (
-/obj/structure/table/wood,
-/obj/item/storage/box/evidence,
-/obj/item/hand_labeler{
-	pixel_x = 5
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/item/taperecorder,
-/turf/open/floor/plasteel/grimy,
-/area/security/detectives_office)
 "aZa" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/flora/ausbushes/stalkybush,
@@ -21149,11 +21299,20 @@
 "aZA" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "aZB" = (
 /obj/machinery/portable_atmospherics/pump,
 /obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer1{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "aZC" = (
@@ -21213,18 +21372,18 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
 "aZJ" = (
-/obj/structure/table/wood,
-/obj/item/camera/detective,
+/obj/structure/chair{
+	dir = 8
+	},
 /turf/open/floor/carpet,
 /area/security/detectives_office)
 "aZK" = (
 /turf/closed/wall,
 /area/quartermaster/sorting)
 "aZL" = (
-/obj/machinery/light_switch{
-	pixel_x = 27
+/obj/structure/chair{
+	dir = 8
 	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
 "aZM" = (
@@ -21571,6 +21730,9 @@
 "baP" = (
 /obj/structure/table/wood,
 /obj/item/storage/fancy/donut_box,
+/obj/item/coin/plasma{
+	pixel_y = -14
+	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain)
 "baQ" = (
@@ -21592,7 +21754,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "baU" = (
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
 "baV" = (
@@ -21609,12 +21770,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/grimy,
-/area/security/detectives_office)
-"baX" = (
-/obj/structure/chair/comfy/brown,
-/obj/effect/landmark/start/detective,
-/turf/open/floor/carpet,
 /area/security/detectives_office)
 "baY" = (
 /obj/structure/closet/crate,
@@ -21777,6 +21934,12 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "bbt" = (
@@ -21912,17 +22075,13 @@
 /area/quartermaster/warehouse)
 "bbQ" = (
 /obj/structure/table/wood,
-/obj/item/reagent_containers/food/drinks/bottle/whiskey{
-	pixel_x = 3
-	},
-/obj/item/lighter,
-/obj/item/restraints/handcuffs,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
 	},
+/obj/machinery/computer/security/wooden_tv,
 /turf/open/floor/carpet,
 /area/security/detectives_office)
 "bbR" = (
@@ -21939,31 +22098,19 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
 "bbT" = (
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp/green,
-/turf/open/floor/carpet,
-/area/security/detectives_office)
+/obj/structure/table/optable{
+	name = "Robotics Operating Table"
+	},
+/obj/item/surgical_drapes,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "bbU" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/door_timer{
-	id = "soli2";
-	name = "Solitary 2 door timer";
-	pixel_x = 31;
-	pixel_y = 37
-	},
-/obj/machinery/button/door{
-	id = "soli2";
-	name = "Solitary Cell 2";
-	pixel_x = 26;
-	pixel_y = 21;
-	req_access_txt = "3"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "bbV" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -22201,16 +22348,21 @@
 /area/quartermaster/warehouse)
 "bcG" = (
 /obj/structure/table/wood,
-/obj/machinery/computer/security/wooden_tv,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
 	},
+/obj/item/reagent_containers/food/drinks/bottle/whiskey{
+	pixel_x = 3
+	},
+/obj/item/lighter,
+/obj/item/flashlight/lamp/green{
+	pixel_x = -9
+	},
+/obj/item/restraints/handcuffs,
 /turf/open/floor/carpet,
 /area/security/detectives_office)
 "bcH" = (
 /obj/structure/table/wood,
-/obj/item/storage/fancy/cigarettes,
-/obj/item/clothing/glasses/sunglasses,
 /turf/open/floor/carpet,
 /area/security/detectives_office)
 "bcI" = (
@@ -22320,7 +22472,9 @@
 	pixel_x = 24
 	},
 /obj/structure/filingcabinet,
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
 "bcW" = (
@@ -22404,9 +22558,32 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "bdi" = (
-/obj/machinery/vending/wardrobe/cap_wardrobe,
-/turf/open/floor/wood,
-/area/crew_quarters/heads/captain)
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/structure/table,
+/obj/item/radio/off{
+	pixel_y = 16
+	},
+/obj/item/radio/off{
+	pixel_x = 8;
+	pixel_y = 16
+	},
+/obj/item/assembly/prox_sensor,
+/obj/item/assembly/prox_sensor{
+	pixel_x = 6
+	},
+/obj/item/assembly/signaler{
+	pixel_x = -9;
+	pixel_y = 9
+	},
+/obj/item/assembly/signaler{
+	pixel_x = -9;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel,
+/area/ai_monitored/storage/eva)
 "bdj" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
@@ -22579,6 +22756,9 @@
 "bdE" = (
 /obj/structure/sign/poster/contraband/have_a_puff{
 	pixel_y = -32
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
@@ -23230,7 +23410,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/goonplaque,
 /area/hallway/primary/central)
 "bfj" = (
 /obj/structure/disposalpipe/trunk,
@@ -23241,34 +23421,17 @@
 /area/quartermaster/sorting)
 "bfk" = (
 /obj/structure/table/reinforced,
-/obj/item/clothing/shoes/sneakers/orange,
-/obj/item/clothing/shoes/sneakers/orange,
-/obj/item/clothing/shoes/sneakers/orange,
 /obj/machinery/camera{
 	c_tag = "Permabrig Prisoner Processing";
 	dir = 8;
 	network = list("ss13","prison");
 	start_active = 1
 	},
-/obj/item/radio/headset{
-	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
-	name = "prisoner headset";
-	prison_radio = 1
-	},
-/obj/item/radio/headset{
-	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
-	name = "prisoner headset";
-	prison_radio = 1
-	},
-/obj/item/radio/headset{
-	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
-	name = "prisoner headset";
-	prison_radio = 1
-	},
-/obj/item/radio/off,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/clothing/suit/straight_jacket,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "bfl" = (
@@ -23402,6 +23565,10 @@
 /obj/item/phone{
 	pixel_x = -10;
 	pixel_y = 8
+	},
+/obj/machinery/recharger{
+	pixel_x = 15;
+	pixel_y = 3
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
@@ -23825,19 +23992,16 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "bgT" = (
-/obj/machinery/computer/communications{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/wood,
-/area/crew_quarters/heads/captain)
-"bgU" = (
 /obj/structure/chair/comfy/brown{
 	dir = 4
 	},
 /obj/effect/landmark/start/captain,
+/turf/open/floor/wood,
+/area/crew_quarters/heads/captain)
+"bgU" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -23850,11 +24014,11 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "bgV" = (
-/obj/structure/table/wood,
-/obj/item/book/manual/wiki/security_space_law,
-/obj/item/coin/plasma,
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/computer/communications{
+	dir = 8
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
@@ -24298,15 +24462,14 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "bil" = (
+/obj/structure/table/glass,
+/obj/item/storage/bag/trash,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
+"bim" = (
 /obj/machinery/computer/card{
 	dir = 8
 	},
-/turf/open/floor/wood,
-/area/crew_quarters/heads/captain)
-"bim" = (
-/obj/structure/table/wood,
-/obj/machinery/recharger,
-/obj/item/melee/chainofcommand,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "biv" = (
@@ -24503,12 +24666,6 @@
 /area/maintenance/starboard)
 "biZ" = (
 /obj/structure/table/reinforced,
-/obj/item/clothing/under/rank/prisoner,
-/obj/item/clothing/under/rank/prisoner,
-/obj/item/clothing/under/rank/prisoner,
-/obj/item/clothing/shoes/sneakers/orange,
-/obj/item/clothing/shoes/sneakers/orange,
-/obj/item/clothing/shoes/sneakers/orange,
 /obj/item/radio/headset{
 	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
 	name = "prisoner headset";
@@ -24752,20 +24909,11 @@
 /area/hallway/primary/central)
 "bjy" = (
 /obj/effect/turf_decal/bot_white/left,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/machinery/airalarm{
 	dir = 8;
 	pixel_x = 24
 	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
 "bjz" = (
@@ -25864,9 +26012,6 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain)
 "bmz" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
 /obj/structure/dresser,
 /obj/item/card/id/captains_spare,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
@@ -26409,8 +26554,8 @@
 /area/crew_quarters/heads/captain)
 "bnZ" = (
 /obj/structure/table/wood,
-/obj/item/flashlight/lamp/green,
-/obj/item/pen/fountain/captain,
+/obj/item/reagent_containers/food/drinks/flask/gold,
+/obj/item/melee/chainofcommand,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain)
 "boa" = (
@@ -26876,6 +27021,7 @@
 	c_tag = "Captain's Quarters";
 	dir = 1
 	},
+/obj/machinery/light/small,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain)
 "bpk" = (
@@ -26891,7 +27037,7 @@
 	pixel_y = 2
 	},
 /obj/item/clothing/mask/cigarette/cigar,
-/obj/item/reagent_containers/food/drinks/flask/gold,
+/obj/item/pen/fountain/captain,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain)
 "bpm" = (
@@ -28217,12 +28363,20 @@
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
 "bsU" = (
-/obj/structure/table/optable{
-	name = "Robotics Operating Table"
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
 	},
-/obj/item/surgical_drapes,
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/ai_monitored/storage/eva)
 "bsV" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -29727,14 +29881,14 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
@@ -30292,23 +30446,22 @@
 /area/science/server)
 "byg" = (
 /obj/structure/table,
-/obj/item/clipboard,
 /obj/item/cartridge/quartermaster{
-	pixel_x = 6;
-	pixel_y = 5
-	},
-/obj/item/cartridge/quartermaster{
-	pixel_x = -4;
+	pixel_x = 8;
 	pixel_y = 7
 	},
-/obj/item/cartridge/quartermaster,
-/obj/item/coin/silver,
-/obj/item/stamp/qm,
+/obj/item/cartridge/quartermaster{
+	pixel_x = 8;
+	pixel_y = 3
+	},
+/obj/item/cartridge/quartermaster{
+	pixel_x = 8;
+	pixel_y = -1
+	},
 /obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
+	pixel_x = -6;
+	pixel_y = 1
 	},
-/obj/item/pen/fountain,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
 	},
@@ -30347,19 +30500,33 @@
 /area/security/checkpoint/science)
 "byl" = (
 /obj/structure/table,
-/obj/item/folder/yellow,
-/obj/item/pen{
-	pixel_x = 4;
-	pixel_y = 4
+/obj/item/folder/yellow{
+	pixel_x = -5;
+	pixel_y = 5
 	},
-/obj/item/pen/red,
+/obj/item/pen/red{
+	pixel_x = 2;
+	pixel_y = 3
+	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
 	},
-/obj/item/phone{
-	pixel_x = -9
-	},
 /obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/item/pen{
+	pixel_x = -1;
+	pixel_y = -1
+	},
+/obj/item/stamp/qm{
+	pixel_x = 15;
+	pixel_y = 9
+	},
+/obj/item/pen/fountain{
+	pixel_x = 4;
+	pixel_y = 7
+	},
+/obj/item/phone{
+	pixel_x = 14
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "byn" = (
@@ -30464,18 +30631,18 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "byB" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk,
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
 	},
+/obj/structure/filingcabinet,
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "byC" = (
-/obj/structure/filingcabinet,
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
 	},
+/obj/structure/disposalpipe/trunk,
+/obj/machinery/disposal/bin,
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "byD" = (
@@ -30487,6 +30654,7 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 5
 	},
+/obj/item/coin/silver,
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "byE" = (
@@ -30988,6 +31156,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 6
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
@@ -34295,6 +34466,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/green/filled/corner{
+	dir = 8
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bIa" = (
@@ -34306,6 +34480,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/green/filled/line,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bIc" = (
@@ -34377,6 +34552,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/lumos/tile/green/fulltile,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bIg" = (
@@ -34626,10 +34802,10 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "bIN" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -35512,7 +35688,9 @@
 /obj/machinery/button/door{
 	id = "misclab";
 	name = "Test Chamber Blast Doors";
-	pixel_y = -2;
+	pixel_x = -7;
+	pixel_y = 8;
+	plane = -4;
 	req_access_txt = "55"
 	},
 /obj/structure/table/reinforced,
@@ -35531,7 +35709,8 @@
 /obj/machinery/computer/security/telescreen{
 	name = "Test Chamber Monitor";
 	network = list("xeno");
-	pixel_y = 2
+	pixel_y = 2;
+	plane = -4
 	},
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/stripes/line,
@@ -35604,6 +35783,7 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bLg" = (
@@ -35755,7 +35935,10 @@
 /turf/open/floor/plating,
 /area/construction)
 "bLE" = (
-/turf/open/floor/plasteel/grimy,
+/obj/structure/table/wood,
+/obj/item/storage/fancy/cigarettes,
+/obj/item/clothing/glasses/sunglasses,
+/turf/open/floor/carpet,
 /area/security/detectives_office)
 "bLF" = (
 /obj/structure/filingcabinet/filingcabinet,
@@ -35871,15 +36054,15 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bLY" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
-"bMa" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1
 	},
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
+/turf/open/floor/plasteel,
+/area/crew_quarters/dorms)
+"bMa" = (
+/obj/structure/chair/stool,
+/turf/open/floor/wood,
+/area/crew_quarters/theatre)
 "bMc" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Surgery Observation"
@@ -37132,6 +37315,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/effect/turf_decal/lumos/shower,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bPr" = (
@@ -38052,6 +38236,7 @@
 	pixel_x = 24
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bRP" = (
@@ -38294,6 +38479,9 @@
 /area/construction)
 "bSy" = (
 /obj/machinery/light/small,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
 "bSz" = (
@@ -44478,7 +44666,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "cjC" = (
-/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cjD" = (
@@ -49689,14 +49877,9 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cEo" = (
-/obj/structure/closet/boxinggloves,
+/obj/structure/closet/lasertag/blue,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
-"cGz" = (
-/obj/structure/table/wood,
-/obj/item/instrument/violin,
-/turf/open/floor/wood,
-/area/crew_quarters/theatre)
 "cHf" = (
 /obj/machinery/light{
 	dir = 1
@@ -50066,6 +50249,13 @@
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics/cloning)
+"cKz" = (
+/obj/machinery/shower{
+	dir = 4
+	},
+/obj/item/soap,
+/turf/open/floor/plasteel/showroomfloor,
+/area/crew_quarters/toilet)
 "cKG" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 5
@@ -50762,6 +50952,12 @@
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
+"dgv" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1
+	},
+/turf/open/floor/carpet,
+/area/crew_quarters/theatre)
 "dgz" = (
 /turf/closed/wall,
 /area/crew_quarters/cryopod)
@@ -50783,7 +50979,7 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "dla" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden/layer1{
 	dir = 9
 	},
 /turf/open/floor/plating,
@@ -50828,12 +51024,6 @@
 /turf/open/space,
 /area/space/nearstation)
 "dqN" = (
-/obj/machinery/camera{
-	c_tag = "Permabrig Entrance";
-	dir = 8;
-	network = list("ss13","prison");
-	start_active = 1
-	},
 /obj/machinery/light/small{
 	dir = 4
 	},
@@ -51033,6 +51223,13 @@
 /obj/effect/landmark/start/geneticist,
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics)
+"dMi" = (
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/ai_monitored/storage/eva)
 "dMZ" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 1
@@ -51106,9 +51303,6 @@
 /obj/machinery/recharger,
 /obj/item/gun/energy/laser/practice,
 /obj/item/gun/energy/laser/practice,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
@@ -51207,6 +51401,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/green/filled/corner,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "eer" = (
@@ -51389,7 +51584,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "eyM" = (
-/obj/machinery/nuclearbomb/beer,
+/obj/machinery/vending/wardrobe/cap_wardrobe,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "eyW" = (
@@ -51432,28 +51627,11 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
 "eCr" = (
-/obj/structure/closet{
-	name = "Suit Closet"
-	},
-/obj/item/clothing/under/suit/white,
-/obj/item/clothing/under/suit/tan,
-/obj/item/clothing/under/suit/red,
-/obj/item/clothing/under/suit/black_really,
-/obj/item/clothing/under/suit/navy,
-/obj/item/clothing/under/suit/green,
-/obj/item/clothing/under/suit/black/skirt,
-/obj/item/clothing/under/suit/checkered,
-/obj/item/clothing/under/suit/charcoal,
-/obj/item/clothing/under/suit/burgundy,
-/obj/item/clothing/under/suit/black,
-/obj/item/clothing/under/rank/civilian/lawyer/black,
-/obj/item/clothing/under/rank/civilian/lawyer/black,
-/obj/item/clothing/under/rank/civilian/lawyer/bluesuit,
-/obj/item/clothing/under/rank/civilian/lawyer/bluesuit,
-/obj/item/clothing/under/rank/civilian/lawyer/female,
-/obj/item/clothing/under/rank/civilian/lawyer/purpsuit,
-/obj/item/clothing/under/rank/civilian/lawyer/really_black,
-/obj/item/clothing/under/rank/civilian/lawyer/red,
+/obj/structure/rack,
+/obj/item/clothing/suit/hooded/wintercoat,
+/obj/item/clothing/suit/hooded/wintercoat,
+/obj/item/clothing/suit/hooded/wintercoat,
+/obj/item/clothing/suit/hooded/wintercoat,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "eCQ" = (
@@ -51480,8 +51658,9 @@
 	name = "Theatre Backstage";
 	req_access_txt = "46"
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -51489,7 +51668,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/wood,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 1
+	},
 /area/crew_quarters/theatre)
 "eFW" = (
 /obj/structure/cable{
@@ -51547,6 +51731,13 @@
 /obj/effect/turf_decal/lumos/tile/blue/fulltile,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/front_office)
+"ePh" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass{
+	name = "Public Theatre"
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/theatre)
 "eQb" = (
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
@@ -51705,23 +51896,10 @@
 /area/maintenance/bar)
 "fgG" = (
 /obj/structure/table/wood,
-/obj/machinery/requests_console{
-	department = "Theatre";
-	name = "theatre RC";
-	pixel_x = -32
-	},
-/obj/item/reagent_containers/food/snacks/baguette,
-/obj/item/toy/dummy,
-/obj/item/lipstick/random{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/lipstick/random{
-	pixel_x = -2;
-	pixel_y = -2
-	},
+/obj/item/instrument/eguitar,
+/obj/item/instrument/violin,
 /turf/open/floor/plasteel/white/side{
-	dir = 4
+	dir = 1
 	},
 /area/crew_quarters/theatre)
 "fhP" = (
@@ -51752,15 +51930,24 @@
 /turf/open/floor/wood,
 /area/maintenance/bar)
 "fne" = (
-/obj/effect/landmark/start/mime,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 4
-	},
 /turf/open/floor/plasteel/white/side{
-	dir = 4
+	dir = 1
 	},
 /area/crew_quarters/theatre)
 "fnC" = (
@@ -52048,11 +52235,14 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "fOA" = (
-/obj/machinery/door/airlock{
-	name = "Theatre Backstage";
-	req_access_txt = "46"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/open/floor/wood,
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
 /area/crew_quarters/theatre)
 "fOI" = (
 /obj/effect/turf_decal/stripes/line{
@@ -52135,9 +52325,13 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "fYr" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -52430,6 +52624,18 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"gwf" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel,
+/area/ai_monitored/storage/eva)
 "gxc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -52645,11 +52851,12 @@
 /turf/open/floor/plasteel/white/side,
 /area/science/research)
 "gOZ" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
 	},
-/turf/open/floor/plating,
-/area/crew_quarters/fitness)
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/turf/open/floor/plasteel,
+/area/ai_monitored/storage/eva)
 "gQX" = (
 /obj/machinery/button/door{
 	desc = "Alright, GAMER! Want to take your PWRGAME addiction to the MAX? Just smash this button with your chubby chetto encrusted hands an- oh, you broke the switch. Good job, idiot.";
@@ -52709,6 +52916,13 @@
 /obj/structure/lattice,
 /turf/closed/wall/r_wall,
 /area/engine/gravity_generator)
+"gVl" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
+	},
+/turf/open/floor/carpet,
+/area/crew_quarters/theatre)
 "gVw" = (
 /obj/structure/lattice,
 /obj/machinery/camera{
@@ -53028,13 +53242,14 @@
 /turf/open/floor/circuit/green,
 /area/security/prison)
 "htK" = (
-/obj/machinery/door/poddoor{
-	id = "soli1"
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
 	},
-/turf/open/floor/mineral/titanium/white{
-	name = "secure isolation floor"
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
 	},
-/area/security/prison)
+/turf/open/floor/plasteel,
+/area/ai_monitored/storage/eva)
 "hvd" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -53315,9 +53530,6 @@
 /obj/machinery/camera{
 	c_tag = "Firing Range";
 	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
@@ -53614,6 +53826,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/medical/psych)
+"iIL" = (
+/obj/effect/landmark/start/detective,
+/obj/structure/chair/comfy/brown{
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/security/detectives_office)
 "iLJ" = (
 /obj/item/reagent_containers/glass/bucket,
 /mob/living/simple_animal/pet/bumbles,
@@ -53778,6 +53997,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/pool)
+"iYZ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plasteel/grimy,
+/area/security/detectives_office)
 "iZs" = (
 /obj/structure/table,
 /obj/machinery/door/window,
@@ -54068,7 +54293,7 @@
 /turf/open/floor/plating,
 /area/crew_quarters/kitchen)
 "jvd" = (
-/obj/structure/closet/athletic_mixed,
+/obj/structure/closet/lasertag/red,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "jvl" = (
@@ -54098,8 +54323,10 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "jxW" = (
-/obj/machinery/airalarm/directional/south,
-/obj/machinery/light,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/preopen{
+	id = "permalock2"
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "jyt" = (
@@ -54345,9 +54572,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
 	},
-/obj/structure/closet/secure_closet/personal{
-	anchored = 1
-	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/pool)
 "jNn" = (
@@ -54589,9 +54813,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/security/range)
 "keg" = (
@@ -54890,9 +55112,6 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "kCo" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
 /obj/effect/turf_decal/lumos/tile/blue/checker{
 	dir = 4
 	},
@@ -55081,10 +55300,12 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "kZl" = (
-/obj/machinery/atmospherics/pipe/manifold/yellow/hidden{
+/obj/machinery/atmospherics/pipe/manifold/yellow/hidden/layer1{
 	dir = 1
 	},
-/obj/machinery/meter,
+/obj/machinery/meter{
+	target_layer = 1
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "kZs" = (
@@ -55107,6 +55328,7 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/plasteel,
 /area/security/range)
 "lcu" = (
@@ -55230,6 +55452,12 @@
 "ltK" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/green/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/green/filled/corner{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/storage/art)
@@ -55380,6 +55608,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"lPB" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/bridge)
 "lQG" = (
 /obj/machinery/door/airlock/research/glass{
 	name = "Test Chamber";
@@ -55476,6 +55710,12 @@
 /obj/structure/barricade/wooden/crude,
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"mfO" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/grimy,
+/area/security/detectives_office)
 "mfY" = (
 /obj/machinery/chem_master,
 /obj/machinery/airalarm{
@@ -55629,10 +55869,12 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "myh" = (
-/obj/structure/musician/piano,
-/obj/structure/window,
-/turf/open/floor/wood,
-/area/crew_quarters/theatre)
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/turf/open/floor/plasteel,
+/area/ai_monitored/storage/eva)
 "mym" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -55661,15 +55903,6 @@
 /obj/effect/turf_decal/lumos/tile/red/half,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
-"mzB" = (
-/obj/machinery/door/window,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/wood,
-/area/crew_quarters/theatre)
 "mAH" = (
 /obj/machinery/atmospherics/components/unary/tank/air{
 	dir = 8
@@ -55935,6 +56168,9 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "mZP" = (
@@ -56011,11 +56247,6 @@
 /obj/structure/sign/warning/vacuum/external,
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
-"nez" = (
-/obj/structure/table/wood,
-/obj/item/instrument/piano_synth,
-/turf/open/floor/wood,
-/area/crew_quarters/theatre)
 "neL" = (
 /turf/open/floor/wood{
 	icon_state = "wood-broken"
@@ -56037,11 +56268,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"ngV" = (
-/obj/structure/table/wood,
-/obj/item/instrument/guitar,
-/turf/open/floor/wood,
-/area/crew_quarters/theatre)
 "nhY" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -56098,6 +56324,9 @@
 	desc = "This poster reminds us all that the Detective is a parasite. Year after year, they must get replacement lungs because of their addiction. ";
 	pixel_y = -32
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
 "noF" = (
@@ -56143,6 +56372,11 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"nws" = (
+/obj/machinery/power/apc/auto_name/south,
+/obj/structure/cable,
+/turf/open/floor/plasteel,
+/area/hydroponics/garden)
 "nwW" = (
 /obj/structure/trash_pile,
 /turf/open/floor/plating,
@@ -56274,6 +56508,18 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"nGB" = (
+/obj/structure/chair/stool,
+/obj/effect/landmark/start/clown,
+/obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
+	},
+/obj/effect/turf_decal/lumos/tile/red/checker,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/theatre)
 "nGI" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -56329,11 +56575,21 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/bar)
+"nNS" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "nQi" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
-/obj/machinery/atmospherics/components/binary/pump/on{
+/obj/machinery/atmospherics/components/binary/pump/on/layer1{
 	dir = 4;
 	name = "Air In"
 	},
@@ -56439,17 +56695,8 @@
 /obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
 /obj/item/reagent_containers/food/drinks/bottle/vodka/badminka,
 /obj/effect/turf_decal/bot_white/left,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/item/gun/ballistic/revolver/nagant,
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
 "nYD" = (
@@ -56466,7 +56713,9 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "nZL" = (
-/obj/machinery/computer/arcade/minesweeper,
+/obj/machinery/computer/arcade/minesweeper{
+	dir = 8
+	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "oax" = (
@@ -56670,9 +56919,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "oqN" = (
-/obj/machinery/atmospherics/components/binary/valve{
-	dir = 1
-	},
+/obj/machinery/atmospherics/components/binary/valve/layer1,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "oqO" = (
@@ -56756,7 +57003,7 @@
 /area/crew_quarters/dorms)
 "oAB" = (
 /obj/structure/fireplace{
-	pixel_y = -6
+	pixel_y = 1
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
@@ -56779,8 +57026,8 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "oHe" = (
-/obj/effect/spawner/blocker,
-/turf/open/floor/carpet/purple,
+/obj/structure/falsewall,
+/turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "oHu" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible,
@@ -57287,17 +57534,21 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "pIf" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/white/side{
-	dir = 4
+	dir = 1
 	},
 /area/crew_quarters/theatre)
 "pIg" = (
@@ -57483,6 +57734,14 @@
 /obj/effect/turf_decal/lumos/tile/bar/checker,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
+"qcs" = (
+/obj/structure/closet/secure_closet/freezer/cream_pie,
+/obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
+	},
+/obj/effect/turf_decal/lumos/tile/red/checker,
+/turf/open/floor/plasteel,
+/area/crew_quarters/theatre)
 "qeb" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -57818,10 +58077,22 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "qTG" = (
-/obj/machinery/light{
-	dir = 8
+/obj/structure/table/wood,
+/obj/structure/mirror{
+	pixel_x = -28
 	},
-/turf/open/floor/carpet,
+/obj/item/flashlight/lamp/bananalamp{
+	pixel_x = 4;
+	pixel_y = 15
+	},
+/obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
+	},
+/obj/effect/turf_decal/lumos/tile/red/checker,
+/obj/item/phone/broken{
+	desc = "Hello? Based Department?"
+	},
+/turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
 "qUr" = (
 /obj/machinery/light/small,
@@ -57905,6 +58176,11 @@
 	},
 /turf/open/floor/plating,
 /area/medical/surgery)
+"ret" = (
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
+/area/crew_quarters/theatre)
 "reA" = (
 /obj/machinery/light{
 	dir = 4;
@@ -57916,6 +58192,19 @@
 "rfW" = (
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
+"rir" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/bridge)
 "rjQ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
@@ -58006,10 +58295,13 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "rqW" = (
-/obj/machinery/light/small{
+/obj/structure/table/wood,
+/obj/item/instrument/trombone,
+/obj/item/instrument/trumpet,
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/structure/dresser,
+/obj/effect/turf_decal/tile/red,
 /obj/machinery/power/apc{
 	areastring = "/area/crew_quarters/theatre";
 	dir = 8;
@@ -58020,7 +58312,7 @@
 	icon_state = "0-4"
 	},
 /turf/open/floor/plasteel/white/side{
-	dir = 4
+	dir = 1
 	},
 /area/crew_quarters/theatre)
 "rrM" = (
@@ -58098,6 +58390,14 @@
 /obj/effect/turf_decal/lumos/tile/blue/fullcorner,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
+"rBc" = (
+/obj/machinery/shower{
+	dir = 8;
+	pixel_y = -4
+	},
+/obj/item/bikehorn/rubberducky,
+/turf/open/floor/plasteel/showroomfloor,
+/area/crew_quarters/toilet)
 "rBj" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -58118,11 +58418,6 @@
 "rDu" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
-	},
-/obj/structure/table,
-/obj/item/storage/box/hug,
-/obj/item/razor{
-	pixel_x = -6
 	},
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/plasteel,
@@ -58199,6 +58494,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"rOV" = (
+/obj/machinery/camera{
+	c_tag = "Port Hallway 2"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
 "rPc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -58217,8 +58518,12 @@
 /turf/open/space,
 /area/space/nearstation)
 "rPU" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/chair/stool,
 /turf/open/floor/plasteel/white/side{
-	dir = 4
+	dir = 1
 	},
 /area/crew_quarters/theatre)
 "rTu" = (
@@ -58303,6 +58608,27 @@
 /obj/effect/turf_decal/lumos/tile/blue/fulltile,
 /turf/open/floor/plasteel,
 /area/security/brig)
+"sax" = (
+/obj/structure/table/wood,
+/obj/machinery/requests_console{
+	department = "Theatre";
+	name = "theatre RC";
+	pixel_x = -32
+	},
+/obj/item/reagent_containers/food/snacks/baguette,
+/obj/item/toy/dummy,
+/obj/item/lipstick/random{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/lipstick/random{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
+/area/crew_quarters/theatre)
 "saK" = (
 /turf/open/floor/engine,
 /area/science/explab)
@@ -58390,6 +58716,16 @@
 	},
 /turf/open/floor/plating,
 /area/space/nearstation)
+"sks" = (
+/obj/effect/landmark/start/mime,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
+/area/crew_quarters/theatre)
 "slk" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -58577,12 +58913,9 @@
 /turf/open/floor/wood,
 /area/medical/psych)
 "szG" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/wood,
+/turf/open/floor/carpet,
 /area/crew_quarters/theatre)
 "sAr" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -58777,9 +59110,7 @@
 "sOA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
 "sPT" = (
@@ -58792,6 +59123,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
+"sQz" = (
+/obj/structure/reagent_dispensers/watertank,
+/obj/structure/sign/warning{
+	pixel_x = 32
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "sQX" = (
 /turf/open/floor/carpet/purple,
 /area/maintenance/starboard/aft)
@@ -58913,6 +59251,17 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"tga" = (
+/obj/machinery/door/airlock{
+	name = "Theatre Backstage";
+	req_access_txt = "46"
+	},
+/obj/effect/turf_decal/lumos/tile/red/checker,
+/obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/theatre)
 "tgH" = (
 /obj/structure/filingcabinet/employment,
 /turf/open/floor/wood,
@@ -59075,6 +59424,10 @@
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/floor/grass,
 /area/medical/virology)
+"twP" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "txm" = (
 /obj/structure/table/wood/fancy/royalblue,
 /obj/item/crowbar/red,
@@ -59189,6 +59542,12 @@
 /obj/item/pen,
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics/cloning)
+"tFO" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/ai_monitored/storage/eva)
 "tIF" = (
 /obj/structure/lattice,
 /obj/machinery/camera{
@@ -59198,21 +59557,20 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "tJi" = (
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -22
-	},
-/obj/structure/closet/crate/wooden/toy,
-/obj/structure/sign/poster/contraband/clown{
-	pixel_y = -32
-	},
-/obj/item/megaphone/clown,
-/obj/effect/turf_decal/lumos/tile/blue/checker{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/lumos/tile/red/checker,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
-/area/crew_quarters/theatre)
+/area/ai_monitored/storage/eva)
 "tJK" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Gravity Generator";
@@ -59403,6 +59761,9 @@
 /obj/machinery/door/airlock/atmos/abandoned{
 	name = "Atmospherics Maintenance";
 	req_access_txt = "12;24"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
@@ -59700,6 +60061,9 @@
 /obj/structure/sign/poster/official/cohiba_robusto_ad{
 	pixel_y = -32
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
 "uIO" = (
@@ -59970,8 +60334,6 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal/incinerator)
 "viF" = (
-/obj/structure/table/wood,
-/obj/item/instrument/trumpet,
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
 "viG" = (
@@ -60049,11 +60411,12 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "vpY" = (
-/obj/structure/closet/lasertag/blue,
-/obj/item/clothing/under/misc/pj/blue,
-/obj/item/clothing/under/misc/pj/blue,
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/ai_monitored/storage/eva)
 "vra" = (
 /obj/machinery/door/window/northleft{
 	base_state = "right";
@@ -60201,6 +60564,12 @@
 /obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"vAj" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics/garden)
 "vAl" = (
 /obj/machinery/camera{
 	c_tag = "Pool East";
@@ -60416,6 +60785,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"vNi" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/ai_monitored/storage/eva)
 "vOU" = (
 /obj/structure/showcase/machinery/cloning_pod{
 	layer = 4;
@@ -60925,11 +61300,20 @@
 /turf/open/pool,
 /area/crew_quarters/fitness/pool)
 "wRn" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer1{
 	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"wTJ" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/ai_monitored/storage/eva)
 "wUg" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -60960,9 +61344,7 @@
 /obj/item/radio/intercom{
 	pixel_y = 20
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 10
-	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel,
 /area/security/range)
 "wVk" = (
@@ -61010,11 +61392,12 @@
 /turf/open/floor/plasteel/dark,
 /area/maintenance/bar)
 "wYs" = (
-/obj/machinery/chem_master/condimaster{
-	name = "HoochMaster 2000"
+/obj/machinery/door/airlock/maintenance{
+	name = "Security Maintenance";
+	req_access_txt = "1"
 	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "wZe" = (
 /obj/structure/chair{
 	dir = 1
@@ -61057,6 +61440,22 @@
 /obj/item/coin/gold,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
+"xec" = (
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -22
+	},
+/obj/structure/closet/crate/wooden/toy,
+/obj/structure/sign/poster/contraband/clown{
+	pixel_y = -32
+	},
+/obj/item/megaphone/clown,
+/obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
+	},
+/obj/effect/turf_decal/lumos/tile/red/checker,
+/turf/open/floor/plasteel,
+/area/crew_quarters/theatre)
 "xez" = (
 /obj/machinery/camera{
 	c_tag = "Permabrig East";
@@ -61181,6 +61580,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
+"xku" = (
+/obj/machinery/vending/autodrobe,
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
+/area/crew_quarters/theatre)
 "xkD" = (
 /obj/machinery/camera{
 	c_tag = "Permabrig Kitchen";
@@ -61211,9 +61616,6 @@
 "xmo" = (
 /obj/structure/cable{
 	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 4
@@ -61448,11 +61850,10 @@
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
 "xPY" = (
-/obj/structure/table/wood,
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/item/instrument/trombone,
+/obj/structure/window,
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
 "xQG" = (
@@ -61547,11 +61948,9 @@
 /turf/open/floor/engine,
 /area/science/explab)
 "xZD" = (
-/obj/structure/closet/lasertag/red,
-/obj/item/clothing/under/misc/pj/red,
-/obj/item/clothing/under/misc/pj/red,
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
+/obj/structure/window,
+/turf/open/floor/wood,
+/area/crew_quarters/theatre)
 "xZL" = (
 /obj/machinery/light{
 	dir = 8
@@ -61559,6 +61958,9 @@
 /obj/machinery/airalarm{
 	dir = 4;
 	pixel_x = -22
+	},
+/obj/structure/closet/secure_closet/personal{
+	anchored = 1
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/pool)
@@ -61624,6 +62026,15 @@
 	},
 /turf/closed/wall,
 /area/maintenance/disposal/incinerator)
+"ygf" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/dresser,
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
+/area/crew_quarters/theatre)
 "ygU" = (
 /obj/machinery/computer/card/minor/cmo{
 	dir = 1
@@ -75123,8 +75534,8 @@ alU
 alU
 alU
 alU
-auT
-aBI
+amC
+wYs
 aIA
 aRL
 aFH
@@ -75380,7 +75791,7 @@ aWw
 axe
 ays
 alU
-auT
+alU
 aBI
 aCY
 bgf
@@ -75634,10 +76045,10 @@ asc
 alU
 auX
 avS
+aYH
 amC
 amC
-alU
-auT
+amC
 aBI
 aDc
 aRL
@@ -75890,10 +76301,10 @@ ank
 asc
 alU
 auZ
-bsU
-axf
 amC
-alU
+bbT
+amC
+amC
 auT
 aBI
 aDf
@@ -76147,12 +76558,12 @@ arF
 asc
 alU
 auY
+aUq
+axf
 amC
-amC
-ayt
-alU
+bil
 aAw
-aBl
+aBI
 aCZ
 aEJ
 aFL
@@ -76404,8 +76815,8 @@ arG
 asc
 alU
 ava
+aUq
 amC
-axg
 ayu
 azF
 azF
@@ -76661,7 +77072,7 @@ arG
 ash
 alU
 alU
-atw
+aVP
 alU
 alU
 azF
@@ -76931,7 +77342,7 @@ azF
 aIR
 ayl
 ayl
-aNi
+ayl
 ayl
 ayl
 ayl
@@ -77182,8 +77593,8 @@ azi
 aAx
 aBm
 axK
-aAQ
-aAQ
+vAj
+nws
 azF
 azF
 azF
@@ -81550,12 +81961,12 @@ arP
 fgG
 rqW
 aGD
-tJi
 aCr
-hcb
+sax
+ygf
 qTG
-hcb
-aKu
+xec
+aCr
 aLF
 aLF
 aOs
@@ -81809,11 +82220,11 @@ fne
 aGr
 aHI
 fOA
-aMr
-aMr
-hcb
-aKu
-aLL
+sks
+nGB
+kCo
+tga
+aLE
 bDe
 gxc
 aPF
@@ -82064,13 +82475,13 @@ arP
 aCh
 pIf
 kCo
-aHK
 aCr
-hcb
-aMr
-hcb
-aKu
-aLE
+xku
+ret
+kCo
+qcs
+aCr
+rOV
 aLE
 gxc
 aPH
@@ -82323,10 +82734,10 @@ eEe
 aCr
 aCr
 aCr
-hcb
-aMr
-aBJ
-aKu
+aCr
+aCr
+aCr
+aCr
 aLE
 aLE
 gxc
@@ -82578,14 +82989,14 @@ ayA
 sNK
 xmo
 aBV
-mzB
 szG
 szG
-szG
-aJe
-aKw
-aPc
-aMR
+gVl
+dgv
+hcb
+aKu
+aLE
+aLE
 aNU
 aPG
 aPG
@@ -82832,14 +83243,14 @@ ecD
 arP
 xxi
 arP
-azI
+viF
 rjQ
 aBU
-myh
+hcb
 uRS
 hcb
 uRS
-aBK
+hcb
 aKu
 bbk
 aMQ
@@ -83089,15 +83500,15 @@ aqR
 xhn
 xxi
 arP
-cGz
+viF
 aMr
-aMr
-aDv
-uRS
+xZD
 hcb
 uRS
 hcb
-aKu
+uRS
+hcb
+ePh
 aCe
 aMS
 aOt
@@ -83347,9 +83758,9 @@ arP
 xxi
 arP
 viF
-aMr
-aMr
-aOH
+bMa
+xZD
+hcb
 uRS
 hcb
 uRS
@@ -83603,10 +84014,10 @@ arP
 arP
 xxi
 arP
-nez
-ngV
+viF
+viF
 xPY
-aOH
+hcb
 hcb
 hcb
 syJ
@@ -84139,7 +84550,7 @@ sOA
 asW
 baW
 aJW
-bLE
+iYZ
 apd
 bfj
 bgC
@@ -84651,9 +85062,9 @@ aVa
 apd
 aWE
 aqW
-aqW
+iIL
 bcG
-bLE
+mfO
 apd
 aZH
 bgD
@@ -84908,7 +85319,7 @@ aWF
 apd
 aWG
 bLE
-baX
+bcH
 bcH
 bdE
 apd
@@ -85104,9 +85515,9 @@ aEq
 acd
 acd
 acd
-avB
+axS
 aHX
-avB
+aLL
 aai
 aai
 jNy
@@ -85164,9 +85575,9 @@ aCK
 aUw
 apd
 aXK
-avr
+aqW
 aZJ
-bbT
+aqW
 bSy
 apd
 aZH
@@ -85362,7 +85773,7 @@ aFi
 aFF
 aFg
 aFg
-adI
+aBK
 aFg
 hsU
 ixS
@@ -85420,8 +85831,8 @@ aSa
 aCM
 aSr
 apd
-aYZ
-bLE
+baU
+aqW
 aqW
 aqW
 noy
@@ -85861,7 +86272,7 @@ aai
 aai
 aau
 aat
-acC
+adc
 alf
 acd
 acd
@@ -86133,7 +86544,7 @@ fUD
 aup
 aIi
 acd
-aLJ
+aDv
 jxW
 aai
 aai
@@ -86390,11 +86801,11 @@ auC
 auC
 auC
 acd
-aLJ
-aPi
-acd
+aHK
+aat
+aOH
 aTA
-aVx
+aSG
 aXx
 aYI
 aXx
@@ -86632,7 +87043,7 @@ aan
 abx
 aaU
 adb
-acH
+adc
 ahQ
 acd
 acd
@@ -86648,9 +87059,9 @@ auu
 acd
 acd
 aOK
+aMR
 aat
-aSG
-aUf
+aat
 aVG
 rDu
 acd
@@ -86904,10 +87315,10 @@ aFg
 aFg
 aAg
 akL
-aLJ
+aJe
+aMR
 aat
-aTa
-aUq
+aat
 oWn
 aas
 aYX
@@ -87162,8 +87573,8 @@ ahP
 aep
 aKh
 amk
+aNi
 ahP
-aTp
 ahP
 amu
 aXH
@@ -87418,12 +87829,12 @@ aPw
 aPw
 auA
 aBS
-aLJ
+aJe
+aMR
 aat
-aTa
-aYH
+aat
 dqN
-bbU
+acJ
 bae
 ana
 bdW
@@ -87660,7 +88071,7 @@ aan
 abx
 aaU
 adb
-acH
+adc
 ahQ
 acd
 acd
@@ -87676,15 +88087,15 @@ auu
 acd
 acd
 aOK
+aMR
 aat
-acd
-htK
-acd
+aat
+aat
 aXO
 acd
 aUr
-aVP
-aVP
+aat
+aat
 acd
 awe
 fLS
@@ -87932,11 +88343,11 @@ njP
 auC
 auC
 acd
-aLJ
+aKw
 aat
-acd
+aPc
 aUC
-acd
+aaJ
 aYa
 acd
 bcT
@@ -88189,8 +88600,8 @@ fUD
 auN
 ycV
 acd
-aLJ
-aPi
+aDv
+jxW
 aai
 aai
 aai
@@ -88696,13 +89107,13 @@ auS
 aww
 axZ
 akt
-asX
+axg
 akC
 mYU
 aFj
-asX
-asX
-akC
+axg
+axg
+ayt
 aMv
 aPj
 aTx
@@ -88948,7 +89359,7 @@ ade
 aPw
 aPw
 amQ
-aPw
+avr
 agF
 aPw
 ayB
@@ -88959,7 +89370,7 @@ aPw
 amQ
 xez
 aPw
-agF
+aBl
 aPw
 aPw
 aai
@@ -89001,10 +89412,10 @@ awg
 ayW
 ayR
 azR
-azW
-azW
+gOZ
+wTJ
 afO
-azW
+tFO
 agm
 aBt
 aaa
@@ -89258,10 +89669,10 @@ awg
 ayW
 ayT
 axA
-azW
-azW
+htK
+dMi
 aBt
-azW
+vNi
 aio
 aBt
 aaa
@@ -89513,9 +89924,9 @@ aug
 jGc
 awg
 ayW
-azW
-ayq
-azW
+bdi
+bsU
+myh
 aCj
 ayW
 ayW
@@ -89772,8 +90183,8 @@ awg
 ayW
 ayX
 azY
-azW
-azW
+tJi
+gwf
 afP
 aFb
 aEZ
@@ -90029,8 +90440,8 @@ awj
 ayW
 ayW
 ayW
-aBt
-aBt
+vpY
+vpY
 ayW
 ayW
 ayW
@@ -91015,7 +91426,7 @@ aai
 aai
 jDN
 jDN
-aGp
+aBJ
 jDN
 jDN
 aai
@@ -91272,7 +91683,7 @@ bVk
 aai
 aGK
 aFS
-aGp
+aBJ
 aFS
 aRv
 aai
@@ -91529,7 +91940,7 @@ aEw
 aai
 aai
 aai
-xUe
+aam
 aai
 aai
 aai
@@ -91843,7 +92254,7 @@ aPX
 aRs
 aSE
 aUc
-aVl
+rir
 aWY
 aYC
 bfv
@@ -92101,12 +92512,12 @@ aPR
 aPR
 aUb
 aVq
-aTX
+lPB
 aYr
 aZV
 bbo
 bch
-bdi
+bbw
 bbw
 bfy
 aUX
@@ -92624,7 +93035,7 @@ aHm
 bbw
 bfA
 bgT
-bil
+bbw
 bej
 blb
 bmy
@@ -93620,7 +94031,7 @@ ajo
 aqg
 arf
 aqo
-atm
+aTa
 atm
 arf
 avv
@@ -93629,7 +94040,7 @@ axW
 awr
 uIO
 aAh
-aGk
+cKz
 aSI
 aGk
 aAh
@@ -94145,7 +94556,7 @@ sFW
 aAh
 azq
 aGx
-azq
+rBc
 aAh
 aSF
 aAh
@@ -94649,7 +95060,7 @@ aqi
 arf
 ask
 atm
-atm
+aUf
 arf
 awq
 axO
@@ -95162,7 +95573,7 @@ apr
 aqj
 arf
 ark
-asu
+aTp
 xPk
 arf
 awt
@@ -96194,7 +96605,7 @@ asN
 aur
 avy
 nSt
-axS
+aAp
 azk
 axB
 awr
@@ -96453,7 +96864,7 @@ arf
 aXF
 awr
 aDN
-awr
+bLY
 awr
 awr
 awr
@@ -99033,7 +99444,7 @@ aJC
 aJC
 aKS
 aKR
-wYs
+aJC
 aJC
 aJI
 jAN
@@ -99847,8 +100258,8 @@ lea
 xtF
 ppo
 bQD
-bLY
-bMa
+bOr
+bOr
 bNd
 caU
 bzs
@@ -100103,7 +100514,7 @@ bLW
 mgP
 xtF
 vKc
-bOr
+twP
 bRO
 bIN
 bNd
@@ -100824,8 +101235,8 @@ ayb
 eCr
 jvd
 cEo
-xZD
-vpY
+fHG
+fHG
 alP
 aGJ
 anf
@@ -101129,7 +101540,7 @@ btR
 iCM
 bIa
 bIf
-bOq
+nNS
 bOq
 bLf
 bRP
@@ -101328,13 +101739,13 @@ aaa
 aaa
 aaa
 aaf
-aaf
-alO
+xhY
+xhY
 arj
-arj
-arj
-arj
-gOZ
+fHG
+fHG
+fHG
+fHG
 cVb
 cVb
 cVb
@@ -101587,11 +101998,11 @@ aag
 alO
 arp
 alO
-anf
-anf
-anf
-anf
-anf
+arj
+arj
+arj
+arj
+bbU
 cVb
 jbf
 wrp
@@ -108866,7 +109277,7 @@ cNW
 cNW
 fup
 cOe
-bNA
+sQz
 cOT
 aaa
 aaa
@@ -112920,7 +113331,7 @@ aHy
 eaP
 aNa
 gXs
-gXs
+aaa
 gXs
 aNa
 eaP
@@ -113177,7 +113588,7 @@ aHy
 aQE
 aNa
 gXs
-aaa
+gXs
 gXs
 aNa
 aQE
@@ -113948,7 +114359,7 @@ aHy
 vDB
 aNa
 gXs
-aaa
+gXs
 gXs
 aNa
 vDB

--- a/_maps/map_files/BoxStation/BoxStation_Lumos.dmm
+++ b/_maps/map_files/BoxStation/BoxStation_Lumos.dmm
@@ -1893,6 +1893,9 @@
 	},
 /obj/machinery/suit_storage_unit/hos,
 /obj/effect/turf_decal/delivery,
+/obj/structure/sign/poster/contraband/billyh2{
+	pixel_x = 32
+	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "aeE" = (
@@ -2156,7 +2159,6 @@
 	},
 /obj/effect/landmark/start/assistant,
 /obj/structure/chair/sofa/right,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "afb" = (
@@ -2395,9 +2397,6 @@
 /area/security/main)
 "afE" = (
 /obj/structure/chair/sofa/left{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -3968,6 +3967,7 @@
 	},
 /obj/effect/turf_decal/box,
 /obj/effect/turf_decal/lumos/tile/neutral/fulltile,
+/obj/effect/turf_decal/lumos/shower,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "aiQ" = (
@@ -5556,11 +5556,11 @@
 /turf/open/floor/plating,
 /area/security/courtroom)
 "ams" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -6280,17 +6280,11 @@
 	pixel_y = 25
 	},
 /obj/structure/filingcabinet,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
+/obj/effect/turf_decal/lumos/tile/blue/checker,
 /turf/open/floor/plasteel/dark,
 /area/blueshield)
 "aoc" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
+/obj/effect/turf_decal/lumos/tile/blue/checker,
 /turf/open/floor/plasteel/dark,
 /area/blueshield)
 "aod" = (
@@ -7085,10 +7079,7 @@
 /area/crew_quarters/dorms)
 "aqb" = (
 /obj/structure/rack,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
+/obj/effect/turf_decal/lumos/tile/blue/checker,
 /turf/open/floor/plasteel/dark,
 /area/blueshield)
 "aqc" = (
@@ -7532,10 +7523,7 @@
 	department = "Blueshield";
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
+/obj/effect/turf_decal/lumos/tile/blue/checker,
 /turf/open/floor/plasteel/dark,
 /area/blueshield)
 "arb" = (
@@ -7545,14 +7533,11 @@
 	pixel_y = 7
 	},
 /obj/item/pen,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
 	},
+/obj/effect/turf_decal/lumos/tile/blue/checker,
 /turf/open/floor/plasteel/dark,
 /area/blueshield)
 "arc" = (
@@ -7905,10 +7890,7 @@
 	dir = 4;
 	pixel_x = -24
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
+/obj/effect/turf_decal/lumos/tile/blue/checker,
 /turf/open/floor/plasteel/dark,
 /area/blueshield)
 "arW" = (
@@ -7922,13 +7904,10 @@
 "arX" = (
 /obj/structure/table/wood,
 /obj/item/folder/blue,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
 	},
+/obj/effect/turf_decal/lumos/tile/blue/checker,
 /turf/open/floor/plasteel/dark,
 /area/blueshield)
 "arY" = (
@@ -7945,10 +7924,7 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/blueshield,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
+/obj/effect/turf_decal/lumos/tile/blue/checker,
 /turf/open/floor/plasteel/dark,
 /area/blueshield)
 "asa" = (
@@ -8640,12 +8616,9 @@
 	dir = 1
 	},
 /obj/structure/closet/secure_closet/blueshield,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
 /obj/machinery/power/apc/auto_name/south,
 /obj/structure/cable,
+/obj/effect/turf_decal/lumos/tile/blue/checker,
 /turf/open/floor/plasteel/dark,
 /area/blueshield)
 "auh" = (
@@ -8664,10 +8637,7 @@
 	pixel_y = 8;
 	req_one_access_txt = "71"
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
+/obj/effect/turf_decal/lumos/tile/blue/checker,
 /turf/open/floor/plasteel/dark,
 /area/blueshield)
 "auj" = (
@@ -9180,12 +9150,9 @@
 /turf/open/floor/wood,
 /area/lawoffice)
 "avH" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/lumos/tile/blue/checker,
 /turf/open/floor/plasteel/dark,
 /area/blueshield)
 "avI" = (
@@ -9329,12 +9296,8 @@
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
 "awa" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "awb" = (
@@ -9344,7 +9307,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
 /area/ai_monitored/storage/eva)
 "awc" = (
 /obj/structure/disposalpipe/segment{
@@ -9569,7 +9534,6 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "awA" = (
-/obj/machinery/holopad,
 /obj/machinery/camera{
 	c_tag = "Dorms Central"
 	},
@@ -10161,10 +10125,11 @@
 /turf/open/floor/plating,
 /area/security/prison)
 "axT" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
-/area/ai_monitored/storage/eva)
+/area/security/prison)
 "axU" = (
 /turf/open/floor/plasteel/showroomfloor/shower,
 /area/security/prison)
@@ -10341,7 +10306,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
+	},
 /area/ai_monitored/storage/eva)
 "ayr" = (
 /obj/structure/extinguisher_cabinet{
@@ -10387,9 +10354,7 @@
 /obj/machinery/airalarm{
 	pixel_y = 23
 	},
-/turf/open/floor/plasteel/dark/side{
-	dir = 4
-	},
+/turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
 "ayw" = (
 /obj/structure/cable{
@@ -10452,7 +10417,7 @@
 /area/storage/primary)
 "ayE" = (
 /turf/closed/wall/r_wall,
-/area/maintenance/fore)
+/area/crew_quarters/theatre)
 "ayF" = (
 /obj/structure/closet/crate/bin,
 /obj/effect/turf_decal/trimline/green/filled/line,
@@ -10503,9 +10468,7 @@
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
-/turf/open/floor/plasteel/dark/side{
-	dir = 8
-	},
+/turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
 "ayN" = (
 /obj/structure/rack,
@@ -10543,7 +10506,7 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
 "ayQ" = (
 /obj/structure/table,
@@ -10754,14 +10717,11 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "azh" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
+/area/security/prison)
 "azi" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Garden Maintenance";
@@ -10787,6 +10747,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/holopad,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "azm" = (
@@ -10845,6 +10806,9 @@
 	dir = 8;
 	pixel_y = -4
 	},
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/toilet)
 "azr" = (
@@ -10864,7 +10828,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark/side{
+	dir = 5
+	},
 /area/ai_monitored/storage/eva)
 "azt" = (
 /obj/machinery/power/terminal,
@@ -11117,7 +11083,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
 "azV" = (
 /obj/machinery/shower{
@@ -11484,7 +11450,7 @@
 /area/hydroponics/garden)
 "aAT" = (
 /obj/machinery/seed_extractor,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/hydroponics/garden)
 "aAU" = (
 /obj/structure/sink{
@@ -11658,7 +11624,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
 "aBp" = (
 /obj/structure/rack,
@@ -11725,7 +11691,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/hydroponics/garden)
 "aBx" = (
 /obj/structure/toilet,
@@ -11899,7 +11865,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
 /area/ai_monitored/storage/eva)
 "aBQ" = (
 /turf/closed/wall,
@@ -11924,22 +11892,20 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
 "aBU" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8
-	},
-/obj/structure/window,
-/turf/open/floor/wood,
-/area/crew_quarters/theatre)
-"aBV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
+"aBV" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/light{
 	dir = 8;
 	light_color = "#e8eaff"
 	},
 /obj/machinery/door/window,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
 "aBW" = (
@@ -11962,16 +11928,16 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "aCb" = (
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
+	},
 /area/ai_monitored/storage/eva)
 "aCc" = (
 /obj/effect/turf_decal/stripes/line{
@@ -12000,12 +11966,19 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
 "aCh" = (
-/turf/open/floor/plasteel/white/side{
-	dir = 1
+/obj/structure/sign/poster/contraband/clown{
+	pixel_y = 32
 	},
+/obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
+	},
+/obj/effect/turf_decal/lumos/tile/red/checker,
+/obj/structure/closet/crate/wooden/toy,
+/obj/item/megaphone/clown,
+/turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
 "aCi" = (
 /obj/structure/cable,
@@ -12309,7 +12282,6 @@
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
 "aCY" = (
-/obj/machinery/computer/security,
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_y = 30
 	},
@@ -12321,6 +12293,10 @@
 "aCZ" = (
 /obj/effect/turf_decal/lumos/tile/red/fullcorner{
 	dir = 8
+	},
+/obj/structure/table,
+/obj/machinery/recharger{
+	pixel_y = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
@@ -12341,7 +12317,6 @@
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "aDc" = (
-/obj/machinery/computer/card,
 /obj/machinery/light{
 	dir = 1
 	},
@@ -12352,6 +12327,7 @@
 /obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 1
 	},
+/obj/machinery/computer/security,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
 "aDd" = (
@@ -12391,7 +12367,6 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/pool)
 "aDf" = (
-/obj/machinery/computer/secure_data,
 /obj/machinery/requests_console{
 	department = "Security";
 	departmentType = 5;
@@ -12400,11 +12375,12 @@
 /obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 1
 	},
+/obj/machinery/computer/card,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
 "aDg" = (
 /obj/machinery/biogenerator,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/hydroponics/garden)
 "aDh" = (
 /obj/machinery/vending/assist,
@@ -12606,7 +12582,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
 /area/ai_monitored/storage/eva)
 "aDE" = (
 /obj/machinery/suit_storage_unit/standard_unit,
@@ -12637,16 +12615,11 @@
 /area/crew_quarters/dorms)
 "aDH" = (
 /obj/structure/table,
-/obj/item/paper_bin{
-	pixel_x = 1;
-	pixel_y = 9
-	},
 /obj/item/pen,
 /obj/item/folder/white,
-/obj/item/pen/fountain,
 /obj/item/stamp/rd{
-	pixel_x = 3;
-	pixel_y = -2
+	pixel_x = -4;
+	pixel_y = 13
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/hor)
@@ -13249,7 +13222,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
 "aEY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
@@ -13480,7 +13453,6 @@
 	pixel_x = 6;
 	pixel_y = -25
 	},
-/obj/machinery/vending/wardrobe/sec_wardrobe,
 /obj/effect/turf_decal/lumos/tile/red/fullcorner{
 	dir = 1
 	},
@@ -13508,11 +13480,8 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
 "aFL" = (
-/obj/structure/table,
-/obj/machinery/recharger{
-	pixel_y = 4
-	},
 /obj/effect/turf_decal/lumos/tile/red/fullcorner,
+/obj/machinery/vending/wardrobe/sec_wardrobe,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
 "aFM" = (
@@ -13520,6 +13489,9 @@
 	dir = 9
 	},
 /obj/effect/turf_decal/lumos/tile/red/half,
+/obj/machinery/computer/secure_data{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
 "aFN" = (
@@ -13720,12 +13692,15 @@
 /obj/machinery/shower{
 	dir = 4
 	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/crew_quarters/toilet)
-"aGl" = (
 /obj/machinery/light/small,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/toilet)
+"aGl" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
 "aGm" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -13772,18 +13747,6 @@
 /obj/item/assembly/timer,
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
-"aGr" = (
-/obj/effect/turf_decal/lumos/tile/blue/checker{
-	dir = 4
-	},
-/obj/effect/turf_decal/lumos/tile/red/checker,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/theatre)
 "aGs" = (
 /obj/machinery/suit_storage_unit/rd,
 /turf/open/floor/plasteel/cafeteria,
@@ -13872,8 +13835,9 @@
 /obj/structure/table/wood,
 /obj/item/instrument/piano_synth,
 /obj/item/instrument/guitar,
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/median/whitetodark{
+	dir = 4
+	},
 /area/crew_quarters/theatre)
 "aGE" = (
 /obj/structure/disposalpipe/segment{
@@ -14120,6 +14084,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/lumos/tile/red/fulltile,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
 "aHa" = (
@@ -14386,17 +14351,21 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "aHI" = (
-/obj/machinery/door/airlock{
-	name = "Theatre Backstage";
-	req_access_txt = "46"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/white/side{
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/door/airlock/glass{
+	name = "Theatre Backstage";
+	req_access_txt = "46"
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 8
 	},
 /area/crew_quarters/theatre)
 "aHJ" = (
@@ -15116,13 +15085,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aJz" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/effect/turf_decal/lumos/tile/blue/checker,
 /turf/open/floor/plasteel/dark,
 /area/blueshield)
 "aJA" = (
@@ -15468,13 +15434,10 @@
 /turf/open/floor/plating,
 /area/hydroponics/garden)
 "aKo" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
+/obj/effect/turf_decal/lumos/tile/blue/checker,
 /turf/open/floor/plasteel/dark,
 /area/blueshield)
 "aKp" = (
@@ -16084,15 +16047,11 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "aLS" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 5
-	},
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aLT" = (
@@ -16111,9 +16070,6 @@
 	dir = 8
 	},
 /obj/structure/reagent_dispensers/beerkeg,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4
-	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "aLV" = (
@@ -16200,6 +16156,9 @@
 "aMi" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/landmark/xeno_spawn,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "aMj" = (
@@ -16248,6 +16207,9 @@
 /area/crew_quarters/bar)
 "aMr" = (
 /obj/structure/musician/piano,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
 "aMs" = (
@@ -16942,34 +16904,34 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "aOe" = (
-/obj/item/beacon,
 /obj/machinery/camera{
 	c_tag = "Arrivals Bay 1 South"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/structure/closet/emcloset,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "aOf" = (
-/obj/machinery/vending/snack/random,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/obj/structure/closet/emcloset,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "aOg" = (
-/obj/structure/closet/emcloset,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/obj/machinery/vending/snack/random,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "aOh" = (
-/obj/structure/closet/emcloset,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/item/beacon,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "aOi" = (
@@ -17036,12 +16998,14 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "aOq" = (
 /obj/structure/disposalpipe/junction{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "aOr" = (
@@ -17054,7 +17018,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
 /obj/effect/turf_decal/trimline/green/filled/corner,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
@@ -17171,8 +17134,17 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
 "aOJ" = (
-/obj/structure/chair/comfy/brown{
-	dir = 8
+/obj/structure/table/wood/fancy,
+/obj/item/reagent_containers/food/condiment/peppermill{
+	dir = 1;
+	pixel_x = -13;
+	pixel_y = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
@@ -17191,12 +17163,8 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aOL" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "aOM" = (
@@ -17612,8 +17580,12 @@
 "aQe" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/landmark/xmastree,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "aQf" = (
@@ -17858,6 +17830,9 @@
 /obj/structure/sign/poster/contraband/pwr_game{
 	pixel_y = 32
 	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "aQS" = (
@@ -17870,6 +17845,9 @@
 "aQT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
@@ -18359,11 +18337,6 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "aSh" = (
-/obj/structure/closet/wardrobe/mixed,
-/obj/item/clothing/head/beret,
-/obj/item/clothing/head/beret,
-/obj/item/clothing/head/russobluecamohat,
-/obj/item/clothing/head/russobluecamohat,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
@@ -18371,6 +18344,7 @@
 	name = "Station Intercom (General)";
 	pixel_x = -27
 	},
+/obj/structure/chair/stool,
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "aSj" = (
@@ -18807,12 +18781,9 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "aTw" = (
-/obj/structure/closet/wardrobe/green,
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/item/clothing/under/costume/kilt,
-/obj/item/clothing/under/costume/kilt,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
@@ -19260,9 +19231,6 @@
 	id = "visitflash";
 	pixel_y = 25
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
@@ -19291,16 +19259,10 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "aUU" = (
-/obj/structure/closet/wardrobe/grey,
 /obj/machinery/requests_console{
 	department = "Locker Room";
 	pixel_x = -32
 	},
-/obj/item/clothing/under/misc/assistantformal,
-/obj/item/clothing/under/misc/assistantformal,
-/obj/item/clothing/under/misc/assistantformal,
-/obj/item/clothing/under/color/grey,
-/obj/item/clothing/under/color/grey,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
@@ -19921,19 +19883,12 @@
 /turf/open/floor/wood,
 /area/security/vacantoffice)
 "aWn" = (
-/obj/structure/closet/wardrobe/black,
-/obj/item/clothing/shoes/jackboots,
-/obj/item/clothing/under/rank/civilian/janitor/maid,
-/obj/item/clothing/under/rank/civilian/janitor/maid,
-/obj/item/clothing/under/costume/maid,
-/obj/item/clothing/under/costume/maid,
-/obj/item/clothing/accessory/maidapron,
-/obj/item/clothing/accessory/maidapron,
-/obj/item/clothing/head/beret/black,
-/obj/item/clothing/head/beret/black,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
+/obj/structure/closet/wardrobe/green,
+/obj/item/clothing/under/costume/kilt,
+/obj/item/clothing/under/costume/kilt,
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "aWo" = (
@@ -20741,8 +20696,8 @@
 	},
 /obj/structure/table,
 /obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
+	pixel_x = 5;
+	pixel_y = 3
 	},
 /obj/item/pen,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -21106,8 +21061,8 @@
 	id = "LockerShitter1";
 	name = "Door Bolt Control";
 	normaldoorcontrol = 1;
-	pixel_x = 14;
-	pixel_y = 38;
+	pixel_x = 9;
+	pixel_y = -22;
 	specialfunctions = 4
 	},
 /obj/machinery/light/small{
@@ -21116,6 +21071,7 @@
 /obj/structure/sink{
 	pixel_y = 28
 	},
+/obj/effect/landmark/blobstart,
 /turf/open/floor/mineral/titanium/blue,
 /area/crew_quarters/toilet/locker)
 "aZu" = (
@@ -21131,7 +21087,6 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/crew_quarters/toilet/locker)
 "aZw" = (
-/obj/effect/landmark/blobstart,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/locker)
 "aZx" = (
@@ -21780,7 +21735,7 @@
 /obj/machinery/door/poddoor/shutters{
 	id = "visit"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/security/prison)
 "bbs" = (
 /obj/structure/window/reinforced{
@@ -21914,7 +21869,7 @@
 	id = "visit"
 	},
 /obj/structure/window/reinforced,
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/security/prison)
 "bbO" = (
 /obj/machinery/washing_machine,
@@ -22210,7 +22165,8 @@
 	dir = 8
 	},
 /obj/item/reagent_containers/food/drinks/bottle/whiskey{
-	pixel_x = 3
+	pixel_x = 3;
+	pixel_y = 6
 	},
 /obj/item/lighter,
 /obj/item/flashlight/lamp/green{
@@ -23394,10 +23350,13 @@
 /area/engine/engineering)
 "bfA" = (
 /obj/structure/table/wood,
-/obj/item/hand_tele,
+/obj/item/hand_tele{
+	pixel_x = 10;
+	pixel_y = 3
+	},
 /obj/item/paper_bin{
 	pixel_x = -3;
-	pixel_y = 7
+	pixel_y = 4
 	},
 /obj/item/pen,
 /turf/open/floor/wood,
@@ -23410,7 +23369,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/item/phone{
 	pixel_x = -10;
-	pixel_y = 8
+	pixel_y = 3
 	},
 /obj/machinery/recharger{
 	pixel_x = 15;
@@ -26348,7 +26307,9 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
 "bnT" = (
@@ -26807,6 +26768,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
+/obj/machinery/holopad,
 /turf/open/floor/carpet,
 /area/crew_quarters/theatre)
 "bpf" = (
@@ -28427,7 +28389,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
 "btC" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -28445,6 +28407,9 @@
 /obj/structure/table,
 /obj/item/pen/fourcolor,
 /obj/item/stamp/hop,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
 "btE" = (
@@ -28974,6 +28939,9 @@
 /obj/structure/chair{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
 "buO" = (
@@ -28984,6 +28952,9 @@
 	pixel_y = -1
 	},
 /obj/item/hand_labeler,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
 "buT" = (
@@ -29473,11 +29444,12 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
 "bwj" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/crew_quarters/heads/hop)
+/area/crew_quarters/fitness)
 "bwk" = (
 /obj/structure/table,
 /obj/machinery/recharger,
@@ -29491,9 +29463,6 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
 "bwq" = (
@@ -30375,6 +30344,11 @@
 /area/quartermaster/qm)
 "byo" = (
 /obj/structure/table,
+/obj/item/paper_bin{
+	pixel_x = -5;
+	pixel_y = 6
+	},
+/obj/item/pen/fountain,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/hor)
 "byp" = (
@@ -31083,13 +31057,9 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "bAd" = (
-/obj/item/screwdriver{
-	pixel_y = 10
-	},
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/item/radio/off,
 /obj/machinery/computer/secure_data{
 	dir = 8
 	},
@@ -31372,6 +31342,10 @@
 /obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 4
 	},
+/obj/item/screwdriver{
+	pixel_y = 10
+	},
+/obj/item/radio/off,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science)
 "bAI" = (
@@ -31918,10 +31892,6 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science)
 "bBZ" = (
-/obj/item/screwdriver{
-	pixel_y = 10
-	},
-/obj/item/radio/off,
 /obj/effect/turf_decal/lumos/tile/red/half,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science)
@@ -32130,6 +32100,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/machinery/holopad,
 /turf/open/floor/plasteel,
 /area/gateway)
 "bCz" = (
@@ -35885,6 +35856,9 @@
 /area/crew_quarters/dorms)
 "bMa" = (
 /obj/structure/chair/stool,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
 "bMc" = (
@@ -39564,36 +39538,20 @@
 "bWo" = (
 /obj/structure/table,
 /obj/item/assembly/igniter{
-	pixel_x = -5;
-	pixel_y = 3
+	pixel_x = -4;
+	pixel_y = -2
 	},
 /obj/item/assembly/igniter{
-	pixel_x = 5;
-	pixel_y = -4
+	pixel_x = 7;
+	pixel_y = -3
 	},
 /obj/item/assembly/igniter{
-	pixel_x = 2;
+	pixel_x = -4;
 	pixel_y = 6
 	},
 /obj/item/assembly/igniter{
-	pixel_x = 2;
-	pixel_y = -1
-	},
-/obj/item/assembly/timer{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/assembly/timer{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/assembly/timer{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/assembly/timer{
-	pixel_x = -3;
-	pixel_y = 3
+	pixel_x = 7;
+	pixel_y = 6
 	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
@@ -39916,11 +39874,28 @@
 "bXh" = (
 /obj/structure/table,
 /obj/item/storage/box/beakers{
-	pixel_x = 2;
+	pixel_x = -5;
 	pixel_y = 2
 	},
-/obj/item/grenade/chem_grenade,
-/obj/item/grenade/chem_grenade,
+/obj/item/grenade/chem_grenade{
+	pixel_x = 9;
+	pixel_y = 5
+	},
+/obj/item/grenade/chem_grenade{
+	pixel_x = 9
+	},
+/obj/item/assembly/timer{
+	pixel_x = 6;
+	pixel_y = 15
+	},
+/obj/item/assembly/timer{
+	pixel_x = 1;
+	pixel_y = 15
+	},
+/obj/item/assembly/timer{
+	pixel_x = -6;
+	pixel_y = 15
+	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
 "bXi" = (
@@ -48484,7 +48459,7 @@
 	c_tag = "Arrivals Escape Pod 2";
 	dir = 8
 	},
-/obj/machinery/light/small,
+/obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "cwV" = (
@@ -49716,6 +49691,14 @@
 /obj/structure/closet/lasertag/blue,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
+"cEC" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
+	},
+/area/ai_monitored/storage/eva)
 "cHf" = (
 /obj/machinery/light{
 	dir = 1
@@ -50692,6 +50675,12 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/medical/medbay/lobby)
+"cZe" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/locker)
 "cZP" = (
 /obj/structure/closet/secure_closet/medical1,
 /obj/machinery/firealarm{
@@ -50882,6 +50871,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"drE" = (
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/hallway/primary/central)
 "dtx" = (
 /obj/machinery/door/airlock{
 	name = "Shower Room"
@@ -50909,6 +50905,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/cryopod)
+"dvB" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
 "dxe" = (
 /obj/structure/window,
 /obj/structure/window{
@@ -51074,6 +51079,15 @@
 	},
 /turf/open/floor/engine,
 /area/science/mixing)
+"dNm" = (
+/obj/structure/closet/wardrobe/grey,
+/obj/item/clothing/under/misc/assistantformal,
+/obj/item/clothing/under/misc/assistantformal,
+/obj/item/clothing/under/misc/assistantformal,
+/obj/item/clothing/under/color/grey,
+/obj/item/clothing/under/color/grey,
+/turf/open/floor/plasteel,
+/area/crew_quarters/locker)
 "dOd" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 5
@@ -51503,10 +51517,6 @@
 	name = "Theatre Backstage";
 	req_access_txt = "46"
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
@@ -51516,9 +51526,11 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/white/side{
-	dir = 1
+/obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
 	},
+/obj/effect/turf_decal/lumos/tile/red/checker,
+/turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
 "eFW" = (
 /obj/structure/cable{
@@ -51743,8 +51755,8 @@
 /obj/structure/table/wood,
 /obj/item/instrument/eguitar,
 /obj/item/instrument/violin,
-/turf/open/floor/plasteel/white/side{
-	dir = 1
+/turf/open/floor/plasteel/median/whitetodark{
+	dir = 4
 	},
 /area/crew_quarters/theatre)
 "fhP" = (
@@ -51761,6 +51773,13 @@
 	},
 /turf/open/floor/engine,
 /area/science/mixing)
+"flh" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
 "flE" = (
 /obj/structure/closet/crate/wooden/fish_learning,
 /turf/open/floor/plasteel/showroomfloor,
@@ -51775,10 +51794,6 @@
 /turf/open/floor/wood,
 /area/maintenance/bar)
 "fne" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 6
 	},
@@ -51791,8 +51806,12 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel/white/side{
-	dir = 1
+	dir = 8
 	},
 /area/crew_quarters/theatre)
 "fnC" = (
@@ -51998,6 +52017,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
+"fEk" = (
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/maintenance/port)
 "fEw" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -52085,8 +52108,12 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/white/side{
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/plasteel/white/side{
+	dir = 8
 	},
 /area/crew_quarters/theatre)
 "fOI" = (
@@ -52609,6 +52636,15 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/plasteel/cafeteria,
 /area/medical/medbay/lobby)
+"gIC" = (
+/obj/item/radio/intercom{
+	pixel_y = 25
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "gIU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -52806,6 +52842,20 @@
 	icon_state = "wood-broken7"
 	},
 /area/maintenance/bar)
+"gZE" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/corner{
+	dir = 1
+	},
+/area/ai_monitored/storage/eva)
 "gZG" = (
 /obj/machinery/holopad,
 /turf/open/floor/plasteel/white,
@@ -53035,6 +53085,20 @@
 	},
 /turf/open/floor/plating,
 /area/security/range)
+"hpD" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 9
+	},
+/area/ai_monitored/storage/eva)
 "hrb" = (
 /obj/structure/table/glass,
 /obj/item/paper_bin{
@@ -53317,6 +53381,13 @@
 "hOv" = (
 /obj/structure/table/wood/fancy,
 /obj/item/reagent_containers/food/snacks/burger/plain,
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = 13;
+	pixel_y = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "hPs" = (
@@ -53520,10 +53591,7 @@
 "iuv" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
+/obj/effect/turf_decal/lumos/tile/blue/checker,
 /turf/open/floor/plasteel/dark,
 /area/blueshield)
 "iuE" = (
@@ -54102,6 +54170,19 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/front_office)
+"jpj" = (
+/obj/structure/closet/wardrobe/black,
+/obj/item/clothing/shoes/jackboots,
+/obj/item/clothing/under/rank/civilian/janitor/maid,
+/obj/item/clothing/under/rank/civilian/janitor/maid,
+/obj/item/clothing/under/costume/maid,
+/obj/item/clothing/under/costume/maid,
+/obj/item/clothing/accessory/maidapron,
+/obj/item/clothing/accessory/maidapron,
+/obj/item/clothing/head/beret/black,
+/obj/item/clothing/head/beret/black,
+/turf/open/floor/plasteel,
+/area/crew_quarters/locker)
 "jqu" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-22"
@@ -54889,6 +54970,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"kxg" = (
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/hallway/primary/central)
 "kxz" = (
 /obj/effect/spawner/structure/window/hollow/end{
 	dir = 8
@@ -55314,6 +55402,13 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/medical/medbay/lobby)
+"ltj" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
 "ltK" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 4
@@ -56025,10 +56120,7 @@
 	pixel_y = -22
 	},
 /obj/item/reagent_containers/food/drinks/flask,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
+/obj/effect/turf_decal/lumos/tile/blue/checker,
 /turf/open/floor/plasteel/dark,
 /area/blueshield)
 "mYU" = (
@@ -56384,14 +56476,16 @@
 "nGB" = (
 /obj/structure/chair/stool,
 /obj/effect/landmark/start/clown,
-/obj/effect/turf_decal/lumos/tile/blue/checker{
-	dir = 4
-	},
-/obj/effect/turf_decal/lumos/tile/red/checker,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/plasteel/white/side{
+	dir = 8
+	},
 /area/crew_quarters/theatre)
 "nGI" = (
 /obj/machinery/light/small{
@@ -56410,6 +56504,20 @@
 /obj/structure/barricade/wooden/crude,
 /turf/open/floor/plasteel/showroomfloor,
 /area/maintenance/bar)
+"nKt" = (
+/obj/structure/table,
+/obj/effect/turf_decal/lumos/tile/red/half{
+	dir = 1
+	},
+/obj/item/screwdriver{
+	pixel_y = 10
+	},
+/obj/item/radio/off{
+	pixel_x = 3;
+	pixel_y = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/supply)
 "nLc" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -56604,19 +56712,9 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "oax" = (
-/obj/structure/table/wood/fancy,
 /obj/machinery/light,
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -3;
-	pixel_y = 20
-	},
-/obj/item/reagent_containers/food/condiment/peppermill{
-	dir = 1;
-	pixel_x = 3;
-	pixel_y = 20
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 4
+/obj/structure/chair/comfy/brown{
+	dir = 1
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
@@ -56947,17 +57045,11 @@
 /turf/open/floor/plasteel/white,
 /area/science/explab)
 "oIJ" = (
-/obj/structure/chair/comfy/brown{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
 "oIW" = (
 /obj/structure/toilet{
 	dir = 8
@@ -57189,6 +57281,15 @@
 "phe" = (
 /turf/open/floor/carpet,
 /area/medical/psych)
+"piK" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/plasteel/white/side{
+	dir = 8
+	},
+/area/crew_quarters/theatre)
 "pjp" = (
 /obj/effect/landmark/blobstart,
 /obj/effect/landmark/xeno_spawn,
@@ -57285,6 +57386,9 @@
 	dir = 4
 	},
 /obj/machinery/vending/cigarette,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "pro" = (
@@ -57428,6 +57532,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"pFu" = (
+/obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
+	},
+/obj/effect/turf_decal/lumos/tile/red/checker,
+/obj/machinery/button/door{
+	id = "clownmimedress";
+	name = "Performer's Office Shutter Control";
+	pixel_x = 26;
+	req_access_txt = "46"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/theatre)
 "pHl" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/plasteel,
@@ -57440,10 +57557,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "pIf" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
@@ -57453,9 +57566,11 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/white/side{
-	dir = 1
+/obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
 	},
+/obj/effect/turf_decal/lumos/tile/red/checker,
+/turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
 "pIg" = (
 /obj/machinery/airalarm{
@@ -57535,6 +57650,13 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"pNr" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
 "pOj" = (
 /turf/closed/wall,
 /area/medical/medbay/central)
@@ -57638,6 +57760,14 @@
 	},
 /turf/open/floor/plating,
 /area/security/brig)
+"pXv" = (
+/obj/structure/closet/wardrobe/mixed,
+/obj/item/clothing/head/beret,
+/obj/item/clothing/head/beret,
+/obj/item/clothing/head/russobluecamohat,
+/obj/item/clothing/head/russobluecamohat,
+/turf/open/floor/plasteel,
+/area/crew_quarters/locker)
 "qaY" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/stripes/line,
@@ -57995,14 +58125,12 @@
 	pixel_x = 4;
 	pixel_y = 15
 	},
-/obj/effect/turf_decal/lumos/tile/blue/checker{
-	dir = 4
-	},
-/obj/effect/turf_decal/lumos/tile/red/checker,
 /obj/item/phone/broken{
 	desc = "Hello? Based Department?"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/median/whitetodark{
+	dir = 4
+	},
 /area/crew_quarters/theatre)
 "qUr" = (
 /obj/machinery/light/small,
@@ -58090,9 +58218,11 @@
 /turf/open/floor/plating,
 /area/medical/surgery)
 "ret" = (
-/turf/open/floor/plasteel/white/side{
+/obj/effect/turf_decal/lumos/tile/red/checker,
+/obj/effect/turf_decal/lumos/tile/blue/checker{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
 "reA" = (
 /obj/machinery/light{
@@ -58121,6 +58251,9 @@
 "rjQ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
@@ -58211,10 +58344,6 @@
 /obj/structure/table/wood,
 /obj/item/instrument/trombone,
 /obj/item/instrument/trumpet,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
 /obj/machinery/power/apc{
 	areastring = "/area/crew_quarters/theatre";
 	dir = 8;
@@ -58224,8 +58353,8 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/turf/open/floor/plasteel/white/side{
-	dir = 1
+/turf/open/floor/plasteel/median/whitetodark{
+	dir = 4
 	},
 /area/crew_quarters/theatre)
 "rrM" = (
@@ -58435,8 +58564,12 @@
 	dir = 1
 	},
 /obj/structure/chair/stool,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel/white/side{
-	dir = 1
+	dir = 8
 	},
 /area/crew_quarters/theatre)
 "rTu" = (
@@ -58522,23 +58655,13 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "sax" = (
-/obj/structure/table/wood,
 /obj/machinery/requests_console{
 	department = "Theatre";
 	name = "theatre RC";
 	pixel_x = -32
 	},
-/obj/item/reagent_containers/food/snacks/baguette,
-/obj/item/toy/dummy,
-/obj/item/lipstick/random{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/lipstick/random{
-	pixel_x = -2;
-	pixel_y = -2
-	},
-/turf/open/floor/plasteel/white/side{
+/obj/structure/dresser,
+/turf/open/floor/plasteel/median/whitetodark{
 	dir = 4
 	},
 /area/crew_quarters/theatre)
@@ -58635,8 +58758,12 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
 	},
-/turf/open/floor/plasteel/white/side{
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/plasteel/white/side{
+	dir = 8
 	},
 /area/crew_quarters/theatre)
 "slk" = (
@@ -58931,12 +59058,6 @@
 	pixel_x = 3;
 	pixel_y = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 9
-	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "sKl" = (
@@ -59181,28 +59302,27 @@
 /area/maintenance/fore)
 "tga" = (
 /obj/machinery/door/airlock{
-	name = "Theatre Backstage";
+	name = "Performer's Office";
 	req_access_txt = "46"
 	},
-/obj/effect/turf_decal/lumos/tile/red/checker,
-/obj/effect/turf_decal/lumos/tile/blue/checker{
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/white/side{
+	dir = 8
+	},
 /area/crew_quarters/theatre)
 "tgH" = (
 /obj/structure/filingcabinet/employment,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "tif" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
+/obj/machinery/firealarm{
+	pixel_y = 24
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
 "tjo" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -59476,6 +59596,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
+"tHf" = (
+/obj/effect/spawner/structure/window,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "clownmimedress";
+	name = "Changing Room Shutters"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/theatre)
 "tIF" = (
 /obj/structure/lattice,
 /obj/machinery/camera{
@@ -59650,6 +59778,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
+"udW" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/corner{
+	dir = 4
+	},
+/area/ai_monitored/storage/eva)
 "uei" = (
 /obj/machinery/door/airlock/external{
 	req_access_txt = "13"
@@ -60065,8 +60207,8 @@
 /turf/closed/wall/r_wall,
 /area/engine/gravity_generator)
 "uRS" = (
-/obj/structure/chair/stool{
-	pixel_y = 8
+/obj/structure/chair/comfy/brown{
+	dir = 1
 	},
 /turf/open/floor/carpet{
 	icon_state = "carpetsymbol"
@@ -60337,10 +60479,7 @@
 /obj/machinery/computer/secure_data{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
+/obj/effect/turf_decal/lumos/tile/blue/checker,
 /turf/open/floor/plasteel/dark,
 /area/blueshield)
 "voW" = (
@@ -60496,6 +60635,12 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"vyH" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "vzp" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
@@ -60894,6 +61039,15 @@
 /obj/effect/turf_decal/trimline/green/filled/line,
 /turf/open/floor/plasteel,
 /area/security/prison)
+"wgq" = (
+/obj/machinery/newscaster{
+	pixel_y = 32
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "wgv" = (
 /obj/structure/chair{
 	dir = 1
@@ -61387,16 +61541,18 @@
 	dir = 4;
 	pixel_x = -22
 	},
-/obj/structure/closet/crate/wooden/toy,
-/obj/structure/sign/poster/contraband/clown{
-	pixel_y = -32
+/obj/structure/table/wood,
+/obj/item/lipstick/random{
+	pixel_x = -2;
+	pixel_y = -2
 	},
-/obj/item/megaphone/clown,
-/obj/effect/turf_decal/lumos/tile/blue/checker{
+/obj/item/lipstick/random{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/turf/open/floor/plasteel/median/whitetodark{
 	dir = 4
 	},
-/obj/effect/turf_decal/lumos/tile/red/checker,
-/turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
 "xez" = (
 /obj/machinery/camera{
@@ -61532,9 +61688,11 @@
 /area/crew_quarters/fitness)
 "xku" = (
 /obj/machinery/vending/autodrobe,
-/turf/open/floor/plasteel/white/side{
+/obj/effect/turf_decal/lumos/tile/red/checker,
+/obj/effect/turf_decal/lumos/tile/blue/checker{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
 "xkD" = (
 /obj/machinery/camera{
@@ -61567,10 +61725,8 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3,
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
 "xmS" = (
@@ -61815,8 +61971,9 @@
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
 "xQG" = (
-/obj/structure/sign/warning/docking,
-/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "xTy" = (
@@ -61941,8 +62098,8 @@
 	id = "LockerShitter2";
 	name = "Door Bolt Control";
 	normaldoorcontrol = 1;
-	pixel_x = 14;
-	pixel_y = 38;
+	pixel_x = 9;
+	pixel_y = -22;
 	specialfunctions = 4
 	},
 /obj/machinery/light/small{
@@ -61951,6 +62108,7 @@
 /obj/structure/sink{
 	pixel_y = 28
 	},
+/obj/effect/landmark/blobstart,
 /turf/open/floor/mineral/titanium/blue,
 /area/crew_quarters/toilet/locker)
 "ycu" = (
@@ -61988,8 +62146,14 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/structure/dresser,
-/turf/open/floor/plasteel/white/side{
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/snacks/baguette,
+/obj/item/toy/dummy,
+/obj/item/lipstick/random{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/turf/open/floor/plasteel/median/whitetodark{
 	dir = 4
 	},
 /area/crew_quarters/theatre)
@@ -70863,7 +71027,7 @@ apJ
 apJ
 apJ
 apJ
-auO
+xQG
 auP
 cwT
 aAC
@@ -70886,11 +71050,11 @@ aaa
 aaa
 aaa
 aaa
-awW
+arB
 awW
 ayl
 awW
-xQG
+aAC
 kls
 aaa
 aaa
@@ -74707,7 +74871,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+gXs
 aMW
 aaf
 aaf
@@ -74966,7 +75130,7 @@ aaa
 aae
 gXs
 gXs
-aaa
+gXs
 aag
 alU
 alU
@@ -78335,7 +78499,7 @@ aQM
 aQM
 aTv
 aUT
-aPz
+fEk
 aXQ
 aXQ
 aXQ
@@ -79102,11 +79266,11 @@ aLE
 aNm
 aOl
 aPA
-aQN
-aQN
+dNm
 aQN
 aQN
 aXt
+pXv
 aXQ
 aYe
 bbq
@@ -79359,7 +79523,7 @@ aLk
 aNo
 aOo
 aPA
-aQN
+jpj
 jGW
 aQN
 jGW
@@ -80128,9 +80292,9 @@ aIW
 aBQ
 jGq
 aLE
-aOl
+ltj
 aPC
-aQN
+cZe
 aQN
 aXt
 aXt
@@ -80642,7 +80806,7 @@ aIY
 gCC
 aLE
 aLE
-aOl
+dvB
 aPA
 pqs
 aQN
@@ -81668,9 +81832,9 @@ aBR
 aBR
 aBR
 aBR
-wVV
-aLE
-aOl
+pNr
+aLF
+flh
 aPA
 vJu
 kqI
@@ -81915,7 +82079,7 @@ aae
 aaH
 aqQ
 axo
-arP
+aCr
 fgG
 rqW
 aGD
@@ -81924,9 +82088,9 @@ sax
 ygf
 qTG
 xec
-aCr
-aLF
-aLF
+tHf
+aLE
+aLE
 aOs
 aPG
 aPG
@@ -82172,15 +82336,15 @@ aqQ
 aqQ
 arP
 axo
-arP
+aCr
 rPU
 fne
-aGr
+fOA
 aHI
 fOA
 sks
 nGB
-kCo
+piK
 tga
 aLE
 bDe
@@ -82429,16 +82593,16 @@ aGh
 aqR
 avW
 axo
-arP
+aCr
 aCh
 pIf
 kCo
 aCr
 xku
 ret
-kCo
+pFu
 qcs
-aCr
+tHf
 rOV
 aLE
 gxc
@@ -82686,7 +82850,7 @@ arP
 arP
 arP
 axp
-arP
+aCr
 aCr
 eEe
 aCr
@@ -83200,10 +83364,10 @@ kXd
 ecD
 arP
 xxi
-arP
+aCr
 viF
 rjQ
-aBU
+xZD
 hcb
 uRS
 blV
@@ -83457,7 +83621,7 @@ aqR
 aqR
 xhn
 xxi
-arP
+aCr
 viF
 aMr
 xZD
@@ -83714,7 +83878,7 @@ usK
 tQi
 arP
 xxi
-arP
+aCr
 viF
 bMa
 xZD
@@ -83971,7 +84135,7 @@ arP
 arP
 arP
 xxi
-arP
+aCr
 viF
 viF
 xPY
@@ -85808,7 +85972,7 @@ cBq
 uQS
 wag
 bwd
-bxD
+nKt
 byK
 cBv
 byO
@@ -87570,7 +87734,7 @@ aph
 awg
 ayL
 ayN
-azE
+udW
 aAW
 azW
 aDB
@@ -88087,7 +88251,7 @@ ayP
 azU
 aBo
 aCg
-axT
+ayU
 aEX
 ayU
 aAc
@@ -88341,10 +88505,10 @@ aph
 awg
 ayL
 ayv
-azE
+hpD
 ayq
 aCb
-aDD
+cEC
 aCi
 aEZ
 aHC
@@ -88598,7 +88762,7 @@ aph
 awg
 ayL
 ayQ
-azE
+gZE
 aBq
 azW
 aDE
@@ -88891,7 +89055,7 @@ bqz
 bqq
 btC
 buN
-bwj
+brS
 bmr
 byP
 aJq
@@ -89076,7 +89240,7 @@ aMv
 aPj
 aTx
 aLS
-aat
+ams
 aaJ
 bbN
 aaJ
@@ -89333,7 +89497,7 @@ aPw
 aPw
 aai
 aUP
-aat
+axT
 aat
 acd
 aat
@@ -89589,8 +89753,8 @@ aJN
 acd
 acd
 aai
-ams
-aat
+aLJ
+azh
 aaJ
 bbN
 aaJ
@@ -90177,7 +90341,7 @@ bsb
 yhz
 ouQ
 cQT
-nbT
+kxg
 byS
 aJq
 bBi
@@ -91719,7 +91883,7 @@ fxV
 vOU
 xBk
 fTC
-nbT
+drE
 bwh
 aJq
 bBu
@@ -93519,7 +93683,7 @@ btJ
 buV
 bws
 bqH
-ftE
+gIC
 aJq
 byW
 bCv
@@ -94257,7 +94421,7 @@ awr
 dtx
 aGx
 aMo
-aGl
+aGx
 aAh
 aBy
 aAh
@@ -94290,7 +94454,7 @@ btN
 buZ
 fUj
 bqH
-byN
+wgq
 iTU
 bBA
 bCz
@@ -96834,7 +96998,7 @@ aKR
 aKR
 aKR
 sLj
-sLj
+aKR
 aKR
 aYy
 aKR
@@ -97346,9 +97510,9 @@ aOZ
 aJC
 aKN
 aKR
-aKR
+aNF
 aOJ
-oIJ
+hSZ
 unA
 aZa
 bdq
@@ -97604,8 +97768,8 @@ aJC
 aKM
 aKR
 aKR
+aSq
 aKR
-tif
 aYv
 eTo
 aKR
@@ -98358,8 +98522,8 @@ ujS
 aqs
 coh
 awa
-coh
-coh
+aBU
+bwj
 coh
 pPi
 coh
@@ -98614,9 +98778,9 @@ eVJ
 wHk
 qeA
 fHG
-azh
 fHG
-fHG
+aGl
+oIJ
 fHG
 axh
 fHG
@@ -99144,7 +99308,7 @@ aGL
 aJC
 aJm
 aKz
-aKR
+vyH
 aND
 aJC
 aab
@@ -101700,7 +101864,7 @@ aaf
 xhY
 xhY
 arj
-fHG
+tif
 fHG
 fHG
 fHG

--- a/_maps/map_files/BoxStation/BoxStation_Lumos.dmm
+++ b/_maps/map_files/BoxStation/BoxStation_Lumos.dmm
@@ -15,10 +15,9 @@
 	dir = 8
 	},
 /obj/structure/table,
-/obj/machinery/chem_dispenser/drinks{
-	dir = 8
-	},
 /obj/effect/turf_decal/lumos/tile/bar/checker,
+/obj/item/book/manual/wiki/barman_recipes,
+/obj/item/reagent_containers/rag,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "aad" = (
@@ -8289,13 +8288,9 @@
 /area/security/prison)
 "asZ" = (
 /obj/structure/closet/wardrobe/white,
-/obj/item/clothing/under/suit/waiter,
-/obj/item/clothing/under/suit/waiter,
-/obj/item/clothing/under/suit/waiter,
 /obj/structure/sign/poster/contraband/lizard{
 	pixel_x = -32
 	},
-/obj/item/clothing/suit/straight_jacket,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "ata" = (
@@ -8575,10 +8570,10 @@
 /obj/structure/closet/wardrobe/mixed,
 /obj/item/clothing/under/costume/kilt,
 /obj/item/clothing/under/costume/kilt,
-/obj/item/clothing/under/dress/skirt/purple,
 /obj/item/clothing/head/beret,
 /obj/item/clothing/head/beret,
 /obj/item/clothing/head/beret,
+/obj/item/clothing/under/dress/sundress,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "aub" = (
@@ -9558,10 +9553,6 @@
 /obj/item/clothing/under/trek/medsci/next,
 /obj/item/clothing/under/trek/medsci/next,
 /obj/item/clothing/under/trek/medsci/next,
-/obj/item/clothing/under/misc/blue_camo,
-/obj/item/clothing/under/misc/blue_camo,
-/obj/item/clothing/under/costume/gladiator,
-/obj/item/clothing/under/costume/gladiator,
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = -24
@@ -18103,7 +18094,6 @@
 /obj/structure/sink/kitchen{
 	pixel_y = 28
 	},
-/obj/machinery/food_cart,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "aRD" = (
@@ -19046,14 +19036,12 @@
 	},
 /area/crew_quarters/dorms)
 "aUh" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/eastleft{
-	name = "Hydroponics Desk";
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass{
+	name = "Hydroponics";
 	req_access_txt = "35"
 	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/crew_quarters/kitchen)
 "aUj" = (
 /obj/machinery/vending/hydronutrients,
@@ -19619,6 +19607,10 @@
 	name = "Food Orders";
 	pixel_y = 26
 	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "kitchen";
+	name = "kitchen shutters"
+	},
 /turf/open/floor/plating,
 /area/crew_quarters/kitchen)
 "aVB" = (
@@ -19689,9 +19681,10 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aVH" = (
-/obj/machinery/biogenerator,
 /obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/dark,
+/obj/machinery/biogenerator,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
 "aVI" = (
 /obj/effect/turf_decal/lumos/tile/green/half{
@@ -20333,8 +20326,6 @@
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_x = 32
 	},
-/obj/item/book/manual/wiki/barman_recipes,
-/obj/item/reagent_containers/rag,
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/lumos/tile/bar/checker,
 /turf/open/floor/plasteel,
@@ -25295,6 +25286,9 @@
 /obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 4
 	},
+/obj/structure/chair{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
 "blm" = (
@@ -25959,6 +25953,7 @@
 /area/quartermaster/office)
 "bmS" = (
 /obj/structure/table,
+/obj/item/reagent_containers/food/snacks/mint,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "bmX" = (
@@ -26410,6 +26405,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/lumos/tile/red/fulltile,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
 "bol" = (
@@ -26903,6 +26899,9 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 1
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/front_office)
 "bpw" = (
@@ -26914,6 +26913,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/front_office)
 "bpy" = (
@@ -29119,6 +29121,7 @@
 	name = "Security Office";
 	req_access_txt = "63"
 	},
+/obj/effect/turf_decal/lumos/tile/red/fulltile,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
 "bvl" = (
@@ -29680,10 +29683,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
-	},
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -30258,9 +30261,6 @@
 	pixel_x = -6;
 	pixel_y = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 1
-	},
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
@@ -30303,9 +30303,6 @@
 /obj/item/pen/red{
 	pixel_x = 2;
 	pixel_y = 3
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1
 	},
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /obj/item/pen{
@@ -30941,6 +30938,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/holopad,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "bzR" = (
@@ -30955,11 +30955,14 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 6
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
@@ -35803,9 +35806,11 @@
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
 "bLS" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plating,
-/area/maintenance/aft)
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/courtroom)
 "bLU" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
@@ -41564,7 +41569,6 @@
 	name = "Research Delivery access";
 	req_access_txt = "12"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cbw" = (
@@ -41718,7 +41722,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "cbR" = (
@@ -44157,9 +44161,18 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "ciG" = (
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/turf/open/floor/plating,
-/area/maintenance/aft)
+/obj/effect/turf_decal/lumos/tile/bar/checker,
+/obj/structure/table,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/machinery/chem_dispenser/drinks/beer{
+	dir = 8;
+	pixel_y = 4
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "ciH" = (
 /obj/structure/rack,
 /obj/item/latexballon,
@@ -44695,7 +44708,7 @@
 	name = "Biohazard Disposals";
 	req_access_txt = "12"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "ckn" = (
@@ -44999,38 +45012,38 @@
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "clk" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer3{
 	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "cll" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/components/binary/pump{
+/obj/machinery/atmospherics/components/binary/pump/layer3{
 	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "clm" = (
 /obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/manifold/general/hidden{
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/general/hidden/layer3{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "cln" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 9
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "clo" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 1
 	},
-/obj/machinery/meter,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "clp" = (
@@ -45175,8 +45188,6 @@
 /area/engine/engineering)
 "clO" = (
 /obj/structure/closet/wardrobe/grey,
-/obj/item/clothing/under/misc/assistantformal,
-/obj/item/clothing/under/misc/assistantformal,
 /obj/machinery/camera{
 	c_tag = "Dorms East - Holodeck";
 	dir = 4
@@ -45259,10 +45270,10 @@
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "cmg" = (
-/obj/machinery/atmospherics/pipe/simple/general/hidden{
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/general/hidden/layer3{
 	dir = 9
 	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "cmh" = (
@@ -45275,7 +45286,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "cmj" = (
@@ -45663,11 +45674,11 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "cnF" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	name = "Waste Out"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/atmospherics/components/binary/pump/on/layer3{
+	name = "Waste Out"
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
@@ -45886,8 +45897,8 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "cot" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "cou" = (
@@ -46676,7 +46687,7 @@
 /area/engine/engineering)
 "csc" = (
 /obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/space,
 /area/maintenance/aft)
 "csg" = (
@@ -46721,7 +46732,7 @@
 /turf/open/space,
 /area/space/nearstation)
 "csm" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer3{
 	dir = 1
 	},
 /turf/open/floor/plating/airless,
@@ -53007,6 +53018,9 @@
 	pixel_y = 24;
 	req_access_txt = "5"
 	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/front_office)
 "hiG" = (
@@ -54276,12 +54290,8 @@
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "jAN" = (
-/obj/effect/turf_decal/lumos/tile/bar/checker,
-/obj/machinery/door/airlock/public/glass{
-	name = "Kitchen";
-	req_access_txt = "28"
-	},
-/turf/open/floor/plasteel,
+/obj/machinery/food_cart,
+/turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "jBi" = (
 /obj/machinery/door/firedoor,
@@ -56065,15 +56075,11 @@
 "mTG" = (
 /obj/effect/turf_decal/lumos/tile/bar/checker,
 /obj/structure/table,
-/obj/machinery/chem_dispenser/drinks/beer{
-	dir = 8
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/machinery/light{
 	dir = 4
+	},
+/obj/machinery/chem_dispenser/drinks{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
@@ -57234,12 +57240,6 @@
 /area/hallway/secondary/exit)
 "oZl" = (
 /obj/structure/closet/wardrobe/pjs,
-/obj/item/clothing/under/costume/maid,
-/obj/item/clothing/under/costume/maid,
-/obj/item/clothing/under/rank/civilian/janitor/maid,
-/obj/item/clothing/under/rank/civilian/janitor/maid,
-/obj/item/clothing/accessory/maidapron,
-/obj/item/clothing/accessory/maidapron,
 /obj/machinery/light{
 	dir = 8
 	},
@@ -57256,6 +57256,10 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/grass,
 /area/medical/virology)
+"pan" = (
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "pek" = (
 /obj/machinery/door/airlock/external{
 	name = "Labor Camp Shuttle Airlock"
@@ -57932,15 +57936,9 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "qus" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "kitchen";
-	name = "kitchen shutters"
-	},
-/obj/item/reagent_containers/food/snacks/mint,
-/turf/open/floor/plating,
-/area/crew_quarters/kitchen)
+/obj/effect/turf_decal/trimline/red/filled/corner,
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "quT" = (
 /obj/structure/lattice,
 /obj/structure/grille/broken,
@@ -58364,7 +58362,8 @@
 /obj/item/clothing/head/beret/black,
 /obj/item/clothing/under/custom/trendy_fit,
 /obj/item/clothing/under/custom/trendy_fit,
-/obj/item/clothing/under/dress/sundress,
+/obj/item/clothing/under/misc/assistantformal,
+/obj/item/clothing/under/misc/assistantformal,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "rtl" = (
@@ -60218,6 +60217,12 @@
 /obj/machinery/pool/drain,
 /turf/open/pool,
 /area/crew_quarters/fitness/pool)
+"uTE" = (
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "uUd" = (
 /obj/structure/lattice,
 /obj/structure/window/reinforced,
@@ -61904,6 +61909,9 @@
 	pixel_x = 28
 	},
 /obj/effect/turf_decal/lumos/tile/red/fullcorner,
+/obj/structure/chair{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
 "xIa" = (
@@ -95943,7 +95951,7 @@ ajn
 trb
 ajn
 amr
-ajp
+bLS
 ajp
 ajp
 ajp
@@ -98294,7 +98302,7 @@ aTB
 aJC
 bcr
 aYV
-aYV
+qus
 svE
 cgq
 ipA
@@ -98551,7 +98559,7 @@ bah
 aJC
 aYV
 aYV
-aYV
+pan
 bvk
 wVk
 blm
@@ -98808,7 +98816,7 @@ bag
 aJC
 cHf
 aYV
-aYV
+uTE
 svE
 sfa
 hDN
@@ -99312,7 +99320,7 @@ vyH
 aND
 aJC
 aab
-aRz
+ciG
 mTG
 aac
 aRz
@@ -99569,7 +99577,7 @@ aKR
 aJC
 aJC
 aJI
-jAN
+aJI
 aJI
 aJI
 aVA
@@ -99827,7 +99835,7 @@ aWd
 aOP
 aJI
 aRA
-aVz
+jAN
 aVz
 aVz
 bqD
@@ -101117,7 +101125,7 @@ cCq
 cCq
 aVz
 aSN
-qus
+bak
 bbz
 aYV
 aYV
@@ -102453,8 +102461,8 @@ bKR
 cfp
 bKR
 bKR
-ciG
-bLS
+bKR
+bKR
 ckm
 cln
 cmh

--- a/_maps/map_files/BoxStation/BoxStation_Lumos.dmm
+++ b/_maps/map_files/BoxStation/BoxStation_Lumos.dmm
@@ -922,9 +922,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4
-	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
 "acA" = (
@@ -937,9 +934,7 @@
 "acB" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
-	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
 "acE" = (
@@ -2124,15 +2119,20 @@
 /area/ai_monitored/security/armory)
 "aeX" = (
 /obj/effect/turf_decal/lumos/tile/neutral/fulltile,
+/obj/structure/window/reinforced{
+	dir = 4;
+	layer = 2.9
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "aeY" = (
 /obj/vehicle/ridden/secway,
 /obj/item/key/security,
-/obj/effect/turf_decal/lumos/tile/blue/half{
-	dir = 1
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/lumos/tile/blue/fullcorner{
+	dir = 4
 	},
-/obj/effect/turf_decal/lumos/tile/neutral/half,
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "aeZ" = (
@@ -2143,6 +2143,7 @@
 /obj/machinery/airalarm{
 	pixel_y = 23
 	},
+/obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 1
 	},
@@ -2169,10 +2170,11 @@
 /area/ai_monitored/security/armory)
 "afc" = (
 /obj/structure/closet/secure_closet/contraband/armory,
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/lumos/tile/blue/fullcorner{
 	dir = 8
 	},
-/obj/effect/turf_decal/lumos/tile/blue/fullcorner{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -2417,27 +2419,17 @@
 /obj/item/reagent_containers/syringe{
 	name = "steel point"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
 /obj/machinery/airalarm{
 	dir = 4;
 	pixel_x = -22
 	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "afI" = (
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/brig)
 "afJ" = (
@@ -2456,16 +2448,6 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "afL" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
 /obj/effect/turf_decal/bot,
 /obj/machinery/firealarm{
 	dir = 8;
@@ -2475,6 +2457,7 @@
 /obj/item/reagent_containers/blood,
 /obj/item/reagent_containers/spray/cleaner,
 /obj/item/storage/box/bodybags,
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "afM" = (
@@ -2969,6 +2952,7 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/effect/turf_decal/lumos/tile/red/fulltile,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "agP" = (
@@ -3047,17 +3031,8 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
 /obj/item/reagent_containers/blood,
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "agZ" = (
@@ -3255,20 +3230,11 @@
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "ahu" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
 /obj/effect/turf_decal/bot,
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
 /obj/machinery/iv_drip,
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "ahv" = (
@@ -3484,22 +3450,13 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "ahS" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/bot,
 /obj/machinery/camera{
 	c_tag = "Brig Infirmary";
 	dir = 4
 	},
 /obj/structure/closet/secure_closet/brig_phys,
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "ahU" = (
@@ -3614,28 +3571,17 @@
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "aid" = (
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/brig)
 "aie" = (
 /obj/structure/bed,
 /obj/machinery/iv_drip,
 /obj/item/bedsheet/medical,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "aig" = (
@@ -3973,17 +3919,8 @@
 /area/security/brig)
 "aiI" = (
 /obj/structure/bodycontainer/morgue,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "aiJ" = (
@@ -4006,12 +3943,11 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/brig)
 "aiM" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
+	},
+/obj/effect/turf_decal/lumos/tile/red/half{
+	dir = 4
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/brig)
@@ -4030,17 +3966,8 @@
 /obj/structure/mirror{
 	pixel_x = 28
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
 /obj/effect/turf_decal/box,
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "aiQ" = (
@@ -5629,13 +5556,10 @@
 /turf/open/floor/plating,
 /area/security/courtroom)
 "ams" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -6562,8 +6486,7 @@
 /area/hallway/primary/fore)
 "aoC" = (
 /obj/effect/turf_decal/tile/red,
-/obj/item/storage/box/drinkingglasses,
-/obj/structure/table,
+/obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aoD" = (
@@ -6576,7 +6499,9 @@
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/tile/red,
-/obj/structure/reagent_dispensers/water_cooler,
+/obj/structure/chair{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aoE" = (
@@ -8275,7 +8200,7 @@
 /obj/structure/table/wood,
 /mob/living/simple_animal/pet/fox/Renault,
 /obj/item/book/manual/wiki/security_space_law,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/captain)
 "asE" = (
 /turf/closed/wall,
@@ -8286,35 +8211,22 @@
 /area/construction/mining/aux_base)
 "asH" = (
 /obj/structure/closet/toolcloset,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/fullcorner{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
 "asI" = (
 /obj/structure/closet/toolcloset,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
 "asJ" = (
 /obj/structure/reagent_dispensers/fueltank,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
+/obj/effect/turf_decal/lumos/tile/yellow/fullcorner{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
@@ -8346,7 +8258,7 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "asQ" = (
-/obj/structure/closet/emcloset,
+/obj/machinery/vending/kink,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "asR" = (
@@ -8419,8 +8331,7 @@
 	amount = 10
 	},
 /obj/item/stack/rods/fifty,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -8600,10 +8511,7 @@
 /turf/open/floor/circuit,
 /area/maintenance/department/electrical)
 "atI" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -8698,21 +8606,14 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "aub" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/lumos/tile/yellow/half,
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
 "auc" = (
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/fullcorner{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
@@ -9364,8 +9265,7 @@
 /obj/machinery/computer/camera_advanced/base_construction{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -9657,11 +9557,11 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "awy" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
+/obj/machinery/pool/filter{
+	pixel_y = 24
 	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
+/turf/open/pool,
+/area/crew_quarters/fitness/pool)
 "awz" = (
 /obj/item/radio/intercom{
 	pixel_y = 25
@@ -9672,9 +9572,6 @@
 /obj/machinery/holopad,
 /obj/machinery/camera{
 	c_tag = "Dorms Central"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -5;
@@ -9950,8 +9847,7 @@
 	dir = 8;
 	pixel_x = 30
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -10217,23 +10113,20 @@
 	},
 /area/hallway/secondary/entry)
 "axH" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 5
 	},
+/obj/effect/turf_decal/lumos/tile/yellow/half{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "axI" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
+/obj/effect/turf_decal/lumos/tile/yellow/half{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -10368,6 +10261,12 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
@@ -10879,13 +10778,13 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -11150,7 +11049,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/maintenance/fore)
 "azR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -12376,8 +12275,7 @@
 /obj/item/stack/sheet/metal/fifty,
 /obj/item/stack/sheet/metal/fifty,
 /obj/item/stack/sheet/glass/fifty,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -12427,9 +12325,9 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
 "aDa" = (
-/obj/machinery/vending/cola/random,
+/obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
+/area/hallway/primary/fore)
 "aDb" = (
 /obj/structure/table,
 /obj/item/wirecutters,
@@ -12878,20 +12776,20 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "aEa" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
@@ -13155,6 +13053,12 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -13445,9 +13349,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "aFm" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aFn" = (
@@ -13471,26 +13373,18 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "aFr" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aFs" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/structure/falsewall,
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/maintenance/fore)
 "aFt" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -13501,14 +13395,12 @@
 /turf/closed/wall,
 /area/library)
 "aFv" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/door/airlock/maintenance{
+	name = "Library Maintenance";
+	req_access_txt = "12"
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aFw" = (
@@ -14012,14 +13904,10 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aGG" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Library Maintenance";
-	req_access_txt = "12"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/turf/open/floor/wood,
+/area/library)
 "aGH" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -14248,14 +14136,23 @@
 /area/hallway/secondary/entry)
 "aHb" = (
 /obj/structure/table/wood,
-/obj/item/paper_bin{
-	pixel_x = 1;
-	pixel_y = 9
+/obj/item/stack/packageWrap{
+	pixel_y = 4
 	},
 /obj/item/stack/packageWrap,
-/obj/item/pen/fourcolor,
-/obj/machinery/newscaster{
-	pixel_y = 32
+/obj/machinery/button/door{
+	id = "PrivateStudy1";
+	name = "Privacy Shutters";
+	pixel_x = 5;
+	pixel_y = 24
+	},
+/obj/machinery/button/door{
+	desc = "Bolts the doors to the Private Study.";
+	id = "PrivateStudy";
+	name = "Private Study Lock";
+	pixel_x = -5;
+	pixel_y = 24;
+	req_access_txt = "37"
 	},
 /turf/open/floor/wood,
 /area/library)
@@ -14764,33 +14661,24 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "aIr" = (
-/obj/machinery/button/door{
-	desc = "Bolts the doors to the Private Study.";
-	id = "PrivateStudy";
-	name = "Private Study Lock";
-	pixel_x = -5;
-	pixel_y = 24;
-	req_access_txt = "37"
-	},
-/obj/machinery/button/door{
-	id = "PrivateStudy1";
-	name = "Privacy Shutters";
-	pixel_x = 5;
-	pixel_y = 24
-	},
+/obj/machinery/photocopier,
 /turf/open/floor/wood,
 /area/library)
 "aIs" = (
-/obj/machinery/camera{
-	c_tag = "Library North"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
-/obj/structure/chair/sofa/right,
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#c1caff"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
-/turf/open/floor/wood,
-/area/library)
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/dorms)
 "aIt" = (
 /turf/open/floor/wood,
 /area/library)
@@ -14810,10 +14698,6 @@
 	dir = 6
 	},
 /obj/effect/landmark/start/assistant,
-/obj/structure/chair/sofa/left,
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
 /turf/open/floor/wood,
 /area/library)
 "aIx" = (
@@ -14882,13 +14766,7 @@
 	pixel_x = 24;
 	req_one_access_txt = "32;47;48"
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/yellow/fullcorner,
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
 "aII" = (
@@ -15299,6 +15177,7 @@
 /obj/machinery/newscaster{
 	pixel_x = 30
 	},
+/obj/structure/chair/sofa/left,
 /turf/open/floor/wood,
 /area/library)
 "aJG" = (
@@ -15384,9 +15263,6 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aJP" = (
-/obj/structure/table/wood,
-/obj/item/folder/yellow,
-/obj/item/pen/blue,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
@@ -15396,10 +15272,6 @@
 /turf/open/floor/wood,
 /area/library)
 "aJQ" = (
-/obj/structure/chair/comfy/brown{
-	dir = 4
-	},
-/obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
 	},
@@ -15409,15 +15281,11 @@
 /turf/open/floor/wood,
 /area/library)
 "aJR" = (
-/obj/structure/chair/comfy/brown{
-	dir = 8
-	},
+/obj/structure/chair/sofa/right,
 /turf/open/floor/wood,
 /area/library)
 "aJS" = (
-/obj/structure/table/wood,
 /obj/structure/disposalpipe/segment,
-/obj/item/paicard,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
 	},
@@ -15468,17 +15336,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"aJY" = (
-/obj/structure/table/reinforced,
-/obj/item/integrated_electronics/analyzer,
-/obj/item/integrated_electronics/debugger,
-/obj/item/integrated_electronics/wirer,
-/obj/item/integrated_electronics/detailer,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/science/circuit)
 "aJZ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -15979,6 +15836,7 @@
 	dir = 4;
 	pixel_x = -22
 	},
+/obj/structure/displaycase/trophy,
 /turf/open/floor/wood,
 /area/library)
 "aLg" = (
@@ -16008,14 +15866,20 @@
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "aLm" = (
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/port)
+/area/crew_quarters/dorms)
 "aLn" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -16039,9 +15903,6 @@
 "aLp" = (
 /obj/structure/cable{
 	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
@@ -16080,6 +15941,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/lumos/tile/yellow/fulltile,
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
 "aLv" = (
@@ -16228,8 +16090,8 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 5
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -17018,7 +16880,9 @@
 /turf/open/floor/carpet,
 /area/hallway/secondary/entry)
 "aNS" = (
-/obj/machinery/bookbinder,
+/obj/structure/chair/comfy/brown{
+	dir = 1
+	},
 /turf/open/floor/wood,
 /area/library)
 "aNT" = (
@@ -17046,9 +16910,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "aNV" = (
-/obj/machinery/photocopier,
-/turf/open/floor/wood,
-/area/library)
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "aNW" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Chapel Office";
@@ -17390,7 +17256,7 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/crew_quarters/toilet)
 "aOV" = (
-/obj/machinery/vending/cigarette,
+/obj/machinery/vending/cola/random,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "aOW" = (
@@ -17438,7 +17304,9 @@
 /turf/open/floor/wood,
 /area/library)
 "aPf" = (
-/obj/machinery/computer/libraryconsole,
+/obj/machinery/computer/libraryconsole{
+	pixel_y = 8
+	},
 /obj/structure/table/wood,
 /turf/open/floor/wood,
 /area/library)
@@ -17808,6 +17676,7 @@
 /area/library)
 "aQr" = (
 /obj/structure/table/wood/fancy,
+/obj/item/book/codex_gigas,
 /obj/item/storage/fancy/candle_box,
 /turf/open/floor/carpet,
 /area/library)
@@ -18294,6 +18163,7 @@
 	},
 /obj/structure/table,
 /obj/machinery/microwave{
+	pixel_x = -1;
 	pixel_y = 6
 	},
 /turf/open/floor/plasteel/cafeteria,
@@ -18779,10 +18649,7 @@
 /turf/open/floor/plasteel/dark,
 /area/hydroponics)
 "aST" = (
-/obj/structure/table,
-/obj/machinery/smartfridge/disks{
-	pixel_y = 2
-	},
+/obj/machinery/seed_extractor,
 /turf/open/floor/plasteel/dark,
 /area/hydroponics)
 "aSW" = (
@@ -18853,7 +18720,9 @@
 /area/library)
 "aTd" = (
 /obj/structure/table/wood,
-/obj/machinery/computer/libraryconsole/bookmanagement,
+/obj/machinery/computer/libraryconsole/bookmanagement{
+	pixel_y = 8
+	},
 /obj/machinery/light_switch{
 	pixel_x = 2;
 	pixel_y = 26
@@ -19397,9 +19266,6 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aUQ" = (
@@ -19444,9 +19310,6 @@
 /obj/machinery/light{
 	dir = 1;
 	light_color = "#cee5d2"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
@@ -20030,11 +19893,9 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
 "aWj" = (
-/obj/structure/grille,
-/obj/structure/window{
-	dir = 8
+/obj/effect/spawner/structure/window/hollow/directional{
+	dir = 10
 	},
-/obj/structure/window,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "aWk" = (
@@ -20045,8 +19906,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "aWl" = (
-/obj/structure/grille,
-/obj/structure/window{
+/obj/effect/spawner/structure/window/hollow/directional{
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -21592,7 +21452,7 @@
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_y = 32
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/captain)
 "bap" = (
 /obj/machinery/door/firedoor,
@@ -21606,7 +21466,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/captain)
 "bar" = (
 /obj/item/kirbyplants/random,
@@ -21649,7 +21509,7 @@
 /area/library)
 "bay" = (
 /obj/structure/chair/comfy/black,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/blue,
 /area/bridge/meeting_room)
 "baA" = (
 /turf/open/floor/carpet{
@@ -21733,13 +21593,13 @@
 /obj/item/coin/plasma{
 	pixel_y = -14
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/captain)
 "baQ" = (
 /obj/structure/chair/comfy/brown{
 	dir = 4
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/captain)
 "baS" = (
 /turf/open/floor/plasteel,
@@ -21765,9 +21625,6 @@
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
 "baW" = (
-/obj/item/storage/secure/safe{
-	pixel_x = -23
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/disposalpipe/segment,
@@ -21785,7 +21642,6 @@
 	layer = 4;
 	pixel_y = 32
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bba" = (
@@ -21971,7 +21827,7 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/captain)
 "bbw" = (
 /turf/open/floor/wood,
@@ -22050,7 +21906,7 @@
 "bbM" = (
 /obj/structure/table/wood,
 /obj/item/storage/fancy/donut_box,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/blue,
 /area/bridge/meeting_room)
 "bbN" = (
 /obj/structure/table/reinforced,
@@ -22147,7 +22003,7 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "bca" = (
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/blue,
 /area/bridge/meeting_room)
 "bcb" = (
 /obj/structure/disposalpipe/segment{
@@ -22212,10 +22068,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bcl" = (
@@ -22229,7 +22087,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/captain)
 "bcn" = (
 /obj/structure/displaycase/captain,
@@ -22404,7 +22262,7 @@
 /obj/item/folder/blue,
 /obj/structure/table/wood,
 /obj/item/hand_labeler,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/blue,
 /area/bridge/meeting_room)
 "bcO" = (
 /obj/machinery/flasher{
@@ -22502,13 +22360,13 @@
 	name = "Station Intercom (Command)"
 	},
 /obj/item/phone,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/blue,
 /area/bridge/meeting_room)
 "bda" = (
 /obj/structure/chair/comfy/black{
 	dir = 4
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/blue,
 /area/bridge/meeting_room)
 "bdb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -22545,16 +22403,7 @@
 /area/ai_monitored/turret_protected/ai_upload)
 "bdh" = (
 /obj/effect/turf_decal/bot_white,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "bdi" = (
@@ -22605,9 +22454,6 @@
 "bdm" = (
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
@@ -22789,7 +22635,7 @@
 /area/maintenance/port)
 "bdK" = (
 /obj/machinery/holopad,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/blue,
 /area/bridge/meeting_room)
 "bdL" = (
 /obj/machinery/light,
@@ -22902,7 +22748,7 @@
 	},
 /obj/item/pen,
 /obj/structure/table/wood,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/blue,
 /area/bridge/meeting_room)
 "bea" = (
 /obj/structure/disposalpipe/segment,
@@ -23015,7 +22861,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/captain)
 "ben" = (
 /obj/structure/table/wood,
@@ -24153,10 +23999,10 @@
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
 "bhx" = (
-/obj/structure/table,
-/obj/machinery/plantgenes{
-	pixel_y = 6
+/obj/structure/disposalpipe/trunk{
+	dir = 4
 	},
+/obj/machinery/disposal/bin,
 /turf/open/floor/plasteel/dark,
 /area/hydroponics)
 "bhy" = (
@@ -25150,7 +24996,8 @@
 	pixel_y = 10;
 	req_access_txt = "3"
 	},
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/plasteel,
 /area/security/prison)
 "bkn" = (
 /obj/machinery/light{
@@ -25435,7 +25282,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/captain)
 "bld" = (
 /obj/machinery/door/airlock/maintenance{
@@ -25803,9 +25650,14 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
 "blV" = (
-/obj/machinery/light/small,
-/turf/open/floor/plating,
-/area/maintenance/disposal)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8
+	},
+/turf/open/floor/carpet,
+/area/crew_quarters/theatre)
 "blW" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -26003,21 +25855,16 @@
 /turf/closed/wall,
 /area/crew_quarters/heads/captain)
 "bmy" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 5
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/captain)
 "bmz" = (
 /obj/structure/dresser,
 /obj/item/card/id/captains_spare,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4
-	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/captain)
 "bmA" = (
 /obj/machinery/door/airlock{
@@ -26029,10 +25876,7 @@
 /obj/machinery/light_switch{
 	pixel_y = 28
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8
-	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/captain)
 "bmC" = (
 /obj/structure/sink{
@@ -26190,9 +26034,9 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "bne" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
+/obj/structure/table,
+/obj/machinery/plantgenes{
+	pixel_y = 6
 	},
 /turf/open/floor/plasteel/dark,
 /area/hydroponics)
@@ -26541,22 +26385,22 @@
 /turf/open/floor/plating,
 /area/engine/gravity_generator)
 "bnX" = (
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/captain)
 "bnY" = (
-/obj/structure/bed,
-/obj/item/bedsheet/captain,
 /obj/machinery/airalarm{
 	dir = 4;
 	pixel_x = -22
 	},
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/captain)
-"bnZ" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/flask/gold,
 /obj/item/melee/chainofcommand,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/royalblue,
+/area/crew_quarters/heads/captain)
+"bnZ" = (
+/obj/structure/bed,
+/obj/item/bedsheet/captain,
+/turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/captain)
 "boa" = (
 /obj/structure/toilet{
@@ -26677,19 +26521,10 @@
 "bot" = (
 /obj/structure/table/glass,
 /obj/machinery/computer/med_data/laptop,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
 /obj/machinery/vending/wallmed{
 	pixel_y = 30
 	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "bou" = (
@@ -26954,7 +26789,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/hop)
 "bpc" = (
 /obj/structure/chair/office/dark{
@@ -26969,11 +26804,11 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
 "bpe" = (
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/hydroponics)
+/turf/open/floor/carpet,
+/area/crew_quarters/theatre)
 "bpf" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -26984,14 +26819,10 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
 "bpg" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /obj/effect/landmark/start/brig_physician,
+/obj/effect/turf_decal/lumos/tile/red/fullcorner{
+	dir = 8
+	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/brig)
 "bph" = (
@@ -27014,31 +26845,27 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "bpj" = (
-/obj/structure/chair/comfy/brown{
-	dir = 4
-	},
 /obj/machinery/camera{
 	c_tag = "Captain's Quarters";
 	dir = 1
 	},
 /obj/machinery/light/small,
-/turf/open/floor/carpet,
+/obj/structure/chair/comfy/brown{
+	dir = 8
+	},
+/turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/captain)
 "bpk" = (
-/obj/structure/closet/secure_closet/captains,
-/obj/item/clothing/under/rank/captain/parade,
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/captain)
-"bpl" = (
 /obj/structure/table/wood,
 /obj/item/storage/box/matches,
-/obj/item/razor{
-	pixel_x = -4;
-	pixel_y = 2
-	},
-/obj/item/clothing/mask/cigarette/cigar,
 /obj/item/pen/fountain/captain,
-/turf/open/floor/carpet,
+/obj/item/clothing/mask/cigarette/cigar,
+/turf/open/floor/carpet/royalblue,
+/area/crew_quarters/heads/captain)
+"bpl" = (
+/obj/structure/closet/secure_closet/captains,
+/obj/item/clothing/under/rank/captain/parade,
+/turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/captain)
 "bpm" = (
 /obj/machinery/shower{
@@ -27463,6 +27290,7 @@
 /obj/machinery/light_switch{
 	pixel_x = 27
 	},
+/obj/effect/turf_decal/lumos/loading_area/corner,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "bqo" = (
@@ -27489,21 +27317,18 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/hop)
 "bqs" = (
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "bqt" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
 	},
-/obj/effect/turf_decal/lumos/tile/green/half{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hydroponics)
+/turf/open/floor/carpet,
+/area/crew_quarters/theatre)
 "bqu" = (
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
@@ -27538,7 +27363,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bqz" = (
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/hop)
 "bqA" = (
 /obj/machinery/computer/card{
@@ -27555,7 +27380,7 @@
 /mob/living/simple_animal/pet/dog/corgi/Ian{
 	dir = 8
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/hop)
 "bqC" = (
 /obj/machinery/airalarm{
@@ -27944,7 +27769,9 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "brN" = (
-/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/lumos/loading_area{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "brO" = (
@@ -28856,10 +28683,10 @@
 /turf/open/floor/plating,
 /area/science/robotics/lab)
 "bul" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
-	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics)
 "bum" = (
@@ -32000,6 +31827,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/grass,
 /area/medical/genetics)
 "bBO" = (
@@ -34418,12 +34246,8 @@
 	dir = 8;
 	sortType = 16
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bHV" = (
@@ -36388,6 +36212,7 @@
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
+/obj/structure/closet/crate,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bMQ" = (
@@ -38092,9 +37917,9 @@
 /turf/open/floor/plating,
 /area/engine/atmos)
 "bRt" = (
-/obj/structure/closet/crate,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
+/obj/machinery/bookbinder,
+/turf/open/floor/wood,
+/area/library)
 "bRu" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -38934,7 +38759,7 @@
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "bUe" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -39365,9 +39190,6 @@
 /obj/item/integrated_electronics/debugger,
 /obj/item/integrated_electronics/wirer,
 /obj/item/integrated_electronics/detailer,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4
-	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
 "bVk" = (
@@ -45285,14 +45107,14 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "clB" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
+	},
+/obj/effect/turf_decal/lumos/tile/yellow/half{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -48745,9 +48567,13 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "cya" = (
-/obj/machinery/light/small,
-/turf/open/floor/plating,
-/area/maintenance/fore)
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#c1caff"
+	},
+/obj/machinery/vending/games,
+/turf/open/floor/wood,
+/area/library)
 "cyb" = (
 /obj/machinery/door/airlock/external{
 	name = "Escape Pod One"
@@ -49149,10 +48975,20 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "cAJ" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/disposal)
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/obj/machinery/camera{
+	c_tag = "Library North"
+	},
+/obj/structure/table/wood,
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/pen/fourcolor,
+/turf/open/floor/wood,
+/area/library)
 "cAK" = (
 /obj/machinery/light/small,
 /turf/open/floor/plating,
@@ -50737,8 +50573,7 @@
 /obj/machinery/computer/shuttle/mining{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -50953,11 +50788,11 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
 "dgv" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/theatre)
+/obj/structure/table/wood,
+/obj/item/folder/yellow,
+/obj/item/pen/blue,
+/turf/open/floor/wood,
+/area/library)
 "dgz" = (
 /turf/closed/wall,
 /area/crew_quarters/cryopod)
@@ -51533,6 +51368,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"eou" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/hallway/secondary/entry)
 "epC" = (
 /obj/machinery/door/airlock{
 	desc = "To keep the station within regulations, space IKEA requires one storage cupboard for their Nanotrasen partnership to continue.";
@@ -51650,9 +51491,13 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "eDf" = (
-/obj/machinery/vending/kink,
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/table/wood,
+/obj/item/paicard,
+/turf/open/floor/wood,
+/area/library)
 "eEe" = (
 /obj/machinery/door/airlock{
 	name = "Theatre Backstage";
@@ -52686,14 +52531,10 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/crew_quarters/dorms)
 "gAf" = (
-/obj/machinery/door/window/westright{
-	dir = 2;
-	name = "Security Checkpoint";
-	req_access_txt = "1"
-	},
 /obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 8
 	},
+/obj/structure/window/reinforced,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
 "gBf" = (
@@ -52847,6 +52688,10 @@
 	},
 /turf/open/floor/wood,
 /area/bridge/meeting_room)
+"gNZ" = (
+/obj/machinery/vending/cigarette,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "gOB" = (
 /turf/open/floor/plasteel/white/side,
 /area/science/research)
@@ -52917,9 +52762,11 @@
 /turf/closed/wall/r_wall,
 /area/engine/gravity_generator)
 "gVl" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/theatre)
@@ -52975,6 +52822,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/lumos/tile/red/fulltile,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "hap" = (
@@ -53222,9 +53070,6 @@
 /turf/open/space,
 /area/solar/port/aft)
 "hsb" = (
-/obj/structure/table/wood,
-/obj/item/book/codex_gigas,
-/obj/item/clothing/under/suit/red,
 /obj/structure/destructible/cult/tome,
 /turf/open/floor/carpet,
 /area/library)
@@ -53787,7 +53632,8 @@
 	map_pad_id = "toxenoarch";
 	map_pad_link_id = "tostation"
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/lumos/tile/purple/fulltile,
+/turf/open/floor/plasteel/white,
 /area/hallway/secondary/entry)
 "iEJ" = (
 /obj/machinery/door/airlock/external{
@@ -54145,6 +53991,12 @@
 /obj/machinery/atmospherics/pipe/manifold4w/violet/hidden,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"jiP" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/hallway/secondary/entry)
 "jjv" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/yellow{
@@ -54399,6 +54251,9 @@
 /area/maintenance/starboard/aft)
 "jEH" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
 	},
 /turf/open/floor/plasteel/dark,
@@ -54962,6 +54817,10 @@
 "kpr" = (
 /turf/closed/wall/r_wall,
 /area/medical/storage)
+"kqG" = (
+/obj/machinery/light/small,
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "kqI" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -55144,6 +55003,11 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"kKY" = (
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/closet,
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "kLD" = (
 /obj/structure/bed,
 /obj/item/bedsheet/orange,
@@ -55402,6 +55266,7 @@
 /area/medical/surgery)
 "lmr" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics)
 "lnk" = (
@@ -55523,6 +55388,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/pool)
+"lDF" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
+	},
+/turf/open/floor/carpet/royalblue,
+/area/crew_quarters/heads/captain)
 "lEt" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -55947,6 +55818,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/range)
 "mHj" = (
@@ -56370,6 +56242,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/lumos/shower,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "nws" = (
@@ -56524,7 +56397,10 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
 /area/hallway/secondary/entry)
 "nIB" = (
 /obj/machinery/door/airlock{
@@ -56641,11 +56517,11 @@
 /turf/open/floor/plasteel,
 /area/science/circuit)
 "nSt" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
+/area/hallway/primary/port)
 "nSN" = (
 /obj/machinery/light{
 	dir = 1;
@@ -56656,6 +56532,15 @@
 "nTb" = (
 /turf/closed/wall,
 /area/medical/genetics/cloning)
+"nTo" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/effect/turf_decal/lumos/tile/purple/checker{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/hallway/secondary/entry)
 "nUn" = (
 /obj/structure/sign/warning/fire,
 /turf/closed/wall/r_wall,
@@ -56837,6 +56722,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "oiu" = (
@@ -56860,6 +56748,9 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/security/range)
 "old" = (
@@ -57011,6 +56902,15 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/cryo)
+"oCG" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "oEP" = (
 /obj/machinery/status_display/evac,
 /turf/closed/wall,
@@ -57507,8 +57407,14 @@
 /area/hallway/primary/central)
 "pBp" = (
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/hop)
+"pCW" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/science/circuit)
 "pEn" = (
 /obj/machinery/light_switch{
 	pixel_x = -20
@@ -57570,10 +57476,7 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/medical/medbay/lobby)
 "pJR" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/chair/comfy/brown{
-	dir = 1
-	},
+/obj/structure/bookcase/random/nonfiction,
 /turf/open/floor/wood,
 /area/library)
 "pKc" = (
@@ -57699,6 +57602,13 @@
 	},
 /turf/open/space,
 /area/solar/starboard/aft)
+"pUx" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/effect/turf_decal/lumos/tile/purple/checker,
+/turf/open/floor/plasteel/white,
+/area/hallway/secondary/entry)
 "pUC" = (
 /obj/machinery/camera{
 	c_tag = "Departures Security Checkpoint";
@@ -58127,11 +58037,14 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "qWV" = (
-/obj/machinery/pool/filter{
-	pixel_y = 24
+/obj/effect/turf_decal/lumos/tile/green/half{
+	dir = 4
 	},
-/turf/open/pool,
-/area/crew_quarters/fitness/pool)
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "qZF" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating,
@@ -58240,7 +58153,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/hop)
 "rmX" = (
 /obj/structure/table,
@@ -58251,7 +58164,7 @@
 /obj/structure/chair/comfy/black{
 	dir = 8
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/blue,
 /area/bridge/meeting_room)
 "roQ" = (
 /obj/structure/window/reinforced,
@@ -58992,7 +58905,10 @@
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "sJx" = (
-/obj/machinery/seed_extractor,
+/obj/structure/table,
+/obj/machinery/smartfridge/disks{
+	pixel_y = 2
+	},
 /turf/open/floor/plasteel/dark,
 /area/hydroponics)
 "sJz" = (
@@ -59111,6 +59027,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/disposalpipe/segment,
+/obj/item/storage/secure/safe{
+	pixel_x = -23
+	},
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
 "sPT" = (
@@ -59165,6 +59084,15 @@
 /obj/machinery/rnd/experimentor,
 /turf/open/floor/engine,
 /area/science/explab)
+"sTy" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/effect/turf_decal/lumos/tile/purple/checker{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/hallway/secondary/entry)
 "sVS" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 1
@@ -60077,7 +60005,11 @@
 /turf/closed/wall,
 /area/medical/psych)
 "uKX" = (
-/obj/structure/window/reinforced,
+/obj/machinery/door/window/westright{
+	dir = 2;
+	name = "Security Checkpoint";
+	req_access_txt = "1"
+	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
 "uNu" = (
@@ -60352,6 +60284,18 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/bar)
+"vkW" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "vlZ" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/stripes/corner{
@@ -60606,10 +60550,10 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge/meeting_room)
 "vBN" = (
-/obj/structure/chair,
 /obj/effect/turf_decal/lumos/tile/red/fullcorner{
 	dir = 8
 	},
+/obj/structure/chair,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
 "vBP" = (
@@ -60859,9 +60803,7 @@
 /turf/open/space,
 /area/solar/starboard/aft)
 "vZR" = (
-/obj/structure/chair/comfy/brown{
-	dir = 1
-	},
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/wood,
 /area/library)
 "vZS" = (
@@ -61476,7 +61418,8 @@
 /area/hallway/secondary/exit)
 "xfS" = (
 /obj/machinery/light/small,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/white,
 /area/hallway/secondary/entry)
 "xgk" = (
 /obj/structure/disposalpipe/segment{
@@ -61522,6 +61465,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
+"xhj" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/effect/turf_decal/lumos/tile/purple/checker,
+/turf/open/floor/plasteel/white,
+/area/hallway/secondary/entry)
 "xhn" = (
 /obj/machinery/door/airlock/maintenance/abandoned{
 	req_access_txt = "12"
@@ -61818,6 +61768,14 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"xMz" = (
+/obj/structure/window/reinforced,
+/mob/living/carbon/monkey,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
+	},
+/turf/open/floor/grass,
+/area/medical/genetics)
 "xNE" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -69900,11 +69858,11 @@ aaa
 aaa
 aaa
 aaa
-asE
+arB
 awW
 awW
 awW
-asE
+arB
 aaa
 aaa
 aaa
@@ -70158,9 +70116,9 @@ aaa
 aaa
 aaa
 awW
-ayl
-ayl
-ayl
+xhj
+eou
+sTy
 awW
 aaa
 aaa
@@ -70672,9 +70630,9 @@ aaa
 aaa
 aaa
 awW
-ayl
-ayl
-ayl
+nTo
+jiP
+pUx
 awW
 aoV
 aaa
@@ -76076,7 +76034,7 @@ bgj
 bgj
 bjc
 cAF
-cAF
+kKY
 bja
 aaa
 aaa
@@ -76332,8 +76290,8 @@ beU
 bgk
 bhL
 bjc
-cAF
-blV
+kqG
+beO
 beO
 aaa
 aaa
@@ -76590,8 +76548,8 @@ beO
 beZ
 bje
 bkC
-cAJ
 beO
+aaa
 aaa
 aaa
 aaa
@@ -76848,7 +76806,7 @@ beO
 bjf
 beO
 beO
-beO
+aaa
 aaa
 aaa
 aaa
@@ -80410,7 +80368,7 @@ aaN
 alU
 amC
 alU
-eDf
+amC
 atU
 alU
 atU
@@ -82992,7 +82950,7 @@ aBV
 szG
 szG
 gVl
-dgv
+hcb
 hcb
 aKu
 aLE
@@ -83248,7 +83206,7 @@ rjQ
 aBU
 hcb
 uRS
-hcb
+blV
 uRS
 hcb
 aKu
@@ -83505,7 +83463,7 @@ aMr
 xZD
 hcb
 uRS
-hcb
+bpe
 uRS
 hcb
 ePh
@@ -83762,7 +83720,7 @@ bMa
 xZD
 hcb
 uRS
-hcb
+bqt
 uRS
 hcb
 aKu
@@ -84268,7 +84226,7 @@ aqR
 arP
 asQ
 aqR
-avW
+aFs
 axr
 ayE
 ayE
@@ -84524,7 +84482,7 @@ tfG
 nqz
 arP
 asP
-cya
+aqR
 arP
 axu
 ayH
@@ -84794,7 +84752,7 @@ ayG
 ayG
 ayG
 ayG
-aLm
+wVV
 aMT
 aNm
 aPM
@@ -85308,7 +85266,7 @@ aFW
 aHh
 aIV
 ayG
-aLN
+nSt
 aMT
 aOx
 iou
@@ -91713,7 +91671,7 @@ apH
 apX
 aqF
 anz
-gfC
+aDa
 ahn
 aqf
 xkL
@@ -93039,7 +92997,7 @@ bbw
 bej
 blb
 bmy
-bnX
+lDF
 bpj
 bqH
 bsi
@@ -93574,7 +93532,7 @@ bZN
 bLK
 bML
 bNT
-bRt
+bOd
 bQo
 bRz
 bSH
@@ -96090,9 +96048,9 @@ aoJ
 aoJ
 aoJ
 avw
-awy
-awr
-axW
+aAp
+aAp
+aIs
 awr
 wqF
 aAh
@@ -96349,13 +96307,13 @@ arf
 arf
 awA
 awr
-axW
+aLm
 awr
 awr
 awr
 aKr
 awr
-aDa
+awr
 aOV
 aJk
 aKR
@@ -96604,8 +96562,8 @@ eSe
 asN
 aur
 avy
-nSt
-aAp
+awr
+awr
 azk
 axB
 awr
@@ -98390,7 +98348,7 @@ aaa
 uEx
 dqb
 gvX
-qWV
+con
 con
 con
 con
@@ -99161,7 +99119,7 @@ aaa
 uEx
 dqb
 gvX
-con
+awy
 con
 con
 con
@@ -99196,7 +99154,7 @@ aac
 aRz
 aXk
 aKR
-aKR
+gNZ
 aJC
 fdf
 aYV
@@ -101318,7 +101276,7 @@ aaf
 aaa
 aaa
 aaa
-aaa
+gXs
 aaa
 aaa
 aaa
@@ -101529,7 +101487,7 @@ dIj
 jEH
 lmr
 bBN
-bJG
+xMz
 gXv
 iBi
 bFM
@@ -101575,7 +101533,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+gXs
 aaa
 aaa
 aaa
@@ -101832,7 +101790,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+gXs
 aaa
 aaa
 aaa
@@ -102089,7 +102047,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+gXs
 aaa
 aaa
 aaa
@@ -102339,19 +102297,19 @@ cmh
 cnd
 cnE
 bPn
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
 aaf
 aaf
 aaf
@@ -102599,11 +102557,11 @@ bPn
 aaa
 aaa
 aaa
+gXs
 aaa
 aaa
 aaa
-aaa
-aaa
+gXs
 aaa
 aaa
 aaa
@@ -102856,11 +102814,11 @@ bzs
 aaa
 aaa
 aaa
+gXs
 aaa
 aaa
 aaa
-aaa
-aaa
+gXs
 aaa
 aaa
 aaa
@@ -103117,7 +103075,7 @@ gJi
 aaa
 aaa
 aaa
-aaa
+gXs
 aaa
 aaa
 aaa
@@ -103305,7 +103263,7 @@ aQm
 aCE
 aCJ
 ohq
-bpe
+aRJ
 aRJ
 aYR
 ban
@@ -103374,7 +103332,7 @@ gJi
 aaa
 aaa
 aaa
-aaa
+gXs
 aaa
 aaa
 aaa
@@ -103561,8 +103519,8 @@ aOR
 aQh
 aRI
 bas
-bas
-bqt
+qWV
+aXo
 aXo
 iLJ
 bap
@@ -103631,7 +103589,7 @@ gJi
 aaa
 aaa
 aaa
-aaa
+gXs
 aaa
 aaa
 aaa
@@ -103888,7 +103846,7 @@ gJi
 aaa
 aaa
 aaa
-aaa
+gXs
 aaa
 aaa
 aaa
@@ -104063,7 +104021,7 @@ alP
 alP
 alP
 alP
-anf
+aNV
 aFm
 aGF
 aIp
@@ -104578,7 +104536,7 @@ anf
 anf
 noF
 aEB
-aFs
+aFu
 aFu
 aFu
 aFu
@@ -104835,14 +104793,14 @@ alP
 alP
 alP
 aEB
-aFs
 aFu
+bRt
 aIr
 aIt
 aLf
-aNV
-qfD
 aRO
+qfD
+pJR
 aQp
 aRN
 aIt
@@ -105099,7 +105057,7 @@ aJQ
 aIt
 aIt
 qfD
-aRO
+pJR
 aIt
 aRN
 aIt
@@ -105349,9 +105307,9 @@ anf
 aty
 aCC
 aGL
-anf
 aFu
-aIs
+cya
+aIt
 aJP
 vZR
 aIt
@@ -105607,10 +105565,10 @@ alP
 alP
 aGL
 aFu
-aFu
+cAJ
 aIw
 aJS
-pJR
+aNP
 aNP
 esZ
 aOS
@@ -105867,8 +105825,8 @@ aFu
 aHb
 aIv
 aJR
-aIt
-aIt
+dgv
+aNS
 qfD
 aRO
 aIt
@@ -105881,7 +105839,7 @@ brD
 bat
 aFu
 aYV
-aXq
+bck
 beE
 bfV
 bhv
@@ -106124,7 +106082,7 @@ aFu
 aHd
 aIx
 aJF
-aQq
+eDf
 aNS
 qfD
 aRO
@@ -106138,7 +106096,7 @@ aDR
 aEY
 bFn
 aYV
-aXq
+bck
 bds
 ptM
 biN
@@ -106377,7 +106335,7 @@ alP
 alP
 awG
 aGL
-alP
+aFw
 aFw
 aFw
 aFw
@@ -106395,7 +106353,7 @@ aXV
 vsT
 aFu
 aYV
-aXq
+bck
 bOL
 bfV
 bhw
@@ -106652,7 +106610,7 @@ aEj
 bax
 bFn
 aYV
-aXq
+bck
 aYV
 bfV
 bfV
@@ -106909,7 +106867,7 @@ aYW
 ckS
 aFu
 aYV
-aXq
+bck
 aYV
 bfW
 bhy
@@ -107166,7 +107124,7 @@ aYW
 aVQ
 bFn
 aYV
-aXq
+bck
 aYV
 bfX
 bhz
@@ -107423,7 +107381,7 @@ aYW
 aZd
 aFu
 aYV
-aXq
+bck
 aYV
 bfX
 bhy
@@ -107680,7 +107638,7 @@ aWe
 aCR
 aCR
 bcs
-aXq
+bck
 aYV
 bfX
 bfV
@@ -107937,7 +107895,7 @@ aRS
 aFz
 aCR
 bcx
-aXq
+vkW
 aYV
 bfY
 bhA
@@ -108194,7 +108152,7 @@ aZf
 aFo
 bbF
 aYV
-aXq
+oCG
 aYV
 bfX
 bhB
@@ -111037,7 +110995,7 @@ bsF
 bxn
 bxn
 bNm
-bUe
+poI
 bVs
 cgn
 fzX
@@ -111808,7 +111766,7 @@ buv
 byv
 byv
 jlM
-bUe
+pCW
 aKK
 cfy
 fzX
@@ -112065,7 +112023,7 @@ bsG
 bvP
 bvP
 bQT
-bUe
+poI
 bVs
 cgn
 fzX
@@ -112322,7 +112280,7 @@ bsI
 poI
 bxs
 byw
-aJY
+bVj
 bVt
 chq
 fzX

--- a/_maps/map_files/BoxStation/BoxStation_Lumos.dmm
+++ b/_maps/map_files/BoxStation/BoxStation_Lumos.dmm
@@ -3,21 +3,10 @@
 /turf/open/space/basic,
 /area/space)
 "aab" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/structure/table,
-/obj/machinery/chem_dispenser/drinks/beer{
-	dir = 8
-	},
 /obj/item/radio/intercom{
 	pixel_y = 25
 	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
+/obj/machinery/vending/boozeomat,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "aac" = (
@@ -29,10 +18,7 @@
 /obj/machinery/chem_dispenser/drinks{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
+/obj/effect/turf_decal/lumos/tile/bar/checker,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "aad" = (
@@ -163,15 +149,12 @@
 	pixel_x = 4;
 	pixel_y = 28
 	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
 /obj/machinery/light_switch{
 	name = "Bar Lights";
 	pixel_x = -6;
 	pixel_y = 28
 	},
+/obj/effect/turf_decal/lumos/tile/bar/checker,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "aaB" = (
@@ -214,9 +197,12 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aaK" = (
-/obj/structure/trash_pile,
-/turf/open/floor/plating,
-/area/maintenance/fore/secondary)
+/obj/structure/closet/secure_closet/security/sec{
+	anchored = 1
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "aaL" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -415,8 +401,7 @@
 /turf/open/floor/circuit/green,
 /area/security/prison)
 "abk" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -425,8 +410,10 @@
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "abn" = (
-/obj/structure/closet/secure_closet/security/sec,
 /obj/effect/turf_decal/bot,
+/obj/structure/closet/secure_closet/security/sec{
+	anchored = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "abo" = (
@@ -560,10 +547,12 @@
 /turf/open/space/basic,
 /area/ai_monitored/security/armory)
 "abH" = (
-/obj/structure/closet/secure_closet/security/sec,
 /obj/effect/turf_decal/bot,
 /obj/machinery/light{
 	dir = 4
+	},
+/obj/structure/closet/secure_closet/security/sec{
+	anchored = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)
@@ -615,16 +604,13 @@
 /area/security/prison)
 "abN" = (
 /obj/effect/landmark/secequipment,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
+	},
+/obj/effect/turf_decal/lumos/tile/red/half{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)
@@ -632,8 +618,14 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
 "abP" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/open/floor/plasteel/dark,
+/obj/effect/landmark/start/security_officer,
+/obj/structure/sign/plaques/golden{
+	pixel_y = 32
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
 /area/security/main)
 "abQ" = (
 /obj/structure/cable{
@@ -769,21 +761,11 @@
 /obj/item/grenade/barrier{
 	pixel_x = -4
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
 /obj/machinery/power/apc/highcap/five_k{
 	areastring = "/area/ai_monitored/security/armory";
 	dir = 8;
 	name = "Armory APC";
 	pixel_x = -24
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
 	},
 /obj/machinery/light{
 	dir = 8
@@ -791,6 +773,7 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "acl" = (
@@ -812,12 +795,6 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "acm" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -825,15 +802,12 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/effect/turf_decal/lumos/tile/red/half{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "acn" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -843,30 +817,26 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/effect/turf_decal/lumos/tile/red/half{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "aco" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/effect/turf_decal/lumos/tile/red/half{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "acq" = (
 /obj/machinery/firealarm{
 	pixel_y = 24
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
@@ -1075,14 +1045,11 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "acO" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/lumos/tile/red/half{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "acP" = (
@@ -1247,20 +1214,16 @@
 	dir = 1;
 	pixel_y = 1
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/bot,
 /obj/machinery/light{
 	dir = 4;
 	light_color = "#c1caff"
+	},
+/obj/effect/turf_decal/lumos/tile/red/half{
+	dir = 4
+	},
+/obj/effect/turf_decal/lumos/tile/neutral/half{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
@@ -1278,15 +1241,11 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
 "adl" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/lumos/tile/red/fullcorner{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "adm" = (
@@ -1295,11 +1254,8 @@
 	pixel_x = 29
 	},
 /obj/effect/landmark/secequipment,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/lumos/tile/red/half,
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "adn" = (
@@ -1488,10 +1444,6 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "adK" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = -26
@@ -1500,32 +1452,23 @@
 	c_tag = "Brig EVA Storage";
 	dir = 4
 	},
+/obj/effect/turf_decal/lumos/tile/red/half{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "adL" = (
 /obj/machinery/suit_storage_unit/security,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
 /obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "adM" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/lumos/tile/red/half{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
@@ -1568,17 +1511,13 @@
 	pixel_y = -3
 	},
 /obj/structure/window/reinforced,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/lumos/tile/neutral/half{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "adQ" = (
@@ -1715,16 +1654,10 @@
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
 "aef" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/structure/table,
 /obj/item/restraints/handcuffs,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -1814,12 +1747,8 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -1884,10 +1813,6 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aew" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
 /obj/machinery/airalarm{
 	dir = 4;
 	pixel_x = -22
@@ -1896,6 +1821,9 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/obj/effect/turf_decal/lumos/tile/red/half{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "aex" = (
@@ -1947,11 +1875,13 @@
 /obj/item/stack/packageWrap,
 /obj/item/stack/packageWrap,
 /obj/item/hand_labeler,
+/obj/effect/turf_decal/lumos/tile/red/fulltile,
 /turf/open/floor/plasteel,
 /area/security/main)
 "aeB" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
+/obj/effect/turf_decal/lumos/tile/red/fulltile,
 /turf/open/floor/plasteel,
 /area/security/main)
 "aeC" = (
@@ -1971,23 +1901,13 @@
 /area/crew_quarters/heads/hos)
 "aeE" = (
 /obj/structure/closet/secure_closet/lethalshots,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/lumos/tile/neutral/half{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 8
 	},
-/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "aeF" = (
@@ -1998,16 +1918,7 @@
 /obj/item/storage/box/firingpins{
 	pixel_x = -3
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "aeG" = (
@@ -2091,12 +2002,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
@@ -2105,6 +2010,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -2136,11 +2044,8 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -2159,10 +2064,6 @@
 /area/security/prison)
 "aeS" = (
 /obj/structure/closet/secure_closet/brig,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/item/radio/headset{
 	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
 	name = "prisoner headset";
@@ -2171,6 +2072,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aeT" = (
@@ -2179,21 +2081,18 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
-/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/trimline/red/filled/corner,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aeU" = (
 /obj/effect/landmark/start/security_officer,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/structure/chair{
 	dir = 4
 	},
 /obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -2219,50 +2118,20 @@
 	pixel_x = -3
 	},
 /obj/item/storage/lockbox/loyalty,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "aeX" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "aeY" = (
 /obj/vehicle/ridden/secway,
 /obj/item/key/security,
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/half,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "aeZ" = (
@@ -2270,25 +2139,13 @@
 /obj/item/gun/energy/ionrifle,
 /obj/item/gun/energy/temperature/security,
 /obj/item/clothing/suit/armor/laserproof,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/machinery/airalarm{
 	pixel_y = 23
 	},
+/obj/effect/turf_decal/lumos/tile/blue/half{
+	dir = 1
+	},
+/obj/effect/turf_decal/lumos/tile/neutral/half,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "afa" = (
@@ -2301,11 +2158,10 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "afb" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+/obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -2313,74 +2169,35 @@
 "afc" = (
 /obj/structure/closet/secure_closet/contraband/armory,
 /obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/obj/effect/turf_decal/lumos/tile/blue/fullcorner{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "afd" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/bot,
 /obj/structure/rack,
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "afe" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
 	},
+/obj/effect/turf_decal/lumos/tile/red/half{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "aff" = (
 /obj/effect/landmark/start/security_officer,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/main)
-"afg" = (
-/obj/effect/landmark/start/security_officer,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
@@ -2400,48 +2217,42 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "afj" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/security/main)
 "afk" = (
 /obj/effect/landmark/start/security_officer,
-/obj/effect/turf_decal/tile/red{
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/security/main)
 "afl" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/effect/turf_decal/lumos/tile/red/fulltile,
 /turf/open/floor/plasteel,
 /area/security/main)
 "afm" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 5
+	},
 /turf/open/floor/plasteel,
 /area/security/main)
 "afn" = (
@@ -2460,19 +2271,13 @@
 /turf/open/space/basic,
 /area/space)
 "afr" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /obj/effect/landmark/start/security_officer,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 9
+	},
 /turf/open/floor/plasteel,
 /area/security/main)
 "afs" = (
@@ -2534,15 +2339,11 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "afz" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -2555,18 +2356,14 @@
 	name = "Station Intercom (General)";
 	pixel_x = 27
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -2583,20 +2380,14 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "afD" = (
-/obj/effect/turf_decal/tile/red{
+/obj/effect/landmark/start/security_officer,
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/landmark/start/security_officer,
 /turf/open/floor/plasteel,
 /area/security/main)
 "afE" = (
@@ -2612,19 +2403,6 @@
 /obj/structure/trash_pile,
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"afG" = (
-/obj/structure/closet/secure_closet/brig,
-/obj/item/radio/headset{
-	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
-	name = "prisoner headset";
-	prison_radio = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel,
-/area/security/brig)
 "afH" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/glass/bottle/charcoal{
@@ -2666,10 +2444,7 @@
 	pixel_x = 1;
 	pixel_y = -27
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "afK" = (
@@ -2705,18 +2480,14 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "afN" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 8
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -2764,15 +2535,14 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "afT" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8
+	},
+/obj/effect/turf_decal/lumos/tile/red/half{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -2788,10 +2558,7 @@
 "afW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "afX" = (
@@ -2825,12 +2592,13 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
+/obj/effect/turf_decal/lumos/tile/red/fulltile,
+/obj/machinery/recharge_station,
 /turf/open/floor/plasteel,
 /area/security/main)
 "agb" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -2890,15 +2658,9 @@
 	name = "Prison Wing";
 	req_access_txt = "2"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/lumos/tile/red/fulltile,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "agj" = (
@@ -2913,15 +2675,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/red/fulltile,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "agl" = (
@@ -2949,18 +2703,9 @@
 /turf/closed/wall/r_wall,
 /area/security/warden)
 "ago" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "agp" = (
@@ -2997,18 +2742,14 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -3030,23 +2771,17 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "agx" = (
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
 "agy" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/security/main)
 "agz" = (
@@ -3060,23 +2795,13 @@
 /obj/item/storage/box/rubbershot,
 /obj/item/storage/box/rubbershot,
 /obj/item/storage/box/rubbershot,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/lumos/tile/neutral/half{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 8
 	},
-/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "agA" = (
@@ -3085,11 +2810,8 @@
 	departmentType = 5;
 	pixel_y = 30
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
@@ -3153,55 +2875,34 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/lumos/loading_area/corner,
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
 "agI" = (
-/obj/effect/turf_decal/tile/red{
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "agJ" = (
 /obj/machinery/flasher/portable,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
 /obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "agK" = (
 /obj/machinery/flasher/portable,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
 /obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "agL" = (
@@ -3213,12 +2914,6 @@
 "agM" = (
 /obj/structure/cable{
 	icon_state = "2-4"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
 	},
 /obj/machinery/power/apc{
 	areastring = "/area/security/brig";
@@ -3234,6 +2929,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -3265,14 +2963,8 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -3440,8 +3132,7 @@
 /obj/effect/turf_decal/loading_area{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -3494,26 +3185,16 @@
 	pixel_x = 1;
 	pixel_y = -1
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/effect/turf_decal/bot,
 /obj/machinery/camera/motion{
 	c_tag = "Armory Motion Sensor";
 	dir = 4
+	},
+/obj/effect/turf_decal/lumos/tile/neutral/half{
+	dir = 4
+	},
+/obj/effect/turf_decal/lumos/tile/blue/half{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
@@ -3525,10 +3206,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "ahp" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/red/half,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "ahq" = (
@@ -3602,28 +3280,15 @@
 /turf/open/floor/plating,
 /area/security/brig)
 "ahy" = (
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "ahz" = (
 /obj/structure/tank_dispenser/oxygen,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
 /obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "ahA" = (
@@ -3637,25 +3302,15 @@
 	pixel_x = 1;
 	pixel_y = -1
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/effect/turf_decal/bot,
 /obj/item/radio/intercom{
 	pixel_x = -30
+	},
+/obj/effect/turf_decal/lumos/tile/neutral/half{
+	dir = 4
+	},
+/obj/effect/turf_decal/lumos/tile/blue/half{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
@@ -3669,19 +3324,10 @@
 	pixel_x = -2;
 	pixel_y = 2
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "ahC" = (
@@ -3701,26 +3347,22 @@
 /area/security/processing)
 "ahE" = (
 /obj/structure/closet/secure_closet/brig,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/item/radio/headset{
 	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
 	name = "prisoner headset";
 	prison_radio = 1
 	},
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "ahG" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/window/westright{
 	name = "Brig Operations";
 	req_one_access_txt = "4; 1"
+	},
+/obj/effect/turf_decal/lumos/tile/red/half{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -3751,13 +3393,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
-"ahK" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
 "ahL" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -3786,8 +3421,10 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/lumos/loading_area/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -3825,17 +3462,13 @@
 	dir = 1;
 	pixel_y = 1
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/lumos/tile/neutral/half{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "ahS" = (
@@ -3867,9 +3500,6 @@
 /turf/open/floor/plasteel,
 /area/security/processing)
 "ahV" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
 /obj/machinery/computer/security/labor{
 	dir = 1
 	},
@@ -3908,22 +3538,6 @@
 	dir = 1;
 	layer = 2.9
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/effect/turf_decal/bot,
 /obj/machinery/light{
 	dir = 8
@@ -3931,11 +3545,16 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -26
 	},
+/obj/effect/turf_decal/lumos/tile/neutral/half{
+	dir = 4
+	},
+/obj/effect/turf_decal/lumos/tile/blue/half{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "ahX" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -3952,16 +3571,9 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/brig)
 "aia" = (
-/obj/structure/noticeboard{
-	dir = 1;
-	pixel_y = -27
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/main)
 "aib" = (
@@ -3969,6 +3581,9 @@
 	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "aic" = (
@@ -3982,7 +3597,7 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
@@ -4049,20 +3664,14 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "aik" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/structure/table,
 /obj/item/gun/energy/laser/practice,
 /obj/machinery/syndicatebomb/training,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
@@ -4097,23 +3706,13 @@
 	pixel_y = -3
 	},
 /obj/structure/window/reinforced,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/lumos/tile/neutral/half{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 8
 	},
-/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "aio" = (
@@ -4131,14 +3730,11 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "aiq" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/lumos/tile/red/half{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "air" = (
@@ -4151,16 +3747,13 @@
 	pixel_x = 5;
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/main)
 "ait" = (
@@ -4179,16 +3772,13 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/main)
 "aiv" = (
@@ -4203,26 +3793,18 @@
 	pixel_y = -3
 	},
 /obj/structure/window/reinforced,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/lumos/tile/neutral/half{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "aiw" = (
 /obj/machinery/light_switch{
 	pixel_y = -23
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
 	},
 /obj/structure/chair/sofa/left{
 	dir = 1
@@ -4233,6 +3815,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/main)
 "aix" = (
@@ -4242,35 +3825,27 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 6
+	},
 /turf/open/floor/plasteel,
 /area/security/main)
 "aiy" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aiz" = (
 /obj/machinery/light,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/structure/chair/sofa{
 	dir = 1
 	},
@@ -4280,22 +3855,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/main)
 "aiA" = (
-/obj/machinery/door/airlock/external{
-	req_access_txt = "13"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
 /turf/open/floor/plating,
-/area/maintenance/fore/secondary)
+/area/security/main)
 "aiB" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/structure/chair/sofa/right{
 	dir = 1
 	},
@@ -4305,6 +3871,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/main)
 "aiC" = (
@@ -4314,10 +3881,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/effect/landmark/start/security_officer,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -4325,6 +3888,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/main)
 "aiD" = (
@@ -4334,29 +3898,18 @@
 /turf/open/floor/plasteel,
 /area/security/processing)
 "aiE" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/item/radio/intercom{
 	pixel_y = 20
 	},
+/obj/effect/turf_decal/lumos/tile/red/fullcorner{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/security/processing)
 "aiF" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/gulag_item_reclaimer{
 	pixel_x = 32
 	},
@@ -4369,6 +3922,9 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Security Docking";
+	dir = 8
+	},
+/obj/effect/turf_decal/lumos/tile/red/fullcorner{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -4389,16 +3945,15 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aiH" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/camera{
 	c_tag = "Brig Central";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aiI" = (
@@ -4446,13 +4001,7 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/brig)
 "aiN" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/red/fullcorner,
 /turf/open/floor/plasteel,
 /area/security/processing)
 "aiO" = (
@@ -4543,15 +4092,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
-"ajc" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "ajd" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -4606,14 +4146,8 @@
 /obj/structure/chair{
 	name = "Judge"
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/fullcorner{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/courtroom)
@@ -4632,12 +4166,8 @@
 /obj/structure/chair{
 	name = "Judge"
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/obj/effect/turf_decal/lumos/tile/blue/fullcorner{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/courtroom)
@@ -4648,11 +4178,8 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/courtroom)
@@ -4680,7 +4207,7 @@
 /area/solar/port/fore)
 "ajr" = (
 /obj/machinery/light,
-/obj/machinery/vending/wardrobe/law_wardrobe,
+/obj/machinery/photocopier,
 /turf/open/floor/wood,
 /area/lawoffice)
 "ajt" = (
@@ -4688,13 +4215,12 @@
 	c_tag = "Law Office";
 	dir = 1
 	},
-/obj/machinery/photocopier,
+/obj/structure/table/wood,
+/obj/item/taperecorder,
+/obj/item/cartridge/lawyer,
 /turf/open/floor/wood,
 /area/lawoffice)
 "aju" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
@@ -4761,11 +4287,11 @@
 /area/security/prison)
 "ajA" = (
 /obj/effect/landmark/start/security_officer,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /obj/structure/chair{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
@@ -4815,27 +4341,23 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "2-4"
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "ajK" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "ajL" = (
@@ -4962,12 +4484,8 @@
 	dir = 8;
 	name = "Defense"
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
+/obj/effect/turf_decal/lumos/tile/green/fullcorner{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/courtroom)
@@ -4994,24 +4512,23 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
 "ajX" = (
-/obj/effect/turf_decal/tile/red,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
 	},
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "ajY" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/window/westleft{
 	name = "Brig Operations";
 	req_one_access_txt = "4; 1"
+	},
+/obj/effect/turf_decal/lumos/tile/red/half{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -5032,13 +4549,10 @@
 /turf/open/floor/plasteel,
 /area/security/processing)
 "akc" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -5051,14 +4565,13 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "ake" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -5074,28 +4587,20 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "akh" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/structure/table,
 /obj/item/storage/fancy/donut_box,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 10
+	},
 /turf/open/floor/plasteel,
 /area/security/main)
 "aki" = (
 /obj/structure/cable{
 	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -5104,6 +4609,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
 	},
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/main)
 "akj" = (
@@ -5124,6 +4630,13 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/lumos/tile/red/fulltile,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/security/main)
 "akl" = (
@@ -5135,6 +4648,9 @@
 "akm" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "akn" = (
@@ -5150,12 +4666,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
@@ -5165,6 +4675,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "akp" = (
@@ -5173,14 +4686,11 @@
 	name = "Cell 1";
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/machinery/camera{
 	c_tag = "Brig West";
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "akq" = (
@@ -5190,6 +4700,9 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "akr" = (
@@ -5200,12 +4713,10 @@
 	dir = 1;
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aks" = (
@@ -5236,9 +4747,6 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -5250,6 +4758,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -5270,7 +4781,7 @@
 /turf/open/floor/plasteel,
 /area/security/courtroom)
 "akx" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -5304,13 +4815,7 @@
 	dir = 8;
 	name = "Defense"
 	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/green/fullcorner,
 /turf/open/floor/plasteel,
 /area/security/courtroom)
 "akB" = (
@@ -5335,14 +4840,13 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/machinery/airalarm{
 	dir = 1;
 	pixel_y = -22
 	},
-/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "akE" = (
@@ -5355,12 +4859,11 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "akF" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "akG" = (
@@ -5416,10 +4919,7 @@
 /area/security/prison)
 "akM" = (
 /obj/machinery/light,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/trimline/green/filled/line,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "akN" = (
@@ -5431,10 +4931,6 @@
 /turf/open/floor/plasteel/white,
 /area/security/prison)
 "akO" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/structure/table,
 /obj/machinery/microwave{
 	pixel_y = 6
@@ -5445,6 +4941,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/main)
 "akP" = (
@@ -5462,10 +4959,6 @@
 	c_tag = "Security Office";
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/structure/table,
 /obj/item/storage/box/donkpockets,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -5474,6 +4967,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/structure/noticeboard{
+	dir = 1;
+	pixel_y = -27
+	},
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/main)
 "akS" = (
@@ -5481,13 +4979,10 @@
 	name = "Station Intercom (General)";
 	pixel_y = -29
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/structure/table,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/main)
 "akT" = (
@@ -5512,16 +5007,6 @@
 /obj/machinery/holopad,
 /turf/open/floor/plasteel/checker,
 /area/security/prison)
-"akX" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "akY" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -5563,14 +5048,8 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/lumos/tile/red/fullcorner{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/courtroom)
@@ -5607,13 +5086,6 @@
 /obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/prison)
-"alg" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "alh" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -5659,10 +5131,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -5721,10 +5190,7 @@
 	name = "Cell 3";
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "alt" = (
@@ -5738,16 +5204,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
+/obj/effect/turf_decal/lumos/tile/red/fulltile,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "alu" = (
@@ -5788,39 +5245,24 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
+/obj/effect/turf_decal/lumos/tile/red/fulltile,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aly" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "alz" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -5829,16 +5271,13 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -5847,10 +5286,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"alC" = (
-/obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "alD" = (
@@ -5882,12 +5317,8 @@
 	dir = 4;
 	name = "Prosecution"
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/lumos/tile/red/fullcorner{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/courtroom)
@@ -5920,14 +5351,7 @@
 /turf/open/floor/plasteel,
 /area/security/courtroom)
 "alK" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/turf/open/floor/plating,
+/turf/closed/wall/r_wall,
 /area/maintenance/fore/secondary)
 "alL" = (
 /obj/structure/disposalpipe/segment,
@@ -5941,6 +5365,7 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "alM" = (
@@ -6059,29 +5484,24 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "amf" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "amg" = (
 /obj/structure/closet{
 	name = "Evidence Closet"
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -6092,10 +5512,7 @@
 	name = "Cell 2";
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "amk" = (
@@ -6129,16 +5546,21 @@
 /turf/open/floor/plating,
 /area/security/prison)
 "amm" = (
-/obj/structure/cable{
-	icon_state = "0-8"
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
 	},
-/obj/structure/cable{
-	icon_state = "0-4"
+/obj/structure/rack,
+/obj/machinery/light/small{
+	dir = 8
 	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/item/clothing/suit/fire/firefighter,
+/obj/item/tank/internals/oxygen,
+/obj/item/clothing/mask/gas,
+/obj/item/extinguisher,
+/obj/item/clothing/head/hardhat/red,
+/obj/item/clothing/glasses/meson,
 /turf/open/floor/plating,
-/area/security/brig)
+/area/maintenance/fore/secondary)
 "amn" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -6155,20 +5577,8 @@
 /turf/open/floor/plating,
 /area/security/prison)
 "amp" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/lumos/tile/red/fullcorner{
 	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"amq" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -6324,12 +5734,8 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "amJ" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/effect/turf_decal/lumos/tile/red/fullcorner{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -6353,6 +5759,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -6489,19 +5898,18 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "anb" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "anc" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
-/turf/open/floor/plating,
+/turf/closed/wall,
 /area/maintenance/fore/secondary)
 "and" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -6630,13 +6038,12 @@
 /obj/structure/closet{
 	name = "Evidence Closet"
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/light{
 	dir = 4;
 	light_color = "#e8eaff"
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/warden)
@@ -6665,7 +6072,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -6698,7 +6105,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -6780,7 +6187,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -6803,7 +6210,6 @@
 	},
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/security/brig)
 "anQ" = (
@@ -6816,7 +6222,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
 /obj/structure/bed,
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -6874,21 +6279,12 @@
 	c_tag = "Courtroom South";
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8
-	},
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
 "anY" = (
 /obj/machinery/airalarm{
 	dir = 1;
 	pixel_y = -22
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
@@ -6928,16 +6324,24 @@
 /turf/open/floor/plasteel/dark,
 /area/blueshield)
 "aod" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/turf/closed/wall,
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 8;
+	name = "Air Out"
+	},
+/turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "aoe" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/turf/closed/wall,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/obj/item/wrench,
+/turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "aof" = (
 /turf/closed/wall/r_wall,
@@ -7028,11 +6432,7 @@
 /turf/open/floor/plasteel/checker,
 /area/security/prison)
 "aot" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/lumos/tile/red/fullcorner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -7141,7 +6541,9 @@
 /area/hallway/primary/fore)
 "aoF" = (
 /obj/effect/turf_decal/tile/red,
-/obj/machinery/chem_dispenser/drinks,
+/obj/machinery/chem_dispenser/drinks{
+	dir = 1
+	},
 /obj/structure/table,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
@@ -7171,6 +6573,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/structure/trash_pile,
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "aoJ" = (
@@ -7178,27 +6581,13 @@
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "aoK" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/chair/stool{
-	pixel_y = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/maintenance/fore/secondary)
+/obj/structure/closet/athletic_mixed,
+/turf/open/floor/plasteel/yellowsiding,
+/area/crew_quarters/fitness/pool)
 "aoL" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 1;
-	name = "Air Out"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/maintenance/fore/secondary)
+/obj/structure/rack,
+/turf/open/floor/plasteel/yellowsiding,
+/area/crew_quarters/fitness/pool)
 "aoM" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -7271,18 +6660,12 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aoY" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = 24;
 	pixel_y = -28
 	},
+/obj/effect/turf_decal/lumos/tile/red/fullcorner,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aoZ" = (
@@ -7318,19 +6701,19 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/plating,
+/turf/open/floor/wood,
 /area/lawoffice)
 "apf" = (
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall,
 /area/security/detectives_office)
 "apg" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
-/area/maintenance/fore)
+/area/security/main)
 "aph" = (
 /turf/closed/wall,
 /area/lawoffice)
@@ -7357,15 +6740,12 @@
 /area/hallway/primary/fore)
 "apl" = (
 /obj/effect/landmark/secequipment,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/lumos/tile/red/half{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "apm" = (
@@ -7476,22 +6856,17 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "apx" = (
-/obj/machinery/door/airlock/atmos/abandoned{
-	name = "Atmospherics Maintenance";
-	req_access_txt = "12;24"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-8"
 	},
 /turf/open/floor/plating,
-/area/maintenance/fore/secondary)
+/area/security/main)
 "apy" = (
-/obj/item/wrench,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
@@ -7549,7 +6924,10 @@
 /turf/open/floor/plating,
 /area/engine/atmos)
 "apG" = (
-/obj/machinery/portable_atmospherics/canister/water_vapor,
+/obj/effect/turf_decal/delivery,
+/obj/vehicle/ridden/janicart{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/janitor)
 "apH" = (
@@ -7622,10 +7000,6 @@
 /obj/structure/closet{
 	name = "Evidence Closet"
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -24
@@ -7633,6 +7007,9 @@
 /obj/machinery/airalarm{
 	dir = 8;
 	pixel_x = 24
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/warden)
@@ -7649,16 +7026,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
+/obj/effect/turf_decal/lumos/tile/red/fulltile,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "apS" = (
@@ -7703,16 +7071,6 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "apW" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/bot,
 /obj/structure/rack,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -7721,6 +7079,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
 	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "apX" = (
@@ -7741,9 +7100,6 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
-	},
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
 "apZ" = (
@@ -7754,9 +7110,6 @@
 /area/security/main)
 "aqa" = (
 /obj/structure/closet/secure_closet/personal,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4
-	},
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
 "aqb" = (
@@ -7907,31 +7260,19 @@
 /area/crew_quarters/dorms)
 "aqo" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4
-	},
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
 "aqp" = (
-/obj/structure/rack,
-/obj/item/clothing/suit/fire/firefighter,
-/obj/item/tank/internals/oxygen,
-/obj/item/clothing/mask/gas,
-/obj/item/extinguisher,
-/obj/item/clothing/head/hardhat/red,
-/obj/item/clothing/glasses/meson,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/maintenance/fore/secondary)
+/obj/structure/chair/stool,
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness/pool)
 "aqq" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/machinery/portable_atmospherics/canister/air,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
@@ -7977,20 +7318,11 @@
 /turf/open/floor/plating,
 /area/security/warden)
 "aqu" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/bot,
 /obj/structure/rack,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "aqv" = (
@@ -8023,10 +7355,10 @@
 /area/maintenance/starboard/fore)
 "aqz" = (
 /obj/structure/table,
-/obj/machinery/light/small{
-	dir = 1
-	},
 /obj/effect/spawner/lootdrop/maintenance,
+/obj/machinery/light/small{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aqA" = (
@@ -8044,11 +7376,8 @@
 /turf/open/floor/plasteel/checker,
 /area/security/prison)
 "aqC" = (
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
@@ -8066,23 +7395,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aqE" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/lumos/tile/red/fulltile,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aqF" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -8225,10 +7542,14 @@
 /turf/open/floor/wood,
 /area/lawoffice)
 "aqZ" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 5
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
+/obj/structure/chair/stool{
+	pixel_y = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
@@ -8303,9 +7624,6 @@
 	pixel_y = 23
 	},
 /obj/structure/table/wood,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8
-	},
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
 "arj" = (
@@ -8315,9 +7633,7 @@
 /obj/machinery/airalarm{
 	pixel_y = 23
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8
-	},
+/obj/structure/closet/secure_closet/personal/cabinet,
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
 "arl" = (
@@ -8382,12 +7698,11 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "ars" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/door/airlock/external{
+	req_access_txt = "13"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
@@ -8492,7 +7807,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -8717,25 +8032,9 @@
 /obj/machinery/airalarm{
 	pixel_y = 23
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "asg" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/structure/sign/warning/fire{
 	desc = "A sign that states the labeled room's number.";
 	dir = 4;
@@ -8792,9 +8091,6 @@
 	pixel_y = 15
 	},
 /obj/structure/dresser,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4
-	},
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
 "asl" = (
@@ -8808,12 +8104,6 @@
 /obj/structure/chair/comfy/brown{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 6
-	},
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
 "asn" = (
@@ -8826,7 +8116,9 @@
 	name = "Blueshield Office Maintenance";
 	req_access_txt = "71"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plating,
 /area/blueshield)
 "asp" = (
@@ -8897,13 +8189,6 @@
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
 "asv" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -8911,6 +8196,7 @@
 	dir = 8;
 	pixel_x = 28
 	},
+/obj/effect/turf_decal/lumos/tile/red/fullcorner,
 /turf/open/floor/plasteel,
 /area/security/processing)
 "asw" = (
@@ -9002,7 +8288,6 @@
 	dir = 4;
 	pixel_x = -23
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
 "asO" = (
@@ -9027,13 +8312,10 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "asT" = (
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/obj/effect/turf_decal/lumos/tile/green/half{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "asV" = (
@@ -9100,65 +8382,38 @@
 /area/hallway/primary/fore)
 "ate" = (
 /obj/effect/landmark/xeno_spawn,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 5
-	},
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
 "atf" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/open/floor/carpet,
-/area/crew_quarters/dorms)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "atg" = (
 /obj/machinery/door/airlock{
 	id_tag = "Dorm4";
 	name = "Room Three"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/dorms)
 "ath" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/dorms)
+/obj/effect/turf_decal/trimline/red/filled/corner,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "atj" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "atk" = (
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "atl" = (
@@ -9172,13 +8427,11 @@
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
 "atn" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/turf/open/floor/plating,
-/area/maintenance/fore/secondary)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "ato" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -9308,6 +8561,9 @@
 "atK" = (
 /obj/structure/table/wood,
 /obj/machinery/photocopier/faxmachine/longrange,
+/obj/structure/sign/poster/official/cohiba_robusto_ad{
+	pixel_y = -32
+	},
 /turf/open/floor/wood,
 /area/lawoffice)
 "atL" = (
@@ -9372,10 +8628,7 @@
 /turf/open/floor/plasteel/checker,
 /area/security/prison)
 "atZ" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -9417,20 +8670,15 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aue" = (
-/obj/machinery/light/small,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/courtroom)
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "auf" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/maintenance/fore/secondary)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/green/filled/line,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "aug" = (
 /obj/machinery/camera{
 	c_tag = "Blueshield's Office";
@@ -9441,15 +8689,15 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/obj/machinery/power/apc/auto_name/south,
+/obj/structure/cable,
 /turf/open/floor/plasteel/dark,
 /area/blueshield)
 "auh" = (
-/obj/structure/table/wood,
-/obj/item/taperecorder,
-/obj/item/cartridge/lawyer,
 /obj/machinery/newscaster{
 	pixel_x = -31
 	},
+/obj/structure/filingcabinet/employment,
 /turf/open/floor/wood,
 /area/lawoffice)
 "aui" = (
@@ -9476,12 +8724,9 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "auk" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
+/obj/effect/turf_decal/trimline/green/filled/line,
 /turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
+/area/security/brig)
 "aum" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -9529,10 +8774,6 @@
 	pixel_x = -25;
 	specialfunctions = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
 "aut" = (
@@ -9542,9 +8783,6 @@
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_y = -29
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
@@ -9576,19 +8814,7 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
 "aux" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
-"auy" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
+/obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "auz" = (
@@ -9610,13 +8836,7 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "auB" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/lumos/tile/red/fullcorner{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -9702,20 +8922,10 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "auQ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 10
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
 "auR" = (
 /obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
 /obj/structure/sign/warning/fire{
@@ -9850,22 +9060,14 @@
 	id_tag = "Dorm5";
 	name = "Room Four"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/dorms)
 "avi" = (
-/obj/machinery/power/apc{
-	areastring = "/area/blueshield";
-	dir = 1;
-	name = "Blueshield's Office APC";
-	pixel_y = 24
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plating,
-/area/maintenance/fore)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "avj" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -9893,8 +9095,6 @@
 	id_tag = "Dorm6";
 	name = "Room Five"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/dorms)
 "avo" = (
@@ -9927,11 +9127,17 @@
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
 "avt" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/obj/machinery/button/door{
+	id = "PoolShut";
+	name = "Pool Shutters";
+	pixel_y = 24
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -24
 	},
 /turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
+/area/crew_quarters/fitness/pool)
 "avu" = (
 /obj/machinery/shower{
 	dir = 4
@@ -9942,12 +9148,6 @@
 "avv" = (
 /obj/machinery/camera{
 	c_tag = "Dorms West"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
@@ -9965,17 +9165,9 @@
 	name = "Room Six - Luxury Suite"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/dorms)
 "avz" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
 /obj/machinery/light{
 	dir = 1;
 	light_color = "#cee5d2"
@@ -9985,12 +9177,6 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "avA" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
 /obj/structure/table,
 /obj/structure/bedsheetbin/towel,
 /turf/open/floor/plasteel,
@@ -10131,12 +9317,6 @@
 	name = "Room Number 4";
 	pixel_y = 24
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "avS" = (
@@ -10178,25 +9358,13 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "avY" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 4
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 9
 	},
 /turf/open/floor/plasteel,
-/area/construction/mining/aux_base)
+/area/security/brig)
 "avZ" = (
-/obj/structure/closet/secure_closet/personal/cabinet,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 6
-	},
+/obj/structure/chair/comfy/brown,
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
 "awa" = (
@@ -10231,11 +9399,8 @@
 /area/hallway/primary/fore)
 "awe" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -10284,22 +9449,15 @@
 /area/maintenance/fore)
 "awi" = (
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/fore)
+/turf/open/floor/plasteel,
+/area/security/brig)
 "awj" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -10360,11 +9518,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 9
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
@@ -10373,21 +9531,9 @@
 	id_tag = "Dorm3";
 	name = "Room Two"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/dorms)
 "awq" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
 /obj/machinery/light{
 	dir = 1;
 	light_color = "#cee5d2"
@@ -10417,12 +9563,6 @@
 	name = "Room Number 5";
 	pixel_y = 24
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "awu" = (
@@ -10430,16 +9570,17 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "awv" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 5
+	},
 /turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
+/area/security/brig)
 "aww" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -10452,24 +9593,12 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "awy" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "awz" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
 /obj/item/radio/intercom{
 	pixel_y = 25
 	},
@@ -10479,12 +9608,6 @@
 /obj/machinery/holopad,
 /obj/machinery/camera{
 	c_tag = "Dorms Central"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -10529,14 +9652,11 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "awD" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 9
 	},
-/obj/effect/spawner/blocker,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/turf/open/floor/plasteel,
+/area/security/brig)
 "awE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/meter,
@@ -10696,14 +9816,16 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "awX" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 5
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
 	},
-/turf/open/floor/carpet,
-/area/crew_quarters/dorms)
+/turf/open/floor/plasteel,
+/area/security/brig)
 "awY" = (
 /obj/machinery/light{
 	dir = 1
@@ -10796,10 +9918,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "axh" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -10937,10 +10056,14 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "axy" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
@@ -10955,7 +10078,10 @@
 /area/crew_quarters/fitness)
 "axA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 10
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
@@ -10992,11 +10118,13 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "axF" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/closet/secure_closet/personal{
+	anchored = 1
 	},
 /turf/open/floor/plasteel,
-/area/ai_monitored/storage/eva)
+/area/crew_quarters/fitness/pool)
 "axG" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -11054,8 +10182,7 @@
 /area/crew_quarters/dorms)
 "axS" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "axT" = (
@@ -11082,10 +10209,19 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "axX" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/structure/bed,
+/obj/effect/turf_decal/trimline/green/filled/line,
 /turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
+/area/security/brig)
 "axY" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
@@ -11136,11 +10272,8 @@
 "ayd" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -11553,10 +10686,14 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
 /obj/structure/cable{
 	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
@@ -11573,15 +10710,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/dorms)
 "azg" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
@@ -11593,6 +10725,9 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 10
+	},
+/obj/effect/turf_decal/lumos/tile/red/half{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
@@ -11622,7 +10757,9 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "azm" = (
@@ -11635,10 +10772,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "azn" = (
@@ -11806,10 +10940,7 @@
 /turf/closed/wall,
 /area/hydroponics/garden)
 "azG" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "azH" = (
@@ -11830,16 +10961,7 @@
 /area/crew_quarters/theatre)
 "azJ" = (
 /obj/effect/turf_decal/bot_white/right,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/gateway)
 "azK" = (
@@ -11851,30 +10973,12 @@
 /area/gateway)
 "azL" = (
 /obj/effect/turf_decal/bot_white/left,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/gateway)
 "azM" = (
 /obj/effect/turf_decal/bot_white,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/gateway)
 "azN" = (
@@ -11930,7 +11034,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
@@ -12018,12 +11122,6 @@
 	id_tag = "Dorm2";
 	name = "Room One"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/dorms)
 "aAc" = (
@@ -12037,17 +11135,13 @@
 /area/ai_monitored/storage/eva)
 "aAd" = (
 /obj/structure/closet/secure_closet/brig,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/item/radio/headset{
 	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
 	name = "prisoner headset";
 	prison_radio = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -12388,12 +11482,6 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
@@ -12418,11 +11506,10 @@
 	pixel_y = 4
 	},
 /obj/item/pen/fountain,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/item/pen/fourcolor,
+/obj/structure/sign/departments/restroom{
+	pixel_y = -32
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "aBa" = (
@@ -12430,21 +11517,13 @@
 /area/ai_monitored/nuke_storage)
 "aBb" = (
 /obj/structure/closet/emcloset,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
 /area/bridge)
 "aBc" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/warehouse)
+/obj/effect/spawner/structure/window/reinforced/tinted,
+/turf/open/floor/plating,
+/area/crew_quarters/fitness/pool)
 "aBe" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel/dark,
@@ -12556,8 +11635,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/ai_monitored/storage/eva)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/plasteel/dark,
+/area/security/courtroom)
 "aBs" = (
 /obj/structure/cable,
 /obj/structure/cable{
@@ -12627,6 +11707,10 @@
 	pixel_y = 22;
 	specialfunctions = 4
 	},
+/obj/machinery/recharge_station,
+/obj/machinery/light/small{
+	dir = 8
+	},
 /turf/open/floor/mineral/titanium/blue,
 /area/crew_quarters/toilet)
 "aBz" = (
@@ -12642,10 +11726,6 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/crew_quarters/toilet)
 "aBA" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral,
 /obj/structure/table/wood,
 /obj/item/paicard,
 /obj/item/clothing/mask/balaclava{
@@ -12669,18 +11749,9 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "aBC" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/lumos/tile/red/fulltile,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aBD" = (
@@ -12702,15 +11773,11 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aBG" = (
-/obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
+/obj/structure/curtain{
+	name = "Changing Room Curtain"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/fitness/pool)
 "aBH" = (
 /obj/machinery/light{
 	dir = 8
@@ -12849,16 +11916,7 @@
 	icon_state = "0-2"
 	},
 /obj/effect/turf_decal/bot_white,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/gateway)
 "aCa" = (
@@ -12887,10 +11945,8 @@
 /obj/machinery/airalarm{
 	pixel_y = 23
 	},
-/obj/machinery/cryopod{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/obj/machinery/cryopod,
+/turf/open/floor/circuit/green,
 /area/crew_quarters/cryopod)
 "aCe" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
@@ -12945,7 +12001,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/structure/closet/athletic_mixed,
+/obj/structure/closet/secure_closet/personal{
+	anchored = 1
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/pool)
 "aCo" = (
@@ -13082,9 +12140,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aCH" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aCI" = (
@@ -13098,12 +12154,13 @@
 	dir = 4;
 	sortType = 21
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aCJ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aCK" = (
@@ -13116,19 +12173,13 @@
 /turf/open/floor/plasteel,
 /area/storage/tools)
 "aCL" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/structure/table,
 /obj/item/radio/off,
 /obj/item/crowbar,
 /obj/item/assembly/flash/handheld,
+/obj/effect/turf_decal/lumos/tile/red/fullcorner{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
 "aCM" = (
@@ -13142,9 +12193,11 @@
 /turf/open/floor/plasteel,
 /area/bridge)
 "aCO" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/obj/effect/turf_decal/lumos/tile/green/half{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
-/area/crew_quarters/locker)
+/area/hallway/primary/fore)
 "aCP" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -13153,7 +12206,9 @@
 	dir = 4
 	},
 /obj/machinery/light,
-/obj/structure/closet/athletic_mixed,
+/obj/structure/closet/secure_closet/personal{
+	anchored = 1
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/pool)
 "aCQ" = (
@@ -13218,28 +12273,18 @@
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_y = 30
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
 "aCZ" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/effect/turf_decal/lumos/tile/red/fullcorner{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
 "aDa" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
 /obj/machinery/vending/cola/random,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
@@ -13264,11 +12309,8 @@
 	name = "Station Intercom (General)";
 	pixel_y = 20
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
@@ -13315,11 +12357,8 @@
 	departmentType = 5;
 	pixel_y = 30
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
@@ -13333,6 +12372,9 @@
 	desc = "A poster promoting a regression to ape-like intelligence for Assistants, suggesting they break, loot and murder enough to make even a caveman blush.";
 	pixel_x = -32;
 	poster_item_desc = "Nanotrasen does not condone such messages. Please don't regress to ape-level intelligence as this poster suggests."
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
@@ -13413,6 +12455,9 @@
 /area/storage/primary)
 "aDq" = (
 /obj/machinery/vending/tool,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "aDr" = (
@@ -13542,10 +12587,6 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "aDG" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/machinery/camera{
 	c_tag = "Dorms South";
 	dir = 8
@@ -13635,12 +12676,11 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/crew_quarters/toilet)
 "aDQ" = (
-/obj/machinery/light/small{
-	dir = 1;
-	light_color = "#ffc1c1"
+/obj/effect/turf_decal/lumos/tile/yellow/half{
+	dir = 1
 	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/crew_quarters/toilet)
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "aDR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -13682,14 +12722,16 @@
 /turf/open/floor/plasteel/freezer,
 /area/security/prison)
 "aDY" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -14024,8 +13066,7 @@
 /obj/item/reagent_containers/food/snacks/grown/citrus/orange,
 /obj/item/reagent_containers/food/snacks/grown/grapes,
 /obj/item/reagent_containers/food/snacks/grown/cocoapod,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/lumos/tile/green/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -14047,8 +13088,7 @@
 /turf/open/floor/carpet,
 /area/security/vacantoffice)
 "aEJ" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -14060,6 +13100,9 @@
 "aEL" = (
 /obj/machinery/door/airlock{
 	name = "Garden"
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
@@ -14216,22 +13259,12 @@
 /turf/closed/wall/r_wall,
 /area/ai_monitored/storage/eva)
 "aFd" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "aFe" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -14404,16 +13437,13 @@
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/entry)
 "aFH" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
 	},
+/obj/effect/turf_decal/lumos/tile/red/half,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
 "aFI" = (
@@ -14429,14 +13459,10 @@
 	pixel_x = 6;
 	pixel_y = -25
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/vending/wardrobe/sec_wardrobe,
+/obj/effect/turf_decal/lumos/tile/red/fullcorner{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/vending/wardrobe/sec_wardrobe,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
 "aFJ" = (
@@ -14451,40 +13477,28 @@
 	},
 /obj/item/pen,
 /obj/structure/table,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
+/obj/effect/turf_decal/lumos/tile/red/half,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
 "aFL" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/structure/table,
 /obj/machinery/recharger{
 	pixel_y = 4
 	},
+/obj/effect/turf_decal/lumos/tile/red/fullcorner,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
 "aFM" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 9
 	},
+/obj/effect/turf_decal/lumos/tile/red/half,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
 "aFN" = (
@@ -14494,8 +13508,7 @@
 /obj/item/crowbar,
 /obj/item/plant_analyzer,
 /obj/item/reagent_containers/glass/bucket,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/lumos/tile/green/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -14531,6 +13544,9 @@
 	pixel_y = 16
 	},
 /obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -14599,6 +13615,9 @@
 	pixel_y = -1
 	},
 /obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -14678,7 +13697,10 @@
 "aGi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/entry)
 "aGj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -14694,10 +13716,7 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/toilet)
 "aGl" = (
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
+/obj/machinery/light/small,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/toilet)
 "aGm" = (
@@ -14749,19 +13768,13 @@
 "aGr" = (
 /obj/structure/chair/stool,
 /obj/effect/landmark/start/clown,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
+/obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
+	},
+/obj/effect/turf_decal/lumos/tile/red/checker,
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
 "aGs" = (
@@ -14834,9 +13847,6 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aGC" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
@@ -14846,22 +13856,15 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aGD" = (
 /obj/structure/table/wood,
 /obj/structure/mirror{
 	pixel_x = -28
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
 	},
 /obj/item/phone{
 	pixel_x = -3;
@@ -14871,6 +13874,10 @@
 	pixel_x = 4;
 	pixel_y = 15
 	},
+/obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
+	},
+/obj/effect/turf_decal/lumos/tile/red/checker,
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
 "aGE" = (
@@ -15032,15 +14039,15 @@
 /area/security/prison)
 "aGS" = (
 /obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
@@ -15056,6 +14063,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
@@ -15164,6 +14174,9 @@
 /obj/item/storage/toolbox/electrical{
 	pixel_x = 1;
 	pixel_y = -1
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
@@ -15275,11 +14288,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "aHt" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
+/turf/open/floor/plasteel/dark,
+/area/security/courtroom)
 "aHu" = (
 /obj/machinery/status_display/evac{
 	pixel_x = 32
@@ -15298,8 +14311,6 @@
 /area/gateway)
 "aHw" = (
 /obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
 "aHx" = (
@@ -15314,12 +14325,8 @@
 /area/security/checkpoint/auxiliary)
 "aHz" = (
 /obj/structure/reagent_dispensers/watertank,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
+/obj/effect/turf_decal/lumos/tile/green/fullcorner{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
@@ -15338,14 +14345,8 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/lumos/tile/green/fullcorner{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
@@ -15375,27 +14376,20 @@
 /obj/item/stack/packageWrap,
 /obj/item/stack/packageWrap,
 /obj/item/stack/packageWrap,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "aHH" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "aHI" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/checker{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/red/checker,
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
 "aHJ" = (
@@ -15405,16 +14399,10 @@
 /area/gateway)
 "aHK" = (
 /obj/structure/closet/secure_closet/freezer/cream_pie,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/checker{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/red/checker,
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
 "aHL" = (
@@ -15432,7 +14420,10 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/entry)
 "aHN" = (
 /obj/structure/table,
@@ -15491,12 +14482,6 @@
 /area/maintenance/starboard/fore)
 "aHT" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/door/airlock/glass_large,
@@ -15607,9 +14592,6 @@
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "aIj" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/disposalpipe/segment,
@@ -15620,14 +14602,9 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "aIl" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/machinery/vending/wardrobe/law_wardrobe,
+/turf/open/floor/wood,
+/area/lawoffice)
 "aIm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -15640,9 +14617,7 @@
 	name = "Hydroponics APC";
 	pixel_y = -24
 	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aIo" = (
@@ -15733,11 +14708,8 @@
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
 "aIA" = (
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
@@ -15803,7 +14775,6 @@
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
 "aIJ" = (
-/obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 9
 	},
@@ -15825,13 +14796,16 @@
 	},
 /area/science/research)
 "aIM" = (
-/obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
+/area/construction/mining/aux_base)
 "aIN" = (
 /obj/structure/table,
 /obj/item/wrench,
 /obj/item/analyzer,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "aIO" = (
@@ -15873,8 +14847,7 @@
 	dir = 4;
 	pixel_x = -24
 	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/lumos/tile/green/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -15891,23 +14864,16 @@
 	pixel_x = -6;
 	pixel_y = -25
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/lumos/tile/green/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
 "aIU" = (
-/obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=8";
-	freq = 1400;
-	location = "Tool Storage"
-	},
-/obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/plasteel,
-/area/storage/primary)
+/area/construction/mining/aux_base)
 "aIV" = (
 /obj/machinery/button/door{
 	id = "stationawaygate";
@@ -15933,7 +14899,7 @@
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "aIY" = (
-/obj/structure/reagent_dispensers/fueltank,
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "aIZ" = (
@@ -15949,12 +14915,20 @@
 /turf/open/floor/plasteel,
 /area/gateway)
 "aJb" = (
-/obj/effect/turf_decal/delivery,
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=8";
+	freq = 1400;
+	location = "Tool Storage"
+	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "aJc" = (
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/disposal/bin,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "aJd" = (
@@ -15983,18 +14957,19 @@
 	c_tag = "EVA South";
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark/corner{
+	dir = 1
+	},
 /area/ai_monitored/storage/eva)
 "aJg" = (
-/obj/machinery/light{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "aJh" = (
 /turf/open/floor/plasteel,
 /area/gateway)
@@ -16063,23 +15038,14 @@
 /obj/machinery/camera{
 	c_tag = "Central Hallway North"
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aJp" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/fullcorner{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -16089,15 +15055,6 @@
 "aJr" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"aJs" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -16123,12 +15080,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aJu" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/lumos/tile/blue/fullcorner{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -16152,23 +15107,20 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "aJy" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aJz" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
 	},
-/obj/machinery/recharge_station,
-/turf/open/floor/mineral/titanium/blue,
-/area/crew_quarters/toilet)
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/blueshield)
 "aJA" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Kitchen Maintenance";
@@ -16185,7 +15137,6 @@
 	name = "Hydroponics Maintenance";
 	req_access_txt = "35"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
@@ -16440,6 +15391,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/gateway)
 "aKe" = (
@@ -16523,25 +15475,25 @@
 /turf/open/floor/plating,
 /area/hydroponics/garden)
 "aKo" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/blueshield)
 "aKp" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/storage/primary)
 "aKq" = (
 /obj/machinery/vr_sleeper,
-/obj/effect/turf_decal/tile/green{
+/obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
+/obj/effect/turf_decal/lumos/tile/green/half{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white/side,
@@ -16549,9 +15501,6 @@
 "aKr" = (
 /obj/machinery/light/small{
 	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
@@ -16641,6 +15590,7 @@
 	id = "stationawaygate";
 	name = "Gateway Access Shutters"
 	},
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/gateway)
 "aKB" = (
@@ -16660,17 +15610,19 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aKE" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aKF" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
+	},
+/obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -16686,7 +15638,7 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aKI" = (
-/obj/structure/closet/secure_closet/hydroponics,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aKJ" = (
@@ -16717,7 +15669,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/obj/machinery/hydroponics/constructable,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aKM" = (
@@ -16946,6 +15898,9 @@
 	},
 /obj/structure/table/glass,
 /obj/structure/bedsheetbin/towel,
+/obj/machinery/light/small{
+	dir = 8
+	},
 /turf/open/floor/mineral/titanium/blue,
 /area/crew_quarters/toilet)
 "aLp" = (
@@ -17106,23 +16061,16 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "aLO" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/plating,
+/area/maintenance/fore/secondary)
 "aLP" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/structure/closet/secure_closet/security,
 /obj/item/book/manual/wiki/security_space_law,
+/obj/effect/turf_decal/lumos/tile/red/half{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
 "aLQ" = (
@@ -17136,17 +16084,14 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aLR" = (
-/obj/machinery/newscaster{
-	pixel_y = 32
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/crew_quarters/dorms)
 "aLS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
@@ -17251,14 +16196,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aMg" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/storage/primary)
 "aMh" = (
 /obj/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -17270,15 +16212,8 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "aMj" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aMk" = (
@@ -17392,9 +16327,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aMz" = (
@@ -17404,7 +16337,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aMA" = (
@@ -17704,23 +16639,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"aNq" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "aNr" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aNs" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -17969,6 +16901,9 @@
 	c_tag = "Port Hallway";
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/green/filled/corner{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "aNV" = (
@@ -17980,7 +16915,9 @@
 	name = "Chapel Office";
 	req_access_txt = "22"
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/median/darktogrime{
+	dir = 1
+	},
 /area/chapel/office)
 "aNX" = (
 /obj/item/radio/intercom{
@@ -18113,6 +17050,7 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/trimline/green/filled/corner,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "aOt" = (
@@ -18305,9 +17243,6 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/crew_quarters/toilet)
 "aOV" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
 /obj/machinery/vending/cigarette,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
@@ -18352,12 +17287,6 @@
 /obj/structure/bookcase/random/reference,
 /turf/open/floor/wood,
 /area/library)
-"aPe" = (
-/obj/structure/chair/stool{
-	pixel_y = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/locker)
 "aPf" = (
 /obj/machinery/computer/libraryconsole,
 /obj/structure/table/wood,
@@ -18494,6 +17423,9 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Art Storage"
 	},
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/storage/art)
 "aPI" = (
@@ -18519,11 +17451,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "aPN" = (
-/obj/structure/table,
 /obj/machinery/airalarm{
 	dir = 1;
 	pixel_y = -22
 	},
+/obj/structure/table,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "aPO" = (
@@ -18657,13 +17589,6 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"aQc" = (
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "aQd" = (
 /obj/structure/window,
 /obj/structure/chair/sofa/right{
@@ -18679,14 +17604,8 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "aQf" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/lumos/tile/green/fullcorner{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
@@ -18699,26 +17618,19 @@
 /turf/open/floor/plating,
 /area/crew_quarters/bar)
 "aQh" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/lumos/tile/green/fullcorner{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aQi" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
+/obj/effect/turf_decal/lumos/tile/bar/checker,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "aQk" = (
@@ -18732,11 +17644,8 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
 "aQm" = (
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/lumos/tile/green/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
@@ -18800,13 +17709,6 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "aQC" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
 /obj/machinery/power/apc{
 	areastring = "/area/security/checkpoint/auxiliary";
 	dir = 8;
@@ -18822,6 +17724,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
 	},
+/obj/effect/turf_decal/lumos/tile/red/fullcorner{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
 "aQD" = (
@@ -18831,15 +17736,12 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/exit)
 "aQF" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = -26
+	},
+/obj/effect/turf_decal/lumos/tile/red/half{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
@@ -18900,13 +17802,37 @@
 /obj/item/clothing/suit/ghost_sheet,
 /obj/item/clothing/suit/ghost_sheet,
 /obj/item/clothing/suit/ghost_sheet,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "aQP" = (
+/obj/structure/closet{
+	name = "Suit Closet"
+	},
+/obj/item/clothing/under/suit/white,
+/obj/item/clothing/under/suit/tan,
+/obj/item/clothing/under/suit/red,
+/obj/item/clothing/under/suit/black_really,
+/obj/item/clothing/under/suit/navy,
+/obj/item/clothing/under/suit/green,
+/obj/item/clothing/under/suit/black/skirt,
+/obj/item/clothing/under/suit/checkered,
+/obj/item/clothing/under/suit/charcoal,
+/obj/item/clothing/under/suit/burgundy,
+/obj/item/clothing/under/suit/black,
+/obj/item/clothing/under/rank/civilian/lawyer/black,
+/obj/item/clothing/under/rank/civilian/lawyer/black,
+/obj/item/clothing/under/rank/civilian/lawyer/bluesuit,
+/obj/item/clothing/under/rank/civilian/lawyer/bluesuit,
+/obj/item/clothing/under/rank/civilian/lawyer/female,
+/obj/item/clothing/under/rank/civilian/lawyer/purpsuit,
+/obj/item/clothing/under/rank/civilian/lawyer/really_black,
+/obj/item/clothing/under/rank/civilian/lawyer/red,
 /obj/machinery/light_switch{
 	pixel_y = 28
 	},
-/obj/machinery/vending/cigarette,
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "aQQ" = (
@@ -18924,9 +17850,12 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "aQS" = (
-/obj/machinery/vending/coffee,
+/obj/structure/reagent_dispensers/fueltank,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
-/area/crew_quarters/locker)
+/area/storage/primary)
 "aQT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -18944,13 +17873,16 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/vending/autodrobe,
+/obj/machinery/vending/coffee,
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "aQW" = (
-/obj/structure/closet/secure_closet/personal,
-/turf/open/floor/plasteel,
-/area/crew_quarters/locker)
+/obj/machinery/power/apc/auto_name/west,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/cryopod)
 "aQX" = (
 /obj/machinery/firealarm{
 	pixel_y = 24
@@ -18969,6 +17901,9 @@
 /obj/item/storage/toolbox/electrical{
 	pixel_y = -10
 	},
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/storage/art)
 "aQZ" = (
@@ -18977,6 +17912,9 @@
 	},
 /obj/machinery/light_switch{
 	pixel_x = 27
+	},
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/storage/art)
@@ -19010,14 +17948,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/storage/tools)
-"aRg" = (
-/obj/machinery/vending/boozeomat,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "aRh" = (
 /obj/machinery/light{
 	dir = 8
@@ -19026,12 +17956,8 @@
 /area/hallway/primary/central)
 "aRi" = (
 /obj/machinery/computer/atmos_alert,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/fullcorner{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
@@ -19052,50 +17978,30 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/yellow/fullcorner,
 /turf/open/floor/plasteel,
 /area/bridge)
 "aRl" = (
 /obj/machinery/computer/station_alert,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/yellow/half,
 /turf/open/floor/plasteel,
 /area/bridge)
 "aRm" = (
 /obj/machinery/computer/communications,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/blue/half,
 /turf/open/floor/plasteel,
 /area/bridge)
 "aRn" = (
 /obj/machinery/computer/shuttle/labor,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/fullcorner{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
 "aRo" = (
 /obj/machinery/modular_computer/console/preset/command,
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/lumos/tile/green/fullcorner{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
@@ -19104,32 +18010,17 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/computer/shuttle/mining,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/blue/fullcorner,
 /turf/open/floor/plasteel,
 /area/bridge)
 "aRq" = (
 /obj/machinery/computer/med_data,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/green/fullcorner,
 /turf/open/floor/plasteel,
 /area/bridge)
 "aRr" = (
 /obj/machinery/computer/crew,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/green/half,
 /turf/open/floor/plasteel,
 /area/bridge)
 "aRs" = (
@@ -19180,13 +18071,7 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "aRz" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
+/obj/effect/turf_decal/lumos/tile/bar/checker,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "aRA" = (
@@ -19252,10 +18137,6 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "aRI" = (
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 9
 	},
@@ -19263,6 +18144,9 @@
 	dir = 9
 	},
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/lumos/tile/green/half{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aRJ" = (
@@ -19332,6 +18216,9 @@
 /obj/structure/rack,
 /obj/item/electronics/apc,
 /obj/item/electronics/airlock,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/storage/tools)
 "aRV" = (
@@ -19351,6 +18238,9 @@
 /obj/structure/table,
 /obj/item/stack/sheet/glass/fifty,
 /obj/item/stack/rods/fifty,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 9
+	},
 /turf/open/floor/plasteel,
 /area/storage/tools)
 "aRX" = (
@@ -19382,6 +18272,9 @@
 /obj/item/stack/sheet/metal/fifty,
 /obj/item/stack/sheet/metal/fifty,
 /obj/item/storage/box/lights/mixed,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/storage/tools)
 "aSb" = (
@@ -19400,6 +18293,9 @@
 "aSc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/storage/tools)
 "aSd" = (
@@ -19432,14 +18328,17 @@
 /area/maintenance/port)
 "aSh" = (
 /obj/structure/closet/wardrobe/mixed,
+/obj/item/clothing/head/beret,
+/obj/item/clothing/head/beret,
+/obj/item/clothing/head/russobluecamohat,
+/obj/item/clothing/head/russobluecamohat,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_x = -27
 	},
-/obj/item/clothing/head/beret,
-/obj/item/clothing/head/beret,
-/obj/item/clothing/head/russobluecamohat,
-/obj/item/clothing/head/russobluecamohat,
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "aSj" = (
@@ -19459,6 +18358,9 @@
 /obj/item/paper_bin/construction,
 /obj/item/stack/cable_coil,
 /obj/item/pen/fourcolor,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/storage/art)
 "aSl" = (
@@ -19503,6 +18405,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "aSr" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/plasteel,
 /area/storage/tools)
 "aSs" = (
@@ -19523,10 +18426,17 @@
 /area/bridge)
 "aSv" = (
 /obj/structure/table/reinforced,
-/obj/item/assembly/flash/handheld,
-/obj/item/assembly/flash/handheld,
-/obj/machinery/keycard_auth{
-	pixel_x = -23
+/obj/item/assembly/flash/handheld{
+	pixel_x = -6;
+	pixel_y = 8
+	},
+/obj/item/assembly/flash/handheld{
+	pixel_x = -6;
+	pixel_y = 4
+	},
+/obj/machinery/recharger{
+	pixel_x = 5;
+	pixel_y = 3
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
@@ -19557,10 +18467,7 @@
 /obj/structure/table/reinforced,
 /obj/item/aicard,
 /obj/item/multitool,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -19576,11 +18483,23 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
+/obj/item/phone,
+/obj/machinery/button/door{
+	id = "bridge blast";
+	name = "Bridge Blast Door Control";
+	pixel_x = -7;
+	pixel_y = 9;
+	plane = -4;
+	req_access_txt = "19"
+	},
+/obj/machinery/keycard_auth{
+	pixel_x = 6;
+	pixel_y = 8;
+	plane = -4
+	},
+/obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 4
 	},
-/obj/item/phone,
 /turf/open/floor/plasteel,
 /area/bridge)
 "aSC" = (
@@ -19630,39 +18549,27 @@
 /turf/open/floor/grass,
 /area/crew_quarters/bar)
 "aSI" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Kitchen";
-	req_access_txt = "28"
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/kitchen)
-"aSJ" = (
-/obj/effect/landmark/start/cook,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+/obj/machinery/shower{
 	dir = 4
 	},
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -23
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/crew_quarters/toilet)
+"aSJ" = (
+/obj/effect/landmark/start/cook,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "aSL" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+/turf/open/floor/plasteel/dark/corner,
+/area/ai_monitored/storage/eva)
+"aSM" = (
+/turf/open/floor/plasteel/dark/corner{
 	dir = 8
 	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
-"aSM" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
+/area/ai_monitored/storage/eva)
 "aSN" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -19706,6 +18613,9 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
 	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/storage/tools)
 "aSX" = (
@@ -19735,21 +18645,15 @@
 "aSY" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/head/that,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/effect/turf_decal/lumos/tile/bar/checker,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "aSZ" = (
 /obj/effect/landmark/start/bartender,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
+/obj/effect/turf_decal/lumos/tile/bar/checker,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "aTa" = (
@@ -19844,6 +18748,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "aTu" = (
@@ -19868,6 +18773,9 @@
 	},
 /obj/item/clothing/under/costume/kilt,
 /obj/item/clothing/under/costume/kilt,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "aTx" = (
@@ -19886,34 +18794,7 @@
 /obj/machinery/door/airlock/titanium,
 /turf/open/floor/plating,
 /area/space/nearstation)
-"aTz" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/structure/window{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/landmark/start/assistant,
-/obj/machinery/door/window/westright{
-	name = "Red Corner"
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/locker)
 "aTA" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/delivery,
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
 	},
@@ -19932,19 +18813,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "aTC" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/structure/window{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
+/obj/structure/table,
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "aTD" = (
@@ -19959,20 +18828,26 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/structure/table,
-/obj/item/reagent_containers/rag/towel/random,
-/obj/item/razor,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "aTE" = (
 /obj/structure/table,
 /obj/item/hand_labeler,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/storage/art)
 "aTF" = (
 /obj/structure/table,
 /obj/item/camera_film,
 /obj/item/camera,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/storage/art)
 "aTG" = (
@@ -20011,6 +18886,9 @@
 	pixel_y = 6
 	},
 /obj/item/storage/toolbox/emergency,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 5
+	},
 /turf/open/floor/plasteel,
 /area/storage/tools)
 "aTM" = (
@@ -20025,18 +18903,24 @@
 "aTN" = (
 /obj/structure/table,
 /obj/item/book/manual/chef_recipes,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "aTO" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass_large,
-/turf/open/floor/plasteel/yellowsiding,
+/turf/open/floor/plasteel/dark,
 /area/crew_quarters/dorms)
 "aTP" = (
 /obj/structure/rack,
 /obj/item/clothing/gloves/color/fyellow,
 /obj/item/clothing/suit/hazardvest,
 /obj/item/multitool,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/storage/tools)
 "aTQ" = (
@@ -20044,37 +18928,22 @@
 /area/bridge)
 "aTR" = (
 /obj/machinery/computer/prisoner/management,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/lumos/tile/red/fullcorner{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
 "aTS" = (
 /obj/machinery/computer/secure_data,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/red/fullcorner,
 /turf/open/floor/plasteel,
 /area/bridge)
 "aTT" = (
 /obj/machinery/computer/security,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/red/half,
 /turf/open/floor/plasteel,
 /area/bridge)
 "aTV" = (
-/obj/structure/table/reinforced,
-/obj/machinery/recharger,
 /obj/machinery/button/door{
 	id = "bridge blast";
 	name = "Bridge Blast Door Control";
@@ -20082,6 +18951,7 @@
 	pixel_y = 22;
 	req_access_txt = "19"
 	},
+/obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/plasteel,
 /area/bridge)
 "aTW" = (
@@ -20158,10 +19028,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"aUg" = (
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/yellowsiding,
-/area/crew_quarters/dorms)
 "aUh" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/eastleft{
@@ -20172,19 +19038,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
-"aUi" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/hydroponics)
 "aUj" = (
 /obj/machinery/vending/hydronutrients,
 /turf/open/floor/plasteel/dark,
@@ -20220,16 +19073,9 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aUs" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
+/obj/structure/table,
+/obj/item/reagent_containers/rag/towel/random,
+/obj/item/razor,
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "aUt" = (
@@ -20237,7 +19083,10 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/entry)
 "aUu" = (
 /obj/structure/cable{
@@ -20257,6 +19106,7 @@
 /area/quartermaster/warehouse)
 "aUw" = (
 /obj/machinery/light/small,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/plasteel,
 /area/storage/tools)
 "aUx" = (
@@ -20347,7 +19197,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/entry)
 "aUN" = (
 /obj/structure/chair/office/dark{
@@ -20407,6 +19260,9 @@
 /obj/item/clothing/under/misc/assistantformal,
 /obj/item/clothing/under/color/grey,
 /obj/item/clothing/under/color/grey,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "aUV" = (
@@ -20440,20 +19296,10 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "aUY" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -20462,9 +19308,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
 	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 10
 	},
+/obj/machinery/vending/clothing,
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "aVa" = (
@@ -20473,6 +19323,9 @@
 	pixel_x = -22
 	},
 /obj/structure/closet/toolcloset,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 10
+	},
 /turf/open/floor/plasteel,
 /area/storage/tools)
 "aVb" = (
@@ -20480,12 +19333,8 @@
 	pixel_y = 32
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/obj/effect/turf_decal/lumos/tile/blue/fullcorner{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -20721,14 +19570,8 @@
 	pixel_y = 32
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/fullcorner{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -20736,11 +19579,8 @@
 /obj/machinery/camera{
 	c_tag = "Bridge East Entrance"
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -20750,15 +19590,6 @@
 /turf/open/space,
 /area/space/nearstation)
 "aVx" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/loading_area{
-	dir = 1
-	},
 /obj/structure/window/reinforced{
 	dir = 4;
 	layer = 2.9
@@ -20770,13 +19601,10 @@
 /area/security/prison)
 "aVy" = (
 /obj/structure/table/reinforced,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/effect/turf_decal/lumos/tile/bar/checker,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "aVz" = (
@@ -20842,6 +19670,12 @@
 	pixel_x = 10
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
+	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "aVE" = (
@@ -20849,15 +19683,12 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "aVG" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /obj/structure/table,
 /obj/item/clothing/suit/straight_jacket,
 /obj/item/clothing/suit/straight_jacket,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aVH" = (
@@ -20866,25 +19697,13 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/kitchen)
 "aVI" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/lumos/tile/green/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aVJ" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/hydroponics)
 "aVK" = (
@@ -20970,7 +19789,6 @@
 /area/chapel/main)
 "aVY" = (
 /obj/structure/closet/secure_closet/hydroponics,
-/obj/item/watertank,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aVZ" = (
@@ -20997,7 +19815,10 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/entry)
 "aWd" = (
 /obj/structure/falsewall,
@@ -21077,18 +19898,15 @@
 /obj/item/clothing/accessory/maidapron,
 /obj/item/clothing/head/beret/black,
 /obj/item/clothing/head/beret/black,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "aWo" = (
 /obj/machinery/camera{
 	c_tag = "Locker Room West";
 	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 5
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
@@ -21117,9 +19935,10 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "aWv" = (
-/obj/structure/closet/crate/wooden/fish_learning,
-/turf/open/floor/plasteel/showroomfloor,
-/area/crew_quarters/kitchen)
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
+/area/ai_monitored/storage/eva)
 "aWw" = (
 /obj/item/reagent_containers/blood/random,
 /turf/open/floor/plating,
@@ -21172,20 +19991,10 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "aWA" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/port)
+/area/ai_monitored/storage/eva)
 "aWB" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Detective Maintenance";
@@ -21207,6 +20016,9 @@
 /area/maintenance/port)
 "aWD" = (
 /obj/structure/reagent_dispensers/fueltank,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 6
+	},
 /turf/open/floor/plasteel,
 /area/storage/tools)
 "aWE" = (
@@ -21221,6 +20033,7 @@
 /area/security/detectives_office)
 "aWF" = (
 /obj/structure/closet/toolcloset,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/plasteel,
 /area/storage/tools)
 "aWG" = (
@@ -21232,8 +20045,7 @@
 /area/security/detectives_office)
 "aWH" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -21304,14 +20116,11 @@
 	pixel_x = -6;
 	pixel_y = -22
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
 /area/bridge)
 "aWP" = (
-/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/plasteel,
 /area/bridge)
 "aWQ" = (
@@ -21319,32 +20128,23 @@
 	dir = 1;
 	pixel_y = -22
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
 /area/bridge)
 "aWR" = (
 /obj/structure/fireaxecabinet{
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
 /area/bridge)
 "aWS" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
 /area/bridge)
 "aWT" = (
@@ -21355,17 +20155,11 @@
 	name = "Bridge RC";
 	pixel_y = -30
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
 /area/bridge)
 "aWU" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
 /area/bridge)
 "aWV" = (
@@ -21378,10 +20172,7 @@
 	c_tag = "Bridge Center";
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
 /area/bridge)
 "aWW" = (
@@ -21392,24 +20183,18 @@
 	},
 /obj/structure/cable,
 /obj/machinery/light,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
 /area/bridge)
 "aWX" = (
 /obj/machinery/newscaster{
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
 /area/bridge)
 "aWY" = (
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -21476,10 +20261,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -21537,10 +20319,6 @@
 /area/crew_quarters/bar)
 "aXj" = (
 /obj/structure/table/reinforced,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
 /obj/item/paper_bin/bundlenatural{
 	pixel_x = 6;
 	pixel_y = 4
@@ -21552,6 +20330,7 @@
 	dir = 8
 	},
 /obj/item/pen/fourcolor,
+/obj/effect/turf_decal/lumos/tile/bar/checker,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "aXk" = (
@@ -21561,11 +20340,8 @@
 	},
 /obj/item/book/manual/wiki/barman_recipes,
 /obj/item/reagent_containers/rag,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
 /obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/lumos/tile/bar/checker,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "aXl" = (
@@ -21573,11 +20349,8 @@
 	name = "Bar Door";
 	req_one_access_txt = "25;28"
 	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
 /obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/lumos/tile/bar/checker,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "aXm" = (
@@ -21595,8 +20368,7 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "aXo" = (
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/lumos/tile/green/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -21613,22 +20385,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"aXr" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/structure/window{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/locker)
 "aXs" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -21636,16 +20392,7 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "aXt" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/structure/chair/stool,
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "aXu" = (
@@ -21653,41 +20400,18 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
 "aXv" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
+/obj/item/chair/stool,
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "aXw" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/structure/window{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/locker)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/plating,
+/area/maintenance/fore/secondary)
 "aXx" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /obj/machinery/conveyor/auto{
 	dir = 1
 	},
@@ -21720,12 +20444,6 @@
 	icon_state = "roomnum";
 	name = "Room Number 6";
 	pixel_y = 24
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
 	},
 /obj/machinery/washing_machine{
 	pixel_x = 7;
@@ -21765,8 +20483,6 @@
 	name = "Cargo Bay Warehouse Maintenance";
 	req_access_txt = "31"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "aXN" = (
@@ -21861,22 +20577,15 @@
 	},
 /area/security/prison)
 "aYc" = (
-/obj/machinery/power/apc{
-	areastring = "/area/maintenance/port";
-	dir = 8;
-	name = "Port Maintenance APC";
-	pixel_x = -27;
-	pixel_y = 2
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
 /turf/open/floor/plating,
 /area/maintenance/port)
 "aYd" = (
@@ -21933,10 +20642,7 @@
 /area/security/detectives_office)
 "aYk" = (
 /obj/machinery/light,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/blue/half,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aYl" = (
@@ -21945,13 +20651,7 @@
 /area/hallway/primary/central)
 "aYm" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/blue/fullcorner,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aYn" = (
@@ -21959,10 +20659,7 @@
 	c_tag = "Bridge West Entrance";
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/blue/half,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aYo" = (
@@ -21984,22 +20681,16 @@
 	name = "Station Intercom (General)";
 	pixel_y = -29
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
 /area/bridge)
 "aYs" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
 /area/bridge)
 "aYt" = (
@@ -22022,12 +20713,8 @@
 	pixel_y = 7
 	},
 /obj/item/pen,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
@@ -22051,9 +20738,10 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "aYx" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
+/turf/open/floor/plasteel/dark/corner{
+	dir = 4
+	},
+/area/ai_monitored/storage/eva)
 "aYy" = (
 /obj/machinery/light{
 	dir = 4
@@ -22067,7 +20755,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "aYA" = (
@@ -22093,12 +20783,8 @@
 	pixel_y = -24
 	},
 /obj/structure/filingcabinet/filingcabinet,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
@@ -22107,22 +20793,15 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
 /area/bridge)
 "aYE" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/fullcorner{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -22133,10 +20812,7 @@
 	pixel_y = -24
 	},
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/blue/half,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aYG" = (
@@ -22184,11 +20860,7 @@
 	name = "Kitchen";
 	req_access_txt = "28"
 	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "aYL" = (
 /obj/machinery/light,
@@ -22233,11 +20905,8 @@
 /area/hydroponics)
 "aYQ" = (
 /obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/lumos/tile/green/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
@@ -22246,20 +20915,6 @@
 /obj/effect/landmark/start/botanist,
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"aYS" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/structure/window,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/locker)
 "aYT" = (
 /obj/machinery/camera{
 	c_tag = "Hydroponics South";
@@ -22271,6 +20926,10 @@
 "aYU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/closet/secure_closet/personal,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "aYV" = (
@@ -22397,8 +21056,6 @@
 /obj/item/stock_parts/cell{
 	maxcharge = 2000
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
 "aZq" = (
@@ -22406,6 +21063,10 @@
 	id = "heads_meeting";
 	name = "Security Shutters";
 	pixel_y = 24
+	},
+/obj/structure/chair/stool{
+	desc = "The most important people get the best seating.";
+	name = "Blueshield stool"
 	},
 /turf/open/floor/wood,
 /area/bridge/meeting_room)
@@ -22464,22 +21125,15 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/locker)
 "aZx" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/machinery/newscaster{
+	pixel_y = 32
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/structure/window,
-/obj/structure/window{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/machinery/light{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/locker)
+/obj/machinery/vending/games,
+/turf/open/floor/plasteel/dark,
+/area/hallway/primary/central)
 "aZy" = (
 /obj/machinery/camera{
 	c_tag = "Conference Room"
@@ -22740,7 +21394,7 @@
 	id = "kitchen";
 	name = "kitchen shutters"
 	},
-/turf/open/floor/plasteel/cafeteria,
+/turf/open/floor/plating,
 /area/crew_quarters/kitchen)
 "bak" = (
 /obj/structure/table/reinforced,
@@ -22749,7 +21403,7 @@
 	id = "kitchen";
 	name = "kitchen shutters"
 	},
-/turf/open/floor/plasteel/cafeteria,
+/turf/open/floor/plating,
 /area/crew_quarters/kitchen)
 "bal" = (
 /obj/machinery/firealarm{
@@ -22800,11 +21454,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bas" = (
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/lumos/tile/green/half{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bat" = (
@@ -22860,7 +21513,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/entry)
 "baJ" = (
 /obj/item/radio/intercom{
@@ -22962,9 +21618,8 @@
 /area/security/detectives_office)
 "baY" = (
 /obj/structure/closet/crate,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
@@ -23244,11 +21899,8 @@
 /area/security/prison)
 "bbO" = (
 /obj/machinery/washing_machine,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/checker{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/locker)
@@ -23542,8 +22194,8 @@
 /area/quartermaster/warehouse)
 "bcF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
@@ -23573,7 +22225,6 @@
 /obj/item/reagent_containers/food/snacks/meat/slab/monkey,
 /obj/item/pizzabox,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
 "bcK" = (
@@ -23632,10 +22283,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bcT" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
 /obj/structure/table/reinforced,
 /obj/item/clothing/head/helmet/space/plasmaman/prisoner,
 /obj/item/clothing/head/helmet/space/plasmaman/prisoner,
@@ -23655,6 +22302,9 @@
 	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
 	name = "prisoner headset";
 	prison_radio = 1
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -23707,12 +22357,9 @@
 /turf/open/floor/carpet,
 /area/bridge/meeting_room)
 "bdb" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bdc" = (
@@ -23761,9 +22408,11 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "bdj" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
-/turf/open/floor/plating,
-/area/storage/tech)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "bdl" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -23800,12 +22449,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bdo" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bdp" = (
@@ -23828,10 +22472,7 @@
 /turf/open/floor/wood,
 /area/medical/psych)
 "bds" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/lumos/tile/red/half,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bdt" = (
@@ -23913,11 +22554,11 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 10
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
@@ -23972,13 +22613,11 @@
 /area/bridge/meeting_room)
 "bdL" = (
 /obj/machinery/light,
-/obj/effect/turf_decal/tile/blue{
+/obj/structure/bedsheetbin/color,
+/obj/effect/turf_decal/lumos/tile/blue/checker{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/structure/bedsheetbin/color,
+/obj/structure/table,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/locker)
 "bdM" = (
@@ -24054,12 +22693,11 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
 "bdV" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -24392,7 +23030,10 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/entry)
 "beN" = (
 /obj/item/radio/intercom{
@@ -24495,11 +23136,8 @@
 	pixel_x = -1;
 	pixel_y = -1
 	},
-/obj/effect/turf_decal/tile/brown{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
@@ -24589,14 +23227,11 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "bfi" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 9
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
+	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/quartermaster/warehouse)
+/area/hallway/primary/central)
 "bfj" = (
 /obj/structure/disposalpipe/trunk,
 /obj/structure/disposaloutlet{
@@ -24605,10 +23240,6 @@
 /turf/open/floor/plating,
 /area/quartermaster/sorting)
 "bfk" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
 /obj/structure/table/reinforced,
 /obj/item/clothing/shoes/sneakers/orange,
 /obj/item/clothing/shoes/sneakers/orange,
@@ -24635,6 +23266,9 @@
 	prison_radio = 1
 	},
 /obj/item/radio/off,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "bfl" = (
@@ -24829,11 +23463,12 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 4
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
@@ -24868,23 +23503,16 @@
 /turf/closed/wall/r_wall,
 /area/science/robotics/lab)
 "bfW" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
 /obj/item/kirbyplants{
 	icon_state = "plant-13"
+	},
+/obj/effect/turf_decal/lumos/tile/purple/fullcorner{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bfX" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/purple/half,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bfY" = (
@@ -24892,41 +23520,26 @@
 	name = "Station Intercom (General)";
 	pixel_y = -29
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/purple/half,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bfZ" = (
 /obj/structure/sign/warning/securearea{
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/purple/half,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bga" = (
 /obj/machinery/light,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/purple/half,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bgb" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
 /obj/item/kirbyplants{
 	icon_state = "plant-10"
 	},
+/obj/effect/turf_decal/lumos/tile/purple/fullcorner,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bgc" = (
@@ -24988,8 +23601,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -25007,17 +23620,11 @@
 /area/hallway/primary/central)
 "bgo" = (
 /obj/machinery/vr_sleeper,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
+/obj/effect/turf_decal/lumos/tile/green/fullcorner{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white/corner,
 /area/crew_quarters/fitness)
@@ -25074,14 +23681,14 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "bgA" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 6
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/quartermaster/warehouse)
+/area/hallway/primary/central)
 "bgB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -25110,11 +23717,8 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/brown{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
@@ -25197,12 +23801,11 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/computer/security{
 	dir = 8
+	},
+/obj/effect/turf_decal/lumos/tile/red/half{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
@@ -25279,38 +23882,28 @@
 /area/crew_quarters/heads/captain)
 "bgY" = (
 /obj/machinery/light,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/lumos/tile/blue/half,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bha" = (
-/obj/structure/table,
-/obj/item/storage/firstaid/regular,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/machinery/light{
 	dir = 1
 	},
 /obj/item/storage/firstaid/regular,
+/obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
+	},
+/obj/structure/table/glass,
 /turf/open/floor/plasteel/cafeteria,
 /area/medical/medbay/lobby)
 "bhe" = (
 /obj/machinery/disposal/bin,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/light{
 	dir = 1
+	},
+/obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/medical/medbay/lobby)
@@ -25371,12 +23964,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 10
 	},
@@ -25386,7 +23973,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/lumos/tile/red/fullcorner{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -25396,13 +23983,9 @@
 	pixel_y = 28
 	},
 /obj/machinery/rnd/production/circuit_imprinter,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/effect/turf_decal/lumos/tile/red/fullcorner{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
 "bhx" = (
@@ -25543,13 +24126,6 @@
 /area/maintenance/disposal)
 "bhK" = (
 /obj/machinery/light,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/delivery,
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
 	},
@@ -25605,11 +24181,7 @@
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "bhR" = (
-/obj/structure/grille,
-/obj/structure/window{
-	dir = 1
-	},
-/obj/structure/window,
+/obj/effect/spawner/structure/window/hollow/middle,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "bhS" = (
@@ -25619,8 +24191,7 @@
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "bhT" = (
-/obj/structure/grille,
-/obj/structure/window,
+/obj/effect/spawner/structure/window/hollow/directional,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "bhV" = (
@@ -25700,44 +24271,17 @@
 /area/bridge/meeting_room)
 "big" = (
 /obj/effect/turf_decal/bot_white,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
 "bih" = (
 /obj/effect/turf_decal/bot_white/right,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
 "bii" = (
 /obj/effect/turf_decal/bot_white/left,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
 "bik" = (
@@ -25766,7 +24310,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "biv" = (
-/obj/effect/turf_decal/tile/brown{
+/obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -25781,6 +24325,7 @@
 /obj/structure/sign/poster/official/help_others{
 	pixel_y = -32
 	},
+/obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "biF" = (
@@ -25831,21 +24376,6 @@
 	},
 /turf/open/floor/circuit,
 /area/science/robotics/mechbay)
-"biK" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/science/robotics/lab)
 "biL" = (
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
@@ -25859,11 +24389,8 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "biN" = (
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
@@ -25892,22 +24419,15 @@
 /area/science/robotics/lab)
 "biP" = (
 /obj/structure/filingcabinet/chestdrawer,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/effect/turf_decal/lumos/tile/red/fullcorner{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
 "biQ" = (
 /obj/structure/chair/stool,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
@@ -25938,22 +24458,16 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "biU" = (
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "biV" = (
 /obj/structure/chair/stool,
 /obj/effect/landmark/start/scientist,
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
@@ -25988,10 +24502,6 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "biZ" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
 /obj/structure/table/reinforced,
 /obj/item/clothing/under/rank/prisoner,
 /obj/item/clothing/under/rank/prisoner,
@@ -26013,6 +24523,9 @@
 	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
 	name = "prisoner headset";
 	prison_radio = 1
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -26131,11 +24644,8 @@
 	departmentType = 2;
 	pixel_y = 30
 	},
-/obj/effect/turf_decal/tile/brown{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
@@ -26143,14 +24653,8 @@
 /obj/structure/table,
 /obj/item/clothing/head/soft,
 /obj/item/clothing/head/soft,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
@@ -26159,11 +24663,8 @@
 	c_tag = "Cargo Bay North"
 	},
 /obj/machinery/vending/wardrobe/cargo_wardrobe,
-/obj/effect/turf_decal/tile/brown{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
@@ -26173,11 +24674,8 @@
 /obj/item/radio/intercom{
 	pixel_y = 20
 	},
-/obj/effect/turf_decal/tile/brown{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
@@ -26189,7 +24687,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/brown{
+/obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -26248,9 +24746,8 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bjy" = (
@@ -26289,10 +24786,7 @@
 /area/maintenance/central)
 "bjD" = (
 /obj/machinery/light,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "bjE" = (
@@ -26405,6 +24899,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
 "bjV" = (
@@ -26412,23 +24907,17 @@
 /obj/machinery/recharger{
 	pixel_y = 4
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
 "bjW" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "bjX" = (
@@ -26451,23 +24940,17 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "bke" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "bkg" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 9
 	},
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "bki" = (
@@ -26492,10 +24975,7 @@
 /obj/machinery/airalarm{
 	pixel_y = 24
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -26531,8 +25011,8 @@
 /obj/machinery/firealarm{
 	pixel_y = 27
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
@@ -26556,6 +25036,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "bkq" = (
@@ -26746,15 +25229,14 @@
 /turf/open/floor/wood,
 /area/medical/psych)
 "bkV" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/maintenance/fore/secondary)
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "bkW" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -26786,25 +25268,15 @@
 "bkZ" = (
 /obj/machinery/gravity_generator/main/station,
 /obj/effect/turf_decal/bot_white,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
 "bla" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
 "blb" = (
@@ -26845,20 +25317,15 @@
 	},
 /area/space/nearstation)
 "bli" = (
-/obj/effect/turf_decal/tile/blue{
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/lumos/tile/blue/checker{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
+/obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/plasteel/cafeteria,
 /area/medical/medbay/lobby)
 "blj" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -26871,12 +25338,8 @@
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_x = 30
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
@@ -26888,6 +25351,7 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/depsec/medical,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
 "blo" = (
@@ -27024,11 +25488,8 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
@@ -27137,6 +25598,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/lumos/tile/red/fulltile,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "blP" = (
@@ -27183,19 +25645,15 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "blU" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/wood,
-/area/crew_quarters/dorms)
+/obj/machinery/vending/cigarette,
+/turf/open/floor/plasteel/dark,
+/area/hallway/primary/central)
 "blV" = (
 /obj/machinery/light/small,
 /turf/open/floor/plating,
@@ -27218,14 +25676,11 @@
 /area/science/research)
 "blY" = (
 /obj/structure/closet/emcloset,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
@@ -27257,10 +25712,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "bmf" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -27270,6 +25722,7 @@
 	name = "Cargo Bay";
 	req_access_txt = "31"
 	},
+/obj/effect/turf_decal/lumos/tile/brown/fulltile,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "bmh" = (
@@ -27318,6 +25771,8 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bmn" = (
@@ -27362,46 +25817,37 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "bmu" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/button/door{
 	id = "locklock";
 	name = "Perma Airlock Lockdown";
 	pixel_y = 26;
 	req_access_txt = "3"
 	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "bmv" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -27482,6 +25928,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
+/obj/effect/turf_decal/lumos/tile/brown/fulltile,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "bmK" = (
@@ -27492,17 +25939,12 @@
 /turf/open/floor/wood,
 /area/medical/psych)
 "bmL" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 6
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/lumos/tile/red/half,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
 "bmO" = (
@@ -27597,11 +26039,8 @@
 "bnd" = (
 /obj/machinery/camera,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -27724,12 +26163,6 @@
 /turf/open/floor/plating,
 /area/science/lab)
 "bnt" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/preopen{
 	id = "cmoofficesh1";
@@ -27739,6 +26172,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/lumos/tile/blue/checker{
 	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
@@ -27853,11 +26289,8 @@
 /turf/open/floor/plating,
 /area/quartermaster/office)
 "bnL" = (
-/obj/effect/turf_decal/tile/brown{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
@@ -27902,16 +26335,10 @@
 	pixel_x = -4;
 	pixel_y = 36
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/machinery/pdapainter,
+/obj/effect/turf_decal/lumos/tile/blue/fullcorner{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/machinery/pdapainter,
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
 "bnQ" = (
@@ -27945,12 +26372,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engine/gravity_generator)
-"bnU" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "bnV" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -27999,26 +26420,7 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/heads/captain)
-"bod" = (
-/obj/structure/chair,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/medical/medbay/lobby)
 "boe" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -28028,6 +26430,9 @@
 	pixel_x = 24
 	},
 /obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/lumos/tile/blue/checker{
 	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
@@ -28289,7 +26694,7 @@
 /turf/open/floor/plasteel/white/corner,
 /area/science/research)
 "boN" = (
-/obj/effect/turf_decal/tile/brown{
+/obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -28326,6 +26731,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "boW" = (
@@ -28346,19 +26754,21 @@
 	id = "hopqueue";
 	name = "HoP Queue Shutters"
 	},
+/obj/effect/turf_decal/loading_area{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "boY" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/structure/sign/poster/official/ian{
 	pixel_x = 32;
 	pixel_y = 32
+	},
+/obj/effect/turf_decal/lumos/tile/red/half{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -28408,10 +26818,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -28452,16 +26859,13 @@
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "bpi" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "bpj" = (
@@ -28551,21 +26955,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"bpu" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/medical/medbay/lobby)
 "bpv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -28704,22 +27093,13 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/front_office)
 "bpM" = (
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/lumos/tile/blue/checker{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/cafeteria,
 /area/medical/medbay/lobby)
 "bpN" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
@@ -28730,6 +27110,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/lumos/tile/blue/checker{
 	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
@@ -28753,6 +27136,7 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/lumos/tile/blue/fulltile,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/front_office)
 "bpQ" = (
@@ -28862,7 +27246,7 @@
 	dir = 4;
 	pixel_y = -32
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+/obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -28950,11 +27334,8 @@
 /obj/structure/table/reinforced,
 /obj/item/destTagger,
 /obj/item/destTagger,
-/obj/effect/turf_decal/tile/brown{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
@@ -28969,12 +27350,11 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "bqt" = (
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 9
+	},
+/obj/effect/turf_decal/lumos/tile/green/half{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
@@ -29018,12 +27398,8 @@
 /obj/machinery/computer/card{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/fullcorner{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
@@ -29108,13 +27484,10 @@
 /turf/open/floor/plasteel/white/side,
 /area/hallway/primary/starboard)
 "bqP" = (
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/lumos/tile/blue/checker{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/cafeteria,
 /area/medical/medbay/lobby)
 "bqS" = (
@@ -29158,14 +27531,11 @@
 "bqX" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/medical/medbay/front_office)
@@ -29321,19 +27691,19 @@
 /area/hallway/primary/starboard)
 "brA" = (
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "brB" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/preopen{
 	id = "cmoofficesh1";
 	name = "biohazard containment door"
+	},
+/obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/medical/medbay/lobby)
@@ -29522,13 +27892,7 @@
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "bsd" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
+/obj/effect/turf_decal/lumos/tile/red/fullcorner,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
 "bse" = (
@@ -29603,10 +27967,7 @@
 /area/teleporter)
 "bsp" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -29623,20 +27984,18 @@
 	name = "Medbay Reception";
 	req_access_txt = "5"
 	},
+/obj/effect/turf_decal/lumos/tile/blue/fulltile,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "bst" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
@@ -29665,12 +28024,10 @@
 /obj/item/pen{
 	pixel_x = 16
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/checker{
 	dir = 4
 	},
+/obj/item/storage/firstaid/regular,
 /turf/open/floor/plasteel/cafeteria,
 /area/medical/medbay/front_office)
 "bsz" = (
@@ -29815,12 +28172,6 @@
 /obj/machinery/computer/med_data{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/machinery/camera{
 	c_tag = "Medical Reception Desk";
 	dir = 4;
@@ -29834,6 +28185,9 @@
 	normaldoorcontrol = 1;
 	pixel_x = -24;
 	req_access_txt = "5"
+	},
+/obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/medical/medbay/front_office)
@@ -30057,10 +28411,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -30089,14 +28440,8 @@
 /obj/machinery/computer/bounty{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/fullcorner{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
@@ -30204,10 +28549,7 @@
 	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -30340,10 +28682,7 @@
 	name = "Medbay RC";
 	pixel_x = 30
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/checker{
 	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
@@ -30645,10 +28984,7 @@
 /obj/machinery/computer/cargo{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -30676,17 +29012,14 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
+	},
+/obj/effect/turf_decal/lumos/tile/blue/half{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
@@ -30748,10 +29081,7 @@
 	pixel_x = -32
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -30824,14 +29154,11 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "bvh" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
+	},
+/obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/medical/medbay/front_office)
@@ -30879,21 +29206,14 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics/cloning)
 "bvw" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/structure/chair,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 1
+	},
+/obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/medical/medbay/lobby)
@@ -30901,21 +29221,14 @@
 /turf/closed/wall/r_wall,
 /area/science/research)
 "bvy" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/structure/chair,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
+	},
+/obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/medical/medbay/lobby)
@@ -30967,17 +29280,11 @@
 /obj/machinery/computer/bounty{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
 /obj/machinery/keycard_auth{
 	pixel_y = 25
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
@@ -31008,15 +29315,12 @@
 /turf/closed/wall,
 /area/crew_quarters/heads/hor)
 "bvL" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/structure/table,
 /obj/machinery/recharger{
 	pixel_y = 4
+	},
+/obj/effect/turf_decal/lumos/tile/red/half{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
@@ -31093,10 +29397,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -31126,10 +29427,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -31142,12 +29440,9 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/lumos/tile/brown/half,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "bwd" = (
@@ -31179,10 +29474,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bwh" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -31193,14 +29485,10 @@
 	name = "Station Intercom (General)";
 	pixel_x = -28
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/structure/filingcabinet/chestdrawer,
+/obj/effect/turf_decal/lumos/tile/blue/fullcorner{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/structure/filingcabinet/chestdrawer,
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
 "bwj" = (
@@ -31366,19 +29654,13 @@
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "bwH" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bwJ" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -31386,6 +29668,9 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/lumos/tile/blue/checker{
 	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
@@ -31401,10 +29686,7 @@
 	name = "Chief Medical Officer RC";
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/checker{
 	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
@@ -31413,14 +29695,11 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/lumos/tile/red/half{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science)
 "bwN" = (
@@ -31435,11 +29714,8 @@
 	pixel_y = 28;
 	req_access_txt = "47"
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science)
@@ -31488,14 +29764,13 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -31577,14 +29852,11 @@
 /turf/open/floor/plating,
 /area/medical/chemistry)
 "bxb" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
+	},
+/obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/medical/medbay/lobby)
@@ -31791,24 +30063,15 @@
 	},
 /obj/item/pen,
 /obj/structure/table,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/lumos/tile/red/fullcorner{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
 "bxD" = (
 /obj/structure/table,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
@@ -31817,14 +30080,10 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/structure/filingcabinet,
+/obj/effect/turf_decal/lumos/tile/red/fullcorner{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
 "bxF" = (
@@ -31873,13 +30132,10 @@
 "bxM" = (
 /obj/structure/chair/office/dark,
 /obj/effect/landmark/event_spawn,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
+/obj/effect/turf_decal/lumos/tile/red/half,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
 "bxN" = (
@@ -31928,29 +30184,23 @@
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "bxT" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
+	},
+/obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/medical/medbay/lobby)
 "bxU" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	icon_state = "1-8"
+	},
+/obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
@@ -32027,23 +30277,14 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/hor)
 "byc" = (
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
 /obj/machinery/computer/card/minor/qm{
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "byd" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
+/obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "byf" = (
@@ -32062,10 +30303,6 @@
 	},
 /obj/item/cartridge/quartermaster,
 /obj/item/coin/silver,
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
 /obj/item/stamp/qm,
 /obj/item/paper_bin{
 	pixel_x = -3;
@@ -32075,6 +30312,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "byh" = (
@@ -32115,28 +30353,18 @@
 	pixel_y = 4
 	},
 /obj/item/pen/red,
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
 	},
 /obj/item/phone{
 	pixel_x = -9
 	},
+/obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "byn" = (
 /obj/machinery/light_switch{
 	pixel_y = -25
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
 	},
 /obj/machinery/button/door{
 	id = "qmsh";
@@ -32146,6 +30374,9 @@
 	},
 /obj/structure/table,
 /obj/machinery/photocopier/faxmachine,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 6
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "byo" = (
@@ -32212,11 +30443,8 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "byz" = (
-/obj/effect/turf_decal/tile/brown{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
@@ -32230,33 +30458,24 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/effect/turf_decal/tile/brown{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "byB" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
-/obj/effect/turf_decal/tile/brown{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "byC" = (
-/obj/effect/turf_decal/tile/brown{
+/obj/structure/filingcabinet,
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/structure/filingcabinet,
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "byD" = (
@@ -32264,14 +30483,10 @@
 /obj/machinery/airalarm{
 	pixel_y = 23
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
 /obj/item/clipboard,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 5
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "byE" = (
@@ -32303,28 +30518,21 @@
 	pixel_y = -25
 	},
 /obj/structure/closet/secure_closet/security/cargo,
-/obj/effect/turf_decal/tile/red{
+/obj/item/book/manual/wiki/security_space_law,
+/obj/effect/turf_decal/lumos/tile/red/fullcorner{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/item/book/manual/wiki/security_space_law,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
 "byI" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
+	},
+/obj/effect/turf_decal/lumos/tile/red/half{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
@@ -32344,8 +30552,7 @@
 	name = "Station Intercom (General)";
 	pixel_x = 27
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -32362,33 +30569,15 @@
 	departmentType = 5;
 	pixel_y = -30
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/red/half,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
 "byP" = (
 /obj/structure/sign/warning/securearea{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"byQ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -32399,11 +30588,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -32411,20 +30597,14 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "byT" = (
 /obj/machinery/vending/wardrobe/sec_wardrobe,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/red/half,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
 "byU" = (
@@ -32525,12 +30705,6 @@
 "bzi" = (
 /obj/structure/table/glass,
 /obj/machinery/photocopier/faxmachine,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/machinery/button/door{
 	id = "cmoofficesh";
 	name = "Chief Medical Officer Shutters";
@@ -32550,6 +30724,9 @@
 	pixel_x = -6;
 	pixel_y = -26;
 	req_access_txt = "40"
+	},
+/obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
@@ -32645,16 +30822,10 @@
 	pixel_y = 25
 	},
 /obj/structure/closet/secure_closet/security/science,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/item/book/manual/wiki/security_space_law,
+/obj/effect/turf_decal/lumos/tile/red/fullcorner{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/item/book/manual/wiki/security_space_law,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science)
 "bzA" = (
@@ -32679,29 +30850,22 @@
 /obj/machinery/recharger{
 	pixel_y = 4
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/effect/turf_decal/lumos/tile/red/fullcorner{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science)
 "bzD" = (
 /obj/structure/table,
 /obj/machinery/computer/security/telescreen/circuitry,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/item/paper_bin{
 	pixel_x = -4;
 	pixel_y = 6
 	},
 /obj/item/pen,
+/obj/effect/turf_decal/lumos/tile/red/half{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science)
 "bzE" = (
@@ -32798,10 +30962,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -32931,12 +31092,11 @@
 	dir = 4
 	},
 /obj/item/radio/off,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/computer/secure_data{
 	dir = 8
+	},
+/obj/effect/turf_decal/lumos/tile/red/half{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
@@ -32947,6 +31107,12 @@
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -32985,14 +31151,13 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bAi" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -33178,10 +31343,7 @@
 	dir = 8
 	},
 /obj/machinery/vending/wardrobe/sec_wardrobe,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -33209,8 +31371,7 @@
 /area/security/checkpoint/science)
 "bAH" = (
 /obj/structure/table,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -33255,11 +31416,11 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 10
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
@@ -33318,12 +31479,8 @@
 /obj/machinery/computer/security/qm{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
@@ -33338,6 +31495,9 @@
 /area/janitor)
 "bAU" = (
 /obj/structure/closet/l3closet/janitor,
+/obj/structure/sign/poster/contraband/billyh{
+	pixel_y = 32
+	},
 /turf/open/floor/plasteel,
 /area/janitor)
 "bAV" = (
@@ -33359,6 +31519,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/lumos/tile/blue/fulltile,
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
 "bAZ" = (
@@ -33394,16 +31555,10 @@
 	c_tag = "Security Post - Cargo";
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/machinery/computer/security/mining{
 	dir = 8
 	},
+/obj/effect/turf_decal/lumos/tile/red/fullcorner,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
 "bBg" = (
@@ -33430,6 +31585,8 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bBi" = (
@@ -33594,6 +31751,8 @@
 /obj/structure/disposalpipe/junction/flip{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bBB" = (
@@ -33754,12 +31913,8 @@
 	pixel_x = -25
 	},
 /obj/structure/filingcabinet,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/lumos/tile/red/fullcorner{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science)
@@ -33768,10 +31923,7 @@
 	pixel_y = 10
 	},
 /obj/item/radio/off,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/red/half,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science)
 "bCa" = (
@@ -33781,21 +31933,12 @@
 	pixel_y = -24
 	},
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/red/half,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science)
 "bCb" = (
 /obj/structure/table,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/red/fullcorner,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science)
 "bCc" = (
@@ -33807,10 +31950,7 @@
 	departmentType = 5;
 	pixel_y = -30
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/red/half,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science)
 "bCd" = (
@@ -33942,6 +32082,8 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "bCs" = (
@@ -33999,6 +32141,8 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "bCA" = (
@@ -34559,6 +32703,8 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "bDR" = (
@@ -34609,6 +32755,7 @@
 	req_access_txt = "5"
 	},
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/lumos/tile/blue/fulltile,
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
 "bEa" = (
@@ -34925,11 +33072,11 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 5
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/storage/tech)
@@ -35006,6 +33153,12 @@
 	icon_state = "4-8"
 	},
 /obj/effect/landmark/blobstart,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/storage/tech)
 "bFe" = (
@@ -35438,14 +33591,8 @@
 /obj/machinery/computer/shuttle/mining{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
+/obj/effect/turf_decal/lumos/tile/brown/fullcorner{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
@@ -35605,10 +33752,6 @@
 "bGE" = (
 /obj/machinery/light,
 /obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/delivery,
-/obj/vehicle/ridden/janicart{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -35955,10 +34098,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "bHA" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
+/obj/effect/turf_decal/lumos/tile/brown/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -36099,6 +34239,7 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/lumos/tile/blue/fulltile,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bHU" = (
@@ -36675,9 +34816,6 @@
 /obj/machinery/light_switch{
 	pixel_x = 27
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 1
-	},
 /turf/open/floor/plating,
 /area/storage/tech)
 "bJo" = (
@@ -36732,14 +34870,14 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/meter{
+	target_layer = 1
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
-	},
-/obj/machinery/meter{
-	target_layer = 1
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
@@ -37076,12 +35214,8 @@
 /area/quartermaster/miningdock)
 "bKl" = (
 /obj/structure/closet/emcloset,
-/obj/effect/turf_decal/tile/brown{
+/obj/effect/turf_decal/lumos/tile/brown/fullcorner{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
@@ -37174,13 +35308,13 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bKA" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 5
+/obj/structure/chair/sofa/right,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
+	dir = 4
 	},
-/obj/structure/chair/sofa/right,
 /turf/open/floor/plating,
 /area/construction)
 "bKB" = (
@@ -37206,10 +35340,10 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "bKE" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 9
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bKF" = (
@@ -37763,6 +35897,7 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/lumos/tile/blue/fulltile,
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "bMd" = (
@@ -38171,8 +36306,7 @@
 /area/maintenance/port/aft)
 "bNh" = (
 /obj/machinery/computer/pandemic,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/lumos/tile/green/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -38807,14 +36941,8 @@
 /obj/machinery/newscaster{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/lumos/tile/red/fullcorner{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
@@ -38829,10 +36957,7 @@
 /obj/item/reagent_containers/syringe/antiviral,
 /obj/item/reagent_containers/dropper,
 /obj/item/reagent_containers/spray/cleaner,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/lumos/tile/green/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -38948,15 +37073,11 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 4
+	},
+/obj/effect/turf_decal/lumos/tile/green/fullcorner{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -39277,9 +37398,11 @@
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "bQc" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
-/turf/open/floor/plating,
-/area/construction)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "bQd" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
@@ -39306,10 +37429,7 @@
 	pixel_x = -27;
 	pixel_y = 4
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -39433,8 +37553,7 @@
 	dir = 4
 	},
 /obj/machinery/vending/wardrobe/sec_wardrobe,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -39491,12 +37610,11 @@
 /obj/machinery/computer/atmos_control/tank/mix_tank{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 10
+	},
+/obj/effect/turf_decal/lumos/tile/green/half{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -39549,10 +37667,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 6
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/lumos/tile/green/half,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bQK" = (
@@ -39711,17 +37826,14 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
+	},
+/obj/effect/turf_decal/lumos/tile/red/half{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
@@ -39755,8 +37867,7 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -39908,13 +38019,7 @@
 	name = "Unfiltered & Air to Mix"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
+/obj/effect/turf_decal/lumos/tile/green/fullcorner,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bRK" = (
@@ -40448,12 +38553,8 @@
 /obj/machinery/recharger{
 	pixel_y = 4
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/lumos/tile/red/fullcorner{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
@@ -40498,30 +38599,24 @@
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_x = 30
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/red/fullcorner,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
 "bTH" = (
 /obj/structure/table,
 /obj/item/book/manual/wiki/security_space_law,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/red/half,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
 "bTI" = (
-/obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
+	},
 /turf/open/floor/plasteel,
-/area/tcommsat/computer)
+/area/hallway/primary/central)
 "bTJ" = (
 /obj/machinery/power/apc{
 	areastring = "/area/hallway/primary/aft";
@@ -40815,6 +38910,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/machinery/holopad,
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "bUz" = (
@@ -41003,10 +39099,7 @@
 /area/maintenance/aft)
 "bVa" = (
 /obj/machinery/smartfridge/chemistry/virology/preloaded,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/lumos/tile/green/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -41024,23 +39117,14 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bVd" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/fullcorner{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -41051,6 +39135,9 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bVg" = (
@@ -41058,12 +39145,8 @@
 	name = "Station Intercom (General)";
 	pixel_y = 20
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
+/obj/effect/turf_decal/lumos/tile/yellow/fullcorner{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -41071,6 +39154,9 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -41258,9 +39344,6 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 4
-	},
 /turf/open/floor/plasteel/dark/corner{
 	dir = 1
 	},
@@ -41377,10 +39460,7 @@
 	},
 /obj/item/healthanalyzer,
 /obj/item/clothing/glasses/hud/health,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/lumos/tile/green/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -41389,8 +39469,7 @@
 /obj/structure/table,
 /obj/item/hand_labeler,
 /obj/item/radio/headset/headset_med,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/lumos/tile/green/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -41611,16 +39690,10 @@
 /area/tcommsat/server)
 "bWH" = (
 /obj/structure/table,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/item/phone,
+/obj/effect/turf_decal/lumos/tile/yellow/fullcorner{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/item/phone,
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "bWI" = (
@@ -41644,17 +39717,14 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bWK" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
+	},
+/obj/effect/turf_decal/lumos/tile/yellow/half{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -41691,9 +39761,6 @@
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4
 	},
 /turf/open/floor/plasteel/dark/corner{
 	dir = 1
@@ -41765,10 +39832,7 @@
 	pixel_y = 2
 	},
 /obj/item/storage/box/syringes,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/lumos/tile/green/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -41780,8 +39844,7 @@
 	pixel_y = 5
 	},
 /obj/item/pen/red,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/lumos/tile/green/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -41910,18 +39973,14 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bXn" = (
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -41930,6 +39989,9 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -41941,11 +40003,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -42056,10 +40118,7 @@
 /obj/machinery/computer/message_monitor{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -42146,12 +40205,8 @@
 /obj/machinery/airalarm{
 	pixel_y = 23
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/effect/turf_decal/lumos/tile/red/fullcorner{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
@@ -42162,11 +40217,8 @@
 	pixel_y = 30
 	},
 /obj/structure/closet/secure_closet/security/engine,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
@@ -42248,8 +40300,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/lumos/tile/green/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -42352,14 +40403,11 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/lumos/tile/yellow/half,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bYo" = (
@@ -42372,21 +40420,14 @@
 /obj/structure/sign/warning/securearea{
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/fullcorner{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bYq" = (
 /obj/machinery/light,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/yellow/half,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bYr" = (
@@ -42461,23 +40502,13 @@
 	dir = 4;
 	network = "tcommsat"
 	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/fullcorner{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "bYE" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 1
-	},
+/obj/effect/turf_decal/lumos/tile/yellow/half,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bYF" = (
@@ -42486,16 +40517,10 @@
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "bYG" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
 /obj/structure/sign/departments/engineering{
 	pixel_y = -32
 	},
+/obj/effect/turf_decal/lumos/tile/yellow/fullcorner,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bYH" = (
@@ -42535,18 +40560,12 @@
 	dir = 1;
 	pixel_y = -22
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1
-	},
+/obj/effect/turf_decal/lumos/tile/yellow/half,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bYN" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -42591,19 +40610,13 @@
 /area/engine/atmos)
 "bYX" = (
 /obj/structure/closet/l3closet/virology,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/green/half,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bYY" = (
 /obj/structure/closet/secure_closet/medical1,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/green/half,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bYZ" = (
@@ -42821,12 +40834,8 @@
 /turf/open/floor/plating,
 /area/crew_quarters/heads/chief)
 "bZE" = (
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/fullcorner{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
@@ -43070,16 +41079,7 @@
 /area/tcommsat/server)
 "cak" = (
 /obj/machinery/telecomms/hub/preset,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
 "cal" = (
@@ -43093,16 +41093,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/computer)
 "can" = (
@@ -43113,41 +41104,17 @@
 	name = "Server Room";
 	req_access_txt = "61"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/computer)
 "cao" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/computer)
 "cap" = (
 /obj/machinery/light,
 /obj/structure/closet/firecloset,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/yellow/fullcorner,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "caq" = (
@@ -43559,35 +41526,17 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/item/rcl/pre_loaded,
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
 "cbq" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /mob/living/simple_animal/parrot/Poly,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
 "cbr" = (
@@ -43729,14 +41678,10 @@
 	dir = 8;
 	name = "CO2 to Pure"
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/effect/turf_decal/lumos/tile/yellow/fullcorner{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "cbH" = (
@@ -43944,31 +41889,16 @@
 "cci" = (
 /obj/structure/table,
 /obj/item/multitool,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/fullcorner{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "ccj" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
 "cck" = (
@@ -43978,36 +41908,18 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
 "ccl" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
 	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
 "ccm" = (
@@ -44118,11 +42030,10 @@
 /obj/machinery/computer/atmos_control/tank/carbon_tank{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "ccB" = (
@@ -44351,10 +42262,7 @@
 	dir = 4;
 	network = "tcommsat"
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -44375,16 +42283,7 @@
 /area/maintenance/port/aft)
 "cdk" = (
 /obj/machinery/computer/atmos_alert,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "cdl" = (
@@ -44524,13 +42423,7 @@
 /obj/machinery/atmospherics/components/trinary/filter/atmos/co2{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
+/obj/effect/turf_decal/lumos/tile/yellow/fullcorner,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "cdD" = (
@@ -44662,12 +42555,8 @@
 "cee" = (
 /obj/structure/table,
 /obj/item/radio/off,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/fullcorner{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
@@ -44771,28 +42660,18 @@
 /area/crew_quarters/heads/chief)
 "ces" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 6
+	},
+/obj/effect/turf_decal/lumos/tile/yellow/fullcorner{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cet" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
+/obj/effect/turf_decal/lumos/tile/yellow/fullcorner{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -44979,18 +42858,15 @@
 "cfa" = (
 /obj/structure/rack,
 /obj/item/storage/belt/utility,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
 /obj/item/weldingtool/largetank,
 /obj/item/clothing/head/welding{
 	pixel_x = -3;
 	pixel_y = 5
 	},
 /obj/item/clothing/glasses/welding,
+/obj/effect/turf_decal/lumos/tile/yellow/half{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cfb" = (
@@ -45013,8 +42889,7 @@
 	pixel_x = 24
 	},
 /obj/structure/closet/radiation,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -45047,12 +42922,9 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cfh" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/lumos/tile/yellow/half,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "cfi" = (
@@ -45158,14 +43030,13 @@
 /area/engine/engineering)
 "cfB" = (
 /obj/structure/closet/secure_closet/engineering_personal,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
 /obj/item/clothing/under/misc/overalls,
 /obj/item/clothing/under/misc/overalls,
 /obj/item/radio/headset/headset_eng,
 /obj/item/airlock_painter/floor_painter,
+/obj/effect/turf_decal/lumos/tile/yellow/half{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cfD" = (
@@ -45204,16 +43075,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
 "cfI" = (
@@ -45222,14 +43084,13 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
 /obj/item/clothing/under/misc/overalls,
 /obj/item/clothing/under/misc/overalls,
 /obj/item/radio/headset/headset_eng,
 /obj/item/airlock_painter/floor_painter,
+/obj/effect/turf_decal/lumos/tile/yellow/half{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cfJ" = (
@@ -45464,18 +43325,12 @@
 	pixel_y = 26;
 	req_access_txt = "5"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable{
 	icon_state = "0-4"
+	},
+/obj/effect/turf_decal/lumos/tile/red/fullcorner{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
@@ -45585,16 +43440,7 @@
 	},
 /obj/item/stock_parts/cell/high/plus,
 /obj/item/reagent_containers/pill/patch/silver_sulf,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
 "cgQ" = (
@@ -45653,25 +43499,18 @@
 /obj/machinery/computer/atmos_control/tank/nitrogen_tank{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
+/obj/effect/turf_decal/lumos/tile/red/half,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "cgW" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/trinary/filter/atmos/n2{
 	dir = 4
+	},
+/obj/effect/turf_decal/lumos/tile/red/fullcorner{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -45688,40 +43527,27 @@
 	dir = 1;
 	name = "N2 Outlet Pump"
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
+/obj/effect/turf_decal/lumos/tile/red/fullcorner,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "cgZ" = (
 /obj/machinery/computer/atmos_control/tank/oxygen_tank{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
+/obj/effect/turf_decal/lumos/tile/blue/half,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "cha" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/o2{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/fullcorner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -45731,16 +43557,10 @@
 	dir = 1;
 	name = "O2 Outlet Pump"
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
+/obj/effect/turf_decal/lumos/tile/blue/fullcorner,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "chc" = (
@@ -46218,16 +44038,7 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "cik" = (
@@ -46238,16 +44049,7 @@
 	dir = 4;
 	pixel_x = -22
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
 "cim" = (
@@ -46257,16 +44059,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
 "cio" = (
@@ -46508,16 +44301,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "cje" = (
@@ -46537,16 +44321,7 @@
 	dir = 1
 	},
 /obj/effect/landmark/start/station_engineer,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "cjg" = (
@@ -46564,16 +44339,7 @@
 	c_tag = "Chief Engineer's Office";
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
 "cjh" = (
@@ -46604,16 +44370,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
 "cjk" = (
@@ -46833,22 +44590,18 @@
 	dir = 4;
 	pixel_x = -24
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
 "cjV" = (
-/obj/structure/closet/emcloset,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
-/area/engine/engineering)
+/area/hallway/primary/central)
 "cjW" = (
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
@@ -46860,16 +44613,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
 "cjY" = (
@@ -47039,6 +44783,7 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
 "ckx" = (
@@ -47060,6 +44805,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
 "ckB" = (
@@ -47185,16 +44931,13 @@
 /area/library)
 "ckT" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/lumos/tile/yellow/half{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "ckU" = (
@@ -47365,15 +45108,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"clC" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engine_smes)
 "clD" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -47411,6 +45145,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
 "clG" = (
@@ -47439,14 +45176,8 @@
 /obj/item/storage/box/lights/mixed,
 /obj/item/clothing/glasses/meson,
 /obj/item/clothing/glasses/meson,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/fullcorner{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -47585,13 +45316,7 @@
 	dir = 1
 	},
 /obj/structure/reagent_dispensers/water_cooler,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/lumos/tile/purple/fullcorner{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -47626,6 +45351,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
 "cmz" = (
@@ -47686,11 +45412,8 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cmF" = (
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -47702,26 +45425,18 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/fullcorner{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
+/obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cmL" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -47732,11 +45447,8 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -47796,12 +45508,8 @@
 	dir = 1
 	},
 /obj/machinery/vending/coffee,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
+/obj/effect/turf_decal/lumos/tile/purple/fullcorner{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
@@ -47856,7 +45564,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
 "cnn" = (
@@ -47886,7 +45594,9 @@
 	c_tag = "SMES Room";
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
 "cnq" = (
@@ -48088,6 +45798,9 @@
 	pixel_x = -32
 	},
 /obj/effect/turf_decal/loading_area,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cnX" = (
@@ -48497,6 +46210,9 @@
 /obj/machinery/computer/rdconsole/production{
 	dir = 4
 	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cps" = (
@@ -48654,6 +46370,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"cqb" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engine_smes)
 "cqn" = (
 /obj/structure/grille,
 /turf/open/floor/plating,
@@ -48805,6 +46530,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cri" = (
@@ -48814,18 +46540,14 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
+	},
+/obj/effect/turf_decal/lumos/tile/purple/fullcorner{
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
@@ -49039,19 +46761,13 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/turf_decal/lumos/tile/purple/fullcorner,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "csD" = (
@@ -49059,14 +46775,11 @@
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat_interior)
 "csK" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/machinery/door/window/northright{
 	name = "Brig Operations";
 	req_one_access_txt = "4; 1"
 	},
+/obj/effect/turf_decal/lumos/tile/red/half,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "csM" = (
@@ -51061,14 +48774,11 @@
 /area/hallway/secondary/exit)
 "czQ" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/violet/hidden,
 /obj/machinery/holopad,
+/obj/effect/turf_decal/lumos/tile/purple/half{
+	dir = 1
+	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "czR" = (
@@ -51424,17 +49134,15 @@
 /turf/open/space,
 /area/space/nearstation)
 "cBg" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/plating,
-/area/hydroponics)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "cBh" = (
 /obj/effect/landmark/event_spawn,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/checker{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/locker)
@@ -51696,16 +49404,13 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/turf_decal/lumos/tile/purple/half,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "cBO" = (
@@ -52139,7 +49844,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "cHL" = (
 /obj/machinery/mech_bay_recharge_port{
@@ -52253,10 +49958,7 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "cHZ" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -52322,16 +50024,13 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "cIv" = (
-/obj/structure/sign/poster/official/cohiba_robusto_ad,
-/turf/closed/wall,
+/obj/machinery/door/airlock/maintenance{
+	name = "Law Office Maintenance";
+	req_access_txt = "38"
+	},
+/turf/open/floor/plating,
 /area/lawoffice)
 "cJi" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
@@ -52343,6 +50042,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
+	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
 "cJW" = (
@@ -52378,16 +50080,7 @@
 	dir = 8;
 	pixel_x = 30
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "cME" = (
@@ -52409,12 +50102,6 @@
 /area/solar/starboard/aft)
 "cMS" = (
 /obj/item/chair/wood,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 9
-	},
 /turf/open/floor/plating,
 /area/maintenance/port)
 "cNa" = (
@@ -52664,16 +50351,7 @@
 	pixel_y = -10;
 	req_access_txt = "10"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
 "cSM" = (
@@ -52682,16 +50360,7 @@
 	name = "Station Intercom (General)";
 	pixel_y = 20
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "cSN" = (
@@ -52779,30 +50448,12 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "cSX" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "cSY" = (
@@ -52812,16 +50463,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "cSZ" = (
@@ -52864,11 +50506,8 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -52882,11 +50521,8 @@
 	name = "Engineering RC";
 	pixel_y = 30
 	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -53019,17 +50655,14 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "cYz" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/lumos/tile/blue/checker{
 	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
@@ -53046,18 +50679,14 @@
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "daA" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/lumos/tile/red/fullcorner{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/security/processing)
 "dbU" = (
@@ -53122,11 +50751,10 @@
 /turf/open/floor/plasteel/white,
 /area/science/explab)
 "dfW" = (
-/obj/effect/turf_decal/tile/blue{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "dgc" = (
@@ -53151,6 +50779,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/lumos/tile/blue/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "dla" = (
@@ -53185,16 +50814,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
+/obj/effect/turf_decal/lumos/tile/green/fulltile,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "dqb" = (
@@ -53303,11 +50923,11 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "dzi" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/cryopod)
@@ -53343,14 +50963,17 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/range)
+"dEj" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "dFX" = (
 /turf/closed/wall,
 /area/crew_quarters/fitness/pool)
@@ -53394,13 +51017,10 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "dLb" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/machinery/holopad,
+/obj/effect/turf_decal/lumos/tile/blue/checker{
 	dir = 4
 	},
-/obj/machinery/holopad,
 /turf/open/floor/plasteel/cafeteria,
 /area/medical/medbay/front_office)
 "dLA" = (
@@ -53483,17 +51103,14 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/machinery/recharger,
 /obj/item/gun/energy/laser/practice,
 /obj/item/gun/energy/laser/practice,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/range)
@@ -53509,6 +51126,7 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/lumos/tile/blue/fulltile,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "dXq" = (
@@ -53545,16 +51163,13 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "eaM" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /mob/living/simple_animal/pet/cat/Runtime,
 /obj/structure/chair,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
+	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
 "eaP" = (
@@ -53614,19 +51229,12 @@
 	pixel_y = 32;
 	req_access_txt = "7"
 	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "egt" = (
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
 /obj/machinery/requests_console{
 	department = "Bar";
 	departmentType = 2;
@@ -53634,6 +51242,7 @@
 	pixel_y = 45;
 	receive_ore_updates = 1
 	},
+/obj/effect/turf_decal/lumos/tile/bar/checker,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "egU" = (
@@ -53693,13 +51302,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
+/obj/effect/turf_decal/lumos/tile/red/fullcorner,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
 "elf" = (
@@ -53730,6 +51333,9 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "epC" = (
@@ -53738,13 +51344,7 @@
 	id_tag = "MaintDorm1";
 	name = "Furniture Storage"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plating,
 /area/maintenance/port)
 "epD" = (
 /obj/machinery/light{
@@ -53785,6 +51385,7 @@
 /obj/item/kirbyplants{
 	icon_state = "plant-14"
 	},
+/obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "eyM" = (
@@ -53807,14 +51408,17 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/front_office)
+"ezF" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "eAb" = (
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/computer/card,
+/obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/computer/card,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
 "eAJ" = (
@@ -53853,12 +51457,6 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "eCQ" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/structure/rack,
 /obj/item/storage/box/zipties{
 	pixel_x = -1;
@@ -53867,6 +51465,9 @@
 /obj/item/storage/box/zipties{
 	pixel_x = 1;
 	pixel_y = -1
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -53943,6 +51544,7 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/lumos/tile/blue/fulltile,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/front_office)
 "eQb" = (
@@ -53968,7 +51570,6 @@
 /area/space/nearstation)
 "eSe" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
 "eSH" = (
@@ -54021,6 +51622,19 @@
 /obj/item/storage/toolbox/electrical,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
+"eXt" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white/corner,
+/area/hallway/secondary/entry)
 "faw" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -54125,17 +51739,9 @@
 /turf/open/floor/engine,
 /area/science/mixing)
 "flE" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
+/obj/structure/closet/crate/wooden/fish_learning,
+/turf/open/floor/plasteel/showroomfloor,
+/area/crew_quarters/kitchen)
 "fmv" = (
 /obj/structure/table/reinforced,
 /obj/item/wrench/medical,
@@ -54194,7 +51800,6 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "fpI" = (
@@ -54223,11 +51828,8 @@
 /area/maintenance/department/medical/morgue)
 "frq" = (
 /obj/structure/chair,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
@@ -54290,10 +51892,8 @@
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
 "fvY" = (
-/obj/machinery/computer/cryopod{
-	pixel_y = 26
-	},
-/turf/open/floor/plasteel/dark,
+/obj/machinery/cryopod,
+/turf/open/floor/circuit/green,
 /area/crew_quarters/cryopod)
 "fwK" = (
 /obj/machinery/door/airlock/external{
@@ -54338,13 +51938,12 @@
 /turf/closed/wall/r_wall,
 /area/science/circuit)
 "fAj" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/structure/sign/poster/official/love_ian{
 	pixel_x = 32;
 	pixel_y = -32
+	},
+/obj/effect/turf_decal/lumos/tile/blue/half{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -54374,7 +51973,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -54392,7 +51991,8 @@
 /obj/item/radio/intercom{
 	pixel_y = 25
 	},
-/obj/machinery/hydroponics/constructable,
+/obj/structure/closet/secure_closet/hydroponics,
+/obj/item/watertank,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "fHG" = (
@@ -54534,6 +52134,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"fYr" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/locker)
 "fZm" = (
 /obj/structure/chair/sofa/left,
 /turf/open/floor/plasteel,
@@ -54567,17 +52175,14 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
 "gcj" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
+	},
+/obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/medical/medbay/lobby)
@@ -54673,12 +52278,6 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
 "gjc" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /obj/item/radio/intercom{
 	pixel_y = 20
 	},
@@ -54687,6 +52286,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -54711,6 +52313,18 @@
 /obj/structure/lattice,
 /turf/closed/wall,
 /area/maintenance/bar)
+"gkq" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "gkw" = (
 /obj/structure/tank_dispenser,
 /obj/effect/turf_decal/bot,
@@ -54770,6 +52384,8 @@
 /area/ai_monitored/nuke_storage)
 "grS" = (
 /obj/structure/grille/broken,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "guS" = (
@@ -54791,7 +52407,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -54815,24 +52431,12 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "gxc" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
+/obj/effect/turf_decal/trimline/green/filled/line,
 /turf/open/floor/plasteel,
-/area/crew_quarters/locker)
+/area/hallway/primary/port)
 "gys" = (
 /obj/machinery/button/door{
 	id = "xenobio9";
@@ -54876,16 +52480,13 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/crew_quarters/dorms)
 "gAf" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/machinery/door/window/westright{
 	dir = 2;
 	name = "Security Checkpoint";
 	req_access_txt = "1"
+	},
+/obj/effect/turf_decal/lumos/tile/red/half{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
@@ -54905,15 +52506,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/circuit)
+"gBu" = (
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "gCm" = (
 /obj/machinery/disposal/bin,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/structure/disposalpipe/trunk,
 /obj/structure/window/reinforced{
 	dir = 8
+	},
+/obj/effect/turf_decal/lumos/tile/red/half{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -54927,18 +52531,12 @@
 /area/space)
 "gDy" = (
 /obj/structure/closet/secure_closet/security,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/airalarm{
 	dir = 4;
 	pixel_x = -22
+	},
+/obj/effect/turf_decal/lumos/tile/red/fullcorner{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
@@ -54954,6 +52552,16 @@
 	},
 /turf/open/space,
 /area/maintenance/disposal/incinerator)
+"gHV" = (
+/obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
+	},
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/turf/open/floor/plasteel/cafeteria,
+/area/medical/medbay/lobby)
 "gIU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -54966,13 +52574,10 @@
 /area/space/nearstation)
 "gJq" = (
 /obj/structure/chair/office/dark,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
+/obj/effect/turf_decal/lumos/tile/red/half,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
 "gLl" = (
@@ -55056,9 +52661,6 @@
 	specialfunctions = 4
 	},
 /obj/structure/table_frame/wood,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 1
-	},
 /turf/open/floor/plating,
 /area/maintenance/port)
 "gRl" = (
@@ -55175,29 +52777,25 @@
 /turf/open/space/basic,
 /area/space)
 "haM" = (
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = -29
+/mob/living/simple_animal/sloth/paperwork{
+	desc = "After the arrival of Cheems, Paperwork was gifted to the Library.";
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
+/turf/open/floor/carpet,
+/area/library)
 "haO" = (
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/floor/grass,
 /area/medical/virology)
 "hbh" = (
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/checker{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
+/obj/structure/table/glass,
+/obj/item/paper_bin{
+	pixel_y = 4
 	},
-/obj/structure/table,
-/obj/item/paicard,
+/obj/item/pen,
 /turf/open/floor/plasteel/cafeteria,
 /area/medical/medbay/lobby)
 "hcb" = (
@@ -55212,17 +52810,14 @@
 /obj/item/folder/white,
 /obj/item/stamp/cmo,
 /obj/item/clothing/glasses/hud/health,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
+	},
+/obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
@@ -55331,12 +52926,6 @@
 	icon_state = "4-8"
 	},
 /obj/effect/landmark/event_spawn,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
@@ -55346,26 +52935,29 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "hkR" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
-"hmk" = (
-/obj/effect/turf_decal/tile/blue{
+"hlx" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
+"hmk" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 1
+	},
+/obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/medical/medbay/lobby)
@@ -55387,31 +52979,25 @@
 	pixel_x = -2;
 	pixel_y = 5
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/item/pen,
 /obj/item/clothing/neck/stethoscope,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
+	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
 "hrE" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "hrF" = (
@@ -55455,16 +53041,13 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "hvu" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/structure/chair/office/light{
 	dir = 1
 	},
 /obj/effect/landmark/start/chief_medical_officer,
+/obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
+	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
 "hvD" = (
@@ -55494,7 +53077,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -55537,8 +53120,7 @@
 /obj/item/radio/intercom{
 	pixel_x = 25
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -55576,16 +53158,13 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "hIL" = (
-/obj/effect/turf_decal/tile/brown{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "hIM" = (
-/obj/effect/turf_decal/tile/brown{
+/obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -55706,9 +53285,9 @@
 /turf/open/floor/plating,
 /area/crew_quarters/abandoned_gambling_den)
 "hRK" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/obj/effect/turf_decal/trimline/yellow/filled/corner,
 /turf/open/floor/plasteel,
-/area/quartermaster/storage)
+/area/hallway/primary/port)
 "hSZ" = (
 /obj/structure/chair/comfy/brown{
 	dir = 1
@@ -55716,10 +53295,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "hWd" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/blue/half,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "hXr" = (
@@ -55727,39 +53303,15 @@
 /turf/open/floor/plating/airless,
 /area/maintenance/port/fore)
 "hYH" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
 /obj/structure/sink{
 	pixel_y = 28
 	},
+/obj/effect/turf_decal/lumos/tile/purple/half{
+	dir = 1
+	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"iaX" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "idK" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/machinery/camera{
 	c_tag = "Firing Range";
 	dir = 1
@@ -55767,21 +53319,22 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/security/range)
 "ifX" = (
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "ihL" = (
-/obj/effect/turf_decal/tile/red{
+/obj/structure/window/reinforced,
+/obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/structure/window/reinforced,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
 "iiG" = (
@@ -55811,26 +53364,9 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"ijG" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/structure/window,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/locker)
 "ikm" = (
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/lumos/tile/green/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
@@ -55849,32 +53385,28 @@
 	},
 /area/maintenance/bar)
 "iou" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/structure/closet/athletic_mixed,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/plasteel,
-/area/crew_quarters/fitness/pool)
+/area/hallway/primary/port)
 "iph" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /obj/machinery/atm{
 	pixel_x = -30
+	},
+/obj/effect/turf_decal/lumos/tile/red/half{
+	dir = 1
 	},
 /turf/open/floor/plasteel/white/corner{
 	dir = 8
 	},
 /area/hallway/secondary/exit)
 "ipA" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/structure/table,
+/obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 8
 	},
-/obj/structure/table,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
 "iqT" = (
@@ -55954,16 +53486,13 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/processing)
 "iuR" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 1
+/obj/effect/turf_decal/lumos/tile/green/fullcorner{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "iwg" = (
@@ -56200,14 +53729,26 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "iTU" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"iVQ" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/storage/tech)
 "iWx" = (
 /obj/structure/rack,
 /obj/item/coin/silver,
@@ -56250,12 +53791,6 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/machinery/light_switch{
 	pixel_x = 28
 	},
@@ -56264,6 +53799,9 @@
 	},
 /obj/machinery/airalarm{
 	pixel_y = 23
+	},
+/obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
@@ -56307,12 +53845,11 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "jcN" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
+	},
+/obj/effect/turf_decal/lumos/tile/blue/half{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
@@ -56360,15 +53897,11 @@
 /turf/open/floor/plasteel/white,
 /area/science/explab)
 "jgA" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/plasteel,
-/area/quartermaster/storage)
+/area/hallway/primary/port)
 "jhb" = (
 /obj/machinery/door/airlock/security{
 	name = "Interrogation";
@@ -56423,19 +53956,15 @@
 	dir = 4;
 	light_color = "#e8eaff"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /obj/machinery/camera{
 	c_tag = "Brig East";
 	dir = 8
 	},
 /obj/machinery/firealarm{
 	pixel_y = 24
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -56500,14 +54029,11 @@
 /obj/item/kirbyplants{
 	icon_state = "plant-22"
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/machinery/light{
 	dir = 8
+	},
+/obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/medical/medbay/lobby)
@@ -56518,6 +54044,13 @@
 /obj/structure/table,
 /turf/open/floor/wood,
 /area/maintenance/bar)
+"jtq" = (
+/mob/living/simple_animal/pet/dog/pug{
+	desc = "Because just like you, Doug can't breath too.";
+	name = "Doug"
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "jtV" = (
 /obj/machinery/chem_master/condimaster,
 /turf/open/floor/plating,
@@ -56532,21 +54065,17 @@
 /obj/item/reagent_containers/food/snacks/bluecherrycupcake{
 	pixel_y = 5
 	},
-/turf/open/floor/plasteel/cafeteria,
+/turf/open/floor/plating,
 /area/crew_quarters/kitchen)
 "jvd" = (
 /obj/structure/closet/athletic_mixed,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "jvl" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
 /obj/machinery/computer/secure_data,
+/obj/effect/turf_decal/lumos/tile/red/fullcorner{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
 "jvs" = (
@@ -56587,14 +54116,13 @@
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "jAN" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
+/obj/effect/turf_decal/lumos/tile/bar/checker,
+/obj/machinery/door/airlock/public/glass{
+	name = "Kitchen";
+	req_access_txt = "28"
 	},
-/turf/open/floor/plasteel/white/side{
-	dir = 8
-	},
-/area/crew_quarters/fitness)
+/turf/open/floor/plasteel,
+/area/crew_quarters/kitchen)
 "jBi" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -56630,16 +54158,10 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
 "jEc" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/vr_sleeper{
 	dir = 1
 	},
+/obj/effect/turf_decal/lumos/tile/red/fullcorner,
 /turf/open/floor/plasteel/white/corner{
 	dir = 1
 	},
@@ -56692,9 +54214,9 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "jGW" = (
-/obj/effect/turf_decal/tile/neutral,
+/obj/effect/landmark/start/assistant,
 /turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
+/area/crew_quarters/locker)
 "jHh" = (
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/plasteel,
@@ -56738,12 +54260,9 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/front_office)
 "jIr" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/effect/turf_decal/lumos/tile/red/fullcorner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
@@ -56801,6 +54320,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
 "jLH" = (
@@ -56824,6 +54344,9 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
+	},
+/obj/structure/closet/secure_closet/personal{
+	anchored = 1
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/pool)
@@ -56851,17 +54374,14 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
 "jOY" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
@@ -56919,16 +54439,13 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "jTe" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable{
 	icon_state = "0-2"
+	},
+/obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/medical/medbay/lobby)
@@ -56972,18 +54489,15 @@
 /turf/open/space/basic,
 /area/science/xenobiology)
 "jVg" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
 /obj/structure/table,
 /obj/item/paper_bin{
 	pixel_x = -4;
 	pixel_y = 5
 	},
 /obj/item/pen,
+/obj/effect/turf_decal/lumos/tile/brown/half{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "jWz" = (
@@ -57093,10 +54607,6 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "ker" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -57172,14 +54682,11 @@
 /area/medical/surgery)
 "kkH" = (
 /obj/machinery/suit_storage_unit/cmo,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/item/radio/intercom{
 	pixel_x = 25
+	},
+/obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
@@ -57234,11 +54741,11 @@
 /turf/closed/wall/r_wall,
 /area/medical/storage)
 "kqI" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
+/area/crew_quarters/locker)
 "ksE" = (
 /turf/closed/mineral/random/labormineral,
 /area/space/nearstation)
@@ -57301,6 +54808,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"kxz" = (
+/obj/effect/spawner/structure/window/hollow/end{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "kxG" = (
 /obj/item/cigbutt/cigarbutt,
 /obj/effect/decal/cleanable/blood/old,
@@ -57316,7 +54829,7 @@
 	name = "Security Checkpoint";
 	req_access_txt = "1"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/security/checkpoint/auxiliary)
 "kyF" = (
 /obj/machinery/conveyor{
@@ -57377,19 +54890,13 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "kCo" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
 	},
+/obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
+	},
+/obj/effect/turf_decal/lumos/tile/red/checker,
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
 "kEY" = (
@@ -57397,14 +54904,11 @@
 /turf/open/space/basic,
 /area/space)
 "kGl" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/machinery/door/window/northleft{
 	name = "Brig Operations";
 	req_one_access_txt = "4; 1"
 	},
+/obj/effect/turf_decal/lumos/tile/red/half,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "kGJ" = (
@@ -57466,23 +54970,23 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/junction/flip,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "kPY" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -57508,8 +55012,24 @@
 /area/medical/medbay/front_office)
 "kSb" = (
 /obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"kTo" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "kTs" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -57525,7 +55045,7 @@
 "kUA" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
-/obj/structure/sign/poster/contraband/purp{
+/obj/structure/sign/poster/contraband/billyh{
 	pixel_y = 32
 	},
 /turf/open/floor/carpet/purple,
@@ -57590,14 +55110,11 @@
 /turf/open/floor/plasteel,
 /area/security/range)
 "lcu" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
@@ -57629,34 +55146,23 @@
 	dir = 9
 	},
 /obj/structure/bed,
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "lip" = (
-/obj/structure/closet{
-	name = "Suit Closet"
+/obj/effect/turf_decal/lumos/tile/green,
+/obj/effect/turf_decal/trimline/green/filled/corner{
+	dir = 1
 	},
-/obj/item/clothing/under/suit/white,
-/obj/item/clothing/under/suit/tan,
-/obj/item/clothing/under/suit/red,
-/obj/item/clothing/under/suit/black_really,
-/obj/item/clothing/under/suit/navy,
-/obj/item/clothing/under/suit/green,
-/obj/item/clothing/under/suit/black/skirt,
-/obj/item/clothing/under/suit/checkered,
-/obj/item/clothing/under/suit/charcoal,
-/obj/item/clothing/under/suit/burgundy,
-/obj/item/clothing/under/suit/black,
-/obj/item/clothing/under/rank/civilian/lawyer/black,
-/obj/item/clothing/under/rank/civilian/lawyer/black,
-/obj/item/clothing/under/rank/civilian/lawyer/bluesuit,
-/obj/item/clothing/under/rank/civilian/lawyer/bluesuit,
-/obj/item/clothing/under/rank/civilian/lawyer/female,
-/obj/item/clothing/under/rank/civilian/lawyer/purpsuit,
-/obj/item/clothing/under/rank/civilian/lawyer/really_black,
-/obj/item/clothing/under/rank/civilian/lawyer/red,
+/obj/effect/turf_decal/trimline/green/filled/corner,
+/obj/effect/turf_decal/trimline/green/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/green/filled/corner{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
-/area/crew_quarters/locker)
+/area/storage/art)
 "lmc" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -57711,15 +55217,22 @@
 /obj/machinery/vending/clothing,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
-"ltK" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+"lsG" = (
+/obj/structure/chair{
 	dir = 1
 	},
+/obj/structure/window/reinforced,
+/obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/medical/medbay/lobby)
+"ltK" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
+/area/storage/art)
 "lun" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -57728,6 +55241,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/lumos/shower,
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics/cloning)
 "luQ" = (
@@ -57748,10 +55262,7 @@
 /turf/open/floor/carpet/purple,
 /area/maintenance/starboard/aft)
 "lzG" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/checker{
 	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
@@ -57764,13 +55275,10 @@
 /turf/closed/wall,
 /area/science/explab)
 "lCf" = (
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -57895,9 +55403,6 @@
 "lUS" = (
 /obj/structure/table/wood/fancy/black,
 /obj/machinery/light/small,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8
-	},
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
 "lVq" = (
@@ -57928,14 +55433,11 @@
 	},
 /area/maintenance/starboard/aft)
 "lZR" = (
-/obj/structure/sign/plaques/golden{
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/item/radio/intercom{
+	pixel_y = 20
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
@@ -58060,12 +55562,6 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "mps" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
@@ -58077,6 +55573,21 @@
 /obj/structure/plasticflaps,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"msc" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "msI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -58141,16 +55652,13 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "myX" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/red/half,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
 "mzB" = (
@@ -58215,16 +55723,13 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "mHy" = (
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/checker{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/structure/chair{
+/obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/structure/window/reinforced,
+/obj/structure/chair,
 /turf/open/floor/plasteel/cafeteria,
 /area/medical/medbay/lobby)
 "mHU" = (
@@ -58358,24 +55863,20 @@
 /turf/open/floor/plasteel,
 /area/medical/cryo)
 "mTG" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/bar/checker,
+/obj/structure/table,
+/obj/machinery/chem_dispenser/drinks/beer{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+/obj/machinery/light{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/crew_quarters/locker)
+/area/crew_quarters/bar)
 "mTO" = (
 /obj/machinery/computer/crew{
 	dir = 1
@@ -58384,10 +55885,7 @@
 	dir = 1;
 	pixel_y = -24
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/checker{
 	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
@@ -58568,17 +56066,14 @@
 /turf/closed/wall/r_wall,
 /area/medical/cryo)
 "nlz" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/lumos/tile/red/half{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "nlJ" = (
@@ -58705,7 +56200,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -58803,31 +56298,17 @@
 /turf/open/floor/plating,
 /area/maintenance/bar)
 "nLu" = (
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "nLw" = (
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/structure/window{
-	dir = 1
-	},
-/obj/structure/window{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/crew_quarters/locker)
+/area/hydroponics)
 "nLL" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -58849,7 +56330,13 @@
 	},
 /area/maintenance/bar)
 "nQi" = (
-/obj/machinery/recharge_station,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 4;
+	name = "Air In"
+	},
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "nQv" = (
@@ -58869,13 +56356,10 @@
 	pixel_y = 9
 	},
 /obj/item/pen,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 9
 	},
+/obj/effect/turf_decal/lumos/tile/red/half,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
 "nQM" = (
@@ -58901,17 +56385,9 @@
 /turf/open/floor/plasteel,
 /area/science/circuit)
 "nSt" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "nSN" = (
@@ -58941,16 +56417,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
+/obj/effect/turf_decal/lumos/tile/yellow/fulltile,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "nWJ" = (
@@ -59020,14 +56487,11 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "oaZ" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
@@ -59060,26 +56524,20 @@
 	},
 /area/hallway/secondary/exit)
 "ocv" = (
-/obj/structure/table,
-/obj/item/clothing/gloves/boxing/yellow,
-/obj/item/clothing/gloves/boxing/green,
-/obj/item/clothing/gloves/boxing/blue,
-/obj/item/clothing/gloves/boxing/blue,
-/obj/item/clothing/gloves/boxing,
-/obj/item/clothing/gloves/boxing,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/obj/machinery/vending/autodrobe,
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "odk" = (
 /obj/structure/chair{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/turf_decal/lumos/tile/blue/half,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "odx" = (
@@ -59127,13 +56585,11 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "ohq" = (
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -22
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
 	},
-/obj/structure/closet/athletic_mixed,
 /turf/open/floor/plasteel,
-/area/crew_quarters/fitness/pool)
+/area/hydroponics)
 "oiu" = (
 /obj/structure/chair/stool/bar,
 /turf/open/floor/plating{
@@ -59184,7 +56640,6 @@
 	name = "Dresser";
 	pixel_y = 7
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "oof" = (
@@ -59231,6 +56686,9 @@
 	dir = 4;
 	light_color = "#c1caff"
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "ouQ" = (
@@ -59264,41 +56722,21 @@
 /turf/open/floor/grass,
 /area/crew_quarters/bar)
 "oyl" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/structure/window{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
-/area/crew_quarters/locker)
+/area/hallway/secondary/exit)
 "oyN" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/space/nearstation)
 "oyX" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 4;
-	name = "Air In"
-	},
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/light/small{
 	dir = 8
 	},
-/turf/open/floor/plating,
-/area/maintenance/fore/secondary)
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness/pool)
 "oAw" = (
 /obj/structure/window{
 	dir = 1
@@ -59311,12 +56749,6 @@
 /turf/open/floor/grass,
 /area/hallway/secondary/exit)
 "oAA" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
 /obj/machinery/atm{
 	pixel_y = 30
 	},
@@ -59355,6 +56787,7 @@
 /turf/open/floor/engine,
 /area/science/mixing)
 "oHB" = (
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/dorms)
 "oHU" = (
@@ -59432,11 +56865,8 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "oMZ" = (
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
-	},
-/obj/item/radio/intercom{
-	pixel_y = 20
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -59447,13 +56877,12 @@
 /turf/open/floor/wood,
 /area/hallway/primary/central)
 "oOt" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/effect/turf_decal/lumos/tile/red/fullcorner{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel,
 /area/security/processing)
 "oPU" = (
@@ -59466,13 +56895,9 @@
 /turf/open/space,
 /area/space/nearstation)
 "oQQ" = (
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/lumos/tile/red/fullcorner{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
 "oRg" = (
@@ -59547,9 +56972,6 @@
 	},
 /obj/structure/cable{
 	icon_state = "2-8"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -59630,7 +57052,10 @@
 	pixel_x = -27;
 	pixel_y = 1
 	},
-/obj/structure/closet/athletic_mixed,
+/obj/machinery/camera{
+	c_tag = "Pool West";
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/pool)
 "plk" = (
@@ -59650,12 +57075,19 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "plC" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/structure/chair/stool,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
+"pnU" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/mob/living/simple_animal/pet/dog/corgi/puppy{
+	desc = "One of Ian's many brood. She's now a therapy dog, keep her close.";
+	name = "Laika"
+	},
+/turf/open/floor/wood,
+/area/medical/psych)
 "poc" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -59702,10 +57134,10 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "pqs" = (
-/obj/machinery/vending/clothing,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/vending/cigarette,
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "pro" = (
@@ -59734,14 +57166,11 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
 "psz" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
@@ -59760,11 +57189,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/front_office)
-"puh" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+"ptM" = (
+/obj/machinery/door/airlock/research{
+	name = "Robotics Lab";
+	req_access_txt = "29"
 	},
+/obj/effect/turf_decal/lumos/tile/red/fulltile,
+/turf/open/floor/plasteel/white,
+/area/science/robotics/lab)
+"puh" = (
 /obj/machinery/light/small,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 5;
@@ -59773,6 +57206,7 @@
 /obj/machinery/vr_sleeper{
 	dir = 1
 	},
+/obj/effect/turf_decal/lumos/tile/red/half,
 /turf/open/floor/plasteel/white/side{
 	dir = 1
 	},
@@ -59832,7 +57266,6 @@
 /obj/machinery/light_switch{
 	pixel_x = -20
 	},
-/obj/structure/filingcabinet/employment,
 /turf/open/floor/wood,
 /area/lawoffice)
 "pEL" = (
@@ -59868,12 +57301,6 @@
 	},
 /area/crew_quarters/theatre)
 "pIg" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/machinery/airalarm{
 	dir = 1;
 	pixel_y = -22
@@ -59885,6 +57312,9 @@
 	},
 /obj/effect/turf_decal/loading_area{
 	dir = 8
+	},
+/obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/medical/medbay/lobby)
@@ -59899,6 +57329,19 @@
 /mob/living/simple_animal/opossum,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"pKp" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/camera{
+	c_tag = "Locker Room South";
+	dir = 8
+	},
+/obj/structure/closet/secure_closet/personal,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/locker)
 "pKR" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -59915,11 +57358,8 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "pLh" = (
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
@@ -59945,16 +57385,19 @@
 /turf/closed/wall,
 /area/medical/medbay/central)
 "pPi" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/lumos/tile/red/half{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
+"pPL" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "pQW" = (
 /obj/structure/window{
 	dir = 8
@@ -60015,13 +57458,10 @@
 	name = "Station Intercom (General)";
 	pixel_x = -28
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/light{
+/obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -60039,11 +57479,8 @@
 /area/security/brig)
 "qaY" = (
 /obj/structure/table/reinforced,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
 /obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/lumos/tile/bar/checker,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "qeb" = (
@@ -60074,21 +57511,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/explab)
 "qfk" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/structure/window,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/landmark/start/assistant,
-/obj/machinery/door/window/eastleft{
-	name = "Blue Corner"
-	},
+/obj/structure/closet/secure_closet/personal,
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "qfD" = (
@@ -60113,14 +57536,11 @@
 /turf/closed/wall,
 /area/quartermaster/miningdock)
 "qkG" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -60185,16 +57605,24 @@
 /obj/machinery/holopad,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"qrm" = (
-/obj/structure/closet/secure_closet/security/med,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+"qrb" = (
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"qrm" = (
+/obj/structure/closet/secure_closet/security/med,
 /obj/item/book/manual/wiki/security_space_law,
+/obj/effect/turf_decal/lumos/tile/red/fullcorner{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
 "qsr" = (
@@ -60212,7 +57640,7 @@
 	name = "kitchen shutters"
 	},
 /obj/item/reagent_containers/food/snacks/mint,
-/turf/open/floor/plasteel/cafeteria,
+/turf/open/floor/plating,
 /area/crew_quarters/kitchen)
 "quT" = (
 /obj/structure/lattice,
@@ -60231,14 +57659,11 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
 "qBa" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
+	},
 /turf/open/floor/plasteel/cafeteria,
 /area/medical/medbay/lobby)
 "qBi" = (
@@ -60261,17 +57686,25 @@
 /obj/structure/lattice/catwalk,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"qGe" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "qGA" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /obj/effect/landmark/secequipment,
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 10
+	},
+/obj/effect/turf_decal/lumos/tile/red/half{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)
@@ -60318,9 +57751,9 @@
 	id = "Prison Gate";
 	name = "prison blast door"
 	},
-/obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "qLn" = (
@@ -60489,6 +57922,14 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
+"rkg" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "rlS" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
@@ -60578,7 +58019,9 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
 /area/crew_quarters/theatre)
 "rrM" = (
 /obj/structure/closet/wardrobe/black,
@@ -60596,9 +58039,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Bar Backroom"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
@@ -60655,13 +58095,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "ryr" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
+/obj/effect/turf_decal/lumos/tile/blue/fullcorner,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "rBj" = (
@@ -60734,20 +58168,19 @@
 /area/library)
 "rKO" = (
 /obj/structure/chair,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
 "rKP" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/construction)
+/turf/open/floor/plasteel/white/corner,
+/area/hallway/secondary/entry)
 "rKX" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -60810,8 +58243,15 @@
 	req_access_txt = "45"
 	},
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/lumos/tile/blue/fulltile,
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
+"rXk" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "rXl" = (
 /obj/structure/chair/office/light,
 /obj/machinery/firealarm{
@@ -60821,23 +58261,17 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "rYa" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
+	},
+/obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/medical/medbay/lobby)
@@ -60845,15 +58279,11 @@
 /obj/machinery/airalarm{
 	pixel_y = 23
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/lumos/tile/red/fullcorner{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
@@ -60870,16 +58300,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
+/obj/effect/turf_decal/lumos/tile/blue/fulltile,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "saK" = (
@@ -60947,13 +58368,6 @@
 /obj/machinery/newscaster{
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/requests_console{
 	department = "Security";
 	departmentType = 5;
@@ -60961,6 +58375,9 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Security Post - Medbay"
+	},
+/obj/effect/turf_decal/lumos/tile/red/fullcorner{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
@@ -61008,21 +58425,12 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /obj/machinery/door/airlock/security/glass{
 	id_tag = "outerbrig";
 	name = "Brig";
 	req_access_txt = "63"
 	},
+/obj/effect/turf_decal/lumos/tile/red/fulltile,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "sqc" = (
@@ -61030,16 +58438,13 @@
 /obj/machinery/recharger{
 	pixel_y = 4
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
 	},
+/obj/effect/turf_decal/lumos/tile/red/half,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
 "sqp" = (
@@ -61066,26 +58471,17 @@
 /turf/open/floor/plating,
 /area/crew_quarters/abandoned_gambling_den)
 "ssm" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "1-8"
+	},
+/obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/medical/medbay/front_office)
 "ssB" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/lumos/tile/green/fullcorner{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
@@ -61146,12 +58542,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
 "syw" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
@@ -61160,6 +58550,9 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
+	},
+/obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
@@ -61216,14 +58609,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "sEi" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/vr_sleeper{
 	dir = 1
 	},
-/obj/machinery/vr_sleeper{
+/obj/effect/turf_decal/lumos/tile/red/fullcorner{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white/corner{
@@ -61237,11 +58626,8 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "sFW" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/structure/sign/departments/restroom{
+/obj/structure/sign/departments/showers{
+	dir = 1;
 	pixel_y = -32
 	},
 /turf/open/floor/plasteel,
@@ -61278,6 +58664,9 @@
 /area/hydroponics)
 "sJz" = (
 /obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -61317,20 +58706,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "sLa" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/structure/window{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/crew_quarters/locker)
 "sLj" = (
 /obj/structure/chair/comfy/brown{
@@ -61347,6 +58723,19 @@
 /obj/machinery/atmospherics/pipe/manifold4w/violet/hidden,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"sLL" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "sMq" = (
 /obj/machinery/power/apc/auto_name/south,
 /obj/structure/cable{
@@ -61376,13 +58765,7 @@
 	dir = 4
 	},
 /obj/structure/chair,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/lumos/tile/red/fullcorner{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -61423,13 +58806,13 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "sSE" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/effect/turf_decal/lumos/tile/red/half{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
 "sSS" = (
@@ -61466,17 +58849,14 @@
 /turf/open/floor/plating,
 /area/quartermaster/office)
 "sXj" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
@@ -61506,6 +58886,19 @@
 /obj/machinery/bloodbankgen,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"tbP" = (
+/obj/machinery/power/apc{
+	areastring = "/area/maintenance/port";
+	dir = 8;
+	name = "Port Maintenance APC";
+	pixel_x = -27;
+	pixel_y = 2
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/locker)
 "tcT" = (
 /obj/item/toy/lumosplush/vadim,
 /turf/open/floor/carpet/purple,
@@ -61541,10 +58934,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "tkB" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/lumos/tile/blue/half,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "tkU" = (
@@ -61557,20 +58947,13 @@
 /turf/open/floor/plating,
 /area/space)
 "tle" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/structure/chair,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/lumos/tile/blue/checker{
 	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
@@ -61621,13 +59004,11 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics/cloning)
 "tqg" = (
-/obj/machinery/cryopod{
-	dir = 4
-	},
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
-/turf/open/floor/plasteel/dark,
+/obj/machinery/cryopod,
+/turf/open/floor/circuit/green,
 /area/crew_quarters/cryopod)
 "tqB" = (
 /obj/effect/turf_decal/stripes/line{
@@ -61658,10 +59039,10 @@
 /turf/open/floor/plasteel,
 /area/medical/cryo)
 "ttL" = (
-/obj/structure/sign/poster/contraband/random{
+/mob/living/simple_animal/opossum,
+/obj/structure/sign/poster/contraband/billyh2{
 	pixel_y = 32
 	},
-/mob/living/simple_animal/opossum,
 /turf/open/floor/carpet/purple,
 /area/maintenance/starboard/aft)
 "ttV" = (
@@ -61677,15 +59058,12 @@
 /obj/structure/chair/office/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable{
 	icon_state = "0-4"
+	},
+/obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/medical/medbay/front_office)
@@ -61714,12 +59092,6 @@
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "tys" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -61729,6 +59101,9 @@
 	},
 /obj/machinery/newscaster{
 	pixel_x = -30
+	},
+/obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
@@ -61758,14 +59133,14 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
 	},
+/obj/structure/closet/secure_closet/personal{
+	anchored = 1
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/pool)
 "tAH" = (
-/obj/machinery/door/airlock/external{
-	req_access_txt = "13"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
+/obj/structure/sign/warning/vacuum/external{
+	pixel_y = 32
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
@@ -61828,20 +59203,14 @@
 	pixel_x = -22
 	},
 /obj/structure/closet/crate/wooden/toy,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/structure/sign/poster/contraband/clown{
 	pixel_y = -32
 	},
 /obj/item/megaphone/clown,
+/obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
+	},
+/obj/effect/turf_decal/lumos/tile/red/checker,
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
 "tJK" = (
@@ -61856,6 +59225,9 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "tJS" = (
@@ -61863,12 +59235,6 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "tKk" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/structure/sign/warning/fire{
 	desc = "A sign that states the labeled room's number.";
 	icon_state = "roomnum";
@@ -61983,24 +59349,8 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "ubj" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/structure/window{
-	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
@@ -62015,8 +59365,11 @@
 /turf/open/floor/plasteel,
 /area/security/processing)
 "uei" = (
-/obj/structure/sign/warning/vacuum/external{
-	pixel_y = 32
+/obj/machinery/door/airlock/external{
+	req_access_txt = "13"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
@@ -62047,8 +59400,9 @@
 /turf/open/floor/plating,
 /area/security/checkpoint/auxiliary)
 "uhm" = (
-/obj/machinery/door/airlock{
-	name = "Recharging Station"
+/obj/machinery/door/airlock/atmos/abandoned{
+	name = "Atmospherics Maintenance";
+	req_access_txt = "12;24"
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
@@ -62069,8 +59423,9 @@
 /turf/closed/wall,
 /area/crew_quarters/toilet)
 "ujF" = (
-/obj/machinery/cryopod{
-	dir = 4
+/obj/machinery/computer/cryopod{
+	dir = 4;
+	pixel_x = -26
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/cryopod)
@@ -62116,6 +59471,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
+"unc" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/storage/tech)
 "unA" = (
 /obj/structure/window{
 	dir = 1
@@ -62183,14 +59547,14 @@
 /turf/closed/wall,
 /area/science/xenobiology)
 "usv" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -62210,10 +59574,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "uua" = (
@@ -62243,10 +59604,6 @@
 /turf/open/floor/plating,
 /area/security/brig)
 "uxY" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral,
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
@@ -62346,10 +59703,10 @@
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
 "uIO" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = -29
 	},
-/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "uJi" = (
@@ -62536,8 +59893,7 @@
 	},
 /obj/item/clothing/head/collectable/HoS{
 	name = "novelty HoS hat";
-	pixel_x = 7;
-	pixel_y = -1
+	pixel_x = 7
 	},
 /obj/machinery/camera{
 	c_tag = "Corporate Showcase"
@@ -62594,17 +59950,17 @@
 "vfe" = (
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "vhb" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/structure/window{
 	dir = 1
+	},
+/obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/locker)
@@ -62634,6 +59990,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/bar)
+"vlZ" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "vnI" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -62656,10 +60019,12 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 1
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "voh" = (
@@ -62715,12 +60080,6 @@
 /area/science/xenobiology)
 "vrc" = (
 /obj/structure/table/glass,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/item/cartridge/medical{
 	pixel_x = -2;
 	pixel_y = 6
@@ -62740,13 +60099,11 @@
 	pixel_x = -14;
 	pixel_y = 5
 	},
+/obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
+	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
-"vsM" = (
-/obj/machinery/power/apc/auto_name/south,
-/obj/structure/cable,
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/cryopod)
 "vsT" = (
 /obj/structure/chair/comfy/black{
 	dir = 8
@@ -62764,18 +60121,15 @@
 /turf/closed/wall,
 /area/hallway/secondary/exit)
 "vvy" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
 /obj/structure/cable{
 	icon_state = "2-4"
+	},
+/obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/medical/medbay/lobby)
@@ -62803,17 +60157,14 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -62830,6 +60181,14 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"vyA" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "vzp" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
@@ -62879,24 +60238,17 @@
 /area/bridge/meeting_room)
 "vBN" = (
 /obj/structure/chair,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/effect/turf_decal/lumos/tile/red/fullcorner{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
 "vBP" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
+	},
+/obj/effect/turf_decal/lumos/tile/blue/half{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
@@ -62994,23 +60346,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
-"vGs" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/structure/table,
-/obj/item/newspaper,
-/obj/item/newspaper{
-	pixel_y = 6
-	},
-/obj/item/newspaper{
-	pixel_x = 6
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/medical/medbay/lobby)
 "vHj" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Cryogenics "
@@ -63067,6 +60402,9 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "vKc" = (
@@ -63116,16 +60454,13 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/turf_decal/lumos/tile/purple/half,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "vVw" = (
@@ -63138,11 +60473,8 @@
 /area/medical/virology)
 "vZl" = (
 /obj/machinery/vending/wardrobe/sec_wardrobe,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
@@ -63174,11 +60506,8 @@
 /turf/open/floor/wood,
 /area/maintenance/bar)
 "wbE" = (
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/checker{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/medical/medbay/lobby)
@@ -63238,11 +60567,8 @@
 	dir = 1;
 	light_color = "#cee5d2"
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
@@ -63260,6 +60586,9 @@
 "wig" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
+	},
+/obj/structure/closet/secure_closet/personal{
+	anchored = 1
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/pool)
@@ -63332,9 +60661,9 @@
 /area/science/misc_lab)
 "woR" = (
 /obj/machinery/cryopod{
-	dir = 8
+	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/circuit/green,
 /area/crew_quarters/cryopod)
 "wph" = (
 /obj/docking_port/stationary{
@@ -63358,10 +60687,6 @@
 /turf/open/floor/wood,
 /area/hallway/primary/central)
 "wqF" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral,
 /obj/machinery/airalarm{
 	dir = 1;
 	pixel_y = -22
@@ -63369,13 +60694,10 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "wqW" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "wrd" = (
@@ -63502,12 +60824,6 @@
 /turf/open/floor/plating,
 /area/security/main)
 "wCv" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -63517,8 +60833,21 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
+	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
+"wES" = (
+/obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "wGf" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -63558,14 +60887,22 @@
 /area/crew_quarters/abandoned_gambling_den)
 "wLh" = (
 /obj/machinery/computer/security,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
+"wNd" = (
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
+"wNp" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "wPh" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -63629,14 +60966,11 @@
 /turf/open/floor/plasteel,
 /area/security/range)
 "wVk" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/lumos/tile/red/half{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
@@ -63663,13 +60997,11 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/pool)
 "wXl" = (
-/obj/machinery/camera{
-	c_tag = "Pool West";
-	dir = 4
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
 	},
-/obj/structure/closet/athletic_mixed,
 /turf/open/floor/plasteel,
-/area/crew_quarters/fitness/pool)
+/area/hallway/secondary/exit)
 "wXo" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -63715,6 +61047,9 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/obj/structure/closet/secure_closet/personal{
+	anchored = 1
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/pool)
 "xbn" = (
@@ -63782,6 +61117,9 @@
 /obj/machinery/light{
 	dir = 8;
 	light_color = "#e8eaff"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
@@ -63906,10 +61244,6 @@
 /area/maintenance/port/aft)
 "xqG" = (
 /obj/structure/table/reinforced,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
@@ -63917,16 +61251,24 @@
 	pixel_x = -3;
 	pixel_y = 5
 	},
+/obj/effect/turf_decal/lumos/tile/bar/checker,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
+"xrt" = (
+/obj/effect/turf_decal/trimline/brown/filled/corner,
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "xrN" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral,
 /obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
+"xrW" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/medical/medbay/lobby)
 "xtF" = (
 /turf/closed/wall/r_wall,
 /area/medical/medbay/central)
@@ -63967,11 +61309,8 @@
 "xBw" = (
 /obj/structure/closet/wardrobe/cargotech,
 /obj/item/radio/headset/headset_cargo,
-/obj/effect/turf_decal/tile/brown{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
@@ -63983,6 +61322,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/security/brig)
+"xDh" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/construction)
 "xDo" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -63999,11 +61344,10 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "xDM" = (
-/obj/machinery/camera{
-	c_tag = "Locker Room South";
+/obj/structure/closet/secure_closet/personal,
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
-/obj/structure/closet/secure_closet/personal,
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "xDQ" = (
@@ -64051,16 +61395,7 @@
 /obj/machinery/light_switch{
 	pixel_x = 28
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/red/fullcorner,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
 "xIa" = (
@@ -64195,15 +61530,11 @@
 /area/hallway/primary/central)
 "xXi" = (
 /obj/machinery/vr_sleeper,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green,
 /obj/structure/window/reinforced{
 	dir = 1
+	},
+/obj/effect/turf_decal/lumos/tile/green/fullcorner{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white/corner{
 	dir = 8
@@ -64225,7 +61556,10 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/structure/closet/athletic_mixed,
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -22
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/pool)
 "ybX" = (
@@ -64297,16 +61631,13 @@
 /obj/machinery/keycard_auth{
 	pixel_y = -24
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/machinery/camera{
 	c_tag = "Chief Medical Officer's Office";
 	dir = 1;
 	network = list("ss13","medbay")
+	},
+/obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
@@ -73935,7 +71266,7 @@ apN
 apN
 apJ
 awZ
-ayl
+ayk
 azy
 auP
 cIh
@@ -73949,7 +71280,7 @@ aaa
 azy
 auP
 cIh
-ayl
+awV
 aRY
 awW
 aaa
@@ -73959,7 +71290,7 @@ aaa
 aaa
 awW
 awZ
-ayl
+ayk
 beK
 auP
 cyt
@@ -75734,7 +73065,7 @@ asF
 asF
 apJ
 awY
-ayl
+ayk
 azy
 auP
 cIh
@@ -75748,7 +73079,7 @@ aaa
 azy
 auP
 cIh
-ayl
+awV
 aRY
 awW
 aaa
@@ -75758,7 +73089,7 @@ aaa
 aaa
 awW
 awZ
-ayl
+ayk
 beL
 auP
 cyu
@@ -75983,7 +73314,7 @@ aaa
 aaf
 apJ
 asH
-avY
+atI
 atI
 atI
 atI
@@ -76241,9 +73572,9 @@ aaa
 asF
 asI
 auQ
-aCX
-aCX
-aCX
+auQ
+aIM
+aIU
 aCX
 aub
 aLu
@@ -77037,14 +74368,14 @@ aBN
 aBv
 aTr
 aUM
-aBN
-aBN
+rKP
+rKP
 aWc
 baG
 aGi
 aUt
 aHM
-beM
+eXt
 asE
 aaa
 aaa
@@ -77541,7 +74872,7 @@ aCL
 aLP
 aFI
 aBI
-aBG
+bcD
 aKk
 aLy
 aNd
@@ -78055,7 +75386,7 @@ aCY
 bgf
 aFK
 aHy
-aIM
+ayl
 aKk
 aLz
 aNe
@@ -78312,7 +75643,7 @@ aDc
 aRL
 bxM
 aHa
-aIM
+ayl
 aKk
 aLj
 aNe
@@ -81393,7 +78724,7 @@ avq
 aAV
 aBQ
 aDh
-aDo
+aMg
 aFQ
 aHe
 aIN
@@ -81406,7 +78737,7 @@ aQN
 aQN
 aQN
 aQN
-aQN
+aXt
 aXQ
 aYe
 bbq
@@ -81659,10 +78990,10 @@ aLk
 aNo
 aOo
 aPA
-aQS
 aQN
+jGW
 aQN
-aQN
+jGW
 aQN
 aXp
 baO
@@ -81919,7 +79250,7 @@ aPA
 aQP
 aQN
 aQN
-aCO
+aQN
 aWo
 aXQ
 aXQ
@@ -82175,18 +79506,18 @@ aOp
 aPA
 aQR
 aQN
-aPe
-aQN
-aWq
 aQN
 aQN
 aQN
-aQN
+xDM
+xDM
+xDM
+xDM
 vhb
 bbO
 aPA
 bgt
-aSg
+kxz
 bjk
 aPz
 aaa
@@ -82432,11 +79763,11 @@ aOl
 aPC
 aQN
 aQN
-aTz
-aXr
+aXt
+aXt
 ubj
-aXr
-aZx
+aQN
+aQN
 aQN
 aQN
 cBh
@@ -82692,9 +80023,9 @@ aQN
 aTC
 aUs
 aUY
-aXv
-aYS
-aPe
+aQN
+qfk
+aQN
 aQN
 vhb
 bbO
@@ -82947,11 +80278,11 @@ aPA
 pqs
 aQN
 aTC
-aUs
-mTG
+aTC
+aWq
+aQN
+qfk
 aXt
-ijG
-aPe
 aQN
 aPA
 aPA
@@ -83203,12 +80534,12 @@ aOl
 aPE
 aQV
 aQN
-aTC
-aXv
-gxc
 aXt
-ijG
-aPe
+aXv
+aWq
+aXt
+qfk
+aXt
 aQN
 aZB
 aPA
@@ -83452,7 +80783,7 @@ aDo
 aDo
 aDo
 aDo
-aIU
+aDo
 aKa
 aLE
 aLE
@@ -83460,10 +80791,10 @@ aOl
 aPA
 aQU
 aQN
-nLw
-sLa
-oyl
-aXw
+aQN
+aQN
+aWq
+aQN
 qfk
 aQN
 aQN
@@ -83706,7 +81037,7 @@ aoX
 atJ
 aBQ
 aDq
-aDo
+aQS
 aFZ
 aHE
 aJc
@@ -83720,7 +81051,7 @@ aQN
 aQN
 aQN
 aWq
-aPe
+aQN
 aQN
 aQN
 aQN
@@ -83734,7 +81065,7 @@ hIL
 hIM
 bmh
 boK
-bjr
+hlx
 boK
 bjr
 bjr
@@ -83973,15 +81304,15 @@ aLE
 aOl
 aPA
 vJu
-aQN
+kqI
 aTD
 ocv
 aUZ
 aYU
 aYU
 aYU
-aYU
-aYU
+pKp
+fYr
 bcu
 bfe
 aUu
@@ -83989,8 +81320,8 @@ aZE
 bjm
 bjr
 bjr
-bmh
-boK
+gkq
+rXk
 kSb
 boK
 bjr
@@ -84233,22 +81564,22 @@ aPG
 aPG
 aPG
 aPG
-lip
-aQW
-aQW
-aQW
-aQW
-xDM
+aPA
+aPA
+aPA
+aPA
+aPA
+aPA
 aPA
 aSg
 bjk
 aZE
 bjp
 bjr
-hRK
-jgA
-boK
 bjr
+bmh
+boK
+ezF
 cBp
 bjr
 buB
@@ -84484,25 +81815,25 @@ hcb
 aKu
 aLL
 bDe
-aOl
+gxc
 aPF
 aQY
 aSk
 aTE
 aPG
-aPA
-aPA
-aPA
-aPA
-aPA
-aPA
-aPA
+sLa
+tbP
+sLa
+sLa
+sLa
+sLa
+sLa
 aSg
 bjk
 aZE
 bjo
 bjr
-aYx
+bjr
 aYz
 boK
 bjr
@@ -84741,10 +82072,10 @@ hcb
 aKu
 aLE
 aLE
-aOl
+gxc
 aPH
 aRa
-aRa
+lip
 aTG
 aPG
 aWu
@@ -84998,10 +82329,10 @@ aBJ
 aKu
 aLE
 aLE
-aOl
+gxc
 aPF
 aQZ
-aRa
+ltK
 aTF
 aPG
 aSX
@@ -85263,7 +82594,7 @@ aPG
 aPG
 aVC
 gjl
-bgA
+baS
 aZp
 baY
 bcJ
@@ -85520,7 +82851,7 @@ lVq
 lVq
 aWx
 gjl
-aBc
+baS
 baS
 bbP
 baS
@@ -85529,9 +82860,9 @@ baS
 bex
 gjl
 bgu
-bjr
-bjr
-bmh
+xrt
+dEj
+msc
 emL
 aZE
 brM
@@ -85775,9 +83106,9 @@ aPK
 aPK
 aPK
 aPK
-aWA
+bjk
 aXM
-bfi
+baS
 cBi
 bbS
 baS
@@ -86603,7 +83934,7 @@ bLv
 aaa
 cjJ
 ckw
-clC
+cnm
 cmy
 cnm
 cnL
@@ -87312,7 +84643,7 @@ aKc
 aLp
 aMV
 aOy
-aLE
+hRK
 aPQ
 aRV
 aSW
@@ -87521,7 +84852,7 @@ aKv
 aaU
 aai
 gXs
-gXs
+eRz
 aaa
 aaa
 aaa
@@ -87569,7 +84900,7 @@ ayG
 aLN
 aMT
 aOx
-aPc
+iou
 aRe
 aRT
 aSt
@@ -87632,7 +84963,7 @@ aaa
 cjJ
 ckz
 clF
-cmy
+cqb
 cnp
 cnO
 coy
@@ -87826,7 +85157,7 @@ aKd
 aLq
 aMY
 aPO
-aPO
+jgA
 aRf
 aSc
 aCK
@@ -88060,7 +85391,7 @@ hMo
 iuJ
 daA
 cxP
-jIr
+aiN
 arP
 aqU
 arg
@@ -88317,7 +85648,7 @@ aiX
 aiX
 rYg
 atq
-jIr
+aiN
 arP
 aqR
 arl
@@ -88881,7 +86212,7 @@ btz
 bwf
 btz
 btz
-btz
+sLL
 bBh
 bCr
 bAK
@@ -89080,7 +86411,7 @@ vIi
 fsj
 dXP
 alz
-xCp
+atf
 jhb
 and
 arS
@@ -89109,7 +86440,7 @@ aHx
 aqR
 aXs
 aJq
-aNq
+aNr
 aOD
 aJq
 aJq
@@ -89129,7 +86460,7 @@ aJq
 bgm
 bjx
 bmm
-bnM
+kTo
 boV
 bnM
 bnM
@@ -89395,7 +86726,7 @@ aYl
 fAj
 aLX
 aJq
-aJq
+aNs
 bBi
 aJw
 aaa
@@ -89623,13 +86954,13 @@ aHN
 aJj
 ayW
 aLV
-aJq
+bQc
 aOE
 aJn
 aJn
 aJn
 aJn
-aJs
+bwh
 aJq
 aYk
 aZM
@@ -89652,7 +86983,7 @@ bqv
 bwg
 aJw
 aJq
-aJq
+bQc
 bBi
 aJw
 aaa
@@ -89875,9 +87206,9 @@ aAW
 azW
 aDB
 aDI
-azW
-azW
-azW
+aSL
+aWv
+aYx
 ayW
 aLX
 aJq
@@ -89886,7 +87217,7 @@ aJn
 aaa
 aaa
 aJn
-aJs
+bwh
 aJq
 aYn
 aZM
@@ -90100,7 +87431,7 @@ acJ
 bkI
 bmv
 bop
-alg
+azG
 agj
 bot
 bpg
@@ -90136,7 +87467,7 @@ aEZ
 aHB
 aEZ
 aBt
-aJs
+bwh
 aJq
 aOE
 aJn
@@ -90357,16 +87688,16 @@ aVP
 acd
 awe
 fLS
-afG
+ahE
 agj
 afL
 ahu
 aie
 aiO
 afn
-iaX
+usv
 agL
-alg
+aue
 uwq
 fEw
 hwJ
@@ -90393,7 +87724,7 @@ ayU
 aAc
 aEZ
 vbD
-aJs
+bwh
 aJq
 bJx
 aJn
@@ -90612,9 +87943,9 @@ bcT
 bfk
 biZ
 acd
-ajc
+oMZ
 apn
-afG
+ahE
 agj
 agj
 agj
@@ -90632,7 +87963,7 @@ anz
 anR
 aov
 cCi
-ata
+aIl
 arT
 asl
 oof
@@ -90650,7 +87981,7 @@ aEZ
 aHC
 aEZ
 aBt
-aJs
+bwh
 aJq
 aOE
 aJn
@@ -90881,11 +88212,11 @@ agj
 hkH
 akl
 akM
-amm
-akx
+uwq
+avY
 anM
 dys
-aqC
+aCO
 anR
 aox
 aph
@@ -90903,8 +88234,8 @@ aBq
 azW
 aDE
 aFc
-azW
-azW
+aSM
+aWA
 aJf
 ayW
 lof
@@ -91126,7 +88457,7 @@ aaJ
 aat
 bjD
 acd
-ajc
+oMZ
 aev
 aeS
 agj
@@ -91137,19 +88468,19 @@ afM
 kGl
 alA
 hxc
-afW
+auf
 dmX
-nBb
-lhh
+awi
+axX
 seP
-aqC
+aCO
 anR
 aov
-apg
+aXs
 aqR
 aqR
 pRx
-apS
+aJg
 apS
 apS
 awh
@@ -91394,9 +88725,9 @@ afM
 csK
 kPY
 alB
-alg
+auk
 uwq
-fEw
+awv
 anB
 amR
 asT
@@ -91408,8 +88739,8 @@ jGc
 jGc
 aso
 jGc
-avi
-awi
+jGc
+awg
 ayL
 ayS
 azS
@@ -91457,14 +88788,14 @@ bCs
 bFa
 bFa
 bFa
-bHH
+unc
 bFa
 bFa
 bFa
 bCs
 bNJ
 bNJ
-bNJ
+xDh
 bNJ
 nxv
 bNI
@@ -91640,7 +88971,7 @@ aat
 bgx
 bke
 acd
-auy
+oMZ
 azm
 agj
 agj
@@ -91663,14 +88994,14 @@ jGc
 aob
 ara
 arV
-aoc
+aJz
 voh
 jGc
 awg
 ayW
 ayR
 azR
-aBr
+azW
 azW
 afO
 azW
@@ -91707,22 +89038,22 @@ bmr
 bmr
 bmr
 bmr
-byQ
+byS
 aJq
 bBi
 bCs
 bFa
 bFa
 bGw
-bHH
+iVQ
 bJk
 bFa
 bLA
 bCs
 cCd
-bQc
+bNJ
 bKA
-rKP
+bNJ
 bSv
 bNI
 bUB
@@ -91732,7 +89063,7 @@ bXG
 bPQ
 bQK
 bYF
-bTI
+bYF
 bUy
 bWs
 ceg
@@ -91908,9 +89239,9 @@ all
 all
 aku
 afM
-azG
-amm
-akx
+aux
+uwq
+awD
 guS
 dys
 atk
@@ -91920,14 +89251,14 @@ jGc
 aoc
 aoc
 aoc
-aoc
+aJz
 mXw
 jGc
 awg
 ayW
 ayT
 axA
-axF
+azW
 azW
 aBt
 azW
@@ -92165,25 +89496,25 @@ akF
 aiy
 akv
 sAr
-afW
+avi
 nVk
-nBb
+awX
 anQ
 seP
-aqC
+aDQ
 atP
 aun
 api
 avH
 arb
 arX
-aoc
+aKo
 aug
 jGc
 awg
 ayW
 azW
-azW
+ayq
 azW
 aCj
 ayW
@@ -92228,7 +89559,7 @@ bCs
 bAL
 bFa
 bGx
-bHH
+bET
 bJl
 bFa
 bHN
@@ -92422,12 +89753,12 @@ aiX
 eCQ
 akz
 afM
-alg
+aux
 amx
 any
 arD
 amR
-aqC
+aDQ
 anR
 fPy
 jGc
@@ -92484,7 +89815,7 @@ bBi
 bCs
 bFa
 bFa
-bdj
+bFa
 bET
 bJn
 bFa
@@ -92676,7 +90007,7 @@ afT
 ahy
 aiX
 aiR
-ajc
+oMZ
 akz
 afM
 als
@@ -92933,10 +90264,10 @@ ago
 ahz
 aiX
 aiW
-ajc
+oMZ
 akz
 afM
-alg
+azG
 alt
 amp
 aot
@@ -92962,7 +90293,7 @@ azZ
 aGt
 aHQ
 aJr
-aJq
+bdj
 aMc
 aNy
 aOE
@@ -93193,7 +90524,7 @@ aaZ
 wfA
 aAe
 aAl
-aqS
+atn
 eRh
 amI
 aqS
@@ -93219,7 +90550,7 @@ anz
 apj
 aHP
 aJq
-aJq
+bfi
 aMb
 aNx
 aOE
@@ -93275,7 +90606,7 @@ cau
 bQQ
 cau
 cbr
-cau
+qrb
 bXk
 bYq
 bCq
@@ -93449,8 +90780,8 @@ ain
 aiZ
 lcu
 akz
-alC
-akX
+afM
+azG
 alw
 amJ
 aoY
@@ -93476,7 +90807,7 @@ aAa
 aGu
 aHR
 aJt
-aJq
+bgA
 aMe
 aNA
 aOE
@@ -93706,7 +91037,7 @@ aip
 aja
 lCf
 akz
-alg
+ath
 agn
 agn
 amN
@@ -93732,8 +91063,8 @@ ahn
 ahn
 ahn
 ahn
-aJs
-aJq
+bwh
+bkV
 aMd
 aNz
 aOE
@@ -93963,13 +91294,13 @@ aiq
 ajb
 hrE
 ajF
-amq
+azG
 akY
 alE
 amU
 apH
 apX
-aqC
+aqF
 anz
 gfC
 ahn
@@ -93980,15 +91311,15 @@ xkL
 xkL
 xkL
 awn
-anF
-anF
-anF
-anF
-anF
-anF
-anF
-anF
-aoa
+aLO
+aLO
+aLO
+aLO
+aLO
+aLO
+aLO
+aLO
+aXw
 aJu
 aKF
 aMf
@@ -94220,13 +91551,13 @@ ait
 aje
 jOY
 alj
-sAr
+atn
 akZ
 alM
 amV
 apc
 aqr
-aqC
+aqF
 anz
 aoA
 ahn
@@ -94467,17 +91798,17 @@ abJ
 abR
 adR
 acq
-ahX
+agS
 adi
 adP
-ahK
-ahK
+ahX
+ahX
 ahR
 aiv
 adg
 oaZ
 akz
-alC
+azG
 ala
 alN
 amW
@@ -94490,18 +91821,18 @@ ahn
 aqg
 arf
 aqa
-atf
+eQb
 arf
 aqa
-atf
+eQb
 arf
 aqa
-atf
+eQb
 dgz
 tqg
 ujF
-ujF
-ujF
+aQW
+woR
 dgz
 aaa
 aJn
@@ -94750,15 +92081,15 @@ apY
 ate
 arf
 apY
-awX
+eQb
 arf
 apY
-awX
+eQb
 dgz
 fvY
 dvc
 dzi
-vsM
+woR
 dgz
 aaa
 aJn
@@ -94988,7 +92319,7 @@ afr
 akc
 aik
 akh
-adR
+apg
 oMZ
 aiG
 amf
@@ -95004,13 +92335,13 @@ ahn
 aqg
 arf
 aqn
-ath
+eQb
 arf
 auw
-ath
+eQb
 arf
 ayV
-ath
+eQb
 dgz
 aCd
 qIw
@@ -95248,7 +92579,7 @@ aki
 akk
 akq
 gbM
-amq
+azG
 agn
 agn
 ant
@@ -95276,7 +92607,7 @@ eVC
 dgz
 aJv
 khV
-aMg
+aJq
 bHt
 aOE
 aJn
@@ -95502,10 +92833,10 @@ agy
 aha
 ahC
 aia
-adR
-bnU
+apx
+oMZ
 akE
-sAr
+atn
 alq
 amd
 anu
@@ -95527,14 +92858,14 @@ tKk
 atj
 aAX
 mps
-atj
+aLR
 aFe
 mps
 aHT
 aJy
 aJy
 aMj
-aJq
+bTI
 aOE
 aJn
 aaa
@@ -95748,7 +93079,7 @@ aaf
 aaf
 abo
 abm
-abP
+abm
 abm
 abm
 abm
@@ -95775,10 +93106,10 @@ ahn
 aqg
 arf
 asf
-auk
-auk
-aux
-avt
+awr
+awr
+awr
+awr
 awr
 bbl
 aFk
@@ -95786,12 +93117,12 @@ nZE
 ker
 aDG
 aFd
-auk
+awr
 aHH
-aJg
-aKo
-aLO
 aJq
+aJq
+aJq
+aNr
 aOE
 aJn
 aaa
@@ -96007,7 +93338,7 @@ adR
 abn
 abH
 abn
-abn
+aaK
 abn
 adR
 adR
@@ -96039,16 +93370,16 @@ oAA
 awu
 axi
 axB
-uIO
+awr
 aAh
 aAh
 aAh
 aAh
 aAh
-aAh
-aAh
-aLR
+aZx
+blU
 aJq
+aNr
 aOE
 aJn
 aaa
@@ -96299,13 +93630,13 @@ awr
 uIO
 aAh
 aGk
-aGk
+aSI
 aGk
 aAh
-aJz
+aAh
 aAh
 aLQ
-aJq
+aNr
 aOE
 aJn
 aaa
@@ -96524,7 +93855,7 @@ aez
 aci
 acs
 acR
-afg
+afD
 afV
 agB
 ahd
@@ -96546,23 +93877,23 @@ ajo
 aqg
 arf
 asm
-blU
-blU
+atm
+atm
 avg
-awv
-axX
+awr
+awr
 axy
 awr
-haM
-aAh
-aDQ
+awr
+dtx
+aGx
 aMo
 aGl
 aAh
 aBy
 aAh
 rqf
-aJq
+aNr
 aOE
 aJn
 aaa
@@ -96591,14 +93922,14 @@ buZ
 fUj
 bqH
 byN
-aJq
+iTU
 bBA
 bCz
 bDQ
-cnb
-bGJ
+rkg
+vyA
 grS
-bGP
+qGe
 bAw
 bLK
 bMP
@@ -96781,7 +94112,7 @@ acQ
 adn
 agw
 abq
-afg
+afD
 afU
 apZ
 ahc
@@ -96797,7 +94128,7 @@ amr
 amY
 amY
 ajp
-aue
+anV
 ajo
 ajo
 aqg
@@ -96819,13 +94150,13 @@ aAh
 aSF
 aAh
 aMm
-aJq
+cjV
 aOE
 aJn
 aJn
 aJn
 aJn
-aJs
+bwh
 aXf
 aYk
 aZV
@@ -96848,7 +94179,7 @@ bqH
 bqH
 bqH
 aJq
-bHt
+wES
 bBz
 bzs
 bzs
@@ -97052,8 +94383,8 @@ ald
 alJ
 amt
 asd
-asd
-asd
+aBr
+aHt
 anY
 ajo
 apq
@@ -97063,11 +94394,11 @@ arf
 arf
 arf
 arf
-ltK
+awr
 axP
 azb
 aAi
-uIO
+awr
 aAh
 aAh
 dtx
@@ -97076,7 +94407,7 @@ aAh
 aDM
 aAh
 aVZ
-aJq
+cBg
 aJq
 aJr
 aJr
@@ -97150,7 +94481,7 @@ ccw
 cDL
 cjl
 cjQ
-cjV
+cgR
 cig
 aaf
 aaf
@@ -97295,7 +94626,7 @@ acu
 acu
 acF
 abq
-afg
+afD
 afU
 aqc
 ahe
@@ -97574,14 +94905,14 @@ aps
 aqk
 arf
 avZ
-blU
+atm
 aHw
 avn
-awv
-axX
+awr
+awr
 aze
 aGm
-flE
+aGm
 aKJ
 aDU
 aBz
@@ -97641,7 +94972,7 @@ bOd
 bOd
 bOd
 bYS
-bOd
+jtq
 bOd
 bOd
 cBJ
@@ -97809,7 +95140,7 @@ abq
 abq
 abq
 abq
-afg
+abP
 afY
 afY
 ahg
@@ -98121,9 +95452,9 @@ bfS
 bfG
 bha
 hbh
-vGs
 wbE
-bpu
+wbE
+tle
 wbE
 wbE
 jqu
@@ -98586,17 +95917,17 @@ adR
 ahl
 abp
 aic
-xkL
+apy
 xkL
 aAk
 xkL
-aqZ
-anb
-anb
+xkL
+xkL
+xkL
 alL
-anb
-anb
-auf
+xkL
+xkL
+xkL
 xkL
 anZ
 apu
@@ -98609,10 +95940,10 @@ awA
 awr
 axW
 awr
-aHt
-kqI
+awr
+awr
 aKr
-kqI
+awr
 aDa
 aOV
 aJk
@@ -98634,12 +95965,12 @@ aYV
 tkB
 bfH
 wbE
-bod
 wbE
+gHV
 mHy
 tle
 wbE
-mHy
+lsG
 bpM
 bqT
 bFD
@@ -98843,17 +96174,17 @@ abp
 ahk
 aoJ
 aib
+aqq
 anD
 anD
 anD
 anD
-ars
 fpz
-bkV
+anD
 jKP
-alK
-atn
-anc
+anD
+anD
+auq
 auq
 anD
 aoI
@@ -98865,7 +96196,7 @@ avy
 nSt
 axS
 azk
-awr
+axB
 awr
 awr
 awr
@@ -98891,12 +96222,12 @@ aYV
 tkB
 brB
 wbE
-bod
 wbE
+gHV
 mHy
 bvw
 bxb
-mHy
+lsG
 bqP
 bqS
 bLX
@@ -99099,21 +96430,21 @@ abp
 abp
 ahn
 ahn
-ahn
+anc
 uhm
 ahn
-aiA
-ahn
-aaK
+anF
+anF
+anF
 anE
-aod
-ahn
-apx
-ahn
-ahn
-ahn
-ahn
-ahn
+dFX
+dFX
+dFX
+dFX
+dFX
+arf
+arf
+arf
 arf
 oAB
 eQb
@@ -99129,7 +96460,7 @@ awr
 awr
 awr
 awr
-aUg
+oHB
 aKR
 aKR
 aKR
@@ -99148,12 +96479,12 @@ aYV
 tkB
 brB
 wbE
-bod
 wbE
+gHV
 mHy
 bvy
 bxT
-mHy
+lsG
 bpM
 bqV
 hFP
@@ -99353,21 +96684,21 @@ abp
 wdv
 afp
 wdv
-abp
-aaa
-aaa
-ahn
+adR
+alK
+amm
+aod
 nQi
 ahn
 uei
 ahn
 arN
 anE
-aod
+dFX
 aoK
 oyX
 aqp
-ahn
+dFX
 tzQ
 pgf
 gzf
@@ -99377,15 +96708,15 @@ eQb
 lUS
 arf
 avz
-awu
+awr
 aDY
-axB
-jGW
-avt
+awr
+awr
+awr
 plC
 plC
 plC
-avt
+awr
 aJk
 sLj
 aKR
@@ -99405,12 +96736,12 @@ aYV
 bgY
 bfH
 wbE
-bod
 wbE
+gHV
 mHy
 tle
 wbE
-mHy
+lsG
 pIg
 bAp
 bAp
@@ -99610,21 +96941,21 @@ adR
 aaa
 aaa
 aaa
-adR
-aaa
-aaa
-ahn
-ahn
+aiA
+alK
+anb
+aoe
+aqZ
 ahn
 tAH
 ahn
 eMs
 anG
-aoe
+dFX
 aoL
-apy
-aqq
-ahn
+dqb
+dqb
+dFX
 qLR
 oIW
 arf
@@ -99868,20 +97199,20 @@ aaa
 aaa
 aaa
 gXs
-aaa
-aaa
-aaa
-aaa
-gJi
-gJi
+alK
+ahn
+ahn
+ahn
+ahn
+ars
 ahn
 ahn
 khB
-ahn
-ahn
-ahn
-ahn
-ahn
+dFX
+aBc
+aBG
+aBc
+dFX
 arf
 arf
 arf
@@ -99920,8 +97251,8 @@ bet
 bfG
 bhe
 bli
-bli
-bli
+xrW
+xrW
 jTe
 boe
 vvy
@@ -100129,15 +97460,15 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+gJi
+gJi
 dFX
-wWW
+avt
 dqb
 lCo
-ohq
-wXl
-iou
+dqb
+dqb
+dqb
 pkF
 xZL
 wig
@@ -100935,9 +98266,9 @@ aNu
 aJC
 aaz
 egt
-aQc
+aRz
 aSZ
-aQc
+aRz
 qaY
 acN
 bag
@@ -101192,9 +98523,9 @@ aNE
 aOO
 aQi
 aRz
-aQc
-aQc
-aQc
+aRz
+aRz
+aRz
 aXl
 aKR
 bai
@@ -101437,7 +98768,7 @@ fHG
 reA
 lsk
 xXi
-jAN
+sci
 jEc
 alP
 aGL
@@ -101448,17 +98779,17 @@ aKR
 aND
 aJC
 aab
-aRg
-aQc
+aRz
+mTG
 aac
-aQc
+aRz
 aXk
 aKR
 aKR
 aJC
 fdf
 aYV
-aYV
+bdo
 brC
 cgt
 kQk
@@ -101705,8 +99036,8 @@ aKR
 wYs
 aJC
 aJI
+jAN
 aJI
-aSI
 aJI
 aVA
 aJI
@@ -101714,7 +99045,7 @@ aYK
 aJI
 aJI
 bcs
-aYV
+wNp
 bdb
 bof
 uhX
@@ -101971,7 +99302,7 @@ aYJ
 aJI
 mNW
 aYV
-aYV
+pPL
 bdo
 brC
 gRl
@@ -102234,7 +99565,7 @@ uJi
 wAq
 wAq
 wAq
-bjN
+pnU
 bkO
 uJi
 bnH
@@ -102734,7 +100065,7 @@ aCw
 aON
 aQk
 aRD
-aSM
+aRD
 aVD
 aIk
 aXm
@@ -102991,7 +100322,7 @@ aNK
 aOM
 aJI
 aRB
-aSL
+aVz
 aTN
 bmS
 aVz
@@ -103218,11 +100549,11 @@ aaa
 dFX
 xaB
 mgF
-mgF
-mgF
+axF
+axF
 vAl
-mgF
-mgF
+axF
+axF
 mgF
 iMv
 fpl
@@ -103245,7 +100576,7 @@ aJK
 aKV
 tMl
 aMF
-aWv
+aMF
 aJI
 aRG
 aVz
@@ -103501,7 +100832,7 @@ anf
 aJI
 aJI
 aJI
-aMF
+flE
 aMF
 aJI
 aRF
@@ -104268,7 +101599,7 @@ fnC
 kPd
 xiw
 aGS
-auE
+anf
 aIp
 aKH
 aMI
@@ -104277,7 +101608,7 @@ aOX
 aOX
 aOX
 aSR
-aUi
+aVJ
 aVJ
 xmk
 aYP
@@ -104782,7 +102113,7 @@ cVb
 cVb
 cVb
 aGC
-aIl
+anf
 aIp
 aKI
 aMy
@@ -104791,10 +102122,10 @@ nGf
 aQm
 aCy
 aCH
-aRJ
+nLw
 aVK
 aRJ
-aRJ
+gBu
 aRJ
 bbB
 aYV
@@ -105052,7 +102383,7 @@ aUj
 sJx
 aRJ
 aYQ
-cBg
+bam
 bam
 aYV
 aYV
@@ -105562,7 +102893,7 @@ aOX
 aQm
 aCE
 aCJ
-aRJ
+ohq
 bpe
 aRJ
 aYR
@@ -108143,7 +105474,7 @@ aXq
 beE
 bfV
 bhv
-biK
+blz
 blz
 blz
 bly
@@ -108398,7 +105729,7 @@ bFn
 aYV
 aXq
 bds
-bsw
+ptM
 biN
 biL
 biL
@@ -109402,7 +106733,7 @@ alP
 awM
 hHQ
 hHQ
-awD
+hHQ
 hHQ
 hHQ
 aEe
@@ -109413,7 +106744,7 @@ aFw
 aLb
 aFw
 xEE
-aYW
+haM
 aYW
 aRQ
 blt
@@ -113273,7 +110604,7 @@ aRL
 bgf
 sqc
 aHy
-aPq
+oyl
 aPq
 aPq
 aPq
@@ -113530,7 +110861,7 @@ aRL
 aRL
 gJq
 kyB
-aPq
+oyl
 aPq
 dfW
 qsr
@@ -113787,7 +111118,7 @@ aRL
 aEK
 nQC
 aHy
-aPq
+oyl
 bBM
 oAw
 frq
@@ -114044,7 +111375,7 @@ aEJ
 aEJ
 bsd
 aHy
-aPq
+oyl
 bBM
 nze
 frq
@@ -114558,7 +111889,7 @@ gAf
 hkR
 oQQ
 aHy
-aPq
+oyl
 bBM
 dxe
 frq
@@ -114815,7 +112146,7 @@ uKX
 aRL
 myX
 aHy
-aPq
+oyl
 aPq
 wqW
 nxQ
@@ -115073,15 +112404,15 @@ sSE
 ekl
 aHy
 aPs
-aPq
+wXl
 aPq
 aPq
 ktD
-aPq
+wNd
 beY
 brA
 bAk
-brA
+vlZ
 vai
 gBf
 aaf


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/26664829/103472860-0fa71100-4d58-11eb-9677-7063e5c35ef3.png)
![image](https://user-images.githubusercontent.com/26664829/103472863-1d5c9680-4d58-11eb-9cde-09c4ad93f0a1.png)
![image](https://user-images.githubusercontent.com/26664829/103472869-28afc200-4d58-11eb-9daa-4dfc67e64c17.png)
![image](https://user-images.githubusercontent.com/26664829/103472874-37967480-4d58-11eb-8f6b-2e3a8fc5fa5d.png)
![image](https://user-images.githubusercontent.com/26664829/103472883-4ed56200-4d58-11eb-8fcb-4e5b007ef989.png)
![image](https://user-images.githubusercontent.com/26664829/103472889-5a288d80-4d58-11eb-9497-744889639563.png)
![image](https://user-images.githubusercontent.com/26664829/103472891-61e83200-4d58-11eb-855c-90bb52d0b69f.png)
![image](https://user-images.githubusercontent.com/26664829/103472895-6ca2c700-4d58-11eb-8956-6f743165ec79.png)

## About The Pull Request

Changes generally here and there for Boxstation, including decals update. Gaming.

## Why It's Good For The Game

General improvements and tweaks for a good map.

## Changelog
:cl:
tweak: Locker Room is now a proper locker room (with small atmos connectors for the scrubber and pump at Krome's request)
tweak: Detective's Office gets a mild renovation
tweak: Theatre with instrument room
del: redundant neutral decals and atmos for Dorms
tweak: Cryo gets another renovation
tweak: Captain's Quarters, desk, and carpets. Carpets are royal blue now.
add: The Blueshield Stool (TM) in Conference Room
del: excess lockers near Holodeck
tweak: Pool gets a changing room and more personal lockers, now the Brig atmos room is closer and on Layer 1
tweak: Perma gets the Solitary removed, the area is now a congregation area similar to those in Jailbreak from Gmod or TF2, without all the death contraptions (you gotta add those yourself)
tweak: Hold Cells get a color code, similar to Pubby. I think Box had it at some point and it just got removed for some reason.
tweak: Updates most decals to the prefab, which helps with load times and generally makes things faster map-wise
add: Billy Posters to certain rooms
tweak: general shortenings of unary and scrubber outputs
add: Main central hall gets a few more scrubbers and vents
add: more buttons to the Bridge
add: Doug the Pug, a new Atmos pet.
/:cl: