### PR TITLE
New Year, New Pubby Rework

### DIFF
--- a/_maps/map_files/PubbyStation/PubbyStation_Lumos.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation_Lumos.dmm
@@ -51,25 +51,8 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aah" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/camera{
-	c_tag = "Surgery";
-	network = list("ss13","surgery")
-	},
-/obj/machinery/airalarm{
-	pixel_y = 22
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/machinery/limbgrower,
-/turf/open/floor/plasteel/white,
-/area/medical/surgery)
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "abf" = (
 /obj/structure/bed,
 /turf/open/floor/plating,
@@ -1060,15 +1043,6 @@
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/AIsatextAS)
 "aeC" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/loading_area{
-	dir = 1
-	},
 /obj/structure/window/reinforced{
 	dir = 4;
 	layer = 2.9
@@ -1185,12 +1159,6 @@
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/AIsatextAS)
 "aeT" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /obj/machinery/conveyor/auto{
 	dir = 1
 	},
@@ -1703,13 +1671,6 @@
 /area/security/execution/transfer)
 "agn" = (
 /obj/machinery/light,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/delivery,
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
 	},
@@ -5697,11 +5658,8 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "apu" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
 /turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
+/area/security/prison)
 "apv" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -6290,12 +6248,8 @@
 /turf/open/floor/plasteel/dark,
 /area/gateway)
 "aqT" = (
-/obj/machinery/computer/arcade,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/checker{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/dorms)
@@ -6305,25 +6259,23 @@
 	department = "Crew Quarters";
 	pixel_y = 30
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/checker{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
+/obj/structure/window{
+	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/dorms)
 "aqV" = (
-/obj/machinery/washing_machine,
 /obj/machinery/airalarm{
 	pixel_y = 22
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/checker{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/structure/table,
+/obj/structure/bedsheetbin/towel,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/dorms)
 "aqY" = (
@@ -6602,37 +6554,25 @@
 /area/bridge)
 "arH" = (
 /obj/machinery/modular_computer/console/preset/command,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/lumos/tile/green/fullcorner{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "arI" = (
 /obj/machinery/computer/med_data,
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/lumos/tile/green/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "arJ" = (
 /obj/machinery/computer/crew,
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/lumos/tile/green/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
@@ -6649,13 +6589,10 @@
 	light_color = "#e8eaff"
 	},
 /obj/item/pen,
-/obj/effect/turf_decal/tile/blue{
+/obj/item/aicard,
+/obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/item/aicard,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "arL" = (
@@ -6663,31 +6600,22 @@
 /obj/machinery/camera{
 	c_tag = "Bridge - Central"
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "arM" = (
 /obj/machinery/computer/communications,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "arN" = (
 /obj/machinery/computer/station_alert,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
@@ -6701,45 +6629,32 @@
 	light_color = "#e8eaff"
 	},
 /obj/machinery/recharger,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "arP" = (
 /obj/machinery/computer/security,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "arQ" = (
 /obj/machinery/computer/secure_data,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "arR" = (
 /obj/machinery/computer/prisoner/management,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/lumos/tile/red/fullcorner{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
@@ -6863,47 +6778,44 @@
 /turf/open/floor/plasteel,
 /area/gateway)
 "asb" = (
-/obj/structure/cable{
-	icon_state = "1-4"
+/obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
 	},
+/obj/machinery/washing_machine,
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/dorms)
+"asc" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/maintenance/department/crew_quarters/dorms)
-"asc" = (
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-4"
 	},
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
+/obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/dorms)
 "asd" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/checker{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/dorms)
 "ase" = (
-/obj/effect/landmark/event_spawn,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/checker{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
+/obj/machinery/washing_machine,
+/obj/structure/window{
+	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/dorms)
@@ -6912,11 +6824,8 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/checker{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/dorms)
@@ -6927,13 +6836,9 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/checker{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/structure/bedsheetbin/color,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/dorms)
 "ash" = (
@@ -7195,14 +7100,11 @@
 	pixel_y = -2;
 	req_access_txt = "19"
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/lumos/tile/green/half{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
@@ -7226,12 +7128,11 @@
 	pixel_y = -2;
 	req_access_txt = "19"
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/lumos/tile/red/half{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
@@ -7316,13 +7217,10 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "atg" = (
-/obj/effect/turf_decal/tile/blue{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+/obj/effect/turf_decal/lumos/tile/blue/checker{
 	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
@@ -7333,16 +7231,13 @@
 	c_tag = "Laundry Room";
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4
+	},
+/obj/effect/turf_decal/lumos/tile/blue/checker{
 	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
@@ -7351,17 +7246,14 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 10
+	},
+/obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/dorms)
@@ -7370,11 +7262,8 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/checker{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/dorms)
@@ -7634,40 +7523,19 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/purple/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "atQ" = (
 /obj/machinery/computer/atmos_alert,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/purple/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "atR" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -7679,21 +7547,15 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "atT" = (
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "atU" = (
 /obj/item/beacon,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
@@ -7707,8 +7569,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -7717,16 +7578,7 @@
 /obj/machinery/computer/shuttle/labor{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/yellow/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "atY" = (
@@ -7874,14 +7726,11 @@
 	name = "Laundry Room"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
+	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/dorms)
 "aul" = (
@@ -7922,10 +7771,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
-"auq" = (
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
 "aur" = (
 /turf/open/floor/engine{
 	name = "Holodeck Projector Floor"
@@ -8111,11 +7956,8 @@
 	dir = 4;
 	pixel_x = -22
 	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
@@ -8123,11 +7965,8 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
@@ -8144,8 +7983,7 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "auQ" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -8155,10 +7993,7 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "auS" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -8167,16 +8002,7 @@
 /obj/machinery/computer/cargo/request{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/yellow/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "auU" = (
@@ -8602,19 +8428,10 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "avN" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "avO" = (
@@ -8624,19 +8441,10 @@
 	dir = 1
 	},
 /obj/machinery/light/small,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "avP" = (
@@ -8644,22 +8452,13 @@
 	name = "Station Intercom (General)";
 	pixel_y = -28
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
 	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "avQ" = (
@@ -8671,37 +8470,24 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "avR" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
+	},
+/obj/effect/turf_decal/lumos/tile/blue/fullcorner{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
@@ -8786,16 +8572,7 @@
 /obj/machinery/computer/security/mining{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/yellow/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "awc" = (
@@ -9245,12 +9022,9 @@
 /turf/open/floor/plating,
 /area/crew_quarters/heads/captain)
 "awU" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/lumos/tile/blue/half,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "awV" = (
@@ -9292,10 +9066,7 @@
 	dir = 4;
 	pixel_x = -28
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -9349,8 +9120,7 @@
 /obj/machinery/computer/rdconsole{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -9627,10 +9397,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -24
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -9659,10 +9426,7 @@
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "ayb" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/blue/half,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "ayc" = (
@@ -9672,14 +9436,13 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "ayd" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -10159,10 +9922,7 @@
 	dir = 9;
 	pixel_x = -22
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -10323,8 +10083,7 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -10662,13 +10421,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aAj" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
 	},
+/obj/effect/turf_decal/lumos/tile/blue/checker,
 /turf/open/floor/plasteel/dark,
 /area/blueshield)
 "aAk" = (
@@ -10796,10 +10552,7 @@
 	pixel_y = -2;
 	req_access_txt = "19"
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -10825,18 +10578,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/lumos/tile/blue/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "aAD" = (
@@ -10858,8 +10602,7 @@
 	pixel_y = -2;
 	req_access_txt = "19"
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -11120,39 +10863,21 @@
 /obj/machinery/porta_turret/ai{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/blue/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "aBt" = (
 /obj/machinery/airalarm{
 	pixel_y = 22
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/fullcorner{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "aBu" = (
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
@@ -11160,25 +10885,19 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/lumos/tile/blue/half{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "aBw" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
@@ -11192,12 +10911,8 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/obj/effect/turf_decal/lumos/tile/blue/fullcorner{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
@@ -11748,14 +11463,8 @@
 	id = "brigentry";
 	pixel_x = -28
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/fullcorner{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
@@ -11801,12 +11510,8 @@
 	id = "brigentry";
 	pixel_x = 28
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/obj/effect/turf_decal/lumos/tile/blue/fullcorner{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
@@ -12245,10 +11950,7 @@
 /obj/machinery/porta_turret/ai{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -12279,8 +11981,7 @@
 /obj/structure/sign/plaques/kiddie{
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -12735,12 +12436,8 @@
 	id = "brigentry";
 	pixel_x = -28
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/fullcorner{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
@@ -12791,13 +12488,7 @@
 	id = "brigentry";
 	pixel_x = 28
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/blue/fullcorner,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "aEJ" = (
@@ -15092,21 +14783,9 @@
 	},
 /area/maintenance/department/cargo)
 "aKp" = (
-/obj/effect/spawner/lootdrop/grille_or_trash,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/obj/machinery/plate_press,
+/turf/open/floor/plasteel/checker,
+/area/security/prison)
 "aKq" = (
 /obj/structure/girder,
 /turf/open/floor/plating,
@@ -15213,6 +14892,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/lumos/tile/blue/checker,
 /turf/open/floor/plasteel/dark,
 /area/blueshield)
 "aKP" = (
@@ -15223,7 +14903,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plating,
 /area/blueshield)
 "aKQ" = (
 /turf/closed/wall,
@@ -15397,28 +15077,19 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/blueshield,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
+/obj/effect/turf_decal/lumos/tile/blue/checker,
 /turf/open/floor/plasteel/dark,
 /area/blueshield)
 "aLA" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
+/obj/effect/turf_decal/lumos/tile/blue/checker,
 /turf/open/floor/plasteel/dark,
 /area/blueshield)
 "aLB" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/lumos/tile/blue/checker,
 /turf/open/floor/plasteel/dark,
 /area/blueshield)
 "aLE" = (
@@ -15853,10 +15524,6 @@
 /obj/machinery/light/small,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"aMA" = (
-/obj/machinery/space_heater,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "aMB" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -15977,10 +15644,7 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
+/obj/effect/turf_decal/lumos/tile/blue/checker,
 /turf/open/floor/plasteel/dark,
 /area/blueshield)
 "aMY" = (
@@ -15991,10 +15655,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
+/obj/effect/turf_decal/lumos/tile/blue/checker,
 /turf/open/floor/plasteel/dark,
 /area/blueshield)
 "aMZ" = (
@@ -16004,26 +15665,20 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 5
 	},
+/obj/effect/turf_decal/lumos/tile/blue/checker,
 /turf/open/floor/plasteel/dark,
 /area/blueshield)
 "aNa" = (
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
 	},
+/obj/effect/turf_decal/lumos/tile/blue/checker,
 /turf/open/floor/plasteel/dark,
 /area/blueshield)
 "aNc" = (
@@ -16356,12 +16011,8 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "aOe" = (
-/obj/machinery/quantumpad{
-	map_pad_id = "toxenoarch";
-	map_pad_link_id = "tostation"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
+/turf/open/floor/plasteel/checker,
+/area/security/prison)
 "aOf" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/tile/neutral{
@@ -16439,10 +16090,7 @@
 /area/hallway/secondary/exit/departure_lounge)
 "aOt" = (
 /obj/structure/closet/secure_closet/blueshield,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
+/obj/effect/turf_decal/lumos/tile/blue/checker,
 /turf/open/floor/plasteel/dark,
 /area/blueshield)
 "aOu" = (
@@ -16450,10 +16098,7 @@
 	dir = 1
 	},
 /obj/machinery/light/small,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
+/obj/effect/turf_decal/lumos/tile/blue/checker,
 /turf/open/floor/plasteel/dark,
 /area/blueshield)
 "aOv" = (
@@ -16464,10 +16109,7 @@
 	pixel_y = -24
 	},
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
+/obj/effect/turf_decal/lumos/tile/blue/checker,
 /turf/open/floor/plasteel/dark,
 /area/blueshield)
 "aOw" = (
@@ -16829,11 +16471,8 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "aPn" = (
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/lumos/tile/red/checker{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
 	},
 /turf/open/floor/plasteel/white/corner{
 	dir = 1
@@ -17230,7 +16869,7 @@
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/floor/plating,
-/area/space/nearstation)
+/area/science/xenobiology)
 "aQw" = (
 /obj/machinery/computer/shuttle/mining,
 /obj/effect/turf_decal/stripes/line{
@@ -18209,7 +17848,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "aSR" = (
-/obj/item/weldingtool,
+/obj/structure/trash_pile,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "aSS" = (
@@ -19043,16 +18682,7 @@
 /area/maintenance/department/crew_quarters/bar)
 "aUQ" = (
 /obj/structure/plasticflaps/opaque,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/hydroponics)
 "aUR" = (
@@ -19505,16 +19135,7 @@
 	freq = 1400;
 	location = "Janitor"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/janitor)
 "aVV" = (
@@ -19843,16 +19464,7 @@
 /obj/structure/sign/plaques/deempisi{
 	pixel_y = 28
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/janitor)
 "aWN" = (
@@ -19869,16 +19481,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/janitor)
 "aWO" = (
@@ -19888,35 +19491,13 @@
 /obj/machinery/light_switch{
 	pixel_x = 24
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/janitor)
 "aWP" = (
 /obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hydroponics)
-"aWQ" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
@@ -19930,6 +19511,9 @@
 	departmentType = 2;
 	pixel_y = 30
 	},
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aWS" = (
@@ -19938,6 +19522,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aWT" = (
@@ -19949,8 +19536,8 @@
 	name = "utility sink";
 	pixel_y = 28
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
@@ -20292,30 +19879,12 @@
 /area/hallway/primary/central)
 "aXN" = (
 /obj/structure/bedsheetbin,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/janitor)
 "aXO" = (
 /obj/effect/landmark/event_spawn,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/janitor)
 "aXP" = (
@@ -20325,16 +19894,7 @@
 /obj/item/grenade/clusterbuster/cleaner,
 /obj/item/grenade/chem_grenade/cleaner,
 /obj/item/grenade/chem_grenade/cleaner,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/janitor)
 "aXQ" = (
@@ -20343,24 +19903,15 @@
 	pixel_x = -12;
 	pixel_y = 2
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aXR" = (
 /obj/item/reagent_containers/glass/bucket,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/lumos/tile/neutral/fullcorner{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
@@ -20368,11 +19919,8 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aXT" = (
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/lumos/tile/neutral/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
 	},
 /turf/open/floor/plasteel{
 	heat_capacity = 1e+006
@@ -20385,17 +19933,13 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aXV" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/obj/effect/turf_decal/lumos/tile/neutral/fullcorner{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aXW" = (
-/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/trimline/green/filled/corner,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aXX" = (
@@ -20404,7 +19948,7 @@
 	name = "Station Intercom (General)";
 	pixel_y = 26
 	},
-/obj/effect/turf_decal/lumos/tile/green/half{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -20418,14 +19962,14 @@
 	dir = 1;
 	light_color = "#e8eaff"
 	},
-/obj/effect/turf_decal/lumos/tile/green/half{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aXZ" = (
 /obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/lumos/tile/green/half{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -20720,33 +20264,21 @@
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
 "aYI" = (
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
 "aYJ" = (
 /obj/machinery/vending/wardrobe/sec_wardrobe,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
@@ -20756,12 +20288,8 @@
 	name = "Station Intercom (General)";
 	pixel_y = 26
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
@@ -20777,45 +20305,33 @@
 	name = "Custodial Quarters";
 	req_access_txt = "26"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/janitor)
 "aYN" = (
 /obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aYO" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
 /obj/structure/table,
 /obj/machinery/plantgenes{
 	pixel_y = 6
+	},
+/obj/effect/turf_decal/trimline/green/filled/corner{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aYP" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/trimline/green/filled/corner{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aYQ" = (
@@ -21120,10 +20636,7 @@
 	dir = 4;
 	pixel_x = -23
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -21150,14 +20663,13 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -21170,22 +20682,13 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
+/obj/effect/turf_decal/lumos/tile/red/fulltile,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
 "aZM" = (
@@ -21244,19 +20747,13 @@
 	dir = 4;
 	pixel_x = -28
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aZS" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/lumos/tile/neutral/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel{
@@ -21264,38 +20761,25 @@
 	},
 /area/hydroponics)
 "aZT" = (
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aZU" = (
 /obj/machinery/vending/hydronutrients,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/hydroponics)
 "aZV" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -21306,6 +20790,9 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
+	},
+/obj/effect/turf_decal/lumos/tile/neutral/half{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
@@ -21592,12 +21079,8 @@
 	pixel_x = -26;
 	pixel_y = -4
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
@@ -21607,19 +21090,13 @@
 /obj/item/paper_bin{
 	layer = 2.9
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
 "baS" = (
 /obj/structure/chair/office/dark,
 /obj/effect/landmark/event_spawn,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
 "baT" = (
@@ -21627,10 +21104,7 @@
 	pixel_y = 4
 	},
 /obj/structure/table,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
 "baU" = (
@@ -21640,12 +21114,8 @@
 	pixel_y = -24
 	},
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
@@ -21702,35 +21172,23 @@
 /obj/machinery/vending/hydroseeds{
 	slogan_delay = 700
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/hydroponics)
 "bbc" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bbd" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-10"
 	},
-/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/trimline/green/filled/corner,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bbg" = (
@@ -22038,16 +21496,7 @@
 /area/janitor)
 "bbZ" = (
 /obj/machinery/seed_extractor,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/hydroponics)
 "bca" = (
@@ -22058,8 +21507,7 @@
 	c_tag = "Hydroponics South";
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/lumos/tile/neutral/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -22499,27 +21947,24 @@
 /turf/open/floor/plasteel,
 /area/janitor)
 "bdj" = (
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bdk" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bdl" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/trimline/green/filled/corner{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bdm" = (
@@ -22834,20 +22279,13 @@
 /turf/open/floor/plasteel,
 /area/janitor)
 "bef" = (
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/lumos/tile/neutral/fullcorner{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "beh" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/half,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bei" = (
@@ -22872,6 +22310,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
+/obj/effect/turf_decal/lumos/tile/neutral/fullcorner,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bek" = (
@@ -23287,35 +22726,24 @@
 /area/janitor)
 "bfj" = (
 /obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hydroponics)
-"bfk" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bfl" = (
 /obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/trimline/green/filled/line,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bfm" = (
 /obj/item/reagent_containers/glass/bucket,
+/obj/effect/turf_decal/trimline/green/filled/line,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bfn" = (
 /obj/structure/reagent_dispensers/watertank/high,
-/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/trimline/green/filled/line,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bfp" = (
@@ -23567,7 +22995,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "bfP" = (
-/obj/machinery/shieldwallgen,
+/obj/machinery/droneDispenser/preloaded,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "bfZ" = (
@@ -24927,14 +24355,8 @@
 	dir = 4;
 	pixel_x = -23
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
@@ -24947,11 +24369,8 @@
 	name = "Station Intercom (General)";
 	pixel_y = 26
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
@@ -24960,22 +24379,15 @@
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_y = 30
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
 "bka" = (
 /obj/machinery/computer/security,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
@@ -25346,6 +24758,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "blg" = (
@@ -25362,10 +24777,7 @@
 	pixel_x = -32
 	},
 /obj/structure/closet/wardrobe/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -25387,8 +24799,7 @@
 /obj/item/paper_bin{
 	layer = 2.9
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -25902,12 +25313,8 @@
 	network = list("ss13","medbay")
 	},
 /obj/structure/closet/secure_closet/security/med,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
@@ -25915,30 +25322,20 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
 "bmu" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
 "bmv" = (
 /obj/structure/table,
 /obj/item/book/manual/wiki/security_space_law,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
@@ -26315,18 +25712,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/lumos/tile/red/fulltile,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
 "bnC" = (
@@ -26702,12 +26090,8 @@
 /turf/open/floor/wood,
 /area/space/station_ruins)
 "boD" = (
-/obj/item/ectoplasm,
-/obj/structure/bodycontainer/morgue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/medical/morgue)
+/turf/open/floor/plasteel/checker,
+/area/space/nearstation)
 "boE" = (
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
@@ -26716,10 +26100,10 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
 	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -26727,14 +26111,11 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/lumos/tile/red/half{
+	dir = 1
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "boG" = (
@@ -29360,6 +28741,16 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/structure/table/glass,
+/obj/item/stack/sheet/mineral/plasma{
+	amount = 2;
+	layer = 2.9
+	},
+/obj/item/stack/cable_coil/random,
+/obj/item/book/manual/wiki/chemistry,
+/obj/item/grenade/chem_grenade,
+/obj/item/screwdriver,
+/obj/item/grenade/chem_grenade,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bup" = (
@@ -31166,14 +30557,8 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "byr" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 10
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/surgery)
+/turf/closed/wall/r_wall,
+/area/space)
 "byt" = (
 /obj/machinery/light{
 	dir = 4
@@ -31225,20 +30610,16 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "byz" = (
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/machinery/door/window/eastright{
-	dir = 1;
-	name = "Chemistry Testing";
-	req_access_txt = "5; 33"
-	},
 /mob/living/simple_animal/mouse/white{
 	name = "Labrette"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
+	},
+/obj/machinery/door/window/eastright{
+	dir = 1;
+	name = "Chemistry Testing";
+	req_access_txt = "5; 33"
 	},
 /turf/open/floor/engine,
 /area/medical/chemistry)
@@ -31905,12 +31286,11 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bzV" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1
+/obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
 	},
-/turf/open/floor/plasteel/white,
-/area/medical/surgery)
+/turf/open/floor/plasteel,
+/area/security/prison)
 "bzW" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -31926,13 +31306,10 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/checker{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
 "bAa" = (
 /obj/machinery/computer/crew,
@@ -31946,39 +31323,30 @@
 	name = "Chief Medical Officer RC";
 	pixel_y = 30
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/checker{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
 "bAb" = (
 /obj/machinery/computer/med_data,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/checker{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
 "bAc" = (
 /obj/machinery/computer/card/minor/cmo,
 /obj/machinery/airalarm{
 	pixel_y = 22
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/checker{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
 "bAd" = (
 /obj/machinery/disposal/bin,
@@ -31996,13 +31364,10 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/checker{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
 "bAe" = (
 /obj/machinery/vending/wardrobe/chem_wardrobe,
@@ -32012,6 +31377,10 @@
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
+	},
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -22
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
@@ -32027,23 +31396,13 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bAg" = (
-/obj/structure/table/glass,
 /obj/machinery/light,
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
-/obj/item/stack/cable_coil/random,
-/obj/item/book/manual/wiki/chemistry,
-/obj/item/grenade/chem_grenade,
-/obj/item/grenade/chem_grenade,
-/obj/item/stack/sheet/mineral/plasma{
-	amount = 2;
-	layer = 2.9
-	},
-/obj/item/screwdriver,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
 	},
 /turf/open/floor/engine,
 /area/medical/chemistry)
@@ -32229,8 +31588,11 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "bAI" = (
-/obj/structure/transit_tube/crossing/horizontal,
-/turf/open/floor/plasteel/white,
+/obj/structure/transit_tube/curved/flipped{
+	dir = 4
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "bAJ" = (
 /obj/structure/transit_tube/horizontal,
@@ -32238,14 +31600,14 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "bAK" = (
-/obj/structure/transit_tube/horizontal,
-/turf/open/floor/plating,
-/area/hallway/secondary/entry)
-"bAL" = (
 /obj/structure/transit_tube/station/reverse/flipped,
 /obj/structure/transit_tube_pod{
 	dir = 8
 	},
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
+"bAL" = (
+/obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "bAM" = (
@@ -32421,26 +31783,20 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/checker{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
 "bBh" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/blue{
+/mob/living/simple_animal/pet/cat/Runtime,
+/obj/effect/turf_decal/lumos/tile/blue/checker{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/mob/living/simple_animal/pet/cat/Runtime,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
 "bBi" = (
 /obj/effect/landmark/start/chief_medical_officer,
@@ -32453,25 +31809,19 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/checker{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
 "bBj" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/checker{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
 "bBk" = (
 /obj/structure/disposalpipe/segment,
@@ -32489,13 +31839,10 @@
 	dir = 8;
 	pixel_x = 30
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/checker{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
 "bBl" = (
 /obj/machinery/door/airlock/maintenance{
@@ -32864,11 +32211,9 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "bBV" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 9
-	},
-/turf/open/floor/plasteel/white,
-/area/hallway/secondary/entry)
+/obj/structure/table,
+/turf/open/floor/plasteel/checker,
+/area/security/prison)
 "bBW" = (
 /turf/open/space,
 /area/space)
@@ -33100,16 +32445,13 @@
 	name = "Chief Medical Office";
 	req_access_txt = "40"
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/turf_decal/lumos/tile/blue/checker{
 	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
@@ -33121,19 +32463,16 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
 "bCs" = (
 /obj/structure/table/glass,
@@ -33147,19 +32486,16 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
 "bCt" = (
 /obj/structure/table/glass,
@@ -33168,19 +32504,16 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/item/phone{
 	pixel_x = 17
 	},
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
 "bCu" = (
 /obj/structure/table/glass,
@@ -33189,16 +32522,13 @@
 	},
 /obj/item/stack/medical/gauze,
 /obj/item/clothing/neck/stethoscope,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
 "bCv" = (
 /obj/structure/cable{
@@ -33211,13 +32541,10 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/checker{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
 "bCw" = (
 /obj/machinery/door/airlock/maintenance{
@@ -33532,12 +32859,9 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "bDf" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/obj/structure/closet/emcloset,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
+/obj/structure/chair/stool,
+/turf/open/floor/plasteel/checker,
+/area/space/nearstation)
 "bDg" = (
 /obj/machinery/atmospherics/components/unary/tank/air,
 /turf/open/floor/plating,
@@ -33642,34 +32966,25 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/checker{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
 "bDv" = (
 /obj/structure/chair/office/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/checker{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
 "bDw" = (
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/checker{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
 "bDx" = (
 /obj/machinery/power/apc{
@@ -33679,17 +32994,18 @@
 	pixel_x = 26
 	},
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/checker{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
 "bDy" = (
-/turf/closed/wall,
-/area/medical/exam_room)
+/obj/machinery/door/airlock/maintenance{
+	name = "Medbay Maintenance";
+	req_one_access_txt = "12;45;5;9"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "bDz" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -34277,25 +33593,19 @@
 "bED" = (
 /obj/structure/closet/secure_closet/CMO,
 /obj/item/valentine,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/checker{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
 "bEE" = (
 /obj/machinery/modular_computer/console/preset/civilian{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/checker{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
 "bEF" = (
 /obj/item/cartridge/medical{
@@ -34313,13 +33623,10 @@
 /obj/structure/table,
 /obj/machinery/light,
 /obj/item/wrench/medical,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/checker{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
 "bEG" = (
 /obj/item/folder/blue,
@@ -34328,101 +33635,55 @@
 	dir = 1;
 	pixel_y = -26
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/item/folder/white,
 /obj/item/stamp/cmo,
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
 "bEH" = (
 /obj/machinery/light_switch{
 	pixel_y = -22
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/structure/table,
 /obj/machinery/photocopier/faxmachine,
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
 "bEI" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/closet,
-/obj/item/clothing/under/rank/medical/doctor/nurse,
-/obj/item/clothing/head/nursehat,
 /obj/effect/decal/cleanable/cobweb,
-/obj/machinery/airalarm{
-	pixel_y = 22
-	},
 /obj/structure/sign/poster/official/no_erp{
 	pixel_x = -32
 	},
-/turf/open/floor/plasteel/dark,
-/area/medical/exam_room)
+/obj/effect/landmark/blobstart,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "bEJ" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/light/small{
 	dir = 1
 	},
 /obj/machinery/vending/wallmed{
 	pixel_y = 28
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/effect/landmark/blobstart,
 /obj/item/melee/baton/cattleprod{
 	preload_cell_type = /obj/item/stock_parts/cell/high
 	},
-/turf/open/floor/plasteel/dark,
-/area/medical/exam_room)
-"bEK" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/button/door{
-	id = "CMOCell";
-	name = "Door Bolt Control";
-	normaldoorcontrol = 1;
-	pixel_y = 26;
-	specialfunctions = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/obj/effect/landmark/xeno_spawn,
-/turf/open/floor/plasteel/dark,
-/area/medical/exam_room)
-"bEL" = (
-/obj/machinery/door/airlock/command{
-	id_tag = "CMOCell";
-	name = "Personal Examination Room";
-	req_access_txt = "40"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/medical/exam_room)
-"bEM" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"bEK" = (
+/obj/effect/landmark/xeno_spawn,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
+"bEL" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/security/prison)
+"bEM" = (
+/turf/open/floor/wood,
+/area/security/prison)
 "bEQ" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
@@ -34896,47 +34157,17 @@
 /turf/closed/wall,
 /area/medical/surgery)
 "bFV" = (
-/obj/structure/table/glass,
-/obj/item/flashlight/pen,
-/obj/item/clothing/neck/stethoscope,
-/obj/item/lipstick/black,
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "Personal Examination Room APC";
-	pixel_x = -25
-	},
-/obj/structure/cable,
-/obj/item/reagent_containers/pill/morphine,
-/turf/open/floor/plasteel/dark,
-/area/medical/exam_room)
-"bFW" = (
-/obj/effect/decal/remains/human,
-/obj/structure/chair/office/dark{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/medical/exam_room)
-"bFX" = (
-/obj/structure/bed,
-/obj/item/bedsheet/cmo,
-/obj/effect/decal/cleanable/blood/drip,
-/obj/item/restraints/handcuffs,
-/obj/item/clothing/mask/muzzle,
-/obj/machinery/light_switch{
-	pixel_y = -22
-	},
-/turf/open/floor/plasteel/dark,
-/area/medical/exam_room)
-"bFY" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/sign/departments/examroom{
-	pixel_x = -32
-	},
+/obj/structure/closet/secure_closet/medical1,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"bFX" = (
+/obj/structure/closet/secure_closet/chemical,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
+"bFY" = (
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "bFZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
@@ -35430,30 +34661,53 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bHb" = (
-/obj/structure/closet/crate/freezer/surplus_limbs,
-/obj/item/reagent_containers/glass/beaker/synthflesh,
-/obj/machinery/newscaster/security_unit{
-	pixel_y = 32
+/obj/structure/closet/crate/freezer/blood,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
 	},
-/turf/open/floor/plasteel/freezer,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/light_switch{
+	pixel_x = -22
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "bHc" = (
-/obj/machinery/computer/med_data,
-/obj/machinery/status_display/evac{
-	pixel_y = 32
+/obj/structure/sink{
+	pixel_y = 28
 	},
-/turf/open/floor/plasteel/freezer,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "bHd" = (
-/obj/structure/table,
-/obj/structure/bedsheetbin,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 24
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_y = 32
+/obj/machinery/camera{
+	c_tag = "Surgery";
+	network = list("ss13","surgery")
 	},
-/turf/open/floor/plasteel/freezer,
+/obj/machinery/airalarm{
+	pixel_y = 22
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/limbgrower,
+/turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "bHf" = (
 /obj/effect/turf_decal/tile/yellow{
@@ -35911,92 +35165,85 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bIj" = (
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/medical{
+	name = "Surgery";
+	req_access_txt = "45"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel/freezer,
 /area/medical/surgery)
 "bIk" = (
-/turf/open/floor/plasteel/freezer,
-/area/medical/surgery)
-"bIl" = (
-/obj/structure/chair/office/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/freezer,
-/area/medical/surgery)
-"bIm" = (
-/obj/machinery/camera{
-	c_tag = "Medbay Recovery Room";
-	dir = 8;
-	network = list("ss13","medbay")
-	},
-/obj/item/radio/intercom{
-	frequency = 1485;
-	name = "Station Intercom (Medbay)";
-	pixel_x = 28
-	},
-/turf/open/floor/plasteel/freezer,
-/area/medical/surgery)
-"bIo" = (
-/obj/structure/closet/crate/freezer/blood,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/light_switch{
-	pixel_x = -22
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/surgery)
+"bIl" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/surgery)
+"bIm" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 10
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/surgery)
+"bIo" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "bIp" = (
-/obj/structure/sink{
-	pixel_y = 28
+/obj/machinery/door/airlock/maintenance{
+	name = "Surgery Maintenance";
+	req_access_txt = "45"
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/surgery)
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "bIr" = (
-/obj/machinery/vending/wallmed{
-	pixel_y = 28
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/structure/closet/crate/freezer/surplus_limbs,
-/obj/item/reagent_containers/glass/beaker/synthflesh,
-/turf/open/floor/plasteel/white,
-/area/medical/surgery)
-"bIs" = (
-/obj/structure/closet/secure_closet/medical2,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/surgery)
+/obj/effect/landmark/start/prisoner/prilate,
+/turf/open/floor/circuit/green,
+/area/security/prison)
+"bIs" = (
+/turf/open/floor/circuit/green,
+/area/security/prison)
 "bIt" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -36464,110 +35711,52 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bJq" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Recovery Room"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/plasteel/freezer,
+/obj/machinery/smartfridge/organ/preloaded,
+/turf/closed/wall,
 /area/medical/surgery)
 "bJr" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/plasteel/freezer,
-/area/medical/surgery)
-"bJs" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 1
-	},
-/turf/open/floor/plasteel/freezer,
-/area/medical/surgery)
-"bJt" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/medical{
-	name = "Surgery";
-	req_access_txt = "45"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/plasteel/freezer,
+/turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "bJu" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "Surgery APC";
+	pixel_x = 26
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/surgery)
-"bJv" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/surgery)
-"bJy" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
+/obj/structure/cable,
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
+"bJv" = (
+/obj/effect/landmark/start/prisoner/prilate,
+/turf/open/floor/circuit/green,
+/area/security/prison)
+"bJy" = (
+/obj/effect/landmark/start/prisoner/prilate,
+/turf/open/floor/plasteel/elevatorshaft{
+	desc = "A simple teleportation pad designed for one-way personnel transfer.";
+	name = "Brig Tele-Reception Pad"
+	},
+/area/security/prison)
 "bJz" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Surgery Maintenance";
-	req_access_txt = "45"
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
+/turf/open/floor/circuit/green,
+/area/security/prison)
 "bJA" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
+/obj/effect/turf_decal/bot_red,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "bJD" = (
 /obj/structure/sign/departments/engineering{
 	pixel_y = -32
@@ -36926,46 +36115,51 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bKB" = (
-/obj/structure/bed/roller,
-/obj/machinery/iv_drip,
-/turf/open/floor/plasteel/freezer,
-/area/medical/surgery)
-"bKC" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1
-	},
-/turf/open/floor/plasteel/freezer,
-/area/medical/surgery)
-"bKD" = (
-/obj/structure/bed,
-/turf/open/floor/plasteel/freezer,
-/area/medical/surgery)
-"bKE" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/structure/table/reinforced,
+/obj/item/storage/backpack/duffelbag/med/surgery,
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
-"bKF" = (
-/turf/open/floor/plasteel/white,
-/area/medical/surgery)
-"bKG" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "Surgery APC";
-	pixel_x = 26
+"bKD" = (
+/obj/effect/landmark/start/medical_doctor,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
 	},
-/obj/structure/cable,
+/turf/open/floor/plasteel/white,
+/area/medical/surgery)
+"bKE" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/structure/table/reinforced,
+/obj/item/storage/backpack/duffelbag/med/surgery,
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
+"bKF" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Visitation - Prisoners"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/preopen{
+	id = "visitexit"
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"bKG" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "bKH" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -37263,7 +36457,6 @@
 	dir = 4
 	},
 /obj/machinery/light,
-/obj/structure/transit_tube/crossing,
 /turf/open/floor/plasteel/white{
 	heat_capacity = 1e+006
 	},
@@ -37399,39 +36592,59 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bLL" = (
-/obj/machinery/light,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
-/turf/open/floor/plasteel/freezer,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/structure/table/optable,
+/turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "bLM" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/structure/table/reinforced,
-/obj/item/storage/backpack/duffelbag/med/surgery,
-/turf/open/floor/plasteel/white,
-/area/medical/surgery)
-"bLO" = (
-/obj/effect/landmark/start/medical_doctor,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/surgery)
-"bLQ" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/structure/table/reinforced,
-/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/computer/operating{
+	dir = 8
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
+"bLO" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"bLQ" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/flasher{
+	id = "visitflash";
+	pixel_y = 25
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "bLR" = (
 /obj/machinery/vending/cigarette,
 /obj/effect/turf_decal/tile/yellow{
@@ -37860,54 +37073,40 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bMP" = (
-/obj/machinery/light,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/machinery/computer/med_data/laptop{
+/obj/machinery/light{
 	dir = 1;
-	pixel_y = 4
+	light_color = "#cee5d2"
 	},
-/obj/structure/table/reinforced,
-/turf/open/floor/plasteel/white,
-/area/medical/surgery)
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/camera{
+	c_tag = "Permabrig Visitations Prisoner-side";
+	dir = 8;
+	network = list("ss13","prison");
+	start_active = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "bMQ" = (
-/obj/effect/turf_decal/tile/blue{
+/obj/machinery/conveyor/auto{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/structure/table/optable,
-/turf/open/floor/plasteel/white,
-/area/medical/surgery)
+/turf/open/floor/plasteel,
+/area/security/prison)
 "bMR" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
+/obj/machinery/light,
+/obj/machinery/button/door{
+	id = "permalock2";
+	name = "Perma Secure Airlock";
+	pixel_y = -26;
+	req_access_txt = "3"
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/machinery/computer/operating{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/surgery)
+/turf/open/floor/plasteel,
+/area/security/prison)
 "bMS" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -38183,10 +37382,8 @@
 /turf/open/floor/plating,
 /area/chapel/dock)
 "bNA" = (
+/obj/structure/transit_tube/horizontal,
 /obj/structure/window/reinforced/fulltile,
-/obj/structure/transit_tube/curved/flipped{
-	dir = 8
-	},
 /turf/open/floor/plating,
 /area/chapel/dock)
 "bNB" = (
@@ -38195,6 +37392,7 @@
 	layer = 2.9
 	},
 /obj/structure/lattice/catwalk,
+/obj/structure/transit_tube/horizontal,
 /turf/open/space,
 /area/space/nearstation)
 "bNE" = (
@@ -38321,9 +37519,11 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bNV" = (
-/obj/item/wrench/medical,
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
+/obj/machinery/door/poddoor/shutters{
+	id = "sexroom"
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "bNW" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -47149,13 +46349,11 @@
 /turf/closed/wall/r_wall,
 /area/space/station_ruins)
 "cnX" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/trash_pile,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "cod" = (
 /obj/structure/table,
-/obj/item/clothing/under/color/grey,
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Dormitory APC";
@@ -47167,11 +46365,9 @@
 /obj/structure/sign/poster/official/random{
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/structure/bedsheetbin/color,
+/obj/effect/turf_decal/lumos/tile/blue/checker{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/dorms)
@@ -47181,12 +46377,15 @@
 	name = "Dormitory Maintenance APC";
 	pixel_x = -24
 	},
-/obj/structure/cable,
 /obj/machinery/light/small,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
+/obj/structure/cable{
+	icon_state = "0-4"
 	},
-/area/maintenance/department/crew_quarters/dorms)
+/obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/dorms)
 "coi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -50611,12 +49810,9 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "cLq" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/transit_tube/horizontal{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/hallway/secondary/entry)
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/security/prison)
 "cLt" = (
 /obj/machinery/holopad,
 /obj/machinery/firealarm{
@@ -51435,6 +50631,11 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/wood,
 /area/space/station_ruins)
+"ecx" = (
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/item/wrench/medical,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "edl" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -51502,9 +50703,6 @@
 	dir = 4
 	},
 /obj/structure/lattice,
-/obj/structure/transit_tube/horizontal{
-	dir = 1
-	},
 /turf/open/space/basic,
 /area/space/nearstation)
 "eiL" = (
@@ -51551,9 +50749,10 @@
 /area/space/station_ruins)
 "epg" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 1
+	dir = 9
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/lumos/tile/purple/checker,
+/turf/open/floor/plasteel/white,
 /area/hallway/secondary/entry)
 "epj" = (
 /obj/machinery/cryopod{
@@ -51573,6 +50772,14 @@
 "epU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
+	},
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 2
 	},
 /turf/open/floor/engine,
 /area/medical/chemistry)
@@ -51841,14 +51048,9 @@
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "ePb" = (
-/obj/machinery/camera{
-	c_tag = "Permabrig Visitations Prisoner-side";
-	dir = 8;
-	network = list("ss13","prison");
-	start_active = 1
-	},
-/turf/open/floor/plasteel,
-/area/space/station_ruins)
+/obj/structure/musician/piano,
+/turf/open/floor/plasteel/dark,
+/area/maintenance/department/crew_quarters/dorms)
 "ePU" = (
 /obj/machinery/light/small,
 /obj/machinery/atmospherics/pipe/layer_manifold{
@@ -52002,14 +51204,11 @@
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
 "ffQ" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1
+/obj/structure/window{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/space/station_ruins)
+/turf/open/floor/plasteel/dark,
+/area/maintenance/department/crew_quarters/dorms)
 "fhM" = (
 /obj/item/storage/secure/safe{
 	pixel_x = -22
@@ -52105,11 +51304,8 @@
 /obj/structure/chair/office/dark{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
@@ -52267,8 +51463,10 @@
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "fAM" = (
-/obj/structure/chair/stool,
-/turf/open/floor/plasteel/dark,
+/obj/structure/window{
+	dir = 4
+	},
+/turf/open/floor/plasteel/stairs/old,
 /area/maintenance/department/crew_quarters/dorms)
 "fBt" = (
 /obj/machinery/door/firedoor,
@@ -52491,6 +51689,25 @@
 /obj/structure/bookcase/random/religion,
 /turf/open/floor/plasteel/dark,
 /area/library/lounge)
+"fXa" = (
+/obj/machinery/light,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/computer/med_data/laptop{
+	dir = 1;
+	pixel_y = 4
+	},
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/white,
+/area/medical/surgery)
 "fZK" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
 	dir = 4
@@ -52515,6 +51732,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
+"gaP" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/surgery)
 "gbM" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -52865,12 +52089,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "gDV" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/transit_tube/curved/flipped{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
 /turf/open/floor/plating,
-/area/hallway/secondary/entry)
+/area/maintenance/department/crew_quarters/dorms)
 "gDZ" = (
 /obj/effect/turf_decal/box/corners{
 	dir = 1
@@ -53003,12 +52226,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/main)
-"gKd" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 6
-	},
-/turf/open/floor/plasteel/white,
-/area/hallway/secondary/entry)
 "gKz" = (
 /obj/structure/table/wood,
 /obj/item/kirbyplants{
@@ -53118,11 +52335,26 @@
 	},
 /obj/structure/lattice,
 /obj/structure/lattice,
-/obj/structure/transit_tube/horizontal{
-	dir = 1
-	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"gTJ" = (
+/obj/structure/closet/secure_closet/medical2,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 28
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/surgery)
 "gTP" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -53305,16 +52537,14 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "hlU" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
-/turf/open/floor/plasteel,
-/area/space/station_ruins)
+/turf/open/floor/plating,
+/area/maintenance/department/crew_quarters/dorms)
 "hnu" = (
 /obj/machinery/button/door{
 	id = "lawyer_shutters";
@@ -53416,12 +52646,14 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "hxw" = (
-/obj/structure/window/reinforced{
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/lumos/tile/blue/checker{
 	dir = 4
 	},
-/obj/structure/transit_tube/curved,
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/dorms)
 "hyh" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 9
@@ -53528,10 +52760,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
+/obj/effect/turf_decal/lumos/tile/blue/checker,
 /turf/open/floor/plasteel/dark,
 /area/blueshield)
 "hKp" = (
@@ -53620,10 +52849,7 @@
 	layer = 2.9
 	},
 /obj/item/pen,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
+/obj/effect/turf_decal/lumos/tile/blue/checker,
 /turf/open/floor/plasteel/dark,
 /area/blueshield)
 "hQC" = (
@@ -53960,10 +53186,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/space/station_ruins)
-"iqc" = (
-/obj/structure/musician/piano,
-/turf/open/floor/plasteel/dark,
-/area/maintenance/department/crew_quarters/dorms)
 "iqx" = (
 /obj/machinery/atmospherics/components/binary/valve/on{
 	dir = 4
@@ -54228,6 +53450,7 @@
 "iQQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/item/ectoplasm,
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "iRm" = (
@@ -54337,6 +53560,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/space/station_ruins)
+"jfy" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/transit_tube/horizontal{
+	dir = 1
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "jgr" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Library"
@@ -54548,12 +53778,14 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "jAu" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/transit_tube/curved{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
-/turf/open/floor/plating,
-/area/hallway/secondary/entry)
+/obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/dorms)
 "jAy" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -54984,6 +54216,22 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"krC" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/computer/operating{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/surgery)
 "krU" = (
 /obj/machinery/field/generator,
 /turf/open/floor/plasteel,
@@ -55097,17 +54345,26 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
 "kAH" = (
-/obj/structure/transit_tube/crossing/horizontal,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel/white,
-/area/hallway/secondary/entry)
-"kBp" = (
-/obj/structure/closet/emcloset,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 6
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
-/turf/open/floor/plasteel/white,
-/area/hallway/secondary/entry)
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"kBp" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/turf_decal/lumos/tile/red/half{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "kCU" = (
 /obj/structure/sign/departments/security{
 	pixel_y = 32
@@ -55170,6 +54427,9 @@
 /obj/structure/table,
 /obj/machinery/smartfridge/disks{
 	pixel_y = 2
+	},
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
@@ -55284,14 +54544,13 @@
 	},
 /area/space/station_ruins)
 "kKv" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "sexroom"
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/space/station_ruins)
+/area/hallway/primary/central)
 "kKI" = (
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/structure/closet,
+/obj/item/wrench,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "kML" = (
@@ -55518,9 +54777,13 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "ldR" = (
-/obj/machinery/light/small,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
+/obj/structure/rack,
+/obj/item/stack/sheet/metal/twenty,
+/obj/item/stack/sheet/rglass{
+	amount = 50
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "lem" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -55965,6 +55228,10 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
+"lTb" = (
+/obj/structure/trash_pile,
+/turf/open/floor/plating,
+/area/maintenance/department/science)
 "lTC" = (
 /obj/item/shard,
 /obj/effect/turf_decal/stripes/line{
@@ -55981,6 +55248,16 @@
 /obj/structure/lattice,
 /turf/open/space,
 /area/space/station_ruins)
+"lUt" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "lUw" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -56259,18 +55536,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "msD" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#cee5d2"
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/space/station_ruins)
+/turf/open/floor/plasteel/dark,
+/area/medical/morgue)
 "msX" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -56501,9 +55771,15 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "mSf" = (
-/obj/structure/chair/stool,
-/turf/open/floor/plasteel,
-/area/space/station_ruins)
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "mSz" = (
 /obj/structure/bookcase/random,
 /turf/open/floor/carpet,
@@ -57062,7 +56338,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/space/nearstation)
+/area/science/xenobiology)
 "nOY" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -57174,11 +56450,14 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
 "nZw" = (
-/obj/machinery/door/airlock/abandoned{
-	name = "Backup Laboratory"
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/hallway/secondary/entry)
 "obj" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -57309,10 +56588,6 @@
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "ooh" = (
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
 /obj/item/wrench/medical,
 /turf/open/floor/engine,
 /area/medical/chemistry)
@@ -57795,6 +57070,13 @@
 	},
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
+"pbf" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/transit_tube/horizontal{
+	dir = 1
+	},
+/turf/open/space,
+/area/space/nearstation)
 "pbm" = (
 /obj/machinery/door/airlock/external{
 	name = "Pod Docking Bay"
@@ -58039,7 +57321,13 @@
 /turf/open/floor/plasteel,
 /area/space/station_ruins)
 "pyw" = (
-/turf/open/space/basic,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/effect/turf_decal/lumos/tile/purple/checker{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
 /area/hallway/secondary/entry)
 "pzx" = (
 /obj/effect/turf_decal/tile/red,
@@ -58137,10 +57425,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/space/station_ruins)
 "pKd" = (
-/obj/effect/spawner/lootdrop/maintenance{
-	name = "2maintenance loot spawner"
-	},
-/obj/structure/closet/crate,
+/obj/structure/trash_pile,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "pLr" = (
@@ -58242,7 +57527,7 @@
 "pWT" = (
 /obj/structure/chair/stool,
 /obj/effect/landmark/start/botanist,
-/obj/effect/turf_decal/lumos/tile/green/half,
+/obj/effect/turf_decal/trimline/green/filled/line,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "pXc" = (
@@ -58434,8 +57719,7 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "qni" = (
-/obj/machinery/smartfridge/organ/preloaded,
-/turf/closed/wall,
+/turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "qnT" = (
 /obj/machinery/iv_drip,
@@ -58541,7 +57825,8 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "qDe" = (
-/turf/open/floor/plasteel/stairs/old,
+/obj/structure/window,
+/turf/open/floor/plasteel/dark,
 /area/maintenance/department/crew_quarters/dorms)
 "qDJ" = (
 /obj/structure/table/reinforced,
@@ -58695,6 +57980,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/structure/chair/stool,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/crew_quarters/dorms)
 "qPT" = (
@@ -59027,6 +58313,13 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/department/security/brig)
+"rrm" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/transit_tube/curved/flipped{
+	dir = 8
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "rrU" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -59484,9 +58777,8 @@
 	},
 /area/space/station_ruins)
 "sty" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/transit_tube/horizontal,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/plasteel/white,
 /area/hallway/secondary/entry)
 "stQ" = (
 /obj/structure/cable{
@@ -59515,10 +58807,10 @@
 /turf/closed/wall/r_wall,
 /area/engine/engineering)
 "svN" = (
-/obj/effect/spawner/lootdrop/maintenance,
 /obj/structure/sign/departments/restroom{
 	pixel_y = 32
 	},
+/obj/structure/trash_pile,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "swg" = (
@@ -59535,8 +58827,9 @@
 /obj/machinery/atm{
 	pixel_x = 30
 	},
-/turf/open/floor/plasteel/white,
-/area/hallway/secondary/entry)
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "syn" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -59634,6 +58927,13 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/plasteel/grimy,
 /area/space/station_ruins)
+"sHY" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/transit_tube/curved{
+	dir = 1
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "sJp" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /obj/effect/turf_decal/stripes/line,
@@ -59837,16 +59137,15 @@
 	},
 /obj/structure/lattice,
 /obj/structure/lattice,
-/obj/structure/transit_tube/horizontal{
-	dir = 1
-	},
 /turf/open/space/basic,
 /area/space/nearstation)
 "tbY" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
+/obj/machinery/quantumpad{
+	map_pad_id = "toxenoarch";
+	map_pad_link_id = "tostation"
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/lumos/tile/purple/fulltile,
+/turf/open/floor/plasteel/white,
 /area/hallway/secondary/entry)
 "tcg" = (
 /obj/effect/turf_decal/tile/red{
@@ -60059,7 +59358,7 @@
 "ttS" = (
 /obj/structure/chair/stool,
 /mob/living/simple_animal/pet/bumbles,
-/obj/effect/turf_decal/lumos/tile/green/half,
+/obj/effect/turf_decal/trimline/green/filled/line,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "tue" = (
@@ -60156,9 +59455,11 @@
 /turf/open/floor/plating,
 /area/construction/mining/aux_base)
 "tDn" = (
-/obj/item/wrench,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/hallway/secondary/entry)
 "tDE" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8;
@@ -60265,21 +59566,14 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "tYj" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/purple/checker{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/machinery/computer/operating{
-	dir = 8
-	},
 /turf/open/floor/plasteel/white,
-/area/medical/surgery)
+/area/hallway/secondary/entry)
 "tZG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -60537,7 +59831,10 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
 "upR" = (
-/obj/machinery/light,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/effect/turf_decal/lumos/tile/purple/checker,
 /turf/open/floor/plasteel/white,
 /area/hallway/secondary/entry)
 "uqJ" = (
@@ -60626,8 +59923,10 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "uxI" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/hallway/secondary/entry)
 "uxP" = (
 /obj/structure/chair{
@@ -60812,17 +60111,9 @@
 /turf/open/floor/plasteel/vaporwave,
 /area/space/station_ruins)
 "uPg" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Visitation - Prisoners"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/preopen{
-	id = "visitexit"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/obj/structure/closet/emcloset,
 /turf/open/floor/plasteel,
-/area/space/station_ruins)
+/area/hallway/secondary/entry)
 "uQR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 6
@@ -60878,6 +60169,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/wood,
 /area/space/station_ruins)
+"uWo" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/transit_tube/horizontal,
+/turf/open/space/basic,
+/area/space/nearstation)
 "uXG" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -61836,18 +61132,10 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/space/station_ruins)
 "wCR" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/flasher{
-	id = "visitflash";
-	pixel_y = 25
-	},
+/obj/machinery/light/small,
+/obj/structure/closet/firecloset,
 /turf/open/floor/plasteel,
-/area/space/station_ruins)
+/area/hallway/secondary/entry)
 "wDe" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Monastery Transit"
@@ -62046,10 +61334,13 @@
 /turf/open/floor/plasteel/white,
 /area/space/station_ruins)
 "wPW" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
 	},
-/turf/open/floor/plasteel,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/hallway/secondary/entry)
 "wQU" = (
 /obj/effect/spawner/lootdrop/maintenance,
@@ -62258,7 +61549,7 @@
 /turf/open/floor/wood,
 /area/lawoffice)
 "xeN" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/light,
 /turf/open/floor/plasteel/white,
 /area/hallway/secondary/entry)
 "xgh" = (
@@ -62415,10 +61706,7 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port)
 "xvT" = (
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
+/obj/effect/turf_decal/trimline/green/filled/line,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "xwo" = (
@@ -62459,8 +61747,13 @@
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "xyl" = (
-/obj/structure/table,
-/obj/item/assembly/timer,
+/obj/structure/rack,
+/obj/item/clothing/head/ushanka,
+/obj/item/clothing/head/xenos,
+/obj/item/clothing/head/radiation,
+/obj/item/clothing/head/chicken,
+/obj/item/clothing/head/bearpelt,
+/obj/item/clothing/head/cardborg,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "xyB" = (
@@ -62522,11 +61815,12 @@
 /turf/open/floor/plating,
 /area/crew_quarters/kitchen)
 "xCb" = (
-/obj/structure/transit_tube/crossing,
-/turf/open/floor/plasteel/white{
-	heat_capacity = 1e+006
+/obj/structure/transit_tube/horizontal{
+	dir = 1
 	},
-/area/hallway/secondary/entry)
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space/nearstation)
 "xCV" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -62604,11 +61898,8 @@
 /turf/closed/wall/r_wall,
 /area/science/xenobiology)
 "xLi" = (
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/lumos/tile/red/checker{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
 	},
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/exit/departure_lounge)
@@ -62808,6 +62099,20 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"yik" = (
+/obj/machinery/vending/wallmed{
+	pixel_y = 28
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/structure/closet/crate/freezer/surplus_limbs,
+/obj/item/reagent_containers/glass/beaker/synthflesh,
+/turf/open/floor/plasteel/white,
+/area/medical/surgery)
 "ymb" = (
 /obj/machinery/camera{
 	c_tag = "Engineering Telecomms Access";
@@ -71352,10 +70657,10 @@ ugw
 lKk
 eNz
 fxz
-ara
-ara
-ara
-ara
+rmC
+rmC
+rmC
+rmC
 rmC
 rmC
 rmC
@@ -71609,10 +70914,10 @@ lKk
 gAr
 nfk
 waW
-ara
-eNz
-azI
-mSf
+rmC
+rmC
+rmC
+rmC
 rmC
 rmC
 rmC
@@ -71866,10 +71171,10 @@ fIo
 pfY
 vvq
 jCM
-uPg
-hlU
-ffQ
-mSf
+rmC
+rmC
+rmC
+rmC
 rmC
 rmC
 rmC
@@ -72123,10 +71428,10 @@ skm
 ibA
 skm
 skm
-ara
-wCR
-pvl
-azI
+rmC
+rmC
+rmC
+rmC
 rmC
 rmC
 rmC
@@ -72380,10 +71685,10 @@ lKk
 wCj
 lKk
 lKk
-ara
-eNz
-azI
-mSf
+rmC
+rmC
+rmC
+rmC
 rmC
 rmC
 rmC
@@ -72637,10 +71942,10 @@ ftO
 rKv
 ftO
 fTo
-ara
-msD
-ePb
-mSf
+rmC
+rmC
+rmC
+rmC
 rmC
 rmC
 rmC
@@ -72894,10 +72199,10 @@ kUq
 rKv
 jYk
 nRs
-ara
-ara
-ara
-kKv
+rmC
+rmC
+rmC
+rmC
 rmC
 rmC
 rmC
@@ -80598,14 +79903,14 @@ ycE
 ycE
 ycE
 ycE
+aem
+aem
+aem
+aem
 ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
+aem
+aem
+aem
 ycE
 ycE
 ycE
@@ -80854,15 +80159,15 @@ ycE
 ycE
 ycE
 ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
+aem
+aem
+aah
+aig
+aig
+aig
+aig
+aig
+agy
 ycE
 ycE
 ycE
@@ -80941,7 +80246,7 @@ aaa
 aaa
 aaa
 aaa
-pyw
+aaa
 bsl
 btL
 aZx
@@ -81111,14 +80416,14 @@ ycE
 ycE
 ycE
 ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
+aem
+aah
+aah
+aig
+aig
+aig
+aig
+aig
 ycE
 ycE
 ycE
@@ -81198,7 +80503,7 @@ aaa
 aaa
 aaa
 aaa
-pyw
+aaa
 aZx
 bcX
 aZx
@@ -81368,15 +80673,15 @@ ycE
 ycE
 ycE
 ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
+aem
+aah
+aah
+aig
+aig
+aig
+aig
+aig
+agy
 ycE
 ycE
 ycE
@@ -81625,15 +80930,15 @@ ycE
 ycE
 ycE
 ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
+aem
+aah
+aah
+aig
+aig
+aig
+aig
+aig
+agy
 ycE
 ycE
 ycE
@@ -81720,20 +81025,20 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
 bVp
-hxw
+bVp
+bVp
+bVp
+bVp
 eit
 gTy
 eit
 eit
 tbF
-cLq
-xCb
+aZx
+bIY
 bLs
-jAu
+bcX
 bNB
 bMy
 abI
@@ -81882,19 +81187,19 @@ ycE
 ycE
 ycE
 ycE
+aem
+aem
+aah
+aig
+aig
+aig
+aig
+aig
+agy
 ycE
 ycE
 ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
+agy
 ycE
 ycE
 ycE
@@ -81974,13 +81279,13 @@ baK
 bon
 aZx
 aaa
-aZx
-aZx
-aZx
-aZx
-aZx
 aaa
-gDV
+aaa
+bGI
+aZx
+aZx
+aZx
+aZx
 aZx
 aZx
 aZx
@@ -81991,7 +81296,7 @@ aZx
 bIY
 wZs
 aZx
-cdm
+uWo
 aaa
 aht
 aby
@@ -82139,26 +81444,26 @@ ycE
 ycE
 ycE
 ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
+aem
+aem
 agy
+agy
+apu
+aig
+apu
+agy
+agy
+agy
+aig
+agy
+agy
+bEL
+ycE
+bEL
+aem
+aem
+aem
+aem
 aem
 aem
 aem
@@ -82231,14 +81536,14 @@ aJH
 bon
 aZx
 aaa
-aZx
-baK
-baK
-baK
-aZx
 aaa
+aaa
+bGI
+aZx
+wPW
 sty
-gKd
+sty
+sty
 aQP
 vxZ
 dpc
@@ -82248,7 +81553,7 @@ vxZ
 bIY
 nho
 aZx
-cdm
+uWo
 aht
 aht
 aaa
@@ -82402,19 +81707,19 @@ ycE
 ycE
 ycE
 ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
+aig
+aig
+aig
+aig
+aig
+agy
+aig
+aig
+aig
+aig
+aig
+aig
+bMQ
 afn
 aeT
 aeC
@@ -82488,14 +81793,14 @@ baL
 bon
 aZx
 aaa
-aZx
-wPW
-aOe
-ldR
-aZx
 aaa
-sty
+aaa
+bGI
+aZx
 aQG
+dpc
+dpc
+dpc
 wUc
 vaB
 vaB
@@ -82505,7 +81810,7 @@ vaB
 vaB
 kVy
 aZx
-cdm
+uWo
 aaa
 aht
 aaa
@@ -82659,19 +81964,19 @@ ycE
 ycE
 ycE
 ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
+aig
+aig
+aig
+aig
+aig
+agy
+aig
+bFY
+aig
+aig
+aig
+aig
+aig
 agy
 afC
 mbU
@@ -82696,7 +82001,7 @@ apE
 apE
 ari
 apE
-bBW
+abI
 apE
 avq
 apE
@@ -82745,13 +82050,10 @@ aJI
 boo
 aZx
 aaa
-aZx
-baK
-baK
-baK
-aZx
 aaa
-sty
+aaa
+bGI
+aZx
 aQG
 dpc
 aZx
@@ -82762,7 +82064,10 @@ aZx
 aZx
 aZx
 aZx
-cdm
+aZx
+aZx
+aZx
+uWo
 aht
 aht
 aht
@@ -82916,19 +82221,19 @@ ycE
 ycE
 ycE
 ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
+aig
+aig
+aig
+aig
+aig
+aig
+aig
+bFY
+aig
+aig
+aig
+aig
+aig
 afo
 aig
 dOw
@@ -83001,25 +82306,25 @@ aZx
 bnr
 bon
 aZx
+aaa
+aaa
+aaa
+bGI
 aZx
-aZx
-bsl
-baK
-aZx
-aZx
-aZx
-sty
 aQG
 dpc
 aZx
-koE
-koE
-koE
-koE
-koE
-koE
-koE
-cdm
+aht
+aht
+aht
+aht
+aht
+aht
+aht
+aht
+aht
+aht
+rrm
 aaa
 aht
 aaa
@@ -83173,19 +82478,19 @@ ycE
 ycE
 ycE
 ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
+aig
+aig
+aig
+aig
+aig
+aig
+aig
+bFY
+aig
+aig
+bJA
+aig
+bMR
 agy
 afE
 ark
@@ -83258,24 +82563,24 @@ bdV
 bnr
 bon
 aZx
-bDf
-tbY
 aZx
-baK
 aZx
-kBp
+aZx
+aZx
+aZx
+aQG
 xeN
-kAH
-bBV
-dpc
 aZx
-ahi
-cdm
-cdm
-cdm
-cdm
-cdm
-cdm
+apS
+xCb
+xCb
+pbf
+ahR
+jfy
+jfy
+jfy
+jfy
+sHY
 aht
 aaa
 aht
@@ -83430,19 +82735,19 @@ ycE
 ycE
 ycE
 ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
+aig
+aig
+aig
+aig
+aig
+aig
+aig
+bFY
+aig
+aig
+aig
+aig
+aig
 afq
 aiG
 agb
@@ -83517,15 +82822,15 @@ bon
 aZx
 epg
 uxI
-bsl
-baK
+tYj
+uPg
 aZx
 aQG
 dpc
 bAI
 swB
-upR
-aZx
+aht
+aaa
 abI
 aaa
 bva
@@ -83687,19 +82992,19 @@ ycE
 ycE
 ycE
 ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
+aig
+aig
+aig
+aig
+aig
+agy
+aig
+bFY
+aig
+aig
+aig
+aig
+aig
 agy
 afG
 eSB
@@ -83771,11 +83076,11 @@ bbR
 bbR
 bnr
 baK
-baK
-baK
-baK
-baK
-baK
+aZx
+nZw
+tbY
+bzz
+wCR
 aZx
 kIc
 hCb
@@ -83943,20 +83248,20 @@ ycE
 ycE
 ycE
 ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
+aig
+aig
+aig
+aig
+aig
+aig
+agy
+aig
+aig
+aig
+aig
+aig
+aig
+aig
 agy
 afH
 aeH
@@ -84028,10 +83333,10 @@ baK
 baK
 bnq
 baK
-baK
-baK
-baK
-baK
+aZx
+pyw
+tDn
+upR
 baK
 aZx
 bxY
@@ -84203,17 +83508,17 @@ ycE
 ycE
 ycE
 ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
+agy
+agy
+bzV
+agy
+agy
+bIr
+bIs
+bIr
+aem
+bKF
+aem
 aem
 aem
 aem
@@ -84460,17 +83765,17 @@ ycE
 ycE
 ycE
 ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
+agy
+bzV
+bzV
+bzV
+agy
+bIs
+bJy
+bIs
+aem
+bKG
+vbG
 afr
 vbG
 aig
@@ -84717,17 +84022,17 @@ ycE
 ycE
 ycE
 ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
+agy
+bzV
+bzV
+bzV
+agy
+bJv
+bJz
+bJv
+aem
+bLO
+vbG
 iPH
 vbG
 agd
@@ -84974,17 +84279,17 @@ ycE
 ycE
 ycE
 ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
+agy
+bzV
+bzV
+bzV
+agy
+agy
+agy
+agy
+aem
+bLQ
+aig
 agy
 aig
 kEx
@@ -85231,17 +84536,17 @@ ycE
 ycE
 ycE
 ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
+agy
+bzV
+bzV
+bzV
+agy
+apu
+apu
+apu
+aem
+bKG
+vbG
 iPH
 vbG
 arl
@@ -85488,17 +84793,17 @@ ycE
 ycE
 ycE
 ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
+agy
+agy
+agy
+apu
+agy
+apu
+apu
+apu
+aem
+bMP
+vbG
 afr
 vbG
 nWL
@@ -85747,15 +85052,15 @@ ycE
 ycE
 ycE
 ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
+agy
+apu
+apu
+apu
+apu
+apu
+aem
+aem
+bNV
 aem
 aem
 aem
@@ -86004,18 +85309,18 @@ ycE
 ycE
 ycE
 ycE
+agy
+apu
+apu
+apu
+apu
+apu
+byr
 ycE
 ycE
 ycE
 ycE
-ycE
-ycE
-aaa
-ycE
-ycE
-ycE
-ycE
-rmD
+cLq
 aaa
 agP
 dBd
@@ -86261,18 +85566,18 @@ ycE
 ycE
 ycE
 ycE
+agy
+agy
+agy
+agy
+agy
+agy
+byr
 ycE
 ycE
 ycE
 ycE
-ycE
-ycE
-aaa
-ycE
-ycE
-ycE
-ycE
-rmD
+cLq
 wHu
 agP
 ahq
@@ -86516,19 +85821,19 @@ ycE
 ycE
 ycE
 ycE
+agy
+agy
+agy
+bEM
+bEM
+bEM
+bEM
+bEM
+byr
 ycE
 ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-aaa
-ycE
-ycE
-ycE
-ycE
+cLq
+cLq
 rmD
 abI
 agP
@@ -86581,9 +85886,9 @@ aUK
 aUk
 aDZ
 aGV
-aDZ
-aIS
-aDZ
+kAH
+kBp
+kKv
 aDZ
 aDZ
 bvH
@@ -86775,16 +86080,16 @@ ycE
 ycE
 ycE
 ycE
+bEL
+bEM
+bEM
+bEM
+bEM
+bEM
+byr
 ycE
 ycE
-ycE
-ycE
-ycE
-ycE
-aaa
-ycE
-ycE
-ycE
+cLq
 ycE
 rmD
 aaa
@@ -87032,13 +86337,13 @@ ycE
 ycE
 ycE
 ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-mZE
+bEM
+bEM
+bEM
+bEM
+bEM
+bEM
+shH
 mZE
 mZE
 aht
@@ -87289,13 +86594,13 @@ ycE
 ycE
 ycE
 ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-mZE
+bEL
+bEM
+bEM
+bEM
+bEM
+bEM
+shH
 mZE
 mZE
 aht
@@ -87541,21 +86846,21 @@ ycE
 ycE
 ycE
 ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-mZE
+aem
+aem
+aem
+aOe
+aem
+aem
+bEM
+bEM
+bEM
+bEM
+bEM
+shH
 mZE
 aaa
-aaa
+koE
 aaa
 aby
 aaa
@@ -87798,22 +87103,22 @@ ycE
 ycE
 ycE
 ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
+aem
+aKp
+aOe
+aOe
+bBV
+aem
+aem
+aem
+aem
+aem
+aem
+shH
 mZE
-mZE
 aaa
-aaa
-aaa
+koE
+koE
 aby
 abI
 agP
@@ -88055,12 +87360,12 @@ ycE
 ycE
 ycE
 ycE
-ycE
-ycE
-mZE
-mZE
-mZE
-mZE
+aem
+aKp
+boD
+boD
+bDf
+shH
 mZE
 mZE
 mZE
@@ -88117,7 +87422,7 @@ aOv
 aKJ
 aQF
 aRK
-aLL
+aSR
 aRL
 aUQ
 aVU
@@ -88312,12 +87617,12 @@ ycE
 ycE
 ycE
 ycE
-ycE
-ycE
-mZE
-mZE
-mZE
-mZE
+aem
+aKp
+boD
+boD
+boD
+shH
 mZE
 mZE
 mZE
@@ -88569,12 +87874,12 @@ ycE
 ycE
 ycE
 ycE
-ycE
-ycE
-aaa
-aaa
-aaa
-aaa
+aem
+aem
+byr
+byr
+byr
+byr
 aaa
 aaa
 aaa
@@ -88892,7 +88197,7 @@ aSB
 aTR
 aUT
 aRL
-aWQ
+aXZ
 aXR
 aXS
 aZS
@@ -88900,7 +88205,7 @@ bba
 aZS
 aXS
 bef
-bfk
+bfl
 bdm
 aDZ
 bvH
@@ -89149,7 +88454,7 @@ aSC
 aTS
 aUU
 aRL
-aWQ
+aXZ
 aXS
 aXW
 aZT
@@ -89678,10 +88983,10 @@ bvH
 bil
 biY
 ble
-ble
-ble
-ble
-ble
+msD
+msD
+msD
+msD
 bpH
 biY
 bsC
@@ -90452,7 +89757,7 @@ bjW
 blg
 bmr
 bnz
-boD
+blg
 boG
 biY
 bsE
@@ -91480,7 +90785,7 @@ bjZ
 blj
 bmu
 bnA
-bnG
+mSf
 cqd
 brg
 bsG
@@ -91754,7 +91059,7 @@ bFU
 bFU
 bIj
 bJq
-bIj
+bFU
 bFU
 bFU
 bjc
@@ -92012,9 +91317,9 @@ bHb
 bIk
 bJr
 bKB
-bKB
+krC
 bFU
-bNV
+bDi
 hZB
 bPD
 bPB
@@ -92267,8 +91572,8 @@ bEE
 bFU
 bHc
 bIl
-bJs
-bKC
+qni
+qni
 bLL
 bFU
 bNW
@@ -92524,11 +91829,11 @@ bEF
 bFU
 bHd
 bIm
-bJr
+gaP
 bKD
-bKD
+fXa
 bFU
-bNX
+ecx
 hZB
 bPE
 bQs
@@ -92779,13 +92084,13 @@ bCu
 bDw
 bEG
 bFU
-bFU
-bFU
-bJt
+yik
 qni
+qni
+qni
+bLL
 bFU
-bFU
-bFU
+bDi
 hZB
 bPF
 bTu
@@ -93036,13 +92341,13 @@ bCv
 bDx
 bEH
 bFU
-bFU
+gTJ
 bIo
 bJu
 bKE
 bLM
-bMR
 bFU
+bDi
 hZB
 bPE
 bQu
@@ -93290,16 +92595,16 @@ bpY
 bpY
 bpY
 bCw
-bDy
-bDy
-bDy
+byu
+byu
+bFU
 bFU
 bIp
-bJv
-bKF
-bKF
-bMQ
 bFU
+bFU
+bFU
+bFU
+bDi
 hZB
 bPE
 bQv
@@ -93547,16 +92852,16 @@ byw
 bAe
 bpY
 bCx
-bDy
+bva
 bEI
 bFV
-bFU
-aah
-byr
-bzV
-bLO
-bMP
-bFU
+bva
+bmf
+bIZ
+aaa
+aaa
+bIZ
+bDi
 hZB
 bPE
 bQw
@@ -93804,16 +93109,16 @@ byx
 bAf
 bBl
 bCy
-bDy
+bva
 bEJ
-bFW
-bFU
-bIr
-bKF
-bKF
-bKF
-bMQ
-bFU
+bFX
+bva
+bmf
+bIZ
+aht
+aht
+bIZ
+bDi
 hZB
 bPE
 bQx
@@ -94064,13 +93369,13 @@ bOG
 bDy
 bEK
 bFX
-bFU
-bIs
-bJy
-bKG
-bLQ
-tYj
-bFU
+bva
+bmf
+bIZ
+aaa
+aaa
+bIZ
+bDi
 hZB
 bPE
 bQy
@@ -94318,16 +93623,16 @@ byz
 ooh
 bpY
 bCA
-bDy
-bEL
-bDy
-bFU
-bFU
-bJz
-bFU
-bFU
-bFU
-bFU
+bva
+bva
+bva
+bva
+bmf
+bva
+bIZ
+bIZ
+bva
+bDi
 hZB
 bPE
 bQz
@@ -94576,11 +93881,11 @@ bAi
 bpY
 bCB
 bKH
-bEM
-bFY
 bKH
 bKH
-bJA
+bKH
+lUt
+bKH
 bKH
 bKH
 bKH
@@ -99126,7 +98431,7 @@ aaa
 aaa
 aaa
 aiT
-xbJ
+ePb
 qDe
 akf
 gxe
@@ -99384,7 +98689,7 @@ aaa
 aaa
 aiS
 qPB
-iqc
+qDe
 ngp
 cBr
 cBs
@@ -99640,7 +98945,7 @@ aaa
 aaa
 aiS
 aiS
-xbJ
+ffQ
 fAM
 akf
 uaC
@@ -99911,10 +99216,10 @@ aiS
 aiT
 aiS
 aiS
-aiS
-aiS
-aiS
-aiS
+apX
+apX
+apX
+apX
 apX
 avd
 avd
@@ -100167,9 +99472,9 @@ sbk
 aiS
 alP
 cBB
-apu
-aqH
-aqH
+ajv
+apX
+asb
 asb
 coe
 apX
@@ -100424,11 +99729,11 @@ aju
 ajv
 cBA
 aiS
-akn
-apX
-apX
+gDV
+hlU
+hxw
 asc
-apX
+jAu
 apX
 avf
 awo
@@ -104284,7 +103589,7 @@ aaa
 aiS
 akn
 ajv
-auq
+cnX
 atn
 awB
 axw
@@ -106356,9 +105661,9 @@ aEj
 aEj
 aEj
 aFi
-aKp
+aKn
 aFi
-aMA
+pKd
 aEj
 aaa
 aaa
@@ -107382,7 +106687,7 @@ aFg
 aFR
 aGO
 aFi
-aGO
+pKd
 aFi
 aFi
 aEj
@@ -107907,13 +107212,13 @@ aSl
 aSl
 aSl
 aTv
-aGO
+pKd
 aEj
 aEj
 aEj
 aEj
 aTx
-aGO
+aFi
 bcI
 xud
 aFi
@@ -108173,7 +107478,7 @@ aZw
 aFi
 bcI
 aFi
-aFi
+pKd
 kIo
 bfN
 aEj
@@ -108689,7 +107994,7 @@ bcK
 bdR
 baG
 bfP
-bfP
+ldR
 aEj
 aEj
 aEj
@@ -109203,9 +108508,9 @@ uXH
 bcN
 baG
 eZA
-tDn
 aFi
-nZw
+aFi
+bfu
 aFi
 bcI
 aFi
@@ -111796,7 +111101,7 @@ cDB
 aad
 dtm
 bwm
-bxP
+lTb
 lWy
 jQh
 bwm

--- a/_maps/map_files/PubbyStation/PubbyStation_Lumos.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation_Lumos.dmm
@@ -33419,9 +33419,6 @@
 	name = "Surgery";
 	req_access_txt = "45"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},

--- a/_maps/map_files/PubbyStation/PubbyStation_Lumos.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation_Lumos.dmm
@@ -1006,59 +1006,6 @@
 "aem" = (
 /turf/closed/wall/r_wall,
 /area/security/prison)
-"aen" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plating,
-/area/security/prison)
-"aeo" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/delivery,
-/obj/structure/sign/poster/official/random{
-	pixel_x = -32
-	},
-/obj/structure/plasticflaps,
-/obj/machinery/conveyor/auto{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"aep" = (
-/obj/structure/window/reinforced,
-/obj/machinery/conveyor/auto{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"aeq" = (
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"aet" = (
-/obj/machinery/door/poddoor{
-	id = "soli1"
-	},
-/turf/open/floor/mineral/titanium/white{
-	name = "secure isolation floor"
-	},
-/area/security/prison)
-"aeu" = (
-/obj/machinery/camera{
-	c_tag = "Permabrig Iso Cell 1";
-	network = list("ss13","prison")
-	},
-/obj/structure/bed,
-/turf/open/floor/mineral/titanium/white{
-	name = "secure isolation floor"
-	},
-/area/security/prison)
 "aev" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -1129,48 +1076,6 @@
 /obj/machinery/conveyor/auto{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"aeD" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/table,
-/obj/item/clothing/suit/straight_jacket,
-/obj/item/clothing/suit/straight_jacket,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"aeG" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/camera{
-	c_tag = "Permabrig Entrance";
-	dir = 8;
-	network = list("ss13","prison");
-	start_active = 1
-	},
-/obj/machinery/button/door{
-	id = "soli2";
-	name = "Solitary Cell 2";
-	pixel_x = 26;
-	pixel_y = -10;
-	req_access_txt = "3"
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/door_timer{
-	id = "soli2";
-	name = "Solitary 2 door timer";
-	pixel_x = 31;
-	pixel_y = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aeH" = (
@@ -1293,18 +1198,6 @@
 	dir = 4;
 	layer = 2.9
 	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"aeU" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/table,
-/obj/item/storage/box/hug,
-/obj/item/razor{
-	pixel_x = -6
-	},
-/obj/machinery/airalarm/directional/south,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aeY" = (
@@ -2033,14 +1926,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
-"agW" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"agY" = (
-/obj/machinery/holopad,
-/turf/open/floor/plasteel/grimy,
-/area/security/prison)
 "agZ" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -2082,8 +1967,10 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "ahd" = (
-/obj/structure/closet/secure_closet/security/sec,
-/obj/effect/turf_decal/delivery,
+/obj/structure/table,
+/obj/machinery/recharger{
+	pixel_y = 4
+	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
 "ahh" = (
@@ -2107,6 +1994,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/obj/item/razor,
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
 "ahk" = (
@@ -2157,16 +2045,6 @@
 "ahm" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"ahn" = (
-/obj/structure/chair/stool,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aho" = (
@@ -2291,35 +2169,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
-"ahA" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel/grimy,
-/area/security/prison)
-"ahB" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 10
-	},
-/turf/open/floor/plasteel/grimy,
-/area/security/prison)
-"ahC" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "ahD" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -2386,21 +2235,21 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "ahJ" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"ahK" = (
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
 /obj/machinery/power/apc/highcap/five_k{
 	dir = 1;
 	name = "Prison Wing APC";
 	pixel_x = 1;
 	pixel_y = 24
 	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"ahK" = (
-/obj/structure/table,
-/obj/item/melee/chainofcommand,
-/obj/item/melee/baton,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "ahL" = (
@@ -2417,29 +2266,15 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
 "ahN" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
+/obj/effect/turf_decal/delivery,
+/obj/structure/closet/bombcloset/security,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
 "ahO" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 10
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/main)
-"ahP" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/security/prison)
+/obj/structure/grille,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/station_ruins)
 "ahQ" = (
 /obj/machinery/light{
 	dir = 4
@@ -2462,6 +2297,8 @@
 	dir = 8
 	},
 /obj/structure/table/glass,
+/obj/item/melee/chainofcommand,
+/obj/item/melee/baton,
 /turf/open/floor/plasteel/white,
 /area/security/execution/transfer)
 "ahT" = (
@@ -2557,12 +2394,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"aic" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aid" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -2582,25 +2413,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"aif" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/manifold/cyan/hidden/layer1{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/security/prison)
 "aig" = (
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aih" = (
-/obj/structure/table,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
 	},
-/obj/item/restraints/handcuffs,
-/obj/item/razor,
 /obj/machinery/light{
 	dir = 4;
 	light_color = "#e8eaff"
@@ -2659,8 +2478,11 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
 "aip" = (
-/obj/structure/closet/bombcloset/security,
 /obj/effect/turf_decal/delivery,
+/obj/structure/closet/secure_closet/security/sec,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
 "aiq" = (
@@ -2669,14 +2491,13 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
 "air" = (
-/obj/vehicle/ridden/secway,
-/obj/item/key/security,
 /obj/effect/turf_decal/bot,
+/obj/machinery/vending/security,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
 "ais" = (
-/obj/structure/tank_dispenser/oxygen,
 /obj/effect/turf_decal/bot,
+/obj/machinery/vending/wardrobe/sec_wardrobe,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
 "ait" = (
@@ -2692,6 +2513,8 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/item/electropack,
+/obj/item/assembly/signaler,
 /turf/open/floor/plasteel/white,
 /area/security/execution/transfer)
 "aiw" = (
@@ -2740,21 +2563,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"aiC" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 10
-	},
-/turf/open/floor/wood,
-/area/security/prison)
-"aiD" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 5
-	},
-/turf/open/floor/circuit,
-/area/security/prison)
 "aiE" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -2762,9 +2570,6 @@
 	},
 /obj/machinery/light,
 /turf/open/floor/plasteel,
-/area/security/prison)
-"aiF" = (
-/turf/open/floor/plasteel/showroomfloor/shower,
 /area/security/prison)
 "aiG" = (
 /obj/structure/cable{
@@ -2786,15 +2591,9 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aiK" = (
-/obj/structure/table,
-/obj/item/assembly/signaler,
-/obj/item/electropack,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/station_ruins)
 "aiL" = (
 /obj/structure/table,
 /obj/item/storage/box/flashbangs{
@@ -2870,25 +2669,26 @@
 /area/maintenance/department/crew_quarters/dorms)
 "aiV" = (
 /obj/structure/table,
-/obj/machinery/microwave,
-/turf/open/floor/plating,
-/area/maintenance/department/security/brig)
-"aiW" = (
-/obj/structure/table,
-/obj/structure/bedsheetbin,
-/turf/open/floor/plating,
+/obj/item/paper/fluff/jobs/security/beepsky_mom,
+/turf/open/floor/carpet,
 /area/maintenance/department/security/brig)
 "aiX" = (
-/obj/structure/sink/kitchen{
+/obj/structure/sink{
 	pixel_y = 28
 	},
-/obj/item/reagent_containers/glass/beaker,
-/turf/open/floor/plating,
+/obj/structure/mirror{
+	pixel_y = 30
+	},
+/turf/open/floor/carpet,
 /area/maintenance/department/security/brig)
 "aiY" = (
 /obj/structure/table,
+/obj/item/reagent_containers/food/snacks/donut{
+	pixel_x = 4;
+	pixel_y = 4
+	},
 /obj/item/flashlight/lamp,
-/turf/open/floor/plating,
+/turf/open/floor/carpet,
 /area/maintenance/department/security/brig)
 "aiZ" = (
 /obj/structure/table,
@@ -3034,7 +2834,6 @@
 /turf/open/floor/plasteel/dark,
 /area/security/armory)
 "ajk" = (
-/obj/effect/landmark/start/security_officer,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -3125,7 +2924,6 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "ajq" = (
-/obj/effect/landmark/start/security_officer,
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_x = 32
 	},
@@ -3207,23 +3005,26 @@
 /turf/open/space,
 /area/space/nearstation)
 "ajB" = (
-/obj/item/storage/box/mousetraps,
-/turf/open/floor/plating,
-/area/maintenance/department/security/brig)
-"ajC" = (
-/obj/structure/chair/stool,
-/turf/open/floor/plating,
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/item/stock_parts/cell/potato{
+	name = "\improper Beepsky's emergency battery"
+	},
+/turf/open/floor/carpet,
 /area/maintenance/department/security/brig)
 "ajD" = (
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "ajE" = (
 /obj/structure/bed,
-/obj/item/bedsheet,
 /obj/structure/sign/poster/contraband/random{
 	pixel_x = 32
 	},
-/turf/open/floor/plating,
+/mob/living/simple_animal/bot/secbot/beepsky{
+	name = "Officer Beepsky"
+	},
+/obj/item/bedsheet/hos,
+/turf/open/floor/carpet,
 /area/maintenance/department/security/brig)
 "ajF" = (
 /obj/machinery/atmospherics/components/unary/tank/oxygen,
@@ -3386,34 +3187,33 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "ajV" = (
-/obj/effect/landmark/start/security_officer,
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp/green{
+	pixel_x = -4;
+	pixel_y = 12
+	},
 /turf/open/floor/plasteel,
 /area/security/main)
 "ajW" = (
-/obj/structure/chair/stool,
-/obj/effect/landmark/start/security_officer,
-/turf/open/floor/plasteel,
-/area/security/main)
+/obj/structure/lattice,
+/obj/machinery/camera{
+	c_tag = "Permabrig Space North";
+	dir = 1;
+	name = "aft camera"
+	},
+/turf/open/space/basic,
+/area/space/station_ruins)
 "ajX" = (
-/obj/effect/landmark/start/security_officer,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/main)
+/obj/structure/sign/warning/electricshock,
+/turf/closed/wall/r_wall,
+/area/space/station_ruins)
 "ajY" = (
-/obj/effect/landmark/start/security_officer,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/main)
+/turf/open/floor/plating,
+/area/space/station_ruins)
 "ajZ" = (
 /obj/machinery/light{
 	dir = 4
@@ -3422,12 +3222,8 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/cyan/hidden/layer1{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/security/main)
 "aka" = (
@@ -3469,6 +3265,7 @@
 /obj/machinery/newscaster/security_unit{
 	pixel_y = 32
 	},
+/obj/item/key/security,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "ake" = (
@@ -3583,29 +3380,15 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "akr" = (
-/obj/machinery/washing_machine,
 /obj/item/radio/intercom{
 	dir = 4;
 	name = "Station Intercom (General)";
 	pixel_x = -31
 	},
-/turf/open/floor/plating,
-/area/maintenance/department/security/brig)
-"aks" = (
-/obj/machinery/light/small,
-/turf/open/floor/plating,
+/turf/open/floor/carpet,
 /area/maintenance/department/security/brig)
 "akt" = (
-/obj/structure/bed,
-/obj/item/bedsheet,
-/obj/machinery/button/door{
-	id = "mainthideout";
-	name = "Door Bolt Control";
-	normaldoorcontrol = 1;
-	pixel_x = 25;
-	specialfunctions = 4
-	},
-/turf/open/floor/plating,
+/turf/open/floor/carpet,
 /area/maintenance/department/security/brig)
 "aku" = (
 /obj/machinery/atmospherics/components/trinary/mixer/flipped{
@@ -3811,10 +3594,6 @@
 /obj/item/gun/energy/e_gun/advtaser,
 /turf/open/floor/plasteel/dark,
 /area/security/armory)
-"akM" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
-/turf/open/floor/wood,
-/area/security/prison)
 "akN" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/rack,
@@ -3823,9 +3602,6 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
 /turf/open/floor/plasteel/dark,
 /area/security/armory)
-"akO" = (
-/turf/open/floor/circuit,
-/area/security/prison)
 "akP" = (
 /obj/structure/rack,
 /obj/item/gun/ballistic/shotgun/riot,
@@ -3878,6 +3654,7 @@
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/obj/vehicle/ridden/secway,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "akV" = (
@@ -3965,12 +3742,15 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "ali" = (
-/obj/machinery/door/airlock/abandoned{
-	id_tag = "mainthideout";
-	name = "Hideout"
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/security/brig)
+/area/space/station_ruins)
 "alj" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
 	dir = 8
@@ -4016,17 +3796,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/processing/cremation)
-"alp" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/manifold/cyan/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "alq" = (
 /obj/item/storage/box/bodybags,
 /obj/structure/extinguisher_cabinet{
@@ -4071,36 +3840,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/security/brig)
-"alu" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "alv" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"alx" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aly" = (
 /obj/machinery/light/small,
 /obj/effect/turf_decal/tile/red{
@@ -4160,26 +3905,34 @@
 /area/security/main)
 "alC" = (
 /obj/structure/table/wood,
-/obj/item/flashlight/lamp/green{
-	pixel_x = -4;
-	pixel_y = 12
-	},
+/obj/item/folder/red,
 /obj/item/pen,
-/obj/item/folder/red{
-	layer = 2.9;
-	pixel_x = 8
-	},
 /turf/open/floor/plasteel,
 /area/security/main)
 "alD" = (
-/obj/machinery/computer/secure_data,
-/turf/open/floor/plasteel,
-/area/security/main)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/space/station_ruins)
 "alE" = (
 /turf/open/floor/plasteel,
 /area/security/main)
 "alF" = (
-/obj/machinery/computer/security,
+/obj/structure/chair/office/dark{
+	dir = 1
+	},
+/obj/effect/landmark/start/security_officer,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/security/main)
 "alG" = (
@@ -4187,8 +3940,10 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/security/main)
 "alH" = (
@@ -4493,31 +4248,28 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "amn" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 4
+/obj/structure/closet/secure_closet/security/sec,
+/obj/effect/turf_decal/delivery,
+/obj/structure/window/reinforced{
+	dir = 8
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
 "amo" = (
-/obj/structure/chair/stool,
-/obj/effect/landmark/start/security_officer,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-8"
 	},
-/turf/open/floor/plasteel,
-/area/security/main)
+/turf/open/floor/plating,
+/area/space/station_ruins)
 "amp" = (
 /obj/machinery/holopad,
 /turf/open/floor/plasteel,
 /area/security/main)
 "amq" = (
-/obj/structure/chair/office/dark{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/effect/landmark/start/security_officer,
 /turf/open/floor/plasteel,
 /area/security/main)
 "amr" = (
@@ -4687,21 +4439,6 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
-"amJ" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/cyan/hidden/layer1{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "amK" = (
 /obj/machinery/door/window/eastright{
 	base_state = "left";
@@ -4827,8 +4564,6 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "amS" = (
-/obj/structure/closet/secure_closet/warden,
-/obj/item/clothing/mask/gas/sechailer,
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Brig Control APC";
@@ -4840,17 +4575,18 @@
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_y = 30
 	},
+/obj/machinery/computer/prisoner/management{
+	dir = 4
+	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "amT" = (
-/obj/machinery/computer/prisoner/management,
 /obj/machinery/airalarm{
 	pixel_y = 22
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "amU" = (
-/obj/machinery/computer/security,
 /obj/machinery/light{
 	dir = 1
 	},
@@ -4862,39 +4598,39 @@
 	name = "Station Intercom (General)";
 	pixel_y = 24
 	},
+/obj/structure/closet/secure_closet/warden,
+/obj/item/clothing/mask/gas/sechailer,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "amV" = (
-/obj/machinery/computer/secure_data,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/bed/dogbed,
+/mob/living/simple_animal/pet/dog/pug{
+	name = "McGriff"
+	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
-"amW" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "amX" = (
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
-"amY" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "amZ" = (
 /obj/structure/table,
-/obj/machinery/recharger,
 /obj/machinery/light/small{
 	dir = 4
 	},
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = 28
+	},
+/obj/machinery/recharger{
+	pixel_x = -5;
+	pixel_y = 4
+	},
+/obj/machinery/recharger{
+	pixel_x = 5;
+	pixel_y = 4
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
@@ -4916,7 +4652,10 @@
 /area/security/main)
 "anc" = (
 /obj/structure/table/wood,
-/obj/machinery/recharger,
+/obj/machinery/recharger{
+	pixel_x = 5;
+	pixel_y = 4
+	},
 /turf/open/floor/plasteel,
 /area/security/main)
 "and" = (
@@ -4927,8 +4666,11 @@
 /area/crew_quarters/kitchen)
 "ane" = (
 /obj/structure/table/wood,
-/obj/machinery/recharger,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/recharger{
+	pixel_x = 5;
+	pixel_y = 4
+	},
 /turf/open/floor/plasteel,
 /area/security/main)
 "anf" = (
@@ -4993,9 +4735,12 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "anq" = (
-/obj/structure/grille/broken,
-/turf/open/floor/plating,
-/area/maintenance/department/security/brig)
+/obj/structure/punching_bag,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "anr" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -5038,15 +4783,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
-"anv" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
 "anw" = (
 /obj/structure/plasticflaps/opaque,
 /obj/effect/turf_decal/tile/neutral{
@@ -5124,44 +4860,11 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/machinery/computer/security{
+	dir = 4
+	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
-"anD" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
-"anE" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
-"anF" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"anG" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "anH" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -5180,7 +4883,6 @@
 /area/security/warden)
 "anJ" = (
 /obj/structure/table,
-/obj/machinery/recharger,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "anK" = (
@@ -5240,16 +4942,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)
-"anQ" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "anR" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -5263,6 +4955,8 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
 	},
+/obj/structure/bed/dogbed,
+/mob/living/simple_animal/hostile/retaliate/samak/mcchonks,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "anS" = (
@@ -5442,14 +5136,13 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aop" = (
-/obj/structure/bed/dogbed,
 /obj/machinery/requests_console{
 	department = "Security";
 	departmentType = 5;
 	pixel_x = -32
 	},
-/mob/living/simple_animal/pet/dog/pug{
-	name = "McGriff"
+/obj/machinery/computer/secure_data{
+	dir = 4
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
@@ -5517,6 +5210,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/security/main)
 "aow" = (
@@ -5613,18 +5307,28 @@
 /turf/open/space,
 /area/solar/port)
 "aoI" = (
-/obj/structure/lattice,
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/space,
 /area/solar/port)
 "aoJ" = (
-/obj/structure/lattice,
-/obj/structure/grille/broken,
-/turf/open/space,
-/area/solar/port)
-"aoK" = (
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
+/obj/structure/weightmachine/weightlifter,
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
+"aoK" = (
+/obj/item/target/clown,
+/turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "aoL" = (
 /obj/structure/cable{
@@ -5683,14 +5387,19 @@
 	id = "Secure Gate";
 	name = "Entrance Lockdown";
 	pixel_x = 5;
-	pixel_y = -2
+	pixel_y = -2;
+	plane = -4
 	},
 /obj/machinery/button/door{
 	id = "Prison Gate";
 	name = "Permabrig Lockdown";
 	pixel_x = 5;
 	pixel_y = 8;
+	plane = -4;
 	req_access_txt = "2"
+	},
+/obj/item/phone{
+	pixel_x = -6
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
@@ -5702,6 +5411,9 @@
 "aoU" = (
 /obj/machinery/computer/crew{
 	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
@@ -5721,23 +5433,22 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "aoX" = (
-/obj/structure/rack,
-/obj/item/crowbar,
-/obj/item/wrench,
-/obj/item/laser_pointer/red,
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "aoY" = (
-/obj/structure/filingcabinet/chestdrawer,
 /obj/machinery/light_switch{
 	pixel_y = -22
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/structure/rack,
+/obj/item/crowbar,
+/obj/item/wrench,
+/obj/item/laser_pointer/red,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "aoZ" = (
@@ -5786,8 +5497,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 6
+/obj/machinery/atmospherics/pipe/manifold/cyan/hidden/layer1{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
@@ -6009,8 +5720,10 @@
 	},
 /area/maintenance/department/crew_quarters/dorms)
 "apz" = (
-/obj/item/target/clown,
-/turf/open/floor/plating,
+/obj/structure/sign/warning{
+	pixel_y = -32
+	},
+/turf/closed/wall,
 /area/maintenance/department/security/brig)
 "apB" = (
 /obj/structure/girder,
@@ -6072,15 +5785,6 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
-"apL" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "apM" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Brig Control";
@@ -6159,7 +5863,7 @@
 /area/crew_quarters/dorms)
 "aqa" = (
 /obj/structure/cable{
-	icon_state = "0-4"
+	icon_state = "0-8"
 	},
 /obj/machinery/power/solar{
 	id = "portsolar";
@@ -6168,18 +5872,17 @@
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/solar/port)
 "aqb" = (
-/obj/structure/lattice/catwalk,
 /obj/structure/cable{
-	icon_state = "2-8"
+	icon_state = "4-8"
 	},
-/obj/structure/cable{
-	icon_state = "2-4"
+/obj/machinery/jukebox{
+	req_one_access = null
 	},
-/turf/open/space,
-/area/solar/port)
-"aqc" = (
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
+"aqd" = (
 /obj/structure/cable{
-	icon_state = "0-8"
+	icon_state = "0-4"
 	},
 /obj/machinery/power/solar{
 	id = "portsolar";
@@ -6187,20 +5890,19 @@
 	},
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/solar/port)
-"aqd" = (
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/power/solar{
-	id = "starboardsolar";
-	name = "Starboard Solar Array"
-	},
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/solar/port)
 "aqe" = (
-/obj/item/target/alien,
-/turf/open/floor/plating,
-/area/maintenance/department/security/brig)
+/obj/structure/punching_bag,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "aqg" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
@@ -6640,18 +6342,8 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "ara" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/space,
-/area/solar/port)
+/turf/closed/wall/r_wall,
+/area/space/station_ruins)
 "arc" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -6722,10 +6414,9 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aro" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+/obj/structure/closet/secure_closet/security/sec,
+/obj/effect/turf_decal/delivery,
+/obj/structure/window/reinforced{
 	dir = 4
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -6964,6 +6655,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/item/aicard,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "arL" = (
@@ -7260,6 +6952,18 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/crew_quarters/dorms)
+"ask" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/cyan/hidden/layer1{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "asl" = (
 /obj/structure/grille/broken,
 /obj/structure/cable{
@@ -9053,18 +8757,18 @@
 /area/bridge)
 "avX" = (
 /obj/structure/table/glass,
-/obj/item/storage/toolbox/emergency,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 10
 	},
+/obj/item/phone,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "avY" = (
 /obj/structure/table/glass,
-/obj/item/aicard,
+/obj/item/storage/toolbox/emergency,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "avZ" = (
@@ -9780,6 +9484,9 @@
 /obj/item/kirbyplants{
 	icon_state = "plant-10"
 	},
+/obj/effect/turf_decal/lumos/tile/blue/half{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "axG" = (
@@ -9789,6 +9496,12 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
 	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "axI" = (
@@ -9797,6 +9510,12 @@
 	},
 /obj/machinery/airalarm{
 	pixel_y = 22
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
@@ -10131,10 +9850,12 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "ayy" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable,
-/turf/open/space,
-/area/solar/port)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating,
+/area/space/station_ruins)
 "ayz" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/vacuum/external{
@@ -10409,6 +10130,9 @@
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
+	},
+/obj/item/phone{
+	pixel_x = 17
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
@@ -10761,12 +10485,9 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "azG" = (
-/obj/machinery/power/tracker,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/solar/port)
+/obj/structure/sign/poster/official/random,
+/turf/closed/wall/r_wall,
+/area/space/station_ruins)
 "azH" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -10775,28 +10496,28 @@
 /turf/open/space,
 /area/solar/port)
 "azI" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/space,
-/area/solar/port)
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "azJ" = (
-/obj/structure/lattice/catwalk,
-/obj/item/stack/cable_coil,
-/turf/open/space,
-/area/solar/port)
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "azK" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/solar/port)
 "azL" = (
+/obj/machinery/computer/arcade,
 /obj/structure/cable{
-	icon_state = "0-4"
+	icon_state = "4-8"
 	},
-/obj/structure/lattice/catwalk,
-/turf/open/space,
-/area/solar/port)
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "azN" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -10838,23 +10559,27 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port)
 "azY" = (
-/obj/structure/plasticflaps,
-/turf/open/floor/plating,
+/obj/structure/grille/broken,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
 /area/maintenance/department/security/brig)
 "azZ" = (
-/mob/living/simple_animal/bot/secbot/beepsky{
-	name = "Officer Beepsky"
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#cee5d2"
 	},
-/turf/open/floor/plating,
-/area/maintenance/department/security/brig)
+/obj/machinery/computer/arcade,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "aAa" = (
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/potato{
-	name = "\improper Beepsky's emergency battery"
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
 	},
-/obj/item/paper/fluff/jobs/security/beepsky_mom,
-/turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "aAb" = (
 /obj/machinery/power/apc{
@@ -11246,12 +10971,11 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "aAV" = (
-/obj/structure/lattice/catwalk,
 /obj/structure/cable{
-	icon_state = "0-2"
+	icon_state = "4-8"
 	},
-/turf/open/space,
-/area/solar/port)
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "aAW" = (
 /obj/structure/rack,
 /obj/item/clothing/mask/gas,
@@ -11725,18 +11449,17 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "aCa" = (
-/obj/structure/lattice/catwalk,
 /obj/structure/cable{
-	icon_state = "1-4"
+	icon_state = "4-8"
 	},
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/turf/open/space,
-/area/solar/port)
+/turf/open/floor/wood,
+/area/space/station_ruins)
 "aCc" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
@@ -13195,9 +12918,6 @@
 /turf/closed/wall,
 /area/storage/emergency/starboard)
 "aEU" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -24
-	},
 /obj/item/storage/toolbox,
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -13888,12 +13608,15 @@
 /turf/open/floor/plating,
 /area/storage/emergency/starboard)
 "aGC" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/sign/warning/vacuum/external{
-	pixel_x = -32
+/obj/structure/holohoop,
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/space/station_ruins)
 "aGD" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -14371,22 +14094,13 @@
 	dir = 4
 	},
 /obj/structure/chair/stool/bar,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "aHN" = (
@@ -14396,22 +14110,13 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "aHO" = (
@@ -14624,15 +14329,23 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "aIr" = (
-/obj/structure/lattice/catwalk,
 /obj/structure/cable{
-	icon_state = "1-4"
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
-	icon_state = "1-8"
+	icon_state = "2-8"
 	},
-/turf/open/space,
-/area/solar/port)
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/space/station_ruins)
 "aIC" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -15709,16 +15422,6 @@
 /turf/open/floor/plasteel/dark,
 /area/blueshield)
 "aLE" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/obj/effect/landmark/xeno_spawn,
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -22
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
@@ -16324,10 +16027,6 @@
 /turf/open/floor/plasteel/dark,
 /area/blueshield)
 "aNc" = (
-/obj/structure/toilet{
-	dir = 4
-	},
-/obj/effect/landmark/start/assistant,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/auxiliary)
 "aNd" = (
@@ -18129,10 +17828,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
-	},
 /turf/open/floor/plating,
 /area/crew_quarters/kitchen)
 "aRP" = (
@@ -18483,29 +18178,11 @@
 	name = "Kitchen Delivery";
 	req_access_txt = "28"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/kitchen)
 "aSM" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/crew_quarters/bar)
 "aSN" = (
@@ -18878,6 +18555,14 @@
 	},
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/solar/starboard)
+"aTG" = (
+/obj/structure/table,
+/obj/machinery/microwave,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/space/station_ruins)
 "aTH" = (
 /obj/docking_port/stationary{
 	dir = 8;
@@ -19038,16 +18723,7 @@
 /area/crew_quarters/kitchen)
 "aUb" = (
 /obj/structure/plasticflaps/opaque,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/crew_quarters/bar)
 "aUc" = (
@@ -19978,10 +19654,15 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "aWm" = (
-/obj/structure/disposalpipe/segment,
-/obj/item/storage/box/drinkingglasses,
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/bar)
+/obj/machinery/computer/arcade,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "aWn" = (
 /obj/machinery/power/apc{
 	dir = 8;
@@ -19991,15 +19672,9 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/red/checker,
+/obj/effect/turf_decal/lumos/tile/blue/checker{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
@@ -20008,15 +19683,9 @@
 	icon_state = "4-8"
 	},
 /obj/effect/landmark/start/mime,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/red/checker,
+/obj/effect/turf_decal/lumos/tile/blue/checker{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
@@ -20024,15 +19693,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/red/checker,
+/obj/effect/turf_decal/lumos/tile/blue/checker{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
@@ -20047,15 +19710,9 @@
 	name = "Station Intercom (General)";
 	pixel_y = 26
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/red/checker,
+/obj/effect/turf_decal/lumos/tile/blue/checker{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
@@ -20072,15 +19729,9 @@
 	pixel_x = 28;
 	pixel_y = -2
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/red/checker,
+/obj/effect/turf_decal/lumos/tile/blue/checker{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
@@ -20369,21 +20020,15 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 6
+	},
+/obj/effect/turf_decal/lumos/tile/red/checker,
+/obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
@@ -20395,20 +20040,14 @@
 	c_tag = "Theatre Storage";
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/turf_decal/lumos/tile/red/checker,
+/obj/effect/turf_decal/lumos/tile/blue/checker{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -20424,21 +20063,15 @@
 	pixel_x = -32;
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
+	},
+/obj/effect/turf_decal/lumos/tile/red/checker,
+/obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
@@ -20447,18 +20080,12 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/clown,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
+	},
+/obj/effect/turf_decal/lumos/tile/red/checker,
+/obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
@@ -20471,15 +20098,9 @@
 	pixel_x = 28;
 	pixel_y = -2
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/red/checker,
+/obj/effect/turf_decal/lumos/tile/blue/checker{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
@@ -20783,11 +20404,8 @@
 	name = "Station Intercom (General)";
 	pixel_y = 26
 	},
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/lumos/tile/green/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
@@ -20800,21 +20418,15 @@
 	dir = 1;
 	light_color = "#e8eaff"
 	},
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/lumos/tile/green/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aXZ" = (
 /obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/lumos/tile/green/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
@@ -20851,11 +20463,8 @@
 	icon_state = "plant-18";
 	pixel_y = 10
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
@@ -20863,32 +20472,24 @@
 /obj/structure/table/reinforced,
 /obj/item/book/manual/wiki/barman_recipes,
 /obj/item/reagent_containers/rag,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "aYg" = (
 /obj/structure/table/reinforced,
-/obj/effect/turf_decal/tile/red{
+/obj/item/storage/box/drinkingglasses,
+/obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "aYh" = (
 /obj/structure/table/reinforced,
 /obj/item/instrument/guitar,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
@@ -20899,11 +20500,8 @@
 	icon_state = "plant-18";
 	pixel_y = 10
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
@@ -20913,18 +20511,9 @@
 	req_access_txt = "46"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/theatre)
 "aYk" = (
@@ -20932,16 +20521,7 @@
 	dir = 1
 	},
 /obj/machinery/disposal/bin,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/theatre)
 "aYl" = (
@@ -20950,32 +20530,14 @@
 /obj/structure/table/wood,
 /obj/item/bikehorn,
 /obj/item/toy/cattoy,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/theatre)
 "aYm" = (
 /obj/structure/closet/crate/wooden/toy,
 /obj/item/lipstick/random,
 /obj/item/clothing/gloves/color/rainbow,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/theatre)
 "aYn" = (
@@ -21311,10 +20873,7 @@
 	pixel_y = -2
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -21362,38 +20921,20 @@
 	},
 /obj/structure/chair/stool/bar,
 /obj/effect/landmark/start/assistant,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 8
 	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "aZe" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "aZf" = (
@@ -21403,16 +20944,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "aZg" = (
@@ -21811,39 +21343,18 @@
 	},
 /obj/item/storage/fancy/donut_box,
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/kitchen)
 "bae" = (
 /obj/structure/chair/stool/bar,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "bag" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "bah" = (
@@ -21856,16 +21367,7 @@
 	pixel_y = 1
 	},
 /obj/structure/chair/wood/normal,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "bao" = (
@@ -21873,16 +21375,16 @@
 	name = "Station Intercom (General)";
 	pixel_y = 26
 	},
-/obj/machinery/prize_counter,
+/obj/machinery/computer/arcade/tetris,
 /turf/open/floor/carpet{
 	icon_state = "carpetsymbol"
 	},
 /area/crew_quarters/bar)
 "bap" = (
-/obj/machinery/computer/slot_machine,
 /obj/machinery/airalarm{
 	pixel_y = 24
 	},
+/obj/machinery/computer/arcade,
 /turf/open/floor/carpet{
 	icon_state = "carpetsymbol"
 	},
@@ -22256,10 +21758,7 @@
 	name = "kitchen shutters"
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -22314,12 +21813,9 @@
 /turf/open/floor/plating,
 /area/crew_quarters/bar)
 "bbv" = (
-/obj/structure/chair/stool,
-/obj/item/trash/can,
-/turf/open/floor/carpet{
-	icon_state = "carpetsymbol"
-	},
-/area/crew_quarters/bar)
+/obj/effect/landmark/start/prisoner/prilate,
+/turf/open/floor/circuit/green,
+/area/space/station_ruins)
 "bbw" = (
 /obj/effect/landmark/start/assistant,
 /obj/structure/chair/stool,
@@ -22484,6 +21980,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"bbT" = (
+/obj/structure/chair/stool,
+/turf/open/floor/wood,
+/area/space/station_ruins)
 "bbU" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -22655,22 +22155,12 @@
 /obj/structure/chair/wood/normal{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "bcs" = (
-/obj/item/clothing/shoes/sandal,
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/bar)
+/turf/open/floor/circuit/green,
+/area/space/station_ruins)
 "bct" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -23076,29 +22566,17 @@
 /area/crew_quarters/bar)
 "bdw" = (
 /obj/structure/table/reinforced,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/lumos/tile/red/half{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "bdx" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "bdy" = (
@@ -23534,16 +23012,7 @@
 "bez" = (
 /obj/structure/table/wood,
 /obj/item/instrument/trombone,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "beA" = (
@@ -23585,16 +23054,7 @@
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/snacks/chocolatebar,
 /obj/item/kitchen/fork,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "beE" = (
@@ -23607,16 +23067,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "beG" = (
@@ -23630,6 +23081,10 @@
 /obj/machinery/light{
 	light_color = "#c9d3e8"
 	},
+/obj/structure/window{
+	dir = 8
+	},
+/obj/machinery/prize_counter,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "beH" = (
@@ -23637,16 +23092,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "beI" = (
@@ -24017,6 +23463,7 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
+/obj/item/phone,
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "bfD" = (
@@ -25029,19 +24476,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bip" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "biq" = (
@@ -25076,19 +24514,10 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "biu" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
 	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "biv" = (
@@ -25454,6 +24883,9 @@
 /obj/machinery/airalarm/unlocked{
 	pixel_y = 23
 	},
+/obj/structure/table,
+/obj/item/clothing/gloves/color/latex,
+/obj/item/storage/fancy/candle_box,
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "bjU" = (
@@ -25479,6 +24911,9 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
+/obj/structure/table,
+/obj/item/storage/box/bodybags,
+/obj/item/pen,
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "bjX" = (
@@ -25619,10 +25054,7 @@
 	dir = 8;
 	pixel_x = -12
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/lumos/tile/green/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -25917,7 +25349,7 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "blg" = (
-/obj/structure/chair{
+/obj/structure/bodycontainer/morgue{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -26016,14 +25448,8 @@
 /obj/structure/table,
 /obj/item/paicard,
 /obj/item/clothing/glasses/science,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/lumos/tile/green/fullcorner{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -26031,11 +25457,8 @@
 /obj/structure/table,
 /obj/machinery/cell_charger,
 /obj/item/stock_parts/cell/high/plus,
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/lumos/tile/green/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -26044,11 +25467,8 @@
 	dir = 1
 	},
 /obj/machinery/portable_atmospherics/scrubber,
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/lumos/tile/green/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -26071,47 +25491,28 @@
 /area/hallway/primary/aft)
 "blA" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/lumos/tile/green/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "blC" = (
 /obj/structure/chair/stool,
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/lumos/tile/green/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "blD" = (
 /obj/structure/chair/stool,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
+/obj/effect/turf_decal/lumos/tile/green/fullcorner{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "blE" = (
 /obj/structure/filingcabinet/chestdrawer,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
 "blF" = (
@@ -26119,20 +25520,14 @@
 	dir = 1
 	},
 /obj/effect/landmark/start/roboticist,
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/lumos/tile/green/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "blG" = (
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/lumos/tile/green/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
@@ -26145,11 +25540,8 @@
 	name = "utility sink";
 	pixel_y = 28
 	},
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/lumos/tile/green/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
@@ -26161,13 +25553,10 @@
 	pixel_y = 30;
 	receive_ore_updates = 1
 	},
-/obj/effect/turf_decal/tile/green{
+/obj/effect/landmark/start/roboticist,
+/obj/effect/turf_decal/lumos/tile/green/half{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/landmark/start/roboticist,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "blJ" = (
@@ -26181,11 +25570,8 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/lumos/tile/green/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
@@ -26201,11 +25587,8 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/lumos/tile/green/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
@@ -26214,19 +25597,10 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/machinery/posialert{
 	pixel_y = 28
 	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
 "blM" = (
@@ -26495,15 +25869,19 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "bmq" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
-/turf/open/floor/plasteel/dark,
-/area/medical/morgue)
+/obj/machinery/camera{
+	c_tag = "Permabrig Lounge West";
+	dir = 4;
+	network = list("ss13","prison")
+	},
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "bmr" = (
-/obj/structure/table,
-/obj/item/storage/box/bodybags,
-/obj/item/pen,
 /obj/machinery/camera{
 	c_tag = "Morgue";
+	dir = 8
+	},
+/obj/structure/bodycontainer/morgue{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -26659,16 +26037,7 @@
 	pixel_y = 5
 	},
 /obj/item/clothing/glasses/welding,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
 "bmM" = (
@@ -26747,13 +26116,10 @@
 /turf/open/floor/engine,
 /area/science/explab)
 "bmY" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
 	},
+/obj/effect/turf_decal/lumos/tile/purple/half,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bmZ" = (
@@ -26928,12 +26294,11 @@
 /turf/open/floor/carpet,
 /area/medical/psych)
 "bnz" = (
-/obj/structure/table,
-/obj/item/folder/white,
-/obj/item/clothing/gloves/color/latex,
-/obj/item/storage/fancy/candle_box,
 /obj/machinery/light_switch{
 	pixel_x = 22
+	},
+/obj/structure/bodycontainer/morgue{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
@@ -27015,10 +26380,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/purple/half,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bnM" = (
@@ -27047,16 +26409,7 @@
 	dir = 4;
 	pixel_x = -28
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
 "bnP" = (
@@ -27331,9 +26684,11 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "boA" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/plasteel/dark,
-/area/medical/morgue)
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/space/station_ruins)
 "boB" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -27344,12 +26699,13 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "boC" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel/dark,
-/area/medical/morgue)
+/turf/open/floor/wood,
+/area/space/station_ruins)
 "boD" = (
 /obj/item/ectoplasm,
+/obj/structure/bodycontainer/morgue{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "boE" = (
@@ -27522,16 +26878,7 @@
 "boS" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/aft)
 "boT" = (
@@ -27539,16 +26886,7 @@
 	icon_state = "plant-22"
 	},
 /obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/aft)
 "boU" = (
@@ -27565,16 +26903,7 @@
 /obj/item/kirbyplants{
 	icon_state = "plant-10"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/aft)
 "boX" = (
@@ -27755,6 +27084,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
+"bpm" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/main)
 "bpn" = (
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
@@ -27900,16 +27235,13 @@
 /area/medical/morgue)
 "bpI" = (
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 5
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 5
-	},
-/turf/open/floor/plasteel/dark,
-/area/medical/morgue)
+/turf/open/floor/wood,
+/area/space/station_ruins)
 "bpJ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -27917,11 +27249,11 @@
 /obj/machinery/light{
 	light_color = "#e8eaff"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
@@ -28106,10 +27438,7 @@
 	name = "Research Division"
 	},
 /obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -28131,8 +27460,7 @@
 	name = "Research Division"
 	},
 /obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/lumos/tile/green/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -28152,16 +27480,7 @@
 /obj/item/radio/headset/headset_sci{
 	pixel_x = -3
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
 "bqh" = (
@@ -28193,16 +27512,7 @@
 /area/science/robotics/lab)
 "bqk" = (
 /obj/machinery/aug_manipulator,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
 "bql" = (
@@ -28458,9 +27768,6 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"bqP" = (
-/turf/open/floor/plasteel/elevatorshaft,
-/area/security/prison)
 "bqS" = (
 /obj/machinery/power/apc{
 	areastring = "/area/hallway/secondary/entry";
@@ -28768,11 +28075,8 @@
 	},
 /obj/item/stack/cable_coil/orange,
 /obj/item/storage/toolbox/mechanical,
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
@@ -28787,11 +28091,8 @@
 /obj/machinery/airalarm/unlocked{
 	pixel_y = 23
 	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
@@ -28799,11 +28100,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
@@ -28811,11 +28109,8 @@
 /obj/structure/chair/office/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
@@ -28823,11 +28118,8 @@
 /obj/machinery/light_switch{
 	pixel_x = 25
 	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
@@ -28836,26 +28128,14 @@
 	dir = 4;
 	pixel_x = -23
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "brw" = (
 /obj/machinery/vending/wardrobe/robo_wardrobe,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
 "brx" = (
@@ -29507,27 +28787,17 @@
 	dir = 8;
 	pixel_x = 28
 	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
+	},
+/obj/effect/turf_decal/lumos/tile/green/half{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bsW" = (
 /obj/item/kirbyplants,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
 "bsX" = (
@@ -29535,24 +28805,18 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/lumos/tile/green/half,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "bsY" = (
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
+/obj/effect/turf_decal/lumos/tile/green/half,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "bsZ" = (
@@ -29574,13 +28838,10 @@
 /obj/item/stack/cable_coil,
 /obj/item/stack/cable_coil,
 /obj/structure/table,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
 	},
+/obj/effect/turf_decal/lumos/tile/green/half,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "bta" = (
@@ -30140,10 +29401,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -30153,8 +29411,7 @@
 	dir = 8
 	},
 /obj/item/clothing/mask/cigarette,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/lumos/tile/green/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -30636,11 +29893,8 @@
 /obj/machinery/newscaster{
 	pixel_y = 34
 	},
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/lumos/tile/green/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -30648,11 +29902,8 @@
 /obj/structure/sign/poster/random{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -30663,14 +29914,11 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/lumos/tile/green/half{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bvF" = (
@@ -30680,12 +29928,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
+/obj/effect/turf_decal/lumos/tile/green/fullcorner{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -30880,9 +30124,6 @@
 /area/science/explab)
 "bwb" = (
 /obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
 	},
@@ -31293,17 +30534,14 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
+	},
+/obj/effect/turf_decal/lumos/tile/purple/half{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -31399,14 +30637,13 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/turf_decal/lumos/tile/green/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -31997,11 +31234,11 @@
 	name = "Chemistry Testing";
 	req_access_txt = "5; 33"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
 /mob/living/simple_animal/mouse/white{
 	name = "Labrette"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
 /turf/open/floor/engine,
 /area/medical/chemistry)
@@ -32052,12 +31289,9 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "byH" = (
@@ -32065,11 +31299,8 @@
 /obj/item/multitool,
 /obj/item/clothing/glasses/science,
 /obj/item/clothing/glasses/science,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
 /obj/item/reagent_containers/glass/bucket,
+/obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "byI" = (
@@ -32077,10 +31308,7 @@
 /obj/machinery/cell_charger,
 /obj/item/stock_parts/cell/high/plus,
 /obj/item/stock_parts/cell/high/plus,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
+/obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "byJ" = (
@@ -32131,8 +31359,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/lumos/tile/green/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -32815,25 +32042,21 @@
 	layer = 2.9
 	},
 /obj/item/screwdriver,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/engine,
 /area/medical/chemistry)
 "bAi" = (
 /obj/machinery/smoke_machine,
 /turf/open/floor/engine,
 /area/medical/chemistry)
 "bAl" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
+	},
+/obj/effect/turf_decal/lumos/tile/purple/half{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -32875,14 +32098,9 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/lumos/tile/purple/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hor)
 "bAq" = (
@@ -32917,10 +32135,7 @@
 /area/security/checkpoint/science)
 "bAv" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -32943,8 +32158,7 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/lumos/tile/green/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -33319,11 +32533,8 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hor)
@@ -33338,22 +32549,25 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 5
 	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hor)
 "bBs" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hor)
 "bBt" = (
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
 	},
+/obj/effect/turf_decal/lumos/tile/green/half,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bBu" = (
@@ -33386,12 +32600,11 @@
 	pixel_y = 5;
 	req_access_txt = "47"
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
 /obj/structure/table/glass,
 /obj/machinery/photocopier/faxmachine,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 5
+	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hor)
 "bBw" = (
@@ -33399,19 +32612,15 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science)
 "bBx" = (
 /obj/machinery/computer/security/mining,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science)
@@ -33428,12 +32637,8 @@
 	pixel_x = 28;
 	pixel_y = 24
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science)
@@ -33447,8 +32652,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bBA" = (
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/lumos/tile/green/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -33973,6 +33177,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/item/phone{
+	pixel_x = 17
+	},
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
 "bCu" = (
@@ -34106,10 +33313,7 @@
 	dir = 4;
 	pixel_x = -28
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -34131,8 +33335,7 @@
 	dir = 4;
 	light_color = "#c1caff"
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -34159,11 +33362,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -34179,8 +33378,7 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science)
 "bCM" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -34506,9 +33704,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bDB" = (
@@ -34519,10 +33714,7 @@
 /obj/machinery/computer/rdconsole{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -34548,8 +33740,7 @@
 /obj/machinery/computer/card/minor/rd{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -34562,10 +33753,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -34585,12 +33773,11 @@
 /area/security/checkpoint/science)
 "bDI" = (
 /obj/structure/closet/wardrobe/red,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science)
@@ -35136,7 +34323,6 @@
 /area/crew_quarters/heads/cmo)
 "bEG" = (
 /obj/item/folder/blue,
-/obj/item/stamp/cmo,
 /obj/structure/table,
 /obj/machinery/firealarm{
 	dir = 1;
@@ -35148,6 +34334,8 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/item/folder/white,
+/obj/item/stamp/cmo,
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
 "bEH" = (
@@ -35242,9 +34430,6 @@
 /obj/item/stock_parts/matter_bin,
 /obj/item/stock_parts/matter_bin,
 /obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bER" = (
@@ -35259,12 +34444,8 @@
 	dir = 9;
 	pixel_x = -22
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 10
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hor)
@@ -35281,10 +34462,7 @@
 	},
 /obj/machinery/light,
 /obj/structure/table/glass,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
+/obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hor)
 "bET" = (
@@ -35305,10 +34483,10 @@
 	network = list("ss13","rd")
 	},
 /obj/structure/table/glass,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
+/obj/item/phone{
+	pixel_x = 17
 	},
+/obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hor)
 "bEU" = (
@@ -35326,10 +34504,7 @@
 	dir = 1;
 	pixel_y = -26
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
+/obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hor)
 "bEV" = (
@@ -35339,12 +34514,8 @@
 /obj/machinery/modular_computer/console/preset/research{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 6
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hor)
@@ -35353,12 +34524,8 @@
 	pixel_x = -32
 	},
 /obj/structure/filingcabinet/security,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science)
@@ -35369,12 +34536,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science)
 "bEY" = (
@@ -35387,12 +34551,8 @@
 	icon_state = "0-8"
 	},
 /obj/structure/closet/secure_closet/security/science,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science)
@@ -35793,27 +34953,17 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/lumos/tile/red/fulltile,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science)
 "bGc" = (
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
+	},
+/obj/effect/turf_decal/lumos/tile/green/half{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -35821,10 +34971,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -36318,34 +35465,25 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bHi" = (
 /obj/structure/chair,
-/obj/effect/turf_decal/tile/purple{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bHj" = (
 /obj/item/storage/belt/utility,
 /obj/item/clothing/glasses/science,
 /obj/structure/table/glass,
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -36359,31 +35497,22 @@
 	},
 /obj/item/clothing/ears/earmuffs,
 /obj/structure/table/glass,
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bHl" = (
 /obj/structure/chair,
 /obj/item/clothing/mask/gas,
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bHm" = (
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -36391,14 +35520,11 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/lumos/tile/purple/half{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bHo" = (
@@ -36414,11 +35540,8 @@
 /area/hallway/primary/aft)
 "bHp" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -36443,8 +35566,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/lumos/tile/green/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -37451,27 +36573,18 @@
 	pixel_y = -32
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/green/half,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bJE" = (
 /obj/effect/turf_decal/stripes/corner,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/green/half,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bJG" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/green/half,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bJH" = (
@@ -37484,19 +36597,13 @@
 	dir = 1
 	},
 /obj/machinery/light,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/green/half,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bJJ" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/lumos/tile/green/half,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bJK" = (
@@ -37504,19 +36611,13 @@
 /obj/structure/sign/poster/random{
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/green/half,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bJL" = (
 /obj/machinery/portable_atmospherics/canister/air,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/lumos/tile/green/half,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bJM" = (
@@ -37527,13 +36628,7 @@
 /obj/structure/sign/poster/random{
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/green/fullcorner,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bJN" = (
@@ -43619,6 +42714,17 @@
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/department/engine)
+"bXT" = (
+/obj/machinery/holopad,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/manifold/cyan/hidden/layer1{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "bXU" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -45212,6 +44318,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"cdf" = (
+/obj/structure/rack,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/item/tank/internals/nitrogen/belt,
+/obj/item/tank/internals/nitrogen/belt,
+/obj/item/tank/internals/plasmaman/belt,
+/obj/item/tank/internals/plasmaman/belt,
+/turf/open/floor/plating,
+/area/space/station_ruins)
 "cdg" = (
 /obj/structure/table/glass,
 /obj/item/paper_bin,
@@ -46502,6 +45619,19 @@
 /obj/structure/transit_tube/crossing,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"cil" = (
+/obj/structure/table,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/hatchet,
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "cio" = (
 /obj/structure/closet/cabinet,
 /obj/item/clothing/suit/chaplain/holidaypriest,
@@ -47978,12 +47108,14 @@
 /turf/open/space/basic,
 /area/ai_monitored/turret_protected/AIsatextAS)
 "cnJ" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/vending/wardrobe/sec_wardrobe,
+/obj/machinery/button/door{
+	id = "shootshut";
+	name = "shutters control";
+	pixel_y = 26
+	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
 "cnN" = (
-/obj/structure/closet/secure_closet/security/sec,
 /obj/machinery/camera{
 	c_tag = "Brig Equipment Room"
 	},
@@ -47991,12 +47123,11 @@
 	name = "Station Intercom (General)";
 	pixel_y = 29
 	},
-/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
 "cnP" = (
-/obj/machinery/vending/security,
 /obj/effect/turf_decal/bot,
+/obj/structure/tank_dispenser/oxygen,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
 "cnQ" = (
@@ -48005,13 +47136,18 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
 "cnT" = (
-/obj/structure/weightmachine/weightlifter,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
 "cnV" = (
-/obj/structure/punching_bag,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/main)
+/obj/machinery/requests_console{
+	department = "Prison";
+	departmentType = 1
+	},
+/turf/closed/wall/r_wall,
+/area/space/station_ruins)
 "cnX" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -48115,14 +47251,8 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "cor" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/machinery/door/airlock/external{
-	name = "public external airlock"
-	},
-/turf/open/floor/plating,
-/area/storage/emergency/starboard)
+/turf/open/floor/plasteel/elevatorshaft,
+/area/space/station_ruins)
 "cos" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -48302,16 +47432,7 @@
 	pixel_y = 26;
 	req_access_txt = "28"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "cpi" = (
@@ -48326,16 +47447,7 @@
 	dir = 4
 	},
 /obj/structure/chair/stool/bar,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "cpk" = (
@@ -48397,16 +47509,7 @@
 /area/crew_quarters/kitchen)
 "cpt" = (
 /obj/item/beacon,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "cpu" = (
@@ -48419,6 +47522,9 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hor)
@@ -48687,10 +47793,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "cqi" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/purple/half,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "cql" = (
@@ -48710,11 +47813,8 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "cqp" = (
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/lumos/tile/green/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -48728,10 +47828,7 @@
 	dir = 1
 	},
 /obj/machinery/light,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/purple/half,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "cqv" = (
@@ -48777,18 +47874,12 @@
 /turf/open/floor/plating/airless,
 /area/maintenance/department/engine)
 "cqz" = (
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/green/half,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "cqD" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/green/half,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "cqE" = (
@@ -48796,10 +47887,7 @@
 	icon_state = "plant-18";
 	layer = 3
 	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/green/half,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "cqG" = (
@@ -50888,6 +49976,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/library)
+"czx" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/space/station_ruins)
 "czB" = (
 /obj/structure/table/wood/fancy,
 /obj/item/storage/fancy/candle_box,
@@ -51216,15 +50313,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/library)
-"cAZ" = (
-/obj/machinery/camera{
-	c_tag = "Permabrig Lounge East";
-	dir = 8;
-	network = list("ss13","prison");
-	start_active = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "cBk" = (
 /obj/machinery/vending/boozeomat/pubby_maint,
 /turf/closed/wall,
@@ -51397,6 +50485,15 @@
 /obj/machinery/status_display/ai,
 /turf/closed/wall/r_wall,
 /area/engine/supermatter)
+"cCL" = (
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp/green{
+	pixel_x = -4;
+	pixel_y = 12
+	},
+/obj/item/restraints/handcuffs,
+/turf/open/floor/plasteel,
+/area/security/main)
 "cCO" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -51487,18 +50584,6 @@
 "cDa" = (
 /turf/closed/wall,
 /area/quartermaster/warehouse)
-"cDr" = (
-/obj/machinery/light,
-/obj/machinery/requests_console{
-	department = "Prison";
-	departmentType = 1;
-	pixel_y = -30
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/plasteel/checker,
-/area/security/prison)
 "cDB" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
@@ -51512,19 +50597,9 @@
 /turf/open/space/basic,
 /area/space)
 "cHS" = (
-/obj/machinery/door/airlock/maintenance/abandoned{
-	name = "Firing Range"
-	},
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
-/area/maintenance/department/security/brig)
-"cIn" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/grimy,
-/area/security/prison)
+/obj/structure/grille,
+/turf/open/space/basic,
+/area/space/station_ruins)
 "cKV" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -51542,12 +50617,37 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"cLt" = (
+/obj/machinery/holopad,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "cLw" = (
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
+"cMk" = (
+/obj/machinery/camera{
+	c_tag = "Permabrig Showers";
+	dir = 4;
+	network = list("ss13","prison")
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/space/station_ruins)
 "cOp" = (
 /obj/item/clothing/mask/gas,
 /obj/item/clothing/mask/gas,
@@ -51557,6 +50657,44 @@
 /obj/structure/table,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
+"cPc" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/machinery/camera{
+	c_tag = "Permabrig Garden";
+	dir = 4;
+	network = list("ss13","prison")
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
+"cPn" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/wood,
+/area/space/station_ruins)
+"cPx" = (
+/obj/structure/chair/stool,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "cPy" = (
 /obj/machinery/atmospherics/components/binary/pump,
 /obj/structure/sign/warning/nosmoking{
@@ -51589,33 +50727,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"cRF" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/security/prison)
-"cRH" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/cyan/hidden/layer1,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"cSy" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "cSJ" = (
 /obj/item/reagent_containers/glass/beaker/cryoxadone{
 	pixel_x = -2;
@@ -51667,17 +50778,36 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/lab)
-"cSZ" = (
-/obj/machinery/light{
-	dir = 4
+"cUu" = (
+/obj/structure/table,
+/obj/machinery/computer/libraryconsole,
+/turf/open/floor/wood,
+/area/space/station_ruins)
+"cWb" = (
+/obj/machinery/hydroponics/constructable,
+/obj/machinery/light,
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
 	},
-/turf/open/floor/circuit/green,
-/area/security/prison)
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
+"cXS" = (
+/obj/structure/chair,
+/turf/open/floor/plating,
+/area/maintenance/department/security/brig)
 "cXW" = (
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"cYF" = (
+/obj/machinery/hydroponics/constructable,
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "cZt" = (
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
@@ -51691,13 +50821,6 @@
 /obj/machinery/power/rad_collector/anchored,
 /turf/open/floor/engine,
 /area/engine/supermatter)
-"dat" = (
-/turf/open/floor/circuit/green,
-/area/security/prison)
-"daM" = (
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "daY" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
@@ -51709,13 +50832,18 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "dci" = (
-/obj/structure/rack,
-/obj/item/gun/energy/laser/practice,
-/obj/item/clothing/ears/earmuffs,
-/turf/open/floor/plating,
-/area/maintenance/department/security/brig)
+/obj/structure/lattice,
+/obj/structure/grille,
+/turf/open/space/basic,
+/area/space/station_ruins)
+"dcp" = (
+/obj/machinery/reagentgrinder,
+/obj/structure/table,
+/obj/item/reagent_containers/dropper,
+/turf/open/floor/plasteel/white,
+/area/space/station_ruins)
 "dcL" = (
-/obj/structure/barricade/wooden,
+/obj/item/target/alien,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "dgg" = (
@@ -51767,9 +50895,6 @@
 	name = "Defense"
 	},
 /obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "dir" = (
@@ -51778,20 +50903,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
-"djK" = (
-/obj/machinery/door/airlock/public,
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
-"djN" = (
-/obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/pen/blue,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "dkR" = (
 /obj/effect/turf_decal/box/corners{
 	dir = 4
@@ -51839,6 +50950,20 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"dop" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -24;
+	pixel_y = 28
+	},
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "dpa" = (
 /obj/machinery/light{
 	dir = 1
@@ -51895,6 +51020,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"drj" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/lumos/tile/red/half{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/bar)
 "dse" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -51972,10 +51104,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/security/brig)
-"dvB" = (
-/obj/structure/closet/secure_closet/freezer/fridge/open,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "dxc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -51997,24 +51125,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
-"dxg" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
-/turf/open/floor/circuit,
-/area/security/prison)
-"dxO" = (
-/obj/structure/punching_bag,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
+"dxC" = (
+/obj/machinery/computer/secure_data,
 /turf/open/floor/plasteel,
-/area/security/prison)
+/area/security/main)
 "dye" = (
 /obj/structure/closet/secure_closet/freezer/meat,
 /obj/structure/sign/departments/science{
@@ -52047,6 +51161,19 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/engine,
 /area/science/storage)
+"dBd" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/security/main)
+"dBT" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/condiment/flour,
+/turf/open/floor/plasteel/white,
+/area/space/station_ruins)
 "dCE" = (
 /obj/machinery/light{
 	dir = 8;
@@ -52061,6 +51188,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"dDo" = (
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "dEy" = (
 /obj/machinery/airalarm{
 	dir = 1;
@@ -52071,18 +51209,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
-"dEU" = (
-/obj/machinery/door/airlock/glass{
-	name = "Storage"
-	},
-/obj/machinery/atmospherics/pipe/layer_manifold{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/security/prison)
 "dFJ" = (
 /turf/open/floor/engine,
 /area/engine/supermatter)
+"dGt" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/shutters{
+	id = "shootshut"
+	},
+/turf/open/floor/plating,
+/area/security/main)
 "dHr" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible,
 /obj/machinery/button/door{
@@ -52117,18 +51253,11 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "dIA" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
+/turf/open/floor/plating,
+/area/security/main)
 "dJk" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
@@ -52153,6 +51282,10 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/science)
+"dKx" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/turf/open/floor/wood,
+/area/space/station_ruins)
 "dLt" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -52215,27 +51348,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"dRg" = (
-/obj/machinery/airalarm/directional/east,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"dRV" = (
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/machinery/cryopod{
-	dir = 8
-	},
-/turf/open/floor/circuit/green,
-/area/security/prison)
 "dSp" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/engine_waste{
 	dir = 1
@@ -52246,6 +51358,18 @@
 /obj/item/chair,
 /turf/open/floor/wood,
 /area/maintenance/department/engine)
+"dUt" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/clothing/suit/straight_jacket,
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "dVH" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -52275,16 +51399,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
-"dYe" = (
-/obj/machinery/camera{
-	c_tag = "Permabrig Iso Cell 2";
-	network = list("ss13","prison")
-	},
-/obj/structure/bed,
-/turf/open/floor/mineral/titanium/white{
-	name = "secure isolation floor"
-	},
-/area/security/prison)
 "dZj" = (
 /obj/machinery/atmospherics/pipe/manifold/green/visible,
 /obj/machinery/airalarm/engine{
@@ -52295,11 +51409,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/supermatter)
-"eal" = (
-/obj/machinery/light,
-/obj/structure/reagent_dispensers/cooking_oil,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "eaw" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -52313,6 +51422,19 @@
 	},
 /turf/open/floor/plating,
 /area/lawoffice)
+"eca" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass{
+	name = "Sleepers"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
+"ecj" = (
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/wood,
+/area/space/station_ruins)
 "edl" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -52324,11 +51446,6 @@
 /obj/effect/landmark/start/scientist,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"eeu" = (
-/obj/structure/table,
-/obj/machinery/computer/libraryconsole,
-/turf/open/floor/wood,
-/area/security/prison)
 "eex" = (
 /obj/machinery/status_display/supply,
 /turf/closed/wall,
@@ -52357,11 +51474,21 @@
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
 "egK" = (
-/obj/structure/girder,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
+/obj/structure/table,
+/obj/item/clothing/head/beret,
+/turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"ehK" = (
+/obj/machinery/airalarm/directional/east,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "ehM" = (
 /obj/effect/decal/remains/human,
 /obj/structure/disposaloutlet,
@@ -52403,21 +51530,25 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
-"elg" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/structure/table,
-/obj/structure/bedsheetbin,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "elk" = (
 /obj/structure/chair/office/dark,
 /turf/open/floor/wood,
 /area/lawoffice)
+"enN" = (
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/space/station_ruins)
+"enT" = (
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#cee5d2"
+	},
+/obj/machinery/vending/cola/random,
+/turf/open/floor/plasteel/cafeteria,
+/area/space/station_ruins)
 "epg" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -52431,16 +51562,38 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/dorms)
 "epJ" = (
-/obj/structure/sign/poster/contraband/random{
-	pixel_y = 32
+/obj/structure/lattice,
+/obj/machinery/camera{
+	c_tag = "Permabrig Space Northwest";
+	dir = 1;
+	name = "aft camera"
 	},
-/turf/open/floor/carpet,
-/area/maintenance/department/crew_quarters/dorms)
+/turf/open/space/basic,
+/area/space/station_ruins)
+"epU" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/engine,
+/area/medical/chemistry)
 "epV" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"eqA" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Library"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/space/station_ruins)
 "eqD" = (
 /obj/structure/sign/poster/contraband/random{
 	pixel_x = -32
@@ -52480,10 +51633,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"exJ" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/security/prison)
 "eyj" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating,
@@ -52500,6 +51649,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"eAy" = (
+/obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "eAH" = (
 /obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
 	dir = 4
@@ -52529,28 +51685,12 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"eCH" = (
-/obj/machinery/computer/arcade,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "eDC" = (
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
-"eEl" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/security/prison)
 "eEp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -52581,6 +51721,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"eFR" = (
+/obj/structure/lattice,
+/obj/machinery/camera{
+	c_tag = "Permabrig Space East";
+	dir = 4;
+	name = "aft camera"
+	},
+/turf/open/space/basic,
+/area/space/station_ruins)
+"eGB" = (
+/obj/machinery/deepfryer,
+/turf/open/floor/plasteel/white,
+/area/space/station_ruins)
 "eHI" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
@@ -52604,10 +51757,38 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
-"eLl" = (
-/obj/structure/sign/warning/electricshock,
-/turf/closed/wall/r_wall,
-/area/security/prison)
+"eIW" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/space,
+/area/solar/port)
+"eKC" = (
+/obj/structure/table,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/item/camera,
+/obj/item/camera_film,
+/obj/item/storage/photo_album,
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
+"eKN" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "eLt" = (
 /obj/structure/closet/firecloset,
 /obj/effect/turf_decal/tile/neutral{
@@ -52622,12 +51803,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
-"eLP" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/vaporwave,
-/area/security/prison)
 "eNc" = (
 /obj/effect/spawner/lootdrop/maintenance{
 	lootcount = 3;
@@ -52644,6 +51819,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/explab)
+"eNz" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "eNF" = (
 /obj/structure/grille,
 /obj/structure/lattice,
@@ -52656,14 +51840,15 @@
 /obj/item/gavelhammer,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
-"ePO" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+"ePb" = (
+/obj/machinery/camera{
+	c_tag = "Permabrig Visitations Prisoner-side";
+	dir = 8;
+	network = list("ss13","prison");
+	start_active = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/manifold4w/cyan/hidden/layer1,
 /turf/open/floor/plasteel,
-/area/security/prison)
+/area/space/station_ruins)
 "ePU" = (
 /obj/machinery/light/small,
 /obj/machinery/atmospherics/pipe/layer_manifold{
@@ -52690,28 +51875,6 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/security/brig)
-"eRe" = (
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"eRo" = (
-/obj/structure/table,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/item/instrument/accordion,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "eSB" = (
 /obj/structure/chair{
 	dir = 4
@@ -52766,6 +51929,18 @@
 /obj/item/stack/cable_coil/cut/random,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"faI" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "fdS" = (
 /obj/machinery/door/window/southleft{
 	dir = 4;
@@ -52800,31 +51975,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"feI" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+"feH" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/preopen{
-	id = "permalock2"
-	},
-/obj/machinery/button/door{
-	id = "soli1";
-	name = "Solitary Cell 1";
-	pixel_x = 26;
-	pixel_y = 10;
-	req_access_txt = "3"
-	},
-/obj/machinery/door_timer{
-	id = "soli1";
-	name = "Solitary 1 door timer";
-	pixel_x = 31;
-	pixel_y = -5
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/cyan/hidden/layer1{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
-/area/security/prison)
+/area/space/station_ruins)
 "ffJ" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -52838,6 +52001,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
+"ffQ" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "fhM" = (
 /obj/item/storage/secure/safe{
 	pixel_x = -22
@@ -52848,14 +52020,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
-"fiS" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24;
-	pixel_y = 28
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "fjs" = (
 /obj/machinery/light{
 	dir = 8
@@ -52877,6 +52041,32 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engine/supermatter)
+"fkz" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/loading_area{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4;
+	layer = 2.9
+	},
+/obj/machinery/conveyor/auto{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
+"fkG" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "fkH" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -52889,19 +52079,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/explab)
-"flK" = (
-/obj/structure/chair/stool,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "fmh" = (
 /turf/open/floor/wood,
 /area/maintenance/department/engine)
@@ -52915,6 +52092,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
+"fnl" = (
+/obj/structure/closet/secure_closet/freezer/fridge/open,
+/turf/open/floor/plasteel/white,
+/area/space/station_ruins)
 "fon" = (
 /obj/structure/lattice,
 /obj/structure/grille,
@@ -52951,6 +52132,10 @@
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/department/engine)
+"ftO" = (
+/obj/structure/chair/stool,
+/turf/open/floor/plasteel/cafeteria,
+/area/space/station_ruins)
 "ftW" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -52979,6 +52164,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"fvX" = (
+/obj/machinery/holopad,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "fwe" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -52991,6 +52185,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
+"fxz" = (
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "fxC" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/closed/wall/r_wall,
@@ -53039,6 +52246,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
+"fzv" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/machinery/vending/hydronutrients/prisoner,
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "fAx" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -53049,6 +52266,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"fAM" = (
+/obj/structure/chair/stool,
+/turf/open/floor/plasteel/dark,
+/area/maintenance/department/crew_quarters/dorms)
 "fBt" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -53075,18 +52296,17 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
+"fBH" = (
+/obj/machinery/hydroponics/constructable,
+/obj/machinery/holopad,
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "fBZ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
 /turf/open/floor/engine,
 /area/engine/supermatter)
-"fDA" = (
-/obj/machinery/reagentgrinder,
-/obj/structure/table,
-/obj/item/reagent_containers/dropper,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "fFv" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -53108,6 +52328,28 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/science/storage)
+"fGY" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/structure/bedsheetbin,
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
+"fIo" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "fIu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -53118,24 +52360,38 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/dorms)
 "fIN" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/open/floor/plating,
-/area/maintenance/department/security/brig)
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/vending/kink,
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "fIT" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/chapel/main/monastery)
 "fJn" = (
-/obj/structure/lattice,
-/obj/machinery/camera{
-	c_tag = "Permabrig Space North";
-	dir = 1;
-	name = "aft camera"
+/obj/machinery/airalarm/directional/north,
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
+"fJq" = (
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
+"fJx" = (
+/obj/structure/table,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "fKj" = (
 /obj/machinery/door/airlock/maintenance/abandoned{
 	name = "Mineral Room"
@@ -53146,22 +52402,17 @@
 /obj/effect/decal/remains/xeno,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"fLT" = (
-/obj/machinery/light,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "fNv" = (
 /obj/structure/chair{
 	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"fON" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel/white,
+/area/space/station_ruins)
 "fQf" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -53196,9 +52447,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"fRc" = (
+/obj/machinery/camera{
+	c_tag = "Permabrig Cell Hallway 1";
+	dir = 4;
+	network = list("ss13","prison")
+	},
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "fRs" = (
 /turf/closed/wall,
 /area/crew_quarters/heads/hor)
+"fTo" = (
+/obj/structure/chair/stool,
+/obj/machinery/light,
+/turf/open/floor/plasteel/cafeteria,
+/area/space/station_ruins)
 "fTY" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -53251,11 +52515,29 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
+"gbM" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/space/station_ruins)
+"gca" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 5
+	},
+/turf/open/floor/plasteel/checker,
+/area/space/station_ruins)
 "gcj" = (
-/obj/machinery/vending/kink,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/machinery/vending/autodrobe,
 /turf/open/floor/plasteel/white/corner{
 	dir = 1
 	},
@@ -53431,19 +52713,6 @@
 /obj/machinery/portable_atmospherics/pump,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"gpd" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Pressing Room"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel/checker,
-/area/security/prison)
 "gpC" = (
 /obj/structure/chair,
 /obj/machinery/light{
@@ -53465,15 +52734,6 @@
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
-"gqv" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "gsF" = (
 /obj/structure/chair{
 	dir = 4
@@ -53506,13 +52766,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
-"guD" = (
-/obj/machinery/computer/cryopod{
-	dir = 8;
-	pixel_x = 26
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "gvf" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -53521,13 +52774,20 @@
 	heat_capacity = 1e+006
 	},
 /area/hallway/secondary/exit/departure_lounge)
+"gvS" = (
+/obj/structure/lattice,
+/obj/machinery/camera{
+	c_tag = "Permabrig Space southwest";
+	dir = 8;
+	name = "aft camera"
+	},
+/turf/open/space/basic,
+/area/space/station_ruins)
 "gwn" = (
 /obj/structure/sign/warning{
 	pixel_y = 32
 	},
-/obj/structure/sign/warning{
-	pixel_y = -32
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "gxe" = (
@@ -53561,6 +52821,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
+"gxJ" = (
+/obj/effect/turf_decal/lumos/tile/green/half{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "gxK" = (
 /obj/machinery/light/small{
 	dir = 1;
@@ -53571,6 +52837,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"gAr" = (
+/obj/structure/sign/nanotrasen,
+/turf/closed/wall,
+/area/space/station_ruins)
 "gAG" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green,
@@ -53663,11 +52933,14 @@
 /turf/open/floor/plasteel/dark,
 /area/science/lab)
 "gGy" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/open/floor/plating,
-/area/maintenance/department/security/brig)
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/space/station_ruins)
 "gGA" = (
 /obj/structure/table/glass,
 /obj/machinery/reagentgrinder,
@@ -53687,26 +52960,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"gIz" = (
+"gIo" = (
+/obj/structure/table,
+/obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24;
-	pixel_y = 28
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/cyan/hidden/layer1{
-	dir = 8
-	},
+/obj/item/toy/cards/deck,
 /turf/open/floor/plasteel,
-/area/security/prison)
+/area/space/station_ruins)
 "gIC" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -53730,23 +52992,23 @@
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "gJF" = (
-/obj/structure/lattice,
-/obj/machinery/camera,
-/turf/open/space,
-/area/space/nearstation)
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/wood,
+/area/space/station_ruins)
+"gKc" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/security/main)
 "gKd" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
 /area/hallway/secondary/entry)
-"gKv" = (
-/obj/structure/punching_bag,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "gKz" = (
 /obj/structure/table/wood,
 /obj/item/kirbyplants{
@@ -53779,17 +53041,42 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
-"gLW" = (
-/obj/machinery/shower{
-	dir = 8
+"gLY" = (
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/item/soap/homemade,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/prison)
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#c1caff"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "gMO" = (
 /obj/structure/plasticflaps/opaque,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"gMP" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -24;
+	pixel_y = 28
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/cyan/hidden/layer1{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "gNv" = (
 /obj/structure/sign/poster/contraband/random{
 	pixel_x = 32
@@ -53808,16 +53095,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"gOH" = (
-/obj/machinery/light,
-/obj/structure/sign/poster/official/random{
-	pixel_y = -32
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 5
-	},
-/turf/open/floor/wood,
-/area/security/prison)
 "gQf" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -53846,6 +53123,21 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"gTP" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "gUb" = (
 /obj/structure/chair/office/dark{
 	dir = 4
@@ -53857,20 +53149,21 @@
 	icon_state = "wood-broken4"
 	},
 /area/maintenance/department/engine)
-"gVK" = (
-/obj/machinery/light{
+"gVH" = (
+/obj/structure/table,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24;
-	pixel_y = 28
+/obj/item/instrument/accordion,
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
+"gWI" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
 	},
-/obj/machinery/vr_sleeper{
-	dir = 4
-	},
-/turf/open/floor/circuit,
-/area/security/prison)
+/turf/open/floor/plating,
+/area/security/main)
 "gXg" = (
 /obj/item/extinguisher,
 /obj/structure/closet/crate{
@@ -53902,11 +53195,23 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"haP" = (
-/obj/item/caution,
-/obj/item/caution,
-/turf/open/floor/plating,
-/area/security/prison)
+"hcf" = (
+/obj/machinery/airalarm/directional/west,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
+"hcS" = (
+/obj/machinery/camera{
+	c_tag = "Permabrig Space Southeast"
+	},
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/station_ruins)
 "heC" = (
 /obj/machinery/power/apc/highcap/five_k{
 	dir = 8;
@@ -53918,12 +53223,17 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/department/science)
-"heX" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+"hfp" = (
+/obj/machinery/holopad,
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/cyan/hidden/layer1{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/security/prison)
+/area/space/station_ruins)
 "hfZ" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/machinery/requests_console{
@@ -53936,30 +53246,26 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "hiw" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
 /obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/security/brig)
-"hiB" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Garden"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/security/prison)
+/turf/open/floor/wood,
+/area/space/station_ruins)
 "hiY" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=Sci4";
 	location = "Sci3"
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/purple/half,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "hjk" = (
@@ -53980,6 +53286,15 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"hki" = (
+/obj/structure/table/wood,
+/obj/item/folder/red,
+/obj/item/pen,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/main)
 "hkQ" = (
 /obj/machinery/light{
 	dir = 4
@@ -53989,6 +53304,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"hlU" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "hnu" = (
 /obj/machinery/button/door{
 	id = "lawyer_shutters";
@@ -54009,22 +53335,10 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"hoq" = (
-/obj/machinery/hydroponics/constructable,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"hoB" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Visitation - Prisoners"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/preopen{
-	id = "visitexit"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
-/turf/open/floor/plasteel,
-/area/security/prison)
+"hoC" = (
+/obj/machinery/door/airlock/public,
+/turf/open/floor/plasteel/dark,
+/area/space/station_ruins)
 "hoS" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 6
@@ -54050,50 +53364,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"hqv" = (
-/obj/machinery/hydroponics/constructable,
-/obj/machinery/holopad,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"hqU" = (
-/obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/security/prison)
-"hrr" = (
+"hue" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/jukebox{
-	req_one_access = null
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
+/obj/machinery/vending/clothing,
 /turf/open/floor/plasteel,
-/area/security/prison)
-"hrP" = (
-/obj/item/toy/beach_ball/holoball,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/security/prison)
-"hrT" = (
-/obj/machinery/space_heater,
-/turf/open/floor/plating,
-/area/security/prison)
-"hue" = (
-/obj/structure/lattice,
-/obj/machinery/camera{
-	c_tag = "Permabrig Space southwest";
-	dir = 8;
-	name = "aft camera"
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/area/space/station_ruins)
 "hvW" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio4";
@@ -54169,16 +53449,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port)
-"hBx" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
+"hzz" = (
+/obj/structure/lattice,
+/turf/open/space,
+/area/solar/port)
 "hCb" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Monastery Transit"
@@ -54187,20 +53461,6 @@
 	heat_capacity = 1e+006
 	},
 /area/hallway/secondary/entry)
-"hDs" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "hDG" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Auxillary Base Construction";
@@ -54222,21 +53482,25 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/science)
-"hFy" = (
-/obj/structure/sign/warning/vacuum/external{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"hGv" = (
-/obj/machinery/camera{
-	c_tag = "Permabrig Pressing Room";
+"hFv" = (
+/obj/machinery/airalarm{
 	dir = 4;
-	network = list("ss13","prison")
+	pixel_x = -22
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
-/turf/open/floor/plasteel/checker,
-/area/security/prison)
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/turf/open/floor/plasteel/freezer,
+/area/crew_quarters/toilet/auxiliary)
+"hFy" = (
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
+	},
+/turf/open/floor/circuit/green,
+/area/space/station_ruins)
 "hGB" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -54246,23 +53510,16 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"hGU" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "hHr" = (
 /obj/structure/chair/comfy/black{
 	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"hHA" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/turf/open/floor/plasteel,
+/area/security/main)
 "hIp" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -54290,10 +53547,6 @@
 /obj/machinery/power/rad_collector/anchored,
 /turf/open/floor/engine,
 /area/engine/supermatter)
-"hKq" = (
-/obj/effect/landmark/start/prisoner/prilate,
-/turf/open/floor/circuit/green,
-/area/security/prison)
 "hOx" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -54321,22 +53574,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
-"hPQ" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#cee5d2"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/structure/closet/crate/bin,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "hPU" = (
 /obj/structure/table/optable{
 	name = "Robotics Operating Table"
@@ -54440,6 +53677,17 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"hUl" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/airalarm/directional/east,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "hUt" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
@@ -54452,29 +53700,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engine/engineering)
-"hUC" = (
-/obj/machinery/camera{
-	c_tag = "Permabrig Sleepers";
-	dir = 1;
-	network = list("ss13","prison")
-	},
-/obj/machinery/light{
-	light_color = "#cee5d2"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"hVl" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/security/prison)
 "hVx" = (
 /obj/structure/chair{
 	dir = 4
@@ -54485,19 +53710,6 @@
 /obj/structure/girder,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"hXy" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/camera{
-	c_tag = "Permabrig East";
-	dir = 8;
-	network = list("ss13","prison");
-	start_active = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "hXK" = (
 /obj/structure/chair/office/dark{
 	dir = 4
@@ -54533,21 +53745,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"hZG" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/security/prison)
 "iab" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
@@ -54563,6 +53760,19 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
+"ibA" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "ick" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -54577,20 +53787,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/engine,
 /area/engine/engineering)
-"ieP" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"ifS" = (
-/obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
 "igE" = (
 /obj/structure/table/reinforced,
 /obj/machinery/button/door{
@@ -54625,6 +53821,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"iid" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/preopen{
+	id = "permalock2"
+	},
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
+"iiX" = (
+/turf/open/floor/plasteel/white,
+/area/space/station_ruins)
 "ijF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
@@ -54657,19 +53863,13 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "imj" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "imE" = (
 /obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -54710,17 +53910,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"ior" = (
-/obj/machinery/holopad,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/manifold/cyan/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "ioF" = (
 /obj/structure/closet/secure_closet/engineering_electrical,
 /obj/effect/turf_decal/stripes/corner{
@@ -54728,9 +53917,71 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"ioG" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
+"ipj" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
+"ipu" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
+"ipP" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/camera{
+	c_tag = "Permabrig East Hallway 2";
+	dir = 8;
+	network = list("ss13","prison");
+	start_active = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "iqc" = (
-/turf/open/floor/plasteel/stairs/right,
+/obj/structure/musician/piano,
+/turf/open/floor/plasteel/dark,
 /area/maintenance/department/crew_quarters/dorms)
+"iqx" = (
+/obj/machinery/atmospherics/components/binary/valve/on{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/space/station_ruins)
+"isH" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/manifold/cyan/hidden/layer1{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/space/station_ruins)
 "itl" = (
 /obj/structure/sign/departments/xenobio{
 	pixel_y = 32
@@ -54776,15 +54027,6 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
 /turf/open/floor/plasteel/dark,
 /area/security/armory)
-"ixK" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "iyg" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -54851,6 +54093,16 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plating,
 /area/security/execution/transfer)
+"iEH" = (
+/obj/machinery/light,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "iEQ" = (
 /obj/structure/table,
 /obj/item/storage/box/lights/mixed,
@@ -54881,10 +54133,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
-"iJz" = (
-/obj/structure/chair/stool,
-/turf/open/floor/wood,
-/area/security/prison)
 "iKb" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -54903,6 +54151,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
+"iMx" = (
+/obj/structure/mopbucket,
+/obj/item/mop,
+/obj/item/reagent_containers/glass/bucket,
+/turf/open/floor/plating,
+/area/space/station_ruins)
+"iOi" = (
+/obj/machinery/door/poddoor{
+	id = "soli2"
+	},
+/turf/open/floor/mineral/titanium/white{
+	name = "secure isolation floor"
+	},
+/area/space/station_ruins)
 "iPj" = (
 /obj/machinery/igniter{
 	id = "xenoigniter";
@@ -54956,20 +54218,33 @@
 	},
 /turf/open/floor/plating,
 /area/security/execution/transfer)
-"iSe" = (
-/obj/effect/turf_decal/tile/blue{
+"iQz" = (
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -22
+	},
+/turf/open/floor/plasteel/grimy,
+/area/space/station_ruins)
+"iQQ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/plasteel/dark,
+/area/medical/morgue)
+"iRm" = (
+/obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/obj/structure/closet/crate/bin,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
 /turf/open/floor/plasteel,
-/area/security/prison)
+/area/space/station_ruins)
 "iSz" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -54983,6 +54258,24 @@
 /obj/structure/sign/warning/electricshock,
 /turf/closed/wall/r_wall,
 /area/engine/supermatter)
+"iVl" = (
+/obj/machinery/light,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/space/station_ruins)
+"iVw" = (
+/obj/machinery/seed_extractor,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "iVJ" = (
 /obj/effect/spawner/lootdrop/organ_spawner,
 /turf/open/floor/plating{
@@ -55004,14 +54297,17 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/department/chapel/monastery)
+"iZZ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/security/main)
 "jcT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"jdk" = (
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/prison)
 "jeq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -55031,6 +54327,16 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
+"jfc" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "jgr" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Library"
@@ -55042,6 +54348,13 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/library)
+"jgH" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/cyan/hidden/layer1,
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "jhk" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -55067,6 +54380,19 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/crew_quarters/dorms)
+"jia" = (
+/obj/machinery/cryopod{
+	dir = 8
+	},
+/turf/open/floor/circuit/green,
+/area/space/station_ruins)
+"jiV" = (
+/obj/structure/window/reinforced,
+/obj/machinery/conveyor/auto{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "jjC" = (
 /obj/structure/rack,
 /obj/item/storage/briefcase{
@@ -55079,29 +54405,24 @@
 	},
 /turf/open/floor/wood,
 /area/lawoffice)
-"jlV" = (
-/obj/machinery/shower{
-	dir = 4
+"jjI" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/prison)
-"jnr" = (
-/obj/structure/closet/crate/bin,
-/obj/machinery/requests_console{
-	department = "Prison";
-	departmentType = 1;
-	pixel_y = -30
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
+/turf/open/space,
+/area/solar/port)
+"jkW" = (
+/obj/machinery/camera{
+	c_tag = "Permabrig Kitchen";
+	network = list("ss13","prison")
+	},
+/obj/machinery/processor,
 /turf/open/floor/plasteel/white,
-/area/security/prison)
-"jnP" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/condiment/enzyme{
-	layer = 5
-	},
-/obj/item/reagent_containers/food/condiment/sugar,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
+/area/space/station_ruins)
 "jrG" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -55120,9 +54441,11 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "jsf" = (
-/obj/item/toy/katana,
-/turf/open/floor/plating,
-/area/maintenance/department/security/brig)
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/circuit/green,
+/area/space/station_ruins)
 "jsj" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -55162,6 +54485,12 @@
 /obj/machinery/atmospherics/pipe/simple/violet/hidden,
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
+"juv" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "jvi" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -55178,10 +54507,20 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
-"jxi" = (
-/obj/machinery/vending/cola/random,
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
+"jwm" = (
+/obj/machinery/computer/cryopod{
+	dir = 8;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
+"jwo" = (
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#cee5d2"
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/space/station_ruins)
 "jxl" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -55248,19 +54587,39 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"jCM" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/cyan/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "jDA" = (
 /obj/item/chair,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/science)
-"jDL" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#cee5d2"
+"jDZ" = (
+/obj/structure/rack,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/tank/internals/emergency_oxygen,
+/obj/item/tank/internals/emergency_oxygen,
+/obj/item/tank/internals/emergency_oxygen,
+/obj/item/tank/internals/emergency_oxygen,
+/turf/open/floor/plating,
+/area/space/station_ruins)
+"jEd" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
 	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/prison)
+/turf/open/floor/wood,
+/area/space/station_ruins)
 "jEX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -55286,17 +54645,41 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
-"jLT" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-4"
+"jIn" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
-/turf/open/floor/plating,
-/area/security/prison)
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/camera{
+	c_tag = "Permabrig West Hallway 2";
+	dir = 4;
+	network = list("ss13","prison")
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
+"jIO" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/wood,
+/area/space/station_ruins)
 "jLW" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
+"jMl" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "jNW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -55315,6 +54698,20 @@
 /obj/item/kitchen/knife,
 /turf/open/floor/plasteel,
 /area/maintenance/department/engine)
+"jPQ" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -24;
+	pixel_y = 28
+	},
+/obj/machinery/vr_sleeper{
+	dir = 4
+	},
+/turf/open/floor/circuit,
+/area/space/station_ruins)
 "jQh" = (
 /obj/item/stack/sheet/animalhide/xeno,
 /turf/open/floor/plating{
@@ -55334,30 +54731,9 @@
 /obj/machinery/door/airlock/maintenance,
 /turf/open/floor/plating,
 /area/chapel/main/monastery)
-"jSx" = (
-/obj/machinery/camera{
-	c_tag = "Permabrig Visitations Prisoner-side";
-	dir = 8;
-	network = list("ss13","prison");
-	start_active = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "jTc" = (
-/obj/machinery/airalarm{
-	pixel_y = 23
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
+/turf/closed/wall/r_wall,
+/area/security/main)
 "jTh" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -55400,15 +54776,17 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"jWn" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
+"jWW" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
 /turf/open/floor/plasteel,
-/area/security/prison)
+/area/space/station_ruins)
 "jXh" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -55441,6 +54819,14 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/engine)
+"jYk" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/drinks/drinkingglass,
+/turf/open/floor/plasteel/cafeteria,
+/area/space/station_ruins)
+"jYW" = (
+/turf/open/floor/plating,
+/area/space/station_ruins)
 "jZG" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "chemistry_shutters";
@@ -55458,20 +54844,15 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"kev" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
+"kdo" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/security/prison)
+/turf/open/floor/wood,
+/area/space/station_ruins)
 "keD" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -55489,24 +54870,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/science/mixing)
-"kfz" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/security/prison)
 "kfM" = (
 /obj/structure/closet,
 /obj/machinery/light/small,
@@ -55525,6 +54888,25 @@
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"khD" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
+"kjy" = (
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "kjK" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "MiniSat Maintenance";
@@ -55545,16 +54927,6 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/crew_quarters/dorms)
-"kkO" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/machinery/vending/clothing,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "kkQ" = (
 /obj/machinery/vending/cola/pwr_game,
 /turf/open/floor/plating{
@@ -55586,16 +54958,26 @@
 "kmn" = (
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
-"knW" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/item/reagent_containers/food/condiment/peppermill,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "koE" = (
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space)
+"koU" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "kpK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
@@ -55613,12 +54995,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"ksn" = (
+"kul" = (
 /obj/machinery/light{
+	dir = 4;
+	light_color = "#c1caff"
+	},
+/obj/machinery/cryopod{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/security/prison)
+/turf/open/floor/circuit/green,
+/area/space/station_ruins)
 "kvj" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -55632,18 +55018,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"kvm" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "kwm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
@@ -55671,6 +55045,18 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"kxv" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/space/station_ruins)
+"kxC" = (
+/obj/structure/sign/poster/official/random{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/space/station_ruins)
 "kyv" = (
 /obj/structure/closet/secure_closet/engineering_personal,
 /obj/effect/turf_decal/stripes/line{
@@ -55687,13 +55073,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"kzB" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/wood,
-/area/security/prison)
+"kzd" = (
+/obj/structure/rack,
+/obj/item/flashlight,
+/obj/item/storage/bag/trash,
+/obj/item/radio/off,
+/turf/open/floor/plating,
+/area/space/station_ruins)
 "kAa" = (
 /obj/structure/chair{
 	dir = 8
@@ -55722,20 +55108,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/hallway/secondary/entry)
-"kCP" = (
-/obj/machinery/holopad,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
+"kCU" = (
+/obj/structure/sign/departments/security{
+	pixel_y = 32
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 4
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/security/prison)
+/area/hallway/primary/fore)
 "kDf" = (
 /obj/machinery/light/small,
 /turf/open/floor/carpet/black,
@@ -55749,6 +55130,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"kDR" = (
+/obj/structure/table,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "kDY" = (
 /obj/item/shard{
 	icon_state = "small"
@@ -55832,14 +55226,6 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
-"kHc" = (
-/obj/structure/chair/stool,
-/obj/machinery/camera{
-	c_tag = "Permabrig Cafeteria";
-	network = list("ss13","prison")
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
 "kHx" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
@@ -55879,41 +55265,49 @@
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "kJw" = (
-/obj/machinery/door/airlock/maintenance/abandoned{
-	name = "Firing Range Target"
-	},
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
-/area/maintenance/department/security/brig)
-"kKe" = (
-/obj/structure/toilet{
-	contents = newlist(/obj/item/toy/snappop/phoenix);
-	dir = 4
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
-"kKt" = (
-/obj/machinery/airalarm{
+/obj/structure/lattice,
+/obj/machinery/camera{
+	c_tag = "Permabrig Space Northeast";
 	dir = 1;
-	pixel_y = -22
+	name = "aft camera"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
+/turf/open/space/basic,
+/area/space/station_ruins)
+"kJx" = (
+/obj/machinery/camera{
+	c_tag = "Permabrig Iso Cell 1";
+	network = list("ss13","prison")
 	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 4
+/obj/structure/bed,
+/turf/open/floor/mineral/titanium/white{
+	name = "secure isolation floor"
+	},
+/area/space/station_ruins)
+"kKv" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "sexroom"
 	},
 /turf/open/floor/plasteel,
-/area/security/prison)
+/area/space/station_ruins)
 "kKI" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/structure/closet,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"kML" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "kNf" = (
 /obj/machinery/door/window/northleft{
 	base_state = "right";
@@ -55945,20 +55339,6 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/science)
-"kPs" = (
-/obj/machinery/shower{
-	dir = 4
-	},
-/obj/item/soap,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/prison)
-"kQl" = (
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
-	},
-/turf/open/floor/circuit/green,
-/area/security/prison)
 "kQy" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -55998,19 +55378,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
-"kRM" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/camera{
-	c_tag = "Permabrig Cell Hallway 2";
-	dir = 8;
-	network = list("ss13","prison");
-	start_active = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "kSb" = (
 /obj/structure/lattice,
 /obj/structure/grille,
@@ -56053,11 +55420,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"kTN" = (
-/obj/machinery/plate_press,
-/obj/item/stack/license_plates/empty/fifty,
-/turf/open/floor/plasteel/checker,
-/area/security/prison)
+"kTE" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/turf/open/floor/wood,
+/area/space/station_ruins)
 "kTR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
@@ -56065,25 +55431,33 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
+"kUq" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/snacks/hotdog,
+/turf/open/floor/plasteel/cafeteria,
+/area/space/station_ruins)
+"kUE" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "kVy" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
 /area/hallway/secondary/entry)
-"kVK" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
-/turf/open/floor/wood,
-/area/security/prison)
-"kWr" = (
-/obj/effect/turf_decal/tile/green{
+"kWw" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/security/prison)
+/area/space/station_ruins)
 "kWQ" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /obj/structure/cable/yellow{
@@ -56114,37 +55488,27 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
-"kYK" = (
-/obj/machinery/holopad,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "kYM" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
 	},
 /obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"kZm" = (
+/obj/machinery/airalarm/directional/east,
+/obj/structure/closet/crate/bin,
+/turf/open/floor/plasteel/cafeteria,
+/area/space/station_ruins)
+"law" = (
+/obj/structure/lattice/catwalk,
+/obj/item/stack/cable_coil,
+/turf/open/space,
+/area/solar/port)
 "lcU" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/security/brig)
-"lcY" = (
-/obj/item/bedsheet/rd/royal_cape,
-/obj/structure/bed/pod,
-/turf/open/floor/plasteel/vaporwave,
-/area/security/prison)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "lcZ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -56170,13 +55534,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/execution/transfer)
-"leW" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#cee5d2"
-	},
-/turf/open/floor/wood,
-/area/security/prison)
 "lfx" = (
 /obj/structure/table,
 /obj/item/clothing/suit/hooded/wintercoat/engineering,
@@ -56214,6 +55571,12 @@
 /obj/machinery/atmospherics/pipe/simple/general/hidden,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"ljq" = (
+/obj/structure/rack,
+/obj/item/extinguisher,
+/obj/item/clothing/mask/gas,
+/turf/open/floor/plating,
+/area/storage/emergency/starboard)
 "ljG" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 6
@@ -56249,6 +55612,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"llv" = (
+/obj/machinery/plate_chute/inputchute{
+	pixel_y = -25
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
+	},
+/turf/open/floor/plasteel/checker,
+/area/space/station_ruins)
 "lms" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
@@ -56283,13 +55655,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"lpz" = (
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "lqc" = (
 /obj/item/toy/gun,
 /obj/effect/decal/cleanable/oil,
@@ -56304,15 +55669,15 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/library/lounge)
-"lrf" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
+"lrk" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 4
+/obj/effect/turf_decal/tile/green{
+	dir = 1
 	},
-/turf/open/floor/plasteel/white,
-/area/security/prison)
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "lrM" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -56320,53 +55685,41 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"lvP" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+"luT" = (
+/obj/structure/barricade/wooden,
+/turf/open/floor/plating,
+/area/maintenance/department/security/brig)
+"luY" = (
+/obj/machinery/door/airlock/glass{
+	name = "Storage"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"lvR" = (
-/obj/structure/table,
-/obj/machinery/chem_dispenser/drinks/beer,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
-"lxp" = (
-/obj/machinery/atmospherics/components/unary/tank/air{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
 	},
 /turf/open/floor/plating,
-/area/security/prison)
+/area/space/station_ruins)
+"lvA" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/security/main)
 "lxI" = (
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/department/chapel/monastery)
-"lyl" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
+"lyn" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "0-2"
 	},
-/turf/open/floor/plasteel/grimy,
-/area/security/prison)
-"lzt" = (
-/obj/machinery/holopad,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
-/turf/open/floor/plasteel,
-/area/security/prison)
+/turf/open/space,
+/area/solar/port)
 "lzJ" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/carpet,
@@ -56400,15 +55753,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"lDf" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#cee5d2"
-	},
-/obj/structure/table,
-/obj/machinery/chem_dispenser/drinks,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "lEn" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -56417,6 +55761,16 @@
 /obj/structure/window/reinforced,
 /turf/open/space/basic,
 /area/space/nearstation)
+"lEY" = (
+/obj/machinery/light,
+/obj/structure/sign/poster/official/random{
+	pixel_y = -32
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 5
+	},
+/turf/open/floor/wood,
+/area/space/station_ruins)
 "lFh" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -56430,6 +55784,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
+"lGd" = (
+/obj/machinery/button/door{
+	id = "permalock2";
+	name = "Perma Secure Airlock";
+	pixel_y = -26;
+	req_access_txt = "3"
+	},
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "lGv" = (
 /obj/machinery/door/airlock/atmos/abandoned{
 	name = "Atmospherics Maintenance";
@@ -56440,6 +55803,9 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"lGA" = (
+/turf/open/floor/plasteel/showroomfloor/shower,
+/area/space/station_ruins)
 "lGS" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -56463,6 +55829,14 @@
 /obj/item/bedsheet/orange,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"lIi" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "lIr" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -56484,6 +55858,27 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"lJY" = (
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/machinery/cryopod{
+	dir = 8
+	},
+/turf/open/floor/circuit/green,
+/area/space/station_ruins)
+"lKk" = (
+/turf/closed/wall,
+/area/space/station_ruins)
+"lKw" = (
+/obj/structure/closet/crate/bin,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/wood,
+/area/space/station_ruins)
 "lKL" = (
 /obj/machinery/door/airlock/abandoned{
 	name = "Starboard Emergency Storage"
@@ -56497,18 +55892,36 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
-"lNU" = (
-/obj/machinery/atmospherics/components/binary/valve{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/plating,
-/area/security/prison)
+"lNr" = (
+/obj/structure/lattice,
+/obj/structure/grille/broken,
+/turf/open/space,
+/area/solar/port)
 "lNW" = (
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"lOU" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/structure/sink/kitchen{
+	dir = 8;
+	pixel_x = 11
+	},
+/turf/open/floor/plasteel/white,
+/area/space/station_ruins)
+"lPt" = (
+/obj/machinery/holopad,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "lQn" = (
 /obj/machinery/light/small{
 	dir = 1;
@@ -56541,6 +55954,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"lRM" = (
+/obj/machinery/newscaster,
+/turf/closed/wall,
+/area/space/station_ruins)
 "lRX" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
@@ -56548,10 +55965,6 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
-"lTB" = (
-/obj/machinery/vending/dinnerware/prisoner,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "lTC" = (
 /obj/item/shard,
 /obj/effect/turf_decal/stripes/line{
@@ -56564,24 +55977,39 @@
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"lTQ" = (
+/obj/structure/lattice,
+/turf/open/space,
+/area/space/station_ruins)
+"lUw" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/preopen{
+	id = "permalock2"
+	},
+/obj/machinery/button/door{
+	id = "soli1";
+	name = "Solitary Cell 1";
+	pixel_x = 26;
+	pixel_y = 10;
+	req_access_txt = "3"
+	},
+/obj/machinery/door_timer{
+	id = "soli1";
+	name = "Solitary 1 door timer";
+	pixel_x = 31;
+	pixel_y = -5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "lUO" = (
 /obj/structure/sign/warning/radiation,
 /turf/closed/wall/r_wall,
 /area/engine/supermatter)
-"lVV" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"lWq" = (
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "lWs" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/carpet,
@@ -56589,6 +56017,11 @@
 "lWy" = (
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"lWE" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/turf/open/space,
+/area/solar/port)
 "lWH" = (
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
@@ -56612,10 +56045,9 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "lXc" = (
-/obj/structure/table,
-/obj/item/clothing/head/beret,
-/turf/open/floor/plating,
-/area/maintenance/department/security/brig)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "lXJ" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
@@ -56623,10 +56055,14 @@
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
-"mam" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
-/turf/open/floor/plasteel/grimy,
-/area/security/prison)
+"lYx" = (
+/obj/structure/chair/stool,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "mau" = (
 /obj/structure/lattice,
 /obj/structure/grille/broken,
@@ -56664,16 +56100,18 @@
 /obj/machinery/portable_atmospherics/canister/toxins,
 /turf/open/floor/plating,
 /area/engine/engineering)
+"mcP" = (
+/obj/structure/table,
+/obj/item/reagent_containers/glass/bowl,
+/turf/open/floor/plasteel/cafeteria,
+/area/space/station_ruins)
 "mdL" = (
 /obj/structure/table,
 /obj/item/paper_bin,
 /obj/item/pen{
 	layer = 3.1
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
+/obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "meF" = (
@@ -56723,9 +56161,6 @@
 	pixel_x = 32
 	},
 /obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "miw" = (
@@ -56751,12 +56186,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/closed/wall/r_wall,
 /area/engine/engineering)
-"mkZ" = (
-/obj/structure/sign/poster/official/random{
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
 "mlr" = (
 /obj/structure/lattice,
 /obj/structure/disposalpipe/junction{
@@ -56764,6 +56193,11 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"mlP" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/turf/open/floor/plasteel/dark,
+/area/medical/morgue)
 "mmv" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Engineering Supplies";
@@ -56777,6 +56211,9 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/wood,
 /area/maintenance/department/crew_quarters/dorms)
+"mor" = (
+/turf/open/floor/plasteel/dark,
+/area/space/station_ruins)
 "mpd" = (
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
@@ -56790,9 +56227,6 @@
 /obj/machinery/power/rad_collector/anchored,
 /turf/open/floor/engine,
 /area/engine/supermatter)
-"mpt" = (
-/turf/open/floor/plasteel/grimy,
-/area/security/prison)
 "mpy" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -56824,25 +56258,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"mrk" = (
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
+"msD" = (
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#cee5d2"
+	},
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/security/prison)
-"mrz" = (
-/obj/structure/table,
-/obj/machinery/microwave,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/security/prison)
+/area/space/station_ruins)
 "msX" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -56877,16 +56305,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
-"mwg" = (
-/obj/structure/closet/crate{
-	icon_state = "crateopen"
+"mwa" = (
+/obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 4
 	},
-/obj/item/ammo_box/foambox,
-/obj/item/ammo_box/foambox,
-/obj/item/gun/ballistic/shotgun/toy,
-/obj/item/gun/ballistic/shotgun/toy,
-/turf/open/floor/plating,
-/area/maintenance/department/security/brig)
+/turf/open/floor/wood,
+/area/space/station_ruins)
+"mwg" = (
+/obj/machinery/camera{
+	c_tag = "Permabrig Lounge East";
+	dir = 8;
+	network = list("ss13","prison");
+	start_active = 1
+	},
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "mwG" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -56897,6 +56331,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"mxc" = (
+/obj/structure/table,
+/obj/machinery/chem_dispenser/drinks/beer,
+/turf/open/floor/plasteel/white,
+/area/space/station_ruins)
 "mxy" = (
 /obj/machinery/power/terminal{
 	dir = 4
@@ -56937,15 +56376,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"mzd" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/security/prison)
 "mzl" = (
 /obj/structure/chair,
 /obj/machinery/atmospherics/components/unary/outlet_injector/on,
@@ -56955,15 +56385,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall,
 /area/maintenance/department/engine)
-"mAx" = (
-/obj/machinery/plate_chute/inputchute{
-	pixel_y = -25
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 5
-	},
-/turf/open/floor/plasteel/checker,
-/area/security/prison)
 "mCe" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -56972,6 +56393,16 @@
 	},
 /turf/open/floor/plating,
 /area/security/checkpoint/engineering)
+"mCD" = (
+/obj/machinery/airalarm/directional/west,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "mDW" = (
 /obj/machinery/power/smes{
 	charge = 5e+006
@@ -56995,16 +56426,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"mFl" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+"mFe" = (
+/obj/structure/filingcabinet/chestdrawer,
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/vending/kink,
-/turf/open/floor/plasteel,
-/area/security/prison)
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/warden)
 "mHy" = (
 /obj/item/storage/fancy/cigarettes/cigpack_shadyjims,
 /turf/open/floor/wood,
@@ -57018,11 +56446,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"mJu" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/snacks/hotdog,
+"mJX" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
 /turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
+/area/space/station_ruins)
 "mKc" = (
 /obj/structure/bookcase/random/nonfiction,
 /turf/open/floor/plasteel/dark,
@@ -57045,6 +56474,12 @@
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/department/security/brig)
+"mLU" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "mMz" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -57054,13 +56489,6 @@
 	},
 /turf/open/floor/plating,
 /area/science/xenobiology)
-"mPT" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "mQm" = (
 /obj/structure/chair/office/light{
 	dir = 1
@@ -57068,31 +56496,14 @@
 /obj/effect/landmark/start/scientist,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"mQn" = (
-/obj/structure/table,
-/obj/item/storage/pill_bottle/dice,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"mRP" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
-	},
-/obj/machinery/portable_atmospherics/canister/air,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/security/prison)
 "mSc" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"mSf" = (
+/obj/structure/chair/stool,
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "mSz" = (
 /obj/structure/bookcase/random,
 /turf/open/floor/carpet,
@@ -57105,6 +56516,25 @@
 	heat_capacity = 1e+006
 	},
 /area/chapel/dock)
+"mTk" = (
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#c1caff"
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
+"mTs" = (
+/obj/structure/girder,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/department/security/brig)
 "mTS" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -57120,20 +56550,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
-"mWK" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#cee5d2"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/structure/closet/crate/bin,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "mXq" = (
 /obj/item/taperecorder,
 /obj/item/cartridge/lawyer,
@@ -57159,12 +56575,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"nbm" = (
-/obj/machinery/shower{
-	dir = 8
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/prison)
 "ncm" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
@@ -57175,6 +56585,12 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/engine,
 /area/engine/engineering)
+"ncM" = (
+/obj/machinery/shower{
+	dir = 4
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/space/station_ruins)
 "ndI" = (
 /obj/item/reagent_containers/food/drinks/bottle/vodka,
 /turf/open/floor/plating{
@@ -57196,6 +56612,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"ney" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/item/soap/homemade,
+/turf/open/floor/plasteel/showroomfloor,
+/area/space/station_ruins)
 "nfi" = (
 /obj/structure/sign/directions/evac{
 	dir = 1;
@@ -57208,6 +56631,18 @@
 	dir = 1
 	},
 /area/hallway/secondary/exit/departure_lounge)
+"nfk" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "nfz" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -57215,20 +56650,15 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"nga" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
+"nfB" = (
+/obj/structure/lattice,
 /obj/machinery/camera{
-	c_tag = "Permabrig West Hallway 1";
-	dir = 4;
-	network = list("ss13","prison")
+	c_tag = "Permabrig Space West";
+	dir = 8;
+	name = "aft camera"
 	},
-/turf/open/floor/plasteel,
-/area/security/prison)
+/turf/open/space/basic,
+/area/space/station_ruins)
 "nge" = (
 /obj/structure/grille/broken,
 /obj/structure/lattice,
@@ -57267,31 +56697,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
-"niG" = (
-/obj/machinery/airalarm/directional/west,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"njr" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "nku" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Crematorium";
@@ -57310,18 +56715,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"nmK" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "nnh" = (
 /obj/structure/chair{
 	dir = 8
@@ -57330,9 +56723,18 @@
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/crew_quarters/dorms)
 "noC" = (
-/obj/machinery/vending/kink,
-/turf/open/floor/wood,
-/area/maintenance/department/crew_quarters/dorms)
+/obj/machinery/plate_press,
+/obj/item/stack/license_plates/empty/fifty,
+/turf/open/floor/plasteel/checker,
+/area/space/station_ruins)
+"noE" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -24;
+	pixel_y = 28
+	},
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "noM" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -57357,6 +56759,19 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
+"nqT" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/camera{
+	c_tag = "Permabrig Cell Hallway 2";
+	dir = 8;
+	network = list("ss13","prison");
+	start_active = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "nqV" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -57386,15 +56801,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/storage)
-"nrk" = (
-/obj/structure/table,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/item/toy/cards/deck,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "nsy" = (
 /obj/structure/table,
 /obj/item/stack/sheet/metal/fifty,
@@ -57426,37 +56832,14 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
-"nsQ" = (
-/obj/structure/rack,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/tank/internals/emergency_oxygen,
-/obj/item/tank/internals/emergency_oxygen,
-/obj/item/tank/internals/emergency_oxygen,
-/obj/item/tank/internals/emergency_oxygen,
-/turf/open/floor/plating,
-/area/security/prison)
-"ntI" = (
-/obj/machinery/shower{
-	dir = 4
+"nxz" = (
+/obj/structure/chair/stool,
+/obj/machinery/camera{
+	c_tag = "Permabrig Cafeteria";
+	network = list("ss13","prison")
 	},
-/obj/item/soap/homemade,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/prison)
-"nxc" = (
-/obj/structure/table,
-/obj/item/paicard,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/cyan/hidden/layer1,
-/turf/open/floor/plasteel,
-/area/security/prison)
+/turf/open/floor/plasteel/cafeteria,
+/area/space/station_ruins)
 "nxT" = (
 /obj/machinery/smartfridge/extract/preloaded,
 /turf/open/floor/plasteel,
@@ -57478,14 +56861,19 @@
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "nze" = (
-/obj/structure/lattice,
-/obj/machinery/camera{
-	c_tag = "Permabrig Space Northeast";
+/obj/machinery/light{
 	dir = 1;
-	name = "aft camera"
+	light_color = "#cee5d2"
 	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/structure/closet/crate/bin,
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "nzD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
@@ -57505,6 +56893,20 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
+"nAK" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "nAY" = (
 /obj/structure/chair/stool,
 /obj/effect/landmark/start/station_engineer,
@@ -57558,6 +56960,13 @@
 	},
 /turf/open/floor/plating,
 /area/science/xenobiology)
+"nEl" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "nGi" = (
 /obj/structure/chair{
 	dir = 4
@@ -57569,14 +56978,6 @@
 	dir = 1
 	},
 /area/hallway/secondary/exit/departure_lounge)
-"nGy" = (
-/obj/machinery/camera{
-	c_tag = "Permabrig Lounge West";
-	dir = 4;
-	network = list("ss13","prison")
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "nIm" = (
 /obj/machinery/computer/security/telescreen{
 	dir = 8;
@@ -57587,20 +56988,6 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
-"nIw" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 11
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "nIU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -57608,15 +56995,15 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
+/obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "nJw" = (
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/lumos/tile/blue/half{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
@@ -57688,6 +57075,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
+"nPq" = (
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "nPA" = (
 /obj/item/chair,
 /turf/open/floor/plating,
@@ -57702,6 +57093,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"nRs" = (
+/obj/structure/table,
+/obj/structure/sign/poster/official/random{
+	pixel_y = -32
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass,
+/turf/open/floor/plasteel/cafeteria,
+/area/space/station_ruins)
 "nSj" = (
 /obj/structure/grille/broken,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -57717,6 +57116,18 @@
 	},
 /turf/open/floor/wood,
 /area/lawoffice)
+"nSr" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/space/station_ruins)
+"nSt" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "nTr" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -57740,28 +57151,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"nWs" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 5
-	},
-/turf/open/floor/plasteel/checker,
-/area/security/prison)
 "nWL" = (
 /obj/machinery/camera{
 	c_tag = "Permabrig Visitations Visitor-side";
 	dir = 8;
 	network = list("ss13","prison");
 	start_active = 1
-	},
-/obj/machinery/button/door{
-	id = "sexroom";
-	name = "Conjugal Visits";
-	pixel_x = 27;
-	pixel_y = 1;
-	req_access_txt = "3"
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -57784,15 +57179,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"obf" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "obj" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -57820,6 +57206,24 @@
 	luminosity = 2
 	},
 /area/maintenance/department/science)
+"oco" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/space/station_ruins)
 "odM" = (
 /obj/effect/landmark/barthpot,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -57837,12 +57241,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
-"oew" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+"oeQ" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4
 	},
-/turf/open/floor/wood,
-/area/security/prison)
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "ofN" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/blue,
@@ -57860,10 +57267,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"ohQ" = (
+/obj/structure/lattice,
+/obj/structure/grille,
+/turf/open/space,
+/area/space/station_ruins)
 "ohR" = (
 /obj/item/chair,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"ojn" = (
+/obj/machinery/vending/dinnerware/prisoner,
+/turf/open/floor/plasteel/white,
+/area/space/station_ruins)
 "olc" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Bedroom";
@@ -57874,6 +57290,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"olO" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Laundry"
+	},
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "onX" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -57886,19 +57308,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
-"ood" = (
-/obj/machinery/cryopod{
-	dir = 8
-	},
-/turf/open/floor/circuit/green,
-/area/security/prison)
 "ooh" = (
 /obj/structure/window/reinforced{
 	dir = 8;
 	layer = 2.9
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
 	},
 /obj/item/wrench/medical,
 /turf/open/floor/engine,
@@ -57935,13 +57348,6 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
-"osF" = (
-/obj/machinery/camera{
-	c_tag = "Permabrig Space Southeast"
-	},
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/security/prison)
 "ous" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/button/door{
@@ -57964,6 +57370,16 @@
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"ovc" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/space/station_ruins)
 "ovM" = (
 /obj/machinery/camera{
 	c_tag = "Arrivals Port Fore"
@@ -57992,6 +57408,19 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/engine,
 /area/engine/engineering)
+"oxy" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/machinery/biogenerator/prisoner,
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "oyF" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
@@ -58055,10 +57484,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/explab)
-"oEp" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/wood,
-/area/security/prison)
 "oEA" = (
 /turf/closed/wall,
 /area/construction/mining/aux_base)
@@ -58094,14 +57519,9 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "oFf" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/security/brig)
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "oFl" = (
 /obj/structure/chair/office/light{
 	dir = 8
@@ -58125,6 +57545,20 @@
 /obj/item/stack/sheet/mineral/wood,
 /turf/open/floor/plasteel,
 /area/maintenance/department/engine)
+"oGN" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "oHa" = (
 /obj/machinery/power/emitter/anchored{
 	dir = 8;
@@ -58135,10 +57569,6 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
-"oIx" = (
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/wood,
-/area/security/prison)
 "oKa" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance{
@@ -58164,10 +57594,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"oLN" = (
-/obj/machinery/holopad,
-/turf/open/floor/plasteel/checker,
-/area/security/prison)
 "oLR" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -58177,6 +57603,11 @@
 "oMN" = (
 /turf/open/floor/plasteel/stairs/left,
 /area/maintenance/department/crew_quarters/dorms)
+"oMR" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/turf/open/floor/circuit,
+/area/space/station_ruins)
 "oNE" = (
 /obj/structure/chair/office/light,
 /obj/structure/sign/warning/deathsposal{
@@ -58188,20 +57619,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
-"oOa" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24;
-	pixel_y = 28
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "oPx" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -58223,13 +57640,6 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/miningdock)
-"oPL" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/condiment/flour,
-/obj/item/reagent_containers/food/condiment/flour,
-/obj/item/reagent_containers/food/condiment/flour,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "oRX" = (
 /obj/structure/closet,
 /turf/open/floor/plating,
@@ -58322,13 +57732,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"oUC" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/condiment/rice,
-/obj/item/reagent_containers/food/condiment/rice,
-/obj/item/reagent_containers/food/condiment/rice,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "oWu" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
@@ -58412,35 +57815,10 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "pdq" = (
-/obj/effect/decal/cleanable/oil,
-/turf/open/floor/plating,
-/area/maintenance/department/security/brig)
-"pdN" = (
-/obj/structure/chair/stool,
-/obj/machinery/light,
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
-"pek" = (
-/obj/structure/table,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/hatchet,
+/obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
-/area/security/prison)
-"peE" = (
-/obj/machinery/door/poddoor{
-	id = "soli2"
-	},
-/turf/open/floor/mineral/titanium/white{
-	name = "secure isolation floor"
-	},
-/area/security/prison)
+/area/space/station_ruins)
 "pfz" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -58461,6 +57839,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
+"pfY" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/cyan/hidden/layer1{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "pgH" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/effect/turf_decal/stripes/line{
@@ -58468,13 +57861,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"phc" = (
-/obj/machinery/requests_console{
-	department = "Prison";
-	departmentType = 1
-	},
-/turf/closed/wall,
-/area/security/prison)
 "phJ" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -58498,11 +57884,6 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/department/chapel/monastery)
-"pjE" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/drinks/drinkingglass,
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
 "pjH" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -58510,15 +57891,11 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
-"pjS" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel/grimy,
-/area/security/prison)
+"pkg" = (
+/obj/item/caution,
+/obj/item/caution,
+/turf/open/floor/plating,
+/area/space/station_ruins)
 "pkM" = (
 /obj/machinery/door/airlock/external{
 	req_access_txt = "22"
@@ -58526,9 +57903,10 @@
 /turf/open/floor/plating,
 /area/chapel/office)
 "plA" = (
-/obj/structure/musician/piano,
-/turf/open/floor/plasteel/dark,
-/area/maintenance/department/crew_quarters/dorms)
+/obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "pmB" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
@@ -58536,6 +57914,13 @@
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"pny" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel/grimy,
+/area/space/station_ruins)
 "pnU" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
 	dir = 4;
@@ -58588,10 +57973,23 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine,
 /area/engine/supermatter)
+"pud" = (
+/obj/structure/plasticflaps,
+/turf/open/floor/plating,
+/area/maintenance/department/security/brig)
 "puw" = (
 /obj/structure/sign/warning/fire,
 /turf/closed/wall/r_wall,
 /area/engine/supermatter)
+"pvl" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
+"pvq" = (
+/turf/open/floor/circuit,
+/area/space/station_ruins)
 "pvK" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -58615,14 +58013,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
-"pwi" = (
-/obj/machinery/camera{
-	c_tag = "Permabrig Cell Hallway 1";
-	dir = 4;
-	network = list("ss13","prison")
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "pwj" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -58639,14 +58029,18 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"pxw" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "pyw" = (
 /turf/open/space/basic,
 /area/hallway/secondary/entry)
-"pze" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/snacks/fortunecookie,
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
 "pzx" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -58674,17 +58068,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
-"pCe" = (
-/obj/machinery/door/airlock/public/glass,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "pCo" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -58705,27 +58088,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
-"pDS" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#cee5d2"
-	},
-/obj/machinery/computer/arcade,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"pEG" = (
-/obj/machinery/seed_extractor,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "pFe" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/red{
@@ -58765,20 +58127,15 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
-"pIn" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
-"pJz" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 4
+"pJX" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/manifold/cyan/hidden/layer1{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 10
 	},
-/turf/open/floor/plasteel,
-/area/security/prison)
+/turf/open/floor/plasteel/grimy,
+/area/space/station_ruins)
 "pKd" = (
 /obj/effect/spawner/lootdrop/maintenance{
 	name = "2maintenance loot spawner"
@@ -58786,6 +58143,15 @@
 /obj/structure/closet/crate,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"pLr" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 5
+	},
+/turf/open/floor/circuit,
+/area/space/station_ruins)
 "pMG" = (
 /obj/structure/sink{
 	dir = 8;
@@ -58818,28 +58184,26 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
-"pPr" = (
-/obj/machinery/smartfridge/food,
-/turf/closed/wall,
-/area/security/prison)
+"pOx" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/main)
 "pQw" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
 /area/medical/virology)
-"pQP" = (
-/obj/machinery/camera{
-	c_tag = "Permabrig Sleeper Hallway";
-	dir = 1;
-	network = list("ss13","prison")
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/cyan/hidden/layer1,
-/turf/open/floor/plasteel/grimy,
-/area/security/prison)
+"pTF" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "pVD" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -58848,18 +58212,6 @@
 	icon_state = "wood-broken5"
 	},
 /area/maintenance/department/engine)
-"pVH" = (
-/obj/structure/bed,
-/obj/effect/landmark/start/prisoner,
-/obj/item/radio/intercom{
-	desc = "Talk through this. It looks like it has been modified to not broadcast.";
-	name = "Prison Intercom (General)";
-	pixel_y = 24;
-	prison_radio = 1
-	},
-/obj/item/bedsheet/orange,
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "pWm" = (
 /obj/machinery/door/window/southleft{
 	dir = 4;
@@ -58890,10 +58242,7 @@
 "pWT" = (
 /obj/structure/chair/stool,
 /obj/effect/landmark/start/botanist,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/green/half,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "pXc" = (
@@ -58950,11 +58299,6 @@
 /obj/structure/barricade/wooden,
 /turf/open/floor/plasteel,
 /area/maintenance/department/engine)
-"pZq" = (
-/obj/structure/table,
-/obj/item/reagent_containers/glass/bowl,
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
 "qar" = (
 /obj/structure/chair/office/light{
 	dir = 4
@@ -58967,9 +58311,38 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
+"qbV" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/camera{
+	c_tag = "Permabrig Entrance";
+	dir = 8;
+	network = list("ss13","prison");
+	start_active = 1
+	},
+/obj/machinery/button/door{
+	id = "soli2";
+	name = "Solitary Cell 2";
+	pixel_x = 26;
+	pixel_y = -10;
+	req_access_txt = "3"
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/door_timer{
+	id = "soli2";
+	name = "Solitary 2 door timer";
+	pixel_x = 31;
+	pixel_y = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "qbZ" = (
-/obj/structure/rack,
-/obj/item/clothing/mask/gas,
+/obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
 /area/storage/emergency/starboard)
 "qcD" = (
@@ -58992,19 +58365,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
-"qcR" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/manifold/cyan/hidden/layer1{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "qdi" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -59040,22 +58400,22 @@
 /obj/item/stack/sheet/mineral/wood,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"qdw" = (
+"qeY" = (
+/turf/closed/wall/r_wall,
+/area/engine/supermatter)
+"qio" = (
+/obj/machinery/airalarm/directional/north,
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/machinery/flasher{
-	id = "visitflash";
-	pixel_y = 25
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/security/prison)
-"qeY" = (
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
+/area/space/station_ruins)
 "qjx" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/tile/yellow,
@@ -59073,17 +58433,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"qmK" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/structure/sink/kitchen{
-	dir = 8;
-	pixel_x = 11
-	},
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "qni" = (
 /obj/machinery/smartfridge/organ/preloaded,
 /turf/closed/wall,
@@ -59092,24 +58441,6 @@
 /obj/machinery/iv_drip,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"qpc" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/security/prison)
 "qpd" = (
 /obj/machinery/atmospherics/pipe/manifold/green/visible{
 	dir = 8
@@ -59129,24 +58460,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"qqB" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/plating,
-/area/security/prison)
-"qsd" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"qsJ" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "qtA" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
@@ -59181,6 +58494,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"qwm" = (
+/obj/machinery/vr_sleeper{
+	dir = 4
+	},
+/turf/open/floor/circuit,
+/area/space/station_ruins)
 "qxq" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	name = "Air Out"
@@ -59198,15 +58517,32 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"qzM" = (
+/obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/space/station_ruins)
 "qAM" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/item/cigbutt,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"qAN" = (
+/obj/machinery/power/tracker,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/solar/port)
 "qBv" = (
 /obj/item/clothing/head/ushanka,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"qDe" = (
+/turf/open/floor/plasteel/stairs/old,
+/area/maintenance/department/crew_quarters/dorms)
 "qDJ" = (
 /obj/structure/table/reinforced,
 /obj/item/integrated_circuit_printer,
@@ -59226,14 +58562,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
-"qEG" = (
-/obj/structure/closet/crate/bin,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/wood,
-/area/security/prison)
 "qEN" = (
 /obj/machinery/rnd/production/techfab/department/service,
 /obj/structure/window/reinforced{
@@ -59302,23 +58630,17 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"qIY" = (
-/obj/machinery/camera{
-	c_tag = "Permabrig Showers";
-	dir = 4;
-	network = list("ss13","prison")
+"qKT" = (
+/obj/structure/cable{
+	icon_state = "0-4"
 	},
-/obj/structure/sign/poster/official/random{
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/prison)
-"qKY" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
+/obj/structure/lattice/catwalk,
+/turf/open/space,
+/area/solar/port)
+"qLf" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/open/floor/plating,
+/area/space/station_ruins)
 "qLI" = (
 /obj/structure/table,
 /obj/item/stack/sheet/glass/fifty{
@@ -59351,10 +58673,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/execution/transfer)
-"qNy" = (
-/obj/structure/sign/nanotrasen,
-/turf/closed/wall,
-/area/security/prison)
 "qOE" = (
 /turf/open/floor/plasteel/dark,
 /area/library/lounge)
@@ -59374,7 +58692,6 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "qPB" = (
-/obj/structure/chair/stool,
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -59401,6 +58718,20 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"qTw" = (
+/obj/structure/lattice,
+/obj/machinery/camera,
+/turf/open/space,
+/area/space/station_ruins)
+"qTM" = (
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/manifold/cyan/hidden/layer1,
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "qTV" = (
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
@@ -59432,15 +58763,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"qWf" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Sleepers"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
-/turf/open/floor/plasteel,
-/area/security/prison)
+"qWa" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating,
+/area/security/main)
 "qWo" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
@@ -59464,6 +58790,27 @@
 	},
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
+"qXa" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 10
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/main)
+"qXb" = (
+/obj/structure/table,
+/obj/item/paicard,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/cyan/hidden/layer1,
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "qXq" = (
 /obj/machinery/door/airlock/maintenance/abandoned,
 /obj/structure/cable{
@@ -59509,13 +58856,6 @@
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
-"rai" = (
-/obj/structure/rack,
-/obj/item/flashlight,
-/obj/item/storage/bag/trash,
-/obj/item/radio/off,
-/turf/open/floor/plating,
-/area/security/prison)
 "rar" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
@@ -59529,9 +58869,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"rcK" = (
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "reH" = (
 /obj/item/reagent_containers/food/drinks/bottle/vodka,
 /obj/structure/disposalpipe/segment{
@@ -59580,14 +58917,23 @@
 	icon_state = "wood-broken4"
 	},
 /area/maintenance/department/engine)
-"riu" = (
-/obj/structure/table,
-/obj/structure/sign/poster/official/random{
-	pixel_y = -32
+"riD" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
 	},
-/obj/item/reagent_containers/food/drinks/drinkingglass,
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Permabrig Laundry";
+	dir = 4;
+	network = list("ss13","prison")
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "riF" = (
 /obj/machinery/computer/arcade,
 /obj/effect/turf_decal/tile/neutral{
@@ -59602,58 +58948,45 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
-"rke" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
-"rkl" = (
-/obj/structure/bed,
-/obj/item/radio/intercom{
-	desc = "Talk through this. It looks like it has been modified to not broadcast.";
-	name = "Prison Intercom (General)";
-	pixel_y = 24;
-	prison_radio = 1
-	},
-/obj/item/bedsheet/orange,
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
-"rlL" = (
-/obj/structure/lattice,
+"rjC" = (
 /obj/machinery/camera{
-	c_tag = "Permabrig Space Northwest";
+	c_tag = "Permabrig Sleeper Hallway";
 	dir = 1;
-	name = "aft camera"
+	network = list("ss13","prison")
 	},
-/turf/open/space/basic,
-/area/space/nearstation)
-"rlR" = (
-/obj/machinery/airalarm/directional/north,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/cyan/hidden/layer1,
+/turf/open/floor/plasteel/grimy,
+/area/space/station_ruins)
+"rlD" = (
+/obj/structure/bookcase/random,
+/turf/open/floor/wood,
+/area/space/station_ruins)
+"rlL" = (
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#cee5d2"
+	},
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8
+/obj/effect/turf_decal/tile/red,
+/obj/structure/closet/crate/bin,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
 	},
 /turf/open/floor/plasteel,
-/area/security/prison)
+/area/space/station_ruins)
 "rmC" = (
 /turf/open/space/basic,
 /area/space/station_ruins)
-"rmT" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/machinery/vending/hydronutrients/prisoner,
-/turf/open/floor/plasteel,
+"rmD" = (
+/obj/structure/lattice,
+/obj/structure/grille,
+/turf/open/space/basic,
 /area/security/prison)
 "rnr" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -59668,6 +59001,9 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
+"rnG" = (
+/turf/open/floor/plasteel/showroomfloor,
+/area/space/station_ruins)
 "roc" = (
 /obj/structure/cable,
 /obj/structure/lattice/catwalk,
@@ -59682,14 +59018,6 @@
 	luminosity = 2
 	},
 /area/maintenance/department/science)
-"rox" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#cee5d2"
-	},
-/obj/machinery/vending/cola/random,
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
 "rrb" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -59765,19 +59093,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/psych)
-"rwZ" = (
-/obj/structure/table,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "rxa" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
@@ -59802,21 +59117,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
-"ryW" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#cee5d2"
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/machinery/vending/hydroseeds,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "rzp" = (
 /obj/structure/table,
 /obj/item/stack/sheet/metal/fifty,
@@ -59827,16 +59127,27 @@
 	},
 /area/maintenance/department/engine)
 "rBh" = (
-/obj/structure/mopbucket,
-/obj/item/mop,
+/obj/machinery/vending/kink,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"rCs" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/space,
+/area/solar/port)
 "rEh" = (
 /obj/structure/table/glass,
 /obj/item/restraints/handcuffs/cable/zipties,
 /obj/item/reagent_containers/blood/random,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"rEZ" = (
+/obj/structure/chair/stool,
+/obj/effect/landmark/start/security_officer,
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/main)
 "rFq" = (
 /obj/structure/chair,
 /obj/item/reagent_containers/food/snacks/donkpocket,
@@ -59844,27 +59155,23 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/science)
-"rGP" = (
-/obj/machinery/light,
-/obj/machinery/firealarm{
+"rFY" = (
+/obj/machinery/camera{
+	c_tag = "Permabrig Sleepers";
 	dir = 1;
-	pixel_y = -24
+	network = list("ss13","prison")
 	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/prison)
+/obj/machinery/light{
+	light_color = "#cee5d2"
+	},
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "rHA" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
-"rIt" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "rJg" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /obj/machinery/light/small{
@@ -59903,6 +59210,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port)
+"rKv" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/space/station_ruins)
 "rKL" = (
 /obj/item/trash/cheesie,
 /turf/open/floor/plating{
@@ -59910,14 +59226,14 @@
 	},
 /area/maintenance/department/science)
 "rLi" = (
-/obj/machinery/button/door{
-	id = "shootshut";
-	name = "shutters control";
-	pixel_x = 28
+/obj/machinery/camera{
+	c_tag = "Permabrig Prisoner Arrivals";
+	dir = 8;
+	name = "aft camera"
 	},
-/obj/item/ammo_casing/shotgun/improvised,
-/turf/open/floor/plating,
-/area/maintenance/department/security/brig)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "rMV" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -59926,10 +59242,8 @@
 /turf/open/floor/plating/airless,
 /area/maintenance/department/engine)
 "rNl" = (
-/obj/structure/grille,
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/open/floor/plasteel/grimy,
+/area/space/station_ruins)
 "rNB" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -59946,31 +59260,30 @@
 	},
 /turf/closed/wall/r_wall,
 /area/science/mixing)
+"rRM" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "rSH" = (
 /obj/item/trash/can,
 /turf/open/floor/wood,
 /area/maintenance/department/engine)
-"rUC" = (
-/obj/structure/chair/stool,
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
-"rUW" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+"rTp" = (
+/obj/machinery/requests_console{
+	department = "Prison";
+	departmentType = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/camera{
-	c_tag = "Permabrig West Hallway 2";
-	dir = 4;
-	network = list("ss13","prison")
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
+/turf/closed/wall,
+/area/space/station_ruins)
 "rVa" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -59999,26 +59312,19 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "rYC" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/machinery/door/airlock/external{
-	name = "public external airlock"
-	},
-/turf/open/floor/plating,
-/area/storage/emergency/starboard)
+/turf/open/floor/plasteel/grimy,
+/area/space/station_ruins)
+"rZi" = (
+/obj/machinery/vending/snack/random,
+/turf/open/floor/plasteel/cafeteria,
+/area/space/station_ruins)
 "sbk" = (
 /obj/structure/girder,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
-"sbr" = (
-/obj/structure/filingcabinet,
-/obj/machinery/camera{
-	c_tag = "Permabrig Library";
-	network = list("ss13","prison")
-	},
-/turf/open/floor/wood,
-/area/security/prison)
 "sbY" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/wood,
@@ -60050,13 +59356,15 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "sdk" = (
-/obj/structure/lattice,
-/obj/machinery/camera/motion{
-	c_tag = "Armory External";
-	dir = 1
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/turf/open/floor/plasteel/grimy,
+/area/space/station_ruins)
+"sfB" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 4
 	},
-/turf/open/space,
-/area/space/nearstation)
+/turf/open/floor/wood,
+/area/space/station_ruins)
 "sgc" = (
 /obj/machinery/vending/cigarette,
 /obj/effect/turf_decal/tile/neutral{
@@ -60071,6 +59379,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
+"sge" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
+	},
+/turf/open/floor/plating,
+/area/space/station_ruins)
 "shH" = (
 /turf/closed/wall/r_wall,
 /area/space/nearstation)
@@ -60088,6 +59403,13 @@
 /obj/machinery/power/port_gen/pacman,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"skm" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "skw" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /turf/closed/wall,
@@ -60105,15 +59427,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"smj" = (
-/obj/machinery/atmospherics/components/binary/valve/on{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/security/prison)
 "smv" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 8;
@@ -60141,24 +59454,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/crew_quarters/dorms)
+"sqz" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/table/reinforced,
+/obj/item/phone,
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/bar)
 "sqQ" = (
 /turf/open/floor/plating,
 /area/maintenance/disposal)
-"srY" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "srZ" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
@@ -60169,6 +59473,16 @@
 /obj/item/shard,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"ssO" = (
+/obj/machinery/camera{
+	c_tag = "Permabrig Iso Cell 2";
+	network = list("ss13","prison")
+	},
+/obj/structure/bed,
+/turf/open/floor/mineral/titanium/white{
+	name = "secure isolation floor"
+	},
+/area/space/station_ruins)
 "sty" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/transit_tube/horizontal,
@@ -60191,14 +59505,9 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard)
 "suV" = (
-/obj/structure/lattice,
-/obj/machinery/camera{
-	c_tag = "Permabrig Space East";
-	dir = 4;
-	name = "aft camera"
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/machinery/holopad,
+/turf/open/floor/plasteel/grimy,
+/area/space/station_ruins)
 "svA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 6
@@ -60217,19 +59526,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
-"sws" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "sww" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/item/reagent_containers/food/snacks/meat/slab/monkey,
@@ -60274,18 +59570,6 @@
 /obj/item/clothing/mask/gas/plaguedoctor,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"sAS" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/cyan/hidden/layer1{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "sBA" = (
 /obj/machinery/firealarm{
 	pixel_y = 29
@@ -60320,14 +59604,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"sEe" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
+"sCA" = (
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#cee5d2"
 	},
-/turf/open/floor/plasteel,
-/area/security/prison)
+/obj/structure/table,
+/obj/machinery/chem_dispenser/drinks,
+/turf/open/floor/plasteel/white,
+/area/space/station_ruins)
+"sDI" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 10
+	},
+/turf/open/floor/wood,
+/area/space/station_ruins)
 "sEB" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
@@ -60339,16 +59630,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"sEW" = (
-/obj/structure/sign/poster/official/random,
-/turf/closed/wall/r_wall,
-/area/security/prison)
 "sGr" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/security/brig)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/turf/open/floor/plasteel/grimy,
+/area/space/station_ruins)
 "sJp" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /obj/effect/turf_decal/stripes/line,
@@ -60370,6 +59655,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"sKG" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/table,
+/obj/item/storage/box/hug,
+/obj/item/razor{
+	pixel_x = -6
+	},
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "sNz" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -60382,6 +59679,17 @@
 	},
 /turf/open/floor/plating,
 /area/security/execution/transfer)
+"sQe" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/turf/open/floor/plasteel/dark,
+/area/medical/morgue)
+"sQi" = (
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#cee5d2"
+	},
+/turf/open/floor/wood,
+/area/space/station_ruins)
 "sQt" = (
 /obj/machinery/door/airlock/external{
 	name = "Supply Dock Airlock";
@@ -60392,20 +59700,6 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/storage)
-"sQJ" = (
-/obj/structure/chair/stool,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"sTU" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "sexroom"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "sUP" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
@@ -60455,10 +59749,25 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"sXP" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/condiment/rice,
+/obj/item/reagent_containers/food/condiment/rice,
+/obj/item/reagent_containers/food/condiment/rice,
+/turf/open/floor/plasteel/white,
+/area/space/station_ruins)
 "sXR" = (
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall/r_wall,
 /area/science/xenobiology)
+"sYN" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "sYQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -60497,9 +59806,12 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "tap" = (
-/obj/structure/reagent_dispensers/keg/aphro,
-/turf/open/floor/wood,
-/area/maintenance/department/crew_quarters/dorms)
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 28
+	},
+/turf/open/floor/plasteel/grimy,
+/area/space/station_ruins)
 "taA" = (
 /obj/structure/chair/office/light,
 /turf/open/floor/plasteel/dark,
@@ -60536,6 +59848,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"tcg" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/camera{
+	c_tag = "Permabrig East";
+	dir = 8;
+	network = list("ss13","prison");
+	start_active = 1
+	},
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "tcY" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -60603,6 +59928,16 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall,
 /area/maintenance/department/security/brig)
+"thm" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass{
+	name = "Garden"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "thA" = (
 /obj/machinery/atmospherics/pipe/simple/general/hidden,
 /turf/closed/wall/r_wall,
@@ -60630,24 +59965,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"tiS" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"tjC" = (
-/obj/structure/toilet{
-	dir = 8
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "tkL" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/machinery/light{
@@ -60660,10 +59977,14 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "tlc" = (
-/obj/machinery/recharger,
-/obj/structure/table,
-/turf/open/floor/plating,
-/area/maintenance/department/security/brig)
+/obj/machinery/camera{
+	c_tag = "Permabrig Pressing Room";
+	dir = 4;
+	network = list("ss13","prison")
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/turf/open/floor/plasteel/checker,
+/area/space/station_ruins)
 "tlw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
@@ -60683,27 +60004,6 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
-"tmA" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/machinery/biogenerator/prisoner,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"tmE" = (
-/obj/structure/table,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "tnY" = (
 /obj/machinery/button/door{
 	id = "aux_base_shutters";
@@ -60718,36 +60018,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
-"toK" = (
-/obj/structure/table,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/item/camera,
-/obj/item/camera_film,
-/obj/item/storage/photo_album,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "tpb" = (
-/obj/item/reagent_containers/food/snacks/donut,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/maintenance/department/security/brig)
-"tpX" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating,
-/area/security/prison)
+/obj/machinery/holopad,
+/turf/open/floor/plasteel/checker,
+/area/space/station_ruins)
 "tqO" = (
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
@@ -60768,18 +60042,24 @@
 	},
 /turf/open/floor/plating,
 /area/science/xenobiology)
-"tsn" = (
-/obj/machinery/airalarm/directional/east,
-/obj/structure/closet/crate/bin,
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
+"tru" = (
+/obj/machinery/shower{
+	dir = 4
+	},
+/obj/item/soap,
+/turf/open/floor/plasteel/showroomfloor,
+/area/space/station_ruins)
+"trD" = (
+/obj/structure/closet/crate/trashcart,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/space/station_ruins)
 "ttS" = (
 /obj/structure/chair/stool,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
 /mob/living/simple_animal/pet/bumbles,
+/obj/effect/turf_decal/lumos/tile/green/half,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "tue" = (
@@ -60800,16 +60080,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"tuO" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating,
-/area/security/prison)
 "tvj" = (
 /obj/structure/festivus{
 	anchored = 1;
@@ -60818,6 +60088,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/crew_quarters/dorms)
+"tvn" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/washing_machine,
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "tvP" = (
 /obj/item/storage/toolbox/mechanical,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -60837,6 +60117,10 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"txl" = (
+/obj/machinery/light/small,
+/turf/open/floor/carpet,
+/area/maintenance/department/security/brig)
 "typ" = (
 /obj/structure/table/glass,
 /obj/item/hemostat,
@@ -60850,14 +60134,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
-"tyU" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
-/turf/open/floor/plasteel/checker,
-/area/security/prison)
 "tzH" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "research_shutters_2";
@@ -60875,21 +60151,10 @@
 /obj/item/pen,
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
-"tCn" = (
-/obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/security/prison)
 "tCP" = (
 /obj/docking_port/stationary/public_mining_dock,
 /turf/open/floor/plating,
 /area/construction/mining/aux_base)
-"tCX" = (
-/obj/machinery/newscaster,
-/turf/closed/wall,
-/area/security/prison)
 "tDn" = (
 /obj/item/wrench,
 /turf/open/floor/plating,
@@ -60915,9 +60180,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"tIi" = (
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "tJr" = (
 /obj/structure/plasticflaps/opaque,
 /obj/effect/turf_decal/delivery,
@@ -60927,6 +60189,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/lab)
+"tLc" = (
+/turf/open/space,
+/area/space/station_ruins)
 "tLv" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -60947,13 +60212,6 @@
 /obj/machinery/status_display/supply,
 /turf/closed/wall,
 /area/quartermaster/warehouse)
-"tMI" = (
-/obj/structure/closet/crate/trashcart,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/security/prison)
 "tOD" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/effect/turf_decal/stripes/line{
@@ -60967,6 +60225,13 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/department/engine)
+"tRx" = (
+/obj/machinery/shower{
+	dir = 4
+	},
+/obj/item/soap/homemade,
+/turf/open/floor/plasteel/showroomfloor,
+/area/space/station_ruins)
 "tSL" = (
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
@@ -60977,6 +60242,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"tVx" = (
+/obj/machinery/light,
+/obj/structure/reagent_dispensers/cooking_oil,
+/turf/open/floor/plasteel/white,
+/area/space/station_ruins)
 "tXn" = (
 /obj/structure/sink{
 	dir = 4;
@@ -60994,12 +60264,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"tXB" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/wood,
-/area/security/prison)
 "tYj" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -61016,6 +60280,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
+"tZG" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel/grimy,
+/area/space/station_ruins)
 "uaC" = (
 /obj/structure/chair/comfy/black{
 	dir = 8
@@ -61023,11 +60296,13 @@
 /turf/open/floor/carpet,
 /area/maintenance/department/crew_quarters/dorms)
 "uaE" = (
-/obj/effect/decal/cleanable/oil{
-	icon_state = "floor6"
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
 	},
-/turf/open/floor/plating,
-/area/maintenance/department/security/brig)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/turf/open/floor/plasteel/checker,
+/area/space/station_ruins)
 "uaO" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 6
@@ -61044,6 +60319,19 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"uaS" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Pressing Room"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel/checker,
+/area/space/station_ruins)
 "ubW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
@@ -61056,16 +60344,6 @@
 	},
 /turf/open/space,
 /area/space/nearstation)
-"udI" = (
-/obj/machinery/computer/arcade,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "uek" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance{
@@ -61090,6 +60368,8 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
+/obj/structure/mopbucket,
+/obj/item/mop,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -61107,14 +60387,23 @@
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "ufu" = (
-/obj/structure/lattice,
-/obj/machinery/camera{
-	c_tag = "Permabrig Space West";
-	dir = 8;
-	name = "aft camera"
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
+"ugw" = (
+/obj/structure/toilet{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/space/station_ruins)
 "ugC" = (
 /obj/structure/chair/office/light{
 	dir = 4
@@ -61127,19 +60416,27 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"uht" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-8"
+"uhM" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/security/prison)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "uiP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
 /turf/open/floor/wood,
 /area/maintenance/department/engine)
+"uiQ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/security/main)
 "ujI" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -61163,12 +60460,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"ukW" = (
-/turf/open/floor/plasteel/vaporwave,
-/area/security/prison)
-"ula" = (
-/turf/open/floor/wood,
-/area/security/prison)
 "ulu" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -61237,6 +60528,14 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
+"upd" = (
+/obj/effect/turf_decal/caution/stand_clear,
+/obj/effect/turf_decal/box,
+/obj/machinery/door/poddoor/shutters{
+	id = "shootshut"
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/main)
 "upR" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/white,
@@ -61312,19 +60611,15 @@
 	},
 /turf/open/floor/circuit/telecomms,
 /area/science/xenobiology)
-"uwE" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 11
-	},
-/turf/open/floor/plating,
-/area/security/prison)
 "uwH" = (
 /mob/living/simple_animal/opossum/poppy,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/engine)
+"uwL" = (
+/turf/open/floor/plasteel/cafeteria,
+/area/space/station_ruins)
 "uwX" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical,
@@ -61344,9 +60639,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "uzh" = (
@@ -61382,6 +60674,15 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/white,
 /area/medical/psych)
+"uAv" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "uAU" = (
 /obj/structure/table/wood,
 /obj/item/folder/blue,
@@ -61410,27 +60711,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
-"uEq" = (
-/obj/structure/holohoop,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/security/prison)
-"uGM" = (
-/obj/machinery/holopad,
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/cyan/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "uHG" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -61438,6 +60718,10 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
+"uHM" = (
+/obj/machinery/smartfridge/food,
+/turf/closed/wall,
+/area/space/station_ruins)
 "uIn" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -61450,28 +60734,28 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engine/engineering)
-"uJe" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/item/reagent_containers/food/condiment/saltshaker,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
-"uKX" = (
+"uJr" = (
+/obj/machinery/door/poddoor{
+	id = "soli1"
+	},
+/turf/open/floor/mineral/titanium/white{
+	name = "secure isolation floor"
+	},
+/area/space/station_ruins)
+"uLj" = (
 /obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/camera{
-	c_tag = "Permabrig East Hallway 2";
-	dir = 8;
-	network = list("ss13","prison");
-	start_active = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/camera{
+	c_tag = "Permabrig West Hallway 1";
+	dir = 4;
+	network = list("ss13","prison")
+	},
 /turf/open/floor/plasteel,
-/area/security/prison)
+/area/space/station_ruins)
 "uLF" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -61488,12 +60772,6 @@
 /obj/item/clothing/gloves/color/black,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"uMi" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Laundry"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "uMo" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/tile/yellow,
@@ -61511,28 +60789,49 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/machinery/airalarm{
+	pixel_y = 23
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"uPo" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
+"uNt" = (
+/obj/structure/grille,
+/turf/open/space,
+/area/space/station_ruins)
+"uOM" = (
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "0-8"
 	},
+/obj/machinery/power/solar{
+	id = "starboardsolar";
+	name = "Starboard Solar Array"
+	},
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/solar/port)
+"uPf" = (
+/turf/open/floor/plasteel/vaporwave,
+/area/space/station_ruins)
+"uPg" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Visitation - Prisoners"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/preopen{
+	id = "visitexit"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
+"uQR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
+	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 4
+	dir = 6
 	},
 /turf/open/floor/plasteel,
-/area/security/prison)
-"uQR" = (
-/obj/item/ammo_casing/shotgun/beanbag,
-/turf/open/floor/plating,
-/area/maintenance/department/security/brig)
+/area/space/station_ruins)
 "uRk" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 5
@@ -61542,21 +60841,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"uSx" = (
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
-"uST" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "uUQ" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Engineering Maintenance";
@@ -61583,6 +60867,17 @@
 /obj/item/stamp/law,
 /turf/open/floor/carpet,
 /area/lawoffice)
+"uVx" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/wood,
+/area/space/station_ruins)
 "uXG" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -61619,6 +60914,23 @@
 /obj/structure/window/reinforced,
 /turf/open/space,
 /area/space/nearstation)
+"uZz" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/delivery,
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
+/obj/structure/plasticflaps,
+/obj/machinery/conveyor/auto{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "vay" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -61629,19 +60941,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/white,
 /area/hallway/secondary/entry)
-"vaD" = (
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "vbn" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/atm{
@@ -61707,10 +61006,35 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
+"vhd" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/structure/closet/crate/bin,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "vhk" = (
 /obj/structure/chair,
 /turf/open/floor/carpet,
 /area/lawoffice)
+"vhA" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/manifold/cyan/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "vim" = (
 /mob/living/simple_animal/pet/roro/roboticsroro,
 /turf/open/floor/plasteel,
@@ -61801,6 +61125,19 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
+"voE" = (
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/structure/closet/crate/bin,
+/obj/machinery/requests_console{
+	department = "Prison";
+	departmentType = 1;
+	pixel_y = -30
+	},
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "vpz" = (
 /obj/structure/girder,
 /turf/open/floor/plating{
@@ -61808,6 +61145,12 @@
 	luminosity = 2
 	},
 /area/maintenance/department/science)
+"vqQ" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Showers"
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/space/station_ruins)
 "vqV" = (
 /obj/structure/chair{
 	dir = 4
@@ -61819,6 +61162,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"vrX" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/snacks/fortunecookie,
+/turf/open/floor/plasteel/cafeteria,
+/area/space/station_ruins)
 "vsk" = (
 /obj/machinery/atmospherics/pipe/simple/general/hidden,
 /obj/structure/cable{
@@ -61837,9 +61185,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"vsy" = (
-/turf/open/floor/plating,
-/area/security/prison)
 "vsG" = (
 /obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
 	dir = 4;
@@ -61876,15 +61221,26 @@
 /obj/item/clothing/mask/gas,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"vvM" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
+"vvq" = (
+/obj/machinery/holopad,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/manifold/cyan/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/manifold/cyan/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
-/area/security/prison)
+/area/space/station_ruins)
+"vvI" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/space/station_ruins)
 "vxp" = (
 /obj/machinery/door/window/eastright{
 	base_state = "left";
@@ -61963,23 +61319,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
-"vAN" = (
-/obj/machinery/light,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"vBf" = (
-/obj/machinery/airalarm/directional/north,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "vBE" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
@@ -62003,23 +61342,21 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
-"vDn" = (
-/obj/machinery/vending/snack/random,
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
-"vFn" = (
-/obj/machinery/requests_console{
-	department = "Prison";
-	departmentType = 1
-	},
-/turf/closed/wall/r_wall,
-/area/security/prison)
 "vGg" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"vGo" = (
+/obj/structure/closet/crate/bin,
+/obj/machinery/requests_console{
+	department = "Prison";
+	departmentType = 1;
+	pixel_y = -30
+	},
+/turf/open/floor/plasteel/white,
+/area/space/station_ruins)
 "vIc" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -62029,19 +61366,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
-"vIZ" = (
-/obj/structure/bookcase/random,
-/turf/open/floor/wood,
-/area/security/prison)
-"vJU" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+"vJC" = (
+/obj/structure/filingcabinet,
+/obj/machinery/camera{
+	c_tag = "Permabrig Library";
+	network = list("ss13","prison")
 	},
 /turf/open/floor/wood,
-/area/security/prison)
+/area/space/station_ruins)
 "vKq" = (
 /obj/machinery/door/firedoor,
 /obj/structure/sign/poster/official/random{
@@ -62064,6 +61396,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
+"vNK" = (
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "vOw" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Library"
@@ -62078,19 +61414,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/library)
-"vPA" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Diner"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
 "vRi" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -62128,19 +61451,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"vSJ" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Library"
+"vRQ" = (
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -22
 	},
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/wood,
-/area/security/prison)
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "vTx" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -62179,12 +61502,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
-"vUr" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/security/prison)
 "vVO" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /obj/structure/cable/yellow{
@@ -62195,15 +61512,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"vXW" = (
-/obj/machinery/button/door{
-	id = "permalock2";
-	name = "Perma Secure Airlock";
-	pixel_y = -26;
-	req_access_txt = "3"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "vYN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8;
@@ -62213,19 +61521,22 @@
 	},
 /turf/open/floor/circuit/telecomms,
 /area/science/xenobiology)
-"vZE" = (
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
-/turf/open/floor/plasteel/grimy,
-/area/security/prison)
 "wat" = (
 /obj/machinery/atm{
 	pixel_y = 30
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"waW" = (
+/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "wbB" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	name = "External Gas to Loop"
@@ -62259,16 +61570,6 @@
 /obj/structure/ore_box,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"wfd" = (
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
-	},
-/obj/machinery/cryopod{
-	dir = 8
-	},
-/turf/open/floor/circuit/green,
-/area/security/prison)
 "wfs" = (
 /obj/structure/table,
 /obj/item/clothing/gloves/color/latex,
@@ -62305,24 +61606,6 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/security/brig)
-"wjj" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/machinery/camera{
-	c_tag = "Permabrig Garden";
-	dir = 4;
-	network = list("ss13","prison")
-	},
-/obj/structure/sign/poster/official/random{
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "wjm" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -62355,6 +61638,22 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"wlJ" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/conveyor/auto{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4;
+	layer = 2.9
+	},
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "wnJ" = (
 /obj/structure/sign/warning,
 /turf/closed/wall,
@@ -62371,15 +61670,39 @@
 /turf/open/floor/plating,
 /area/engine/supermatter)
 "woq" = (
-/obj/structure/chair,
-/turf/open/floor/plating,
-/area/maintenance/department/security/brig)
+/obj/structure/chair/stool,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "wqu" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 8
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
+"wri" = (
+/obj/machinery/light,
+/obj/machinery/requests_console{
+	department = "Prison";
+	departmentType = 1;
+	pixel_y = -30
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel/checker,
+/area/space/station_ruins)
+"wrn" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/item/reagent_containers/food/condiment/saltshaker,
+/turf/open/floor/plasteel/white,
+/area/space/station_ruins)
 "wrU" = (
 /obj/machinery/photocopier,
 /obj/machinery/firealarm{
@@ -62388,17 +61711,14 @@
 	},
 /turf/open/floor/wood,
 /area/lawoffice)
-"wsB" = (
-/obj/machinery/holopad,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+"wtt" = (
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/manifold/cyan/hidden/layer1{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/manifold4w/cyan/hidden/layer1,
 /turf/open/floor/plasteel,
-/area/security/prison)
+/area/space/station_ruins)
 "wtE" = (
 /obj/effect/landmark/start/paramedic,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -62409,16 +61729,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"wub" = (
-/obj/machinery/airalarm/directional/west,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "wun" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -62434,6 +61744,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"wvK" = (
+/obj/machinery/vending/cola/random,
+/turf/open/floor/plasteel/cafeteria,
+/area/space/station_ruins)
 "wwr" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -62444,11 +61758,15 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "wwG" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen/blue,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/maintenance/department/security/brig)
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "wxb" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -62472,10 +61790,6 @@
 /obj/structure/chair,
 /turf/open/floor/wood,
 /area/maintenance/department/engine)
-"wzj" = (
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "wAC" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
 /obj/effect/turf_decal/delivery,
@@ -62508,34 +61822,32 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
-"wBk" = (
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
+"wCj" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Diner"
 	},
-/obj/structure/closet/crate/bin,
-/obj/machinery/requests_console{
-	department = "Prison";
-	departmentType = 1;
-	pixel_y = -30
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"wBS" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"wCp" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/wood,
-/area/security/prison)
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/space/station_ruins)
+"wCR" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/flasher{
+	id = "visitflash";
+	pixel_y = 25
+	},
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "wDe" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Monastery Transit"
@@ -62549,9 +61861,16 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "wDm" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating,
-/area/maintenance/department/security/brig)
+/obj/structure/table,
+/obj/item/storage/pill_bottle/dice,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "wDZ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -62570,23 +61889,6 @@
 	dir = 1
 	},
 /area/hallway/secondary/exit/departure_lounge)
-"wEp" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Permabrig Laundry";
-	dir = 4;
-	network = list("ss13","prison")
-	},
-/obj/structure/sign/poster/official/random{
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "wFT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
@@ -62596,6 +61898,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"wHu" = (
+/obj/machinery/camera/motion{
+	c_tag = "Armory External";
+	dir = 1
+	},
+/turf/open/space/basic,
+/area/space)
 "wHI" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
@@ -62607,10 +61916,14 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
-"wHX" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
-/turf/open/floor/plasteel/grimy,
-/area/security/prison)
+"wIm" = (
+/obj/machinery/atmospherics/components/binary/valve{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/plating,
+/area/space/station_ruins)
 "wIo" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /obj/structure/lattice,
@@ -62628,15 +61941,21 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"wIY" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+"wIX" = (
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#cee5d2"
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
+/obj/machinery/vending/hydroseeds,
 /turf/open/floor/plasteel,
-/area/security/prison)
+/area/space/station_ruins)
 "wJP" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
@@ -62648,6 +61967,14 @@
 /obj/machinery/light/small,
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
+"wKI" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/condiment/enzyme{
+	layer = 5
+	},
+/obj/item/reagent_containers/food/condiment/sugar,
+/turf/open/floor/plasteel/white,
+/area/space/station_ruins)
 "wLo" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -62677,6 +62004,12 @@
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating,
 /area/engine/supermatter)
+"wNj" = (
+/obj/effect/turf_decal/lumos/tile/yellow/half{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "wNq" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -62689,18 +62022,18 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"wNU" = (
-/obj/machinery/vr_sleeper{
-	dir = 4
-	},
-/turf/open/floor/circuit,
-/area/security/prison)
 "wOf" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"wOt" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/item/reagent_containers/food/condiment/peppermill,
+/turf/open/floor/plasteel/white,
+/area/space/station_ruins)
 "wOS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/machinery/light/small{
@@ -62708,6 +62041,10 @@
 	},
 /turf/open/floor/plating,
 /area/science/mixing)
+"wPE" = (
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/plasteel/white,
+/area/space/station_ruins)
 "wPW" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -62805,12 +62142,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"wXf" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Showers"
+"wWU" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
 	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/prison)
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "wXu" = (
 /obj/machinery/disposal/bin,
 /obj/structure/window/reinforced{
@@ -62822,26 +62167,26 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
-"wYu" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "shootshut"
-	},
+"wYs" = (
+/obj/machinery/space_heater,
 /turf/open/floor/plating,
-/area/maintenance/department/security/brig)
+/area/space/station_ruins)
+"wYu" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/space/station_ruins)
 "wYK" = (
 /obj/machinery/power/supermatter_crystal/engine,
 /turf/open/floor/engine,
 /area/engine/supermatter)
-"wZa" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/machinery/washing_machine,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "wZs" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -62850,19 +62195,6 @@
 	heat_capacity = 1e+006
 	},
 /area/hallway/secondary/entry)
-"xab" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Diner"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "xah" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -62903,20 +62235,10 @@
 "xbJ" = (
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/crew_quarters/dorms)
-"xdt" = (
-/obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"xdK" = (
-/obj/machinery/camera{
-	c_tag = "Permabrig Prisoner Arrivals";
-	dir = 8;
-	name = "aft camera"
-	},
+"xea" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/plasteel,
-/area/security/prison)
+/area/security/main)
 "xee" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/vacuum/external,
@@ -62939,12 +62261,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/white,
 /area/hallway/secondary/entry)
-"xfT" = (
-/obj/structure/mopbucket,
-/obj/item/mop,
-/obj/item/reagent_containers/glass/bucket,
-/turf/open/floor/plating,
-/area/security/prison)
 "xgh" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -62982,6 +62298,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"xiy" = (
+/obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/space/station_ruins)
 "xja" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -63066,6 +62389,16 @@
 "xnP" = (
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
+"xqB" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/space,
+/area/solar/port)
 "xsO" = (
 /obj/item/ectoplasm,
 /turf/open/floor/plating{
@@ -63081,17 +62414,6 @@
 /obj/item/broken_bottle,
 /turf/open/floor/plating,
 /area/maintenance/solars/port)
-"xvj" = (
-/obj/structure/rack,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/item/tank/internals/nitrogen/belt,
-/obj/item/tank/internals/nitrogen/belt,
-/obj/item/tank/internals/plasmaman/belt,
-/obj/item/tank/internals/plasmaman/belt,
-/turf/open/floor/plating,
-/area/security/prison)
 "xvT" = (
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
@@ -63100,20 +62422,10 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "xwo" = (
-/obj/structure/lattice,
-/turf/closed/wall/r_wall,
-/area/security/prison)
-"xwG" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/airalarm/directional/east,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
-/turf/open/floor/plasteel,
-/area/security/prison)
+/obj/structure/target_stake,
+/obj/item/target/syndicate,
+/turf/open/floor/plating,
+/area/security/main)
 "xxw" = (
 /obj/machinery/atmospherics/components/binary/pump,
 /turf/open/floor/plasteel/dark,
@@ -63152,9 +62464,8 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "xyB" = (
-/obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating{
-	icon_state = "panelscorched"
+	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/security/brig)
 "xzp" = (
@@ -63164,6 +62475,25 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
+"xzB" = (
+/obj/machinery/atmospherics/components/unary/tank/air{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/space/station_ruins)
+"xzQ" = (
+/obj/structure/toilet{
+	contents = newlist(/obj/item/toy/snappop/phoenix);
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/space/station_ruins)
 "xzR" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible,
 /obj/effect/turf_decal/stripes/line{
@@ -63171,13 +62501,26 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"xAd" = (
+"xAM" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/preopen{
-	id = "permalock2"
+/obj/machinery/door/airlock/public/glass{
+	name = "Diner"
 	},
-/turf/open/floor/plasteel,
-/area/security/prison)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/space/station_ruins)
+"xBf" = (
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/kitchen)
 "xCb" = (
 /obj/structure/transit_tube/crossing,
 /turf/open/floor/plasteel/white{
@@ -63207,14 +62550,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"xEc" = (
-/obj/machinery/camera{
-	c_tag = "Permabrig Kitchen";
-	network = list("ss13","prison")
+"xEb" = (
+/obj/structure/bed,
+/obj/effect/landmark/start/prisoner,
+/obj/item/radio/intercom{
+	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_y = 24;
+	prison_radio = 1
 	},
-/obj/machinery/processor,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
+/obj/item/bedsheet/orange,
+/turf/open/floor/plasteel/dark,
+/area/space/station_ruins)
 "xFl" = (
 /obj/machinery/power/apc/highcap/five_k{
 	areastring = "/area/tcommsat/server";
@@ -63232,11 +62579,6 @@
 /obj/effect/landmark/carpspawn,
 /turf/open/space,
 /area/space/station_ruins)
-"xIb" = (
-/obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "xIx" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
@@ -63281,6 +62623,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/lawoffice)
+"xNu" = (
+/obj/machinery/computer/security,
+/turf/open/floor/plasteel,
+/area/security/main)
 "xNx" = (
 /obj/structure/lattice,
 /obj/structure/disposalpipe/junction/flip,
@@ -63293,10 +62639,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"xNX" = (
-/obj/machinery/deepfryer,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "xOC" = (
 /obj/machinery/door/airlock/external{
 	name = "Construction Zone"
@@ -63323,6 +62665,13 @@
 /obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/plasteel/freezer,
 /area/storage/emergency/port)
+"xQl" = (
+/obj/structure/toilet{
+	dir = 4
+	},
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/plasteel/freezer,
+/area/crew_quarters/toilet/auxiliary)
 "xSd" = (
 /obj/machinery/light/small,
 /turf/open/floor/plating,
@@ -63333,26 +62682,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
-"xTV" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#cee5d2"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"xUV" = (
-/obj/structure/weightmachine/weightlifter,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "xVt" = (
 /obj/effect/spawner/lootdrop/maintenance{
 	name = "2maintenance loot spawner"
@@ -63373,16 +62702,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
-"xWN" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+"xWm" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
 /turf/open/floor/plasteel,
-/area/security/prison)
+/area/security/main)
+"xWy" = (
+/obj/structure/bed,
+/obj/item/radio/intercom{
+	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_y = 24;
+	prison_radio = 1
+	},
+/obj/item/bedsheet/orange,
+/turf/open/floor/plasteel/dark,
+/area/space/station_ruins)
 "xYR" = (
 /mob/living/simple_animal/opossum,
 /turf/open/floor/plating{
@@ -63394,46 +62730,58 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/department/chapel/monastery)
+"xZB" = (
+/obj/effect/turf_decal/lumos/tile/blue/half{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"yaF" = (
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
+"ybI" = (
+/obj/machinery/door/airlock/public/glass,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/space/station_ruins)
 "ybX" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"ycc" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "ycr" = (
-/obj/structure/target_stake,
-/obj/item/target/syndicate,
-/turf/open/floor/plating,
-/area/maintenance/department/security/brig)
+/obj/item/toy/beach_ball/holoball,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/space/station_ruins)
 "ycx" = (
 /turf/open/floor/wood{
 	icon_state = "wood-broken5"
 	},
 /area/maintenance/department/engine)
 "ycE" = (
-/obj/machinery/hydroponics/constructable,
-/obj/machinery/light,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
+/turf/open/space/basic,
 /area/security/prison)
 "ydf" = (
 /obj/machinery/light/small{
@@ -66857,17 +66205,17 @@ rmC
 rmC
 rmC
 rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
+ahO
+ahO
+ahO
+ahO
+ahO
+ahO
+ahO
+ahO
+ahO
+ahO
+ahO
 rmC
 rmC
 rmC
@@ -67114,17 +66462,17 @@ rmC
 rmC
 rmC
 rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
+ahO
+aiK
+aiK
+aiK
+aiK
+aiK
+aiK
+aiK
+gvS
+aiK
+ahO
 rmC
 rmC
 rmC
@@ -67357,31 +66705,31 @@ rmC
 rmC
 rmC
 rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
+ahO
+ahO
+ahO
+ahO
+ahO
+ahO
+ahO
+ahO
+ahO
+ahO
+ahO
+ahO
+ahO
+ahO
+ahO
+aiK
+ara
+ara
+ara
+ara
+ara
+ara
+ara
+aiK
+ahO
 rmC
 rmC
 rmC
@@ -67614,31 +66962,31 @@ rmC
 rmC
 rmC
 rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
+ahO
+aiK
+aiK
+aiK
+aiK
+aiK
+aiK
+aiK
+aiK
+aiK
+aiK
+nfB
+aiK
+aiK
+aiK
+aiK
+ara
+oxy
+lrk
+cPc
+mCD
+cWb
+ara
+aiK
+ahO
 rmC
 rmC
 rmC
@@ -67871,31 +67219,31 @@ rmC
 rmC
 rmC
 rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
+ahO
+epJ
+ara
+ara
+ara
+ara
+ara
+ara
+ara
+ara
+ara
+ara
+ara
+ara
+ara
+ara
+ara
+iVw
+azI
+cYF
+azI
+sYN
+ara
+aiK
+ahO
 rmC
 rmC
 rmC
@@ -68128,31 +67476,31 @@ rmC
 rmC
 rmC
 rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
+ahO
+aiK
+ara
+noC
+tlc
+llv
+ara
+ncM
+tRx
+cMk
+ncM
+tru
+lKk
+nAK
+riD
+fGY
+lKk
+fzv
+azI
+fBH
+kUE
+sYN
+ara
+aiK
+ahO
 rmC
 rmC
 rmC
@@ -68385,31 +67733,31 @@ rmC
 rmC
 rmC
 rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
+ahO
+aiK
+ara
+noC
+tpb
+wri
+ara
+jwo
+rnG
+lGA
+rnG
+iVl
+lKk
+tvn
+lPt
+iEH
+lKk
+cil
+azI
+azI
+oeQ
+voE
+ara
+aiK
+ahO
 rmC
 rmC
 rmC
@@ -68640,33 +67988,33 @@ rmC
 rmC
 rmC
 rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
+ahO
+ahO
+ahO
+aiK
+ara
+noC
+uaE
+gca
+ara
+nSr
+nSr
+rnG
+ney
+nSr
+lKk
+tvn
+pxw
+vhd
+lKk
+wIX
+dDo
+kjy
+yaF
+kML
+ara
+aiK
+aiK
 rmC
 rmC
 rmC
@@ -68897,32 +68245,32 @@ rmC
 rmC
 rmC
 rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
+ahO
+aiK
+aiK
+aiK
+ara
+ara
+ara
+uaS
+ara
+lKk
+lKk
+vqQ
+lKk
+lKk
+lKk
+lKk
+olO
+lKk
+lKk
+lKk
+lKk
+uHM
+thm
+ara
+ara
+aiK
 rmC
 rmC
 rmC
@@ -69152,34 +68500,34 @@ rmC
 rmC
 rmC
 rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
+ahO
+ahO
+ahO
+aiK
+ajX
+ajY
+azG
+nze
+ufu
+gTP
+kWw
+ufu
+hcf
+ufu
+jIn
+faI
+dop
+ufu
+ufu
+ufu
+uLj
+ufu
+kWw
+ufu
+gTP
+ara
+ara
+aiK
 rmC
 rmC
 rmC
@@ -69409,34 +68757,34 @@ rmC
 rmC
 rmC
 rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
+ahO
+aiK
+aiK
+aiK
+ayy
+fIN
+azI
+azI
+uQR
+hfp
+jMl
+uhM
+uhM
+mTk
+vhA
+jWW
+uhM
+uhM
+uhM
+mTk
+uhM
+uhM
+jMl
+bXT
+qTM
+ara
+aiK
+aiK
 rmC
 rmC
 rmC
@@ -69664,36 +69012,36 @@ rmC
 rmC
 rmC
 rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
+ahO
+ahO
+ahO
+aiK
+ara
+ajY
+ara
+fJn
+azI
+oFf
+woq
+lYx
+gAr
+lKk
+lKk
+lKk
+lKk
+lKk
+lKk
+lKk
+lKk
+lKk
+lKk
+lKk
+lKk
+qio
+waW
+ara
+aiK
+aiK
 rmC
 rmC
 rmC
@@ -69730,11 +69078,11 @@ aaa
 aaa
 aaa
 aaa
-aoH
-aoH
-aoH
-aoH
-aoH
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -69921,37 +69269,37 @@ rmC
 rmC
 rmC
 rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
+ahO
+aiK
+aiK
+aiK
+ayy
+azL
+bmq
+aAV
+lcU
+pdq
+wwG
+gIo
+lKk
+xWy
+xzQ
+lKk
+xEb
+xzQ
+lKk
+xWy
+xzQ
+lKk
+xEb
+xzQ
+lKk
+eNz
+ioG
+ara
+ara
+ara
+ara
 rmC
 rmC
 rmC
@@ -69987,11 +69335,11 @@ aaa
 aaa
 aaa
 aaa
-aoH
 aaa
-aoI
 aaa
-aoH
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -70178,77 +69526,77 @@ rmC
 rmC
 rmC
 rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aoI
-aoI
+ahO
+ajW
+ajX
+ajY
 azG
-aoI
-aoI
+azZ
+azI
+aAV
+azI
+oFf
+wDm
+fJx
+lKk
+mor
+mor
+lKk
+mor
+mor
+lKk
+mor
+mor
+lKk
+mor
+mor
+lKk
+eNz
+ioG
+lKk
+uZz
+fkz
+wlJ
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aoH
+aoH
+aoH
+aoH
+aoH
 aaa
 aaa
 aaa
@@ -70435,37 +69783,37 @@ rmC
 rmC
 rmC
 rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
+ahO
+aiK
+ajY
+anq
+azI
+aAV
+azI
+aAV
+azI
+oFf
+woq
+lYx
+lKk
+lKk
+hoC
+lKk
+lKk
+hoC
+lKk
+lKk
+hoC
+lKk
+lKk
+hoC
+gAr
+ipj
+jfc
+rTp
+jiV
+dUt
+sKG
 rmC
 rmC
 rmC
@@ -70492,29 +69840,29 @@ aaa
 aaa
 aaa
 aaa
-aoH
-aoH
-aoH
-aoH
-aoH
-aoH
-aoH
-aoH
-aoH
-aoH
 aaa
-azH
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aoH
+aaa
+hzz
+aaa
 aoH
-aoH
-aoH
-aoH
-aoH
-aoH
-aoH
-aoH
-aoH
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -70692,37 +70040,37 @@ rmC
 rmC
 rmC
 rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
+ahO
+aiK
+ali
+aoJ
+azI
+aCa
+boA
+gGy
+boA
+boA
+wYu
+cPn
+fJq
+azI
+azI
+mLU
+azI
+azI
+nSt
+noE
+azI
+fRc
+azI
+azI
+fJq
+eNz
+ioG
+iid
+nPq
+azI
+azI
 rmC
 rmC
 rmC
@@ -70749,7 +70097,6 @@ aaa
 aaa
 aaa
 aaa
-aoI
 aaa
 aaa
 aaa
@@ -70759,19 +70106,20 @@ aaa
 aaa
 aaa
 aaa
-aaa
-azH
-aaa
-aaa
-aaa
-aaa
-aaa
+hzz
+hzz
+qAN
+hzz
+hzz
 aaa
 aaa
 aaa
 aaa
 aaa
-aoI
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -70949,37 +70297,37 @@ rmC
 rmC
 rmC
 rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
+ahO
+aiK
+ali
+aqb
+azI
+aGC
+boC
+gJF
+boC
+boC
+ycr
+jIO
+fJq
+azI
+azI
+azI
+azI
+azI
+eAy
+azI
+azI
+azI
+azI
+azI
+fJq
+eNz
+ioG
+iid
+azI
+azI
+lGd
 rmC
 rmC
 rmC
@@ -71007,27 +70355,27 @@ aaa
 aaa
 aaa
 aoH
+aoH
+aoH
+aoH
+aoH
+aoH
+aoH
+aoH
+aoH
+aoH
 aaa
-aqa
-aqa
-aqa
-aqa
-aqa
-aqa
-aqa
-aqa
+azH
 aaa
-azI
-aaa
-aqa
-aqa
-aqa
-aqa
-aqa
-aqa
-aqa
-aqa
-aaa
+aoH
+aoH
+aoH
+aoH
+aoH
+aoH
+aoH
+aoH
+aoH
 aoH
 aaa
 aaa
@@ -71206,86 +70554,86 @@ rmC
 rmC
 rmC
 rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-aaa
-aaa
-aaa
-aaa
-aoH
-aoI
-aqb
-ara
-ara
-ara
-ara
-ara
-ara
-ara
-ayy
+ahO
+aiK
+alD
+aqe
 azJ
-aAV
-aCa
-aCa
-aCa
-aCa
-aCa
-aCa
-aCa
 aIr
-aoI
-aoH
+bpI
+hiw
+bpI
+bpI
+oco
+uVx
+eKN
+fkG
+fkG
+nqT
+fkG
+fkG
+hUl
+lIi
+lIi
+gLY
+lIi
+lIi
+uAv
+wWU
+wtt
+lUw
+lIi
+qbV
+lIi
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+aaa
+aaa
+aaa
+aaa
+hzz
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+azH
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+hzz
 aaa
 aaa
 aaa
@@ -71463,37 +70811,37 @@ rmC
 rmC
 rmC
 rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
+ahO
+aiK
+amo
+aoJ
+azI
+aAV
+azI
+aAV
+azI
+oFf
+cPx
+lYx
+gAr
+lKk
+hoC
+lKk
+lKk
+hoC
+lKk
+lKk
+hoC
+lKk
+lKk
+hoC
+lKk
+ipj
+jfc
+lKk
+uJr
+lKk
+iOi
 rmC
 rmC
 rmC
@@ -71522,16 +70870,16 @@ aaa
 aaa
 aoH
 aaa
-aqc
-aqc
-aqc
-aqc
-aqc
-aqc
-aqc
-aqc
+aqd
+aqd
+aqd
+aqd
+aqd
+aqd
+aqd
+aqd
 aaa
-azK
+rCs
 aaa
 aqd
 aqd
@@ -71540,7 +70888,7 @@ aqd
 aqd
 aqd
 aqd
-aqc
+aqd
 aaa
 aoH
 aaa
@@ -71720,37 +71068,37 @@ rmC
 rmC
 rmC
 rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
+ahO
+aiK
+ajX
+amo
+azG
+azZ
+azI
+aAV
+azI
+oFf
+kDR
+eKC
+lKk
+mor
+mor
+lKk
+mor
+mor
+lKk
+mor
+mor
+lKk
+mor
+mor
+lKk
+eNz
+ioG
+lKk
+kJx
+lKk
+ssO
 rmC
 rmC
 rmC
@@ -71777,28 +71125,28 @@ aaa
 aaa
 aaa
 aaa
-aoJ
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-azK
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aoH
+hzz
+xqB
+aoI
+aoI
+aoI
+aoI
+aoI
+aoI
+aoI
+lWE
+law
+lyn
+eIW
+eIW
+eIW
+eIW
+eIW
+eIW
+eIW
+jjI
+hzz
 aoH
 aaa
 aaa
@@ -71977,37 +71325,37 @@ rmC
 rmC
 rmC
 rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
+ahO
+aiK
+aiK
+aiK
+ayy
+aWm
+azI
+aAV
+lXc
+plA
+qXb
+gVH
+lKk
+xEb
+ugw
+lKk
+xWy
+ugw
+lKk
+xEb
+ugw
+lKk
+xWy
+ugw
+lKk
+eNz
+fxz
+ara
+ara
+ara
+ara
 rmC
 rmC
 rmC
@@ -72047,13 +71395,13 @@ aqa
 aaa
 azK
 aaa
-aqa
-aqa
-aqa
-aqa
-aqa
-aqa
-aqa
+uOM
+uOM
+uOM
+uOM
+uOM
+uOM
+uOM
 aqa
 aaa
 aoH
@@ -72234,85 +71582,85 @@ rmC
 rmC
 rmC
 rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-aaa
-aaa
-aaa
-aaa
-aoH
-aoI
-aqb
+ahO
+ahO
+ahO
+aiK
 ara
-ara
-ara
-ara
-ara
-ara
-ara
-ayy
-azK
+amo
+cnV
 aAV
-aCa
-aCa
-aCa
-aCa
-aCa
-aCa
-aCa
-aIr
-aoI
+azI
+oFf
+cPx
+lYx
+lKk
+lKk
+lKk
+lKk
+lKk
+lKk
+lKk
+lKk
+lKk
+lKk
+lKk
+lKk
+gAr
+nfk
+waW
+ara
+eNz
+azI
+mSf
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+aaa
+aaa
+aaa
+aaa
+lNr
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+azK
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aoH
 aaa
 aaa
@@ -72493,35 +71841,35 @@ rmC
 rmC
 rmC
 rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
+ahO
+aiK
+aiK
+aiK
+ayy
+hue
+mwg
+azI
+ask
+fvX
+khD
+fIo
+gMP
+oGN
+feH
+rRM
+fIo
+pfY
+fIo
+iRm
+fIo
+fIo
+pfY
+vvq
+jCM
+uPg
+hlU
+ffQ
+mSf
 rmC
 rmC
 rmC
@@ -72550,14 +71898,14 @@ aaa
 aaa
 aoH
 aaa
-aqc
-aqc
-aqc
-aqc
-aqc
-aqc
-aqc
-aqc
+aqd
+aqd
+aqd
+aqd
+aqd
+aqd
+aqd
+aqd
 aaa
 azK
 aaa
@@ -72568,7 +71916,7 @@ aqd
 aqd
 aqd
 aqd
-aqc
+aqd
 aaa
 aoH
 aaa
@@ -72750,35 +72098,35 @@ rmC
 rmC
 rmC
 rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
+ahO
+ahO
+ahO
+aiK
+ajX
+amo
+azG
+rlL
+koU
+skm
+ipu
+skm
+ibA
+skm
+ipP
+ehK
+skm
+ibA
+skm
+ipu
+tcg
+skm
+ibA
+skm
+skm
+ara
+wCR
+pvl
+azI
 rmC
 rmC
 rmC
@@ -72806,27 +72154,27 @@ aaa
 aaa
 aaa
 aoH
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+hzz
+xqB
+aoI
+aoI
+aoI
+aoI
+aoI
+aoI
+aoI
+lWE
 azK
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+lyn
+eIW
+eIW
+eIW
+eIW
+eIW
+eIW
+eIW
+jjI
+hzz
 aoH
 aaa
 aaa
@@ -73009,33 +72357,33 @@ rmC
 rmC
 rmC
 rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
+ahO
+aiK
+aiK
+aiK
+ara
+ara
+ioG
+ara
+lKk
+lKk
+eqA
+lKk
+lKk
+lKk
+lKk
+xAM
+lKk
+lKk
+lKk
+lKk
+wCj
+lKk
+lKk
+ara
+eNz
+azI
+mSf
 rmC
 rmC
 rmC
@@ -73075,13 +72423,13 @@ aqa
 aaa
 azK
 aaa
-aqa
-aqa
-aqa
-aqa
-aqa
-aqa
-aqa
+uOM
+uOM
+uOM
+uOM
+uOM
+uOM
+uOM
 aqa
 aaa
 aoH
@@ -73264,35 +72612,35 @@ rmC
 rmC
 rmC
 rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
+ahO
+aiK
+ara
+ara
+ara
+ara
+ara
+ara
+ybI
+ara
+rlD
+rlD
+kdo
+rlD
+rlD
+lKk
+aTG
+gbM
+tVx
+lKk
+ftO
+ftO
+rKv
+ftO
+fTo
+ara
+msD
+ePb
+mSf
 rmC
 rmC
 rmC
@@ -73320,27 +72668,27 @@ aaa
 aaa
 aaa
 aoH
-aoI
-aqb
-ara
-ara
-ara
-ara
-ara
-ara
-ara
-ayy
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 azK
-aAV
-aCa
-aCa
-aCa
-aCa
-aCa
-aCa
-aCa
-aIr
-aoI
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aoH
 aaa
 aaa
@@ -73521,35 +72869,35 @@ rmC
 rmC
 rmC
 rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
+ahO
+aiK
+ara
+bbv
+bcs
+hFy
+bbv
+lcU
+nEl
+ara
+sQi
+kTE
+isH
+jEd
+boC
+lKk
+eGB
+gbM
+sXP
+lKk
+jYk
+kUq
+rKv
+jYk
+nRs
+ara
+ara
+ara
+kKv
 rmC
 rmC
 rmC
@@ -73585,7 +72933,7 @@ aqd
 aqd
 aqd
 aqd
-aqc
+aqd
 aaa
 azK
 aaa
@@ -73596,7 +72944,7 @@ aqd
 aqd
 aqd
 aqd
-aqc
+aqd
 aaa
 aoH
 aaa
@@ -73778,35 +73126,35 @@ rmC
 rmC
 rmC
 rmC
+ahO
+aiK
+ara
+bcs
+cor
+cor
+bcs
+azI
+cLt
+ara
+rlD
+rlD
+mwa
+rlD
+rlD
+lKk
+dcp
+gbM
+dBT
+lKk
+mcP
+mcP
+rKv
+mcP
+vrX
+ara
 rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
+ara
+uPf
 rmC
 rmC
 rmC
@@ -73834,28 +73182,28 @@ aaa
 aaa
 aaa
 aoH
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+hzz
+xqB
+aoI
+aoI
+aoI
+aoI
+aoI
+aoI
+aoI
+lWE
 azK
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aoJ
+lyn
+eIW
+eIW
+eIW
+eIW
+eIW
+eIW
+eIW
+jjI
+hzz
+aoH
 aaa
 aaa
 aaa
@@ -74035,35 +73383,35 @@ rmC
 rmC
 rmC
 rmC
+ahO
+aiK
+ara
+bcs
+cor
+cor
+bcs
+azI
+vRQ
+ara
+vJC
+boC
+sDI
+dKx
+lEY
+lKk
+fnl
+czx
+vGo
+lKk
+nxz
+ftO
+vvI
+ftO
+ftO
+ara
 rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
+ara
+uPf
 rmC
 rmC
 rmC
@@ -74092,24 +73440,24 @@ aaa
 aaa
 aoH
 aaa
-aqa
-aqa
-aqa
-aqa
-aqa
-aqa
-aqa
+uOM
+uOM
+uOM
+uOM
+uOM
+uOM
+uOM
 aqa
 aaa
 azK
 aaa
-aqa
-aqa
-aqa
-aqa
-aqa
-aqa
-aqa
+uOM
+uOM
+uOM
+uOM
+uOM
+uOM
+uOM
 aqa
 aaa
 aoH
@@ -74292,35 +73640,35 @@ rmC
 rmC
 rmC
 rmC
+ahO
+aiK
+ara
+bbv
+bcs
+jsf
+bbv
+rLi
+jgH
+ara
+cUu
+bbT
+ecj
+lKw
+sfB
+lKk
+jkW
+qzM
+iiX
+uHM
+uwL
+uwL
+xiy
+uwL
+enN
+ara
 rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
+ara
+uPf
 rmC
 rmC
 rmC
@@ -74348,28 +73696,28 @@ aaa
 aaa
 aaa
 aoH
-aoI
-aqb
-ara
-ara
-ara
-ara
-ara
-ara
-ara
-ayy
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 azK
-aAV
-aCa
-aCa
-aCa
-aCa
-aCa
-aCa
-aCa
-aIr
-aoI
-aoH
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+lNr
 aaa
 aaa
 aaa
@@ -74549,35 +73897,35 @@ rmC
 rmC
 rmC
 rmC
+ahO
+aiK
+ara
+ara
+ara
+ara
+ara
+ara
+ybI
+ara
+lKk
+lRM
+lKk
+lKk
+luY
+lKk
+wKI
+kxv
+iiX
+wrn
+uwL
+uwL
+mJX
+uwL
+uwL
+ara
 rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
+ara
+ara
 rmC
 rmC
 rmC
@@ -74613,7 +73961,7 @@ aqd
 aqd
 aqd
 aqd
-aqc
+aqd
 aaa
 azK
 aaa
@@ -74624,7 +73972,7 @@ aqd
 aqd
 aqd
 aqd
-aqc
+aqd
 aaa
 aoH
 aaa
@@ -74806,35 +74154,35 @@ rmC
 rmC
 rmC
 rmC
+ahO
+aiK
 rmC
 rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
+aiK
+aiK
+ara
+rNl
+tZG
+ara
+kzd
+pkg
+iMx
+trD
+qLf
+lKk
+ojn
+iiX
+iiX
+fON
+uwL
+uwL
+uwL
+uwL
+uwL
+ara
+qTw
+lTQ
+ohQ
 rmC
 rmC
 rmC
@@ -74862,28 +74210,28 @@ aaa
 aaa
 aaa
 aoH
-aaa
-aaa
-aaa
+hzz
+xqB
 aoI
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aoI
+aoI
+aoI
+aoI
+aoI
+aoI
+lWE
 azK
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aoI
-aaa
-aaa
-aaa
-aoI
+lyn
+eIW
+eIW
+eIW
+eIW
+eIW
+eIW
+eIW
+jjI
+hzz
+aoH
 aaa
 aaa
 aaa
@@ -75067,31 +74415,31 @@ rmC
 rmC
 rmC
 rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
+cHS
+kJw
+ara
+rNl
+tZG
+ara
+cdf
+jYW
+jYW
+iqx
+wIm
+lKk
+mxc
+iiX
+iiX
+wOt
+uwL
+uwL
+uwL
+uwL
+kxC
+ara
+lTQ
+lTQ
+uNt
 rmC
 rmC
 rmC
@@ -75119,27 +74467,27 @@ aaa
 aaa
 aaa
 aoH
-aoI
-aoH
-aoH
-aoH
 aaa
+uOM
+uOM
+uOM
+uOM
+uOM
+uOM
+uOM
+aqa
 aaa
+azK
 aaa
+uOM
+uOM
+uOM
+uOM
+uOM
+uOM
+uOM
+aqa
 aaa
-aaa
-aaa
-azL
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aoH
-aoI
-aoH
-aoH
 aoH
 aaa
 aaa
@@ -75324,30 +74672,30 @@ rmC
 rmC
 rmC
 rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
+cHS
+aiK
+ara
+rYC
+tZG
+ara
+jDZ
+sge
+wYs
+xzB
+ovc
+lKk
+sCA
+wPE
+lOU
+lKk
+enT
+wvK
+kZm
+rZi
+rZi
+ara
+lTQ
+lTQ
 rmC
 rmC
 rmC
@@ -75375,29 +74723,29 @@ aaa
 aaa
 aaa
 aaa
+aoH
+aaa
+aaa
+aaa
+hzz
 aaa
 aaa
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-azH
-aaa
+azK
 aaa
 aaa
 aaa
 aaa
 aaa
 aaa
+hzz
 aaa
 aaa
 aaa
-aaa
+hzz
 aaa
 aaa
 aaa
@@ -75581,30 +74929,30 @@ rmC
 rmC
 rmC
 rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
+cHS
+aiK
+ara
+sdk
+pny
+ara
+ara
+ara
+ara
+ara
+ara
+ara
+ara
+ara
+ara
+ara
+ara
+ara
+ara
+ara
+ara
+ara
+ohQ
+ohQ
 rmC
 rmC
 rmC
@@ -75632,29 +74980,29 @@ aaa
 aaa
 aaa
 aaa
+aoH
+hzz
+aoH
+aoH
+aoH
 aaa
 aaa
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-azH
-aaa
+qKT
 aaa
 aaa
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
+aoH
+hzz
+aoH
+aoH
+aoH
 aaa
 aaa
 aaa
@@ -75838,28 +75186,28 @@ rmC
 rmC
 rmC
 rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
+cHS
+aiK
+ara
+suV
+tZG
+ara
+qwm
+jPQ
+azI
+qwm
+qwm
+ara
+aiK
+aiK
+aiK
+aiK
+aiK
+aiK
+aiK
+aiK
+aiK
+lTQ
 rmC
 rmC
 rmC
@@ -76095,28 +75443,28 @@ rmC
 rmC
 rmC
 rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
+cHS
+aiK
+ara
+sGr
+rjC
+ara
+azI
+azI
+nSt
+azI
+azI
+ara
+aiK
+ahO
+ahO
+ahO
+ahO
+ahO
+ahO
+ahO
+ahO
+ohQ
 rmC
 rmC
 rmC
@@ -76352,19 +75700,19 @@ rmC
 rmC
 rmC
 rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
+cHS
+aiK
+ara
+rNl
+pJX
+eca
+pTF
+oMR
+pLr
+pvq
+rFY
+ara
+hcS
 rmC
 rmC
 rmC
@@ -76609,20 +75957,20 @@ rmC
 rmC
 rmC
 rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
+cHS
+aiK
+ara
+rYC
+iQz
+ara
+azI
+azI
+pvl
+azI
+azI
+ara
+aiK
+dci
 rmC
 rmC
 rmC
@@ -76866,28 +76214,28 @@ rmC
 rmC
 rmC
 rmC
+cHS
+aiK
+ara
+tap
+rNl
+ara
+lJY
+kul
+jwm
+jia
+jia
+ara
+aiK
+dci
 rmC
 rmC
 rmC
 rmC
 rmC
 rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
+tLc
+tLc
 rmC
 rmC
 rmC
@@ -77123,20 +76471,20 @@ rmC
 rmC
 rmC
 rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
+cHS
+aiK
+ara
+ara
+ara
+ara
+ara
+ara
+ara
+ara
+ara
+ara
+aiK
+dci
 rmC
 rmC
 rmC
@@ -77380,28 +76728,28 @@ rmC
 rmC
 rmC
 rmC
+cHS
+aiK
+aiK
+aiK
+aiK
+aiK
+eFR
+aiK
+aiK
+aiK
+aiK
+aiK
+aiK
+dci
 rmC
 rmC
 rmC
 rmC
 rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
+tLc
+tLc
+tLc
 rmC
 rmC
 rmC
@@ -77429,17 +76777,17 @@ aaa
 aaa
 aaa
 aaa
-aby
-aed
-aby
-aht
-aby
-aby
-aby
-aht
-aby
-aby
-aby
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 azH
@@ -77637,20 +76985,20 @@ rmC
 rmC
 rmC
 rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
-rmC
+dci
+dci
+dci
+dci
+dci
+dci
+dci
+dci
+aiK
+cHS
+cHS
+cHS
+cHS
+cHS
 rmC
 rmC
 rmC
@@ -77686,17 +77034,17 @@ aaa
 aaa
 aaa
 aaa
-aht
 aaa
 aaa
 aaa
 aaa
-aht
 aaa
 aaa
 aaa
 aaa
-aht
+aaa
+aaa
+aaa
 aaa
 aaa
 azH
@@ -77943,18 +77291,18 @@ aaa
 aaa
 aaa
 aaa
-aiu
-ait
-ait
-ait
-aiu
-aiu
-ait
-ait
-ait
-aiu
-aiu
-aht
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 azH
 aaa
@@ -78200,18 +77548,18 @@ aaa
 aaa
 aaa
 aaa
-aiu
-fIN
-wwG
-gGy
-wYu
-uQR
-uaE
-pdq
-ajD
-dci
-aiu
-aht
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 azH
 aaa
@@ -78457,18 +77805,18 @@ aaa
 aaa
 aaa
 aaa
-aiu
-oFf
-ycr
-wDm
-wYu
-ajD
-ajD
-ajD
-ajD
-mwg
-aiu
+aby
+aed
+aby
 aht
+aby
+aby
+aby
+aht
+aby
+aby
+aby
+aaa
 aaa
 azH
 aaa
@@ -78714,17 +78062,17 @@ aaa
 aaa
 aaa
 aaa
-aiu
-lcU
-sGr
-hiw
-wYu
-ajD
-jsf
-ajD
-rLi
-tlc
-aiu
+aht
+aaa
+aaa
+aaa
+aaa
+aht
+aaa
+aaa
+aaa
+aaa
+aht
 aht
 aaa
 azH
@@ -78971,15 +78319,15 @@ aaa
 aaa
 aaa
 aaa
+aht
+aaa
+aaa
+aaa
+aaa
 aiu
-aiu
-kJw
-aiu
-aiu
-aiu
-aiu
-cHS
-aiu
+ait
+ait
+ait
 aiu
 aiu
 axC
@@ -79231,14 +78579,14 @@ aaa
 aht
 aiu
 gwn
-aiu
+ait
 apz
-aqe
+aiu
 aoK
 dcL
+xyB
+luT
 apB
-aiu
-tpb
 axC
 ayz
 azN
@@ -79491,10 +78839,10 @@ wRI
 ajD
 ajD
 ajD
-aoK
-aBa
+ajD
+ajD
 xyB
-aiu
+aBa
 aAa
 axC
 axB
@@ -79715,17 +79063,17 @@ aaa
 aaa
 aaa
 aaa
-rNl
-rNl
-rNl
-rNl
-rNl
-rNl
-rNl
-rNl
-rNl
-rNl
-rNl
+mZE
+mZE
+mZE
+mZE
+mZE
+mZE
+mZE
+mZE
+mZE
+mZE
+mZE
 aaa
 aaa
 aaa
@@ -79741,18 +79089,18 @@ aiV
 ajB
 akr
 aiu
+aht
+aht
 ait
-ait
-aiu
 lMU
-apB
-woq
-lXc
-nPA
-egK
-aBa
 aiu
-azZ
+ajD
+apB
+cXS
+egK
+nPA
+mTs
+aBa
 axC
 ayA
 azP
@@ -79972,17 +79320,17 @@ aaa
 aaa
 aaa
 aaa
-rNl
-aht
-aht
-aht
-aht
-aht
-aht
-aht
-hue
-aht
-rNl
+mZE
+mZE
+mZE
+mZE
+mZE
+mZE
+mZE
+mZE
+mZE
+mZE
+mZE
 aaa
 aaa
 aaa
@@ -79994,20 +79342,20 @@ aaa
 aaa
 aaa
 ait
-aiW
-ajC
-ajD
-ali
-ajD
-ajD
-anq
+akt
+akt
+txl
+aiu
+aht
+aht
+ait
 aoe
+aiu
+aiu
 aiu
 apB
 aiu
 aiu
-aiu
-aoK
 aiu
 azY
 axC
@@ -80215,31 +79563,31 @@ aaa
 aaa
 aaa
 aaa
-rNl
-rNl
-rNl
-rNl
-rNl
-rNl
-rNl
-rNl
-rNl
-rNl
-rNl
-rNl
-rNl
-rNl
-rNl
-aht
-aem
-aem
-aem
-aem
-aem
-aem
-aem
-aht
-rNl
+mZE
+mZE
+mZE
+mZE
+mZE
+mZE
+mZE
+mZE
+mZE
+mZE
+mZE
+mZE
+mZE
+mZE
+mZE
+mZE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+mZE
+mZE
 aaa
 aaa
 aaa
@@ -80252,8 +79600,8 @@ aaa
 aaa
 aiu
 aiX
-ajD
-aks
+akt
+akt
 aiu
 ait
 ait
@@ -80472,31 +79820,31 @@ aaa
 aaa
 aaa
 aaa
-rNl
-aht
-aht
-aht
-aht
-aht
-aht
-aht
-aht
-aht
-aht
-ufu
-aht
-aht
-aht
-aht
-aem
-tmA
-kWr
-wjj
-wub
+mZE
+mZE
+mZE
+mZE
+mZE
+mZE
+mZE
+mZE
+mZE
+mZE
+mZE
+mZE
+mZE
+mZE
+mZE
+mZE
 ycE
-aem
-aht
-rNl
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+mZE
+mZE
 aaa
 aaa
 aaa
@@ -80511,10 +79859,10 @@ ait
 aiY
 ajE
 akt
-aiu
-aaa
-aaa
-aiu
+pud
+ajD
+ajD
+ajD
 qGu
 aiu
 aiu
@@ -80729,31 +80077,31 @@ aaa
 aaa
 aaa
 aaa
-rNl
-rlL
-aem
-aem
-aem
-aem
-aem
-aem
-aem
-aem
-aem
-aem
-aem
-aem
-aem
-aem
-aem
-pEG
-aig
-hoq
-aig
-sEe
-aem
-aht
-rNl
+mZE
+mZE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+mZE
+mZE
 aaa
 aaa
 aaa
@@ -80986,31 +80334,31 @@ aaa
 aaa
 aaa
 aaa
-rNl
-aht
-aem
-kTN
-hGv
-mAx
-aem
-jlV
-ntI
-qIY
-jlV
-kPs
-agy
-kev
-wEp
-elg
-agy
-rmT
-aig
-hqv
-qsd
-sEe
-aem
-aht
-rNl
+mZE
+mZE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+mZE
+mZE
 aaa
 aaa
 aaa
@@ -81243,31 +80591,31 @@ aaa
 aaa
 aaa
 aaa
-rNl
-aht
-aem
-kTN
-oLN
-cDr
-aem
-jDL
-jdk
-aiF
-jdk
-rGP
-agy
-wZa
-kYK
-fLT
-agy
-pek
-aig
-aig
-anG
-wBk
-aem
-aht
-rNl
+mZE
+mZE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+mZE
+mZE
 aaa
 aaa
 afU
@@ -81498,33 +80846,33 @@ aaa
 aaa
 aaa
 aaa
-rNl
-rNl
-rNl
-aht
-aem
-kTN
-tyU
-nWs
-aem
-nbm
-nbm
-jdk
-gLW
-nbm
-agy
-wZa
-jWn
-iSe
-agy
-ryW
-mrk
-lpz
-vaD
-nIw
-aem
-aht
-aht
+mZE
+mZE
+mZE
+mZE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+mZE
+mZE
 aaa
 aaa
 afU
@@ -81755,32 +81103,32 @@ aaa
 aaa
 aaa
 aaa
-rNl
-aht
-aht
-aht
-aem
-aem
-aem
-gpd
-aem
-agy
-agy
-wXf
-agy
-agy
-agy
-agy
-uMi
-agy
-agy
-agy
-agy
-pPr
-hiB
-aem
-aem
-aht
+mZE
+mZE
+mZE
+mZE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+mZE
 aaa
 aaa
 aaa
@@ -82010,34 +81358,34 @@ aaa
 aaa
 aaa
 aaa
-rNl
-rNl
-rNl
-aht
-eLl
-jLT
-sEW
-mWK
-wIY
-srY
-hBx
-wIY
-niG
-wIY
-rUW
-uST
-oOa
-wIY
-wIY
-wIY
-nga
-wIY
-hBx
-wIY
-srY
-aem
-aem
-aht
+mZE
+mZE
+mZE
+mZE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+mZE
 aaa
 aaa
 aaa
@@ -82267,34 +81615,34 @@ aaa
 aaa
 aaa
 aaa
-rNl
-aht
-aht
-aht
-aen
-mFl
-aig
-aig
-tiS
-uGM
-xWN
-gqv
-gqv
-eRe
-alp
-alu
-gqv
-gqv
-gqv
-eRe
-gqv
-gqv
-xWN
-wsB
-vvM
-aem
-aht
-aht
+mZE
+mZE
+mZE
+mZE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+mZE
+mZE
 aaa
 aaa
 aaa
@@ -82522,36 +81870,36 @@ aaa
 aaa
 aaa
 aaa
-rNl
-rNl
-rNl
-aht
-aem
-jLT
-aem
-vBf
-aig
-wzj
-ahn
-sQJ
-qNy
-agy
-agy
-agy
-agy
-agy
-agy
-agy
-agy
-agy
-agy
-agy
-agy
-rlR
-vAN
-aem
-aht
-aht
+mZE
+mZE
+mZE
+mZE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+mZE
+mZE
 aaa
 aaa
 aaa
@@ -82779,37 +82127,37 @@ aaa
 aaa
 aaa
 aaa
-rNl
-aht
-aht
-aht
-aen
-eCH
-nGy
-aic
-wBS
-xIb
-djN
-nrk
-agy
-rkl
-kKe
-agy
-pVH
-kKe
-agy
-rkl
-kKe
-agy
-pVH
-kKe
-agy
-ixK
-jNW
-aem
-aem
-aem
-aem
+mZE
+mZE
+mZE
+mZE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
 agy
 aem
 aem
@@ -83036,37 +82384,37 @@ aaa
 aaa
 aaa
 aaa
-rNl
-fJn
-eLl
-jLT
-sEW
-pDS
-aig
-aic
-aig
-wzj
-mQn
-tmE
-agy
-tIi
-tIi
-agy
-tIi
-tIi
-agy
-tIi
-tIi
-agy
-tIi
-tIi
-agy
-ixK
-jNW
-agy
-aeo
-aeC
-aeT
+mZE
+mZE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
 afn
 aeT
 aeC
@@ -83293,37 +82641,37 @@ aaa
 aaa
 aaa
 aaa
-rNl
-aht
-jLT
-gKv
-aig
-aic
-aig
-aic
-aig
-wzj
-ahn
-sQJ
-agy
-agy
-djK
-agy
-agy
-djK
-agy
-agy
-djK
-agy
-agy
-djK
-qNy
-lVV
-anQ
-phc
-aep
-aeD
-aeU
+mZE
+mZE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
 agy
 afC
 mbU
@@ -83550,37 +82898,37 @@ aaa
 aaa
 aaa
 aaa
-rNl
-aht
-tuO
-xUV
-aig
-cRF
-oew
-mzd
-oew
-oew
-hVl
-kzB
-lWq
-aig
-aig
-ksn
-aig
-aig
-dOw
-fiS
-aig
-pwi
-aig
-aig
-lWq
-ixK
-jNW
-xAd
-aeq
-aig
-aig
+mZE
+mZE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
 afo
 aig
 dOw
@@ -83807,37 +83155,37 @@ aaa
 aaa
 aaa
 aaa
-rNl
-aht
-tuO
-hrr
-aig
-uEq
-ula
-tXB
-ula
-ula
-hrP
-oEp
-lWq
-aig
-aig
-aig
-aig
-aig
-kEx
-aig
-aig
-aig
-aig
-aig
-lWq
-ixK
-jNW
-xAd
-aig
-aig
-vXW
+mZE
+mZE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
 agy
 afE
 ark
@@ -84064,37 +83412,37 @@ aaa
 aaa
 aaa
 aaa
-rNl
-aht
-tpX
-dxO
-heX
-kfz
-vJU
-hZG
-vJU
-vJU
-qpc
-wCp
-qsJ
-ieP
-ieP
-kRM
-ieP
-ieP
-xwG
-aiG
-aiG
-nmK
-aiG
-aiG
-amY
-hDs
-ePO
-feI
-aiG
-aeG
-aiG
+mZE
+mZE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
 afq
 aiG
 agb
@@ -84321,37 +83669,37 @@ aaa
 aaa
 aaa
 aaa
-rNl
-aht
-uht
-xUV
-aig
-aic
-aig
-aic
-aig
-wzj
-flK
-sQJ
-qNy
-agy
-djK
-agy
-agy
-djK
-agy
-agy
-djK
-agy
-agy
-djK
-agy
-lVV
-anQ
-agy
-aet
-agy
-peE
+mZE
+mZE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
 agy
 afG
 eSB
@@ -84380,7 +83728,7 @@ atw
 atI
 avt
 awJ
-axG
+xZB
 ayG
 pFy
 aiu
@@ -84578,37 +83926,37 @@ aaa
 aaa
 aaa
 aaa
-rNl
-aht
-eLl
-uht
-sEW
-pDS
-aig
-aic
-aig
-wzj
-rwZ
-toK
-agy
-tIi
-tIi
-agy
-tIi
-tIi
-agy
-tIi
-tIi
-agy
-tIi
-tIi
-agy
-ixK
-jNW
-agy
-aeu
-agy
-dYe
+mZE
+mZE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
 agy
 afH
 aeH
@@ -84835,37 +84183,37 @@ aaa
 aaa
 aaa
 aaa
-rNl
-aht
-aht
-aht
-aen
-udI
-aig
-aic
-agW
-xdt
-nxc
-eRo
-agy
-pVH
-tjC
-agy
-rkl
-tjC
-agy
-pVH
-tjC
-agy
-rkl
-tjC
-agy
-ixK
-sws
-aem
-aem
-aem
-aem
+mZE
+mZE
+mZE
+mZE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
 aem
 aem
 aem
@@ -85092,37 +84440,37 @@ aaa
 aaa
 aaa
 aaa
-rNl
-rNl
-rNl
-aht
-aem
-uht
-vFn
-aic
-aig
-wzj
-flK
-sQJ
-agy
-agy
-agy
-agy
-agy
-agy
-agy
-agy
-agy
-agy
-agy
-agy
-qNy
-anF
-vAN
-aem
-ixK
-aig
-vbG
+mZE
+mZE
+mZE
+mZE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
 afr
 vbG
 aig
@@ -85130,7 +84478,7 @@ ago
 agy
 uMQ
 jNW
-aem
+aig
 ahJ
 aig
 aiJ
@@ -85151,7 +84499,7 @@ atz
 sCk
 avv
 awK
-axG
+gxJ
 ayM
 axG
 aBd
@@ -85351,35 +84699,35 @@ aaa
 aaa
 aaa
 aaa
-rNl
-aht
-aht
-aht
-aen
-kkO
-cAZ
-aig
-sAS
-lzt
-kvm
-lvP
-gIz
-ycc
-qcR
-alx
-lvP
-amJ
-lvP
-njr
-lvP
-lvP
-amJ
-ior
-pJz
-hoB
-hGU
-apL
-vbG
+mZE
+mZE
+mZE
+mZE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
 iPH
 vbG
 agd
@@ -85390,7 +84738,7 @@ aag
 aem
 ahK
 aih
-aiK
+aiB
 agy
 ajO
 akK
@@ -85408,7 +84756,7 @@ atA
 auA
 avw
 awJ
-axG
+gxJ
 ayM
 axG
 aBd
@@ -85608,41 +84956,41 @@ aaa
 aaa
 aaa
 aaa
-rNl
-rNl
-rNl
-aht
-eLl
-uht
-sEW
-hPQ
-uPo
-rIt
-cSy
-rIt
-ahC
-rIt
-uKX
-dRg
-rIt
-ahC
-rIt
-cSy
-hXy
-rIt
-ahC
-rIt
-rIt
-aem
-qdw
-qKY
-aig
+mZE
+mZE
+mZE
+mZE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
 agy
 aig
 kEx
 qVX
 agy
-npo
+juv
 aig
 aem
 ahL
@@ -85665,7 +85013,7 @@ atD
 auz
 avx
 keD
-axG
+gxJ
 ayM
 axG
 aBe
@@ -85867,41 +85215,41 @@ aaa
 aaa
 aaa
 aaa
-rNl
-aht
-aht
-aht
-aem
-aem
-jNW
-aem
-agy
-agy
-vSJ
-agy
-agy
-agy
-agy
-xab
-agy
-agy
-agy
-agy
-vPA
-agy
-agy
-aem
-ixK
-aig
-vbG
+mZE
+mZE
+mZE
+mZE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
 iPH
 vbG
 arl
 aiB
-agy
 jTc
-aig
-xwo
+jTc
+jTc
+jTc
 ahL
 aii
 aiL
@@ -85912,7 +85260,7 @@ alA
 amh
 amV
 amX
-amX
+mFe
 aoU
 apJ
 aqs
@@ -86122,43 +85470,43 @@ aaa
 aaa
 aaa
 aaa
-rNl
-aht
-aem
-aem
-aem
-aem
-aem
-aem
-pCe
-aem
-vIZ
-vIZ
-ahP
-vIZ
-vIZ
-agy
-mrz
-lrf
-eal
-agy
-rUC
-rUC
-anv
-rUC
-pdN
-aem
-xTV
-jSx
-vbG
+mZE
+mZE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
 afr
 vbG
 nWL
 fQk
-agy
+jTc
 dIA
-aig
-xwo
+iZZ
+gKc
 ahL
 aij
 aiM
@@ -86179,7 +85527,7 @@ qPT
 sCk
 avy
 awK
-axG
+wNj
 ayM
 axG
 aBe
@@ -86379,43 +85727,43 @@ aaa
 aaa
 aaa
 aaa
-rNl
-aht
-aem
-hKq
-dat
-kQl
-hKq
-wBS
-mPT
-aem
-leW
-kVK
-aif
-eEl
-ula
-agy
-xNX
-lrf
-oUC
-agy
-pjE
-mJu
-anv
-pjE
-riu
-aem
-aem
-aem
-sTU
-aem
-sTU
+mZE
+mZE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
 aem
 aem
 aem
 aem
+jTc
+lvA
 xwo
-xwo
+qWa
 ahL
 aik
 aiM
@@ -86436,7 +85784,7 @@ atC
 auA
 avz
 awJ
-axG
+wNj
 ayM
 axG
 aBd
@@ -86636,43 +85984,43 @@ aaa
 aaa
 aaa
 aaa
-rNl
-aht
-aem
-dat
-bqP
-bqP
-dat
-aig
-kCP
-aem
-vIZ
-vIZ
-tCn
-vIZ
-vIZ
-agy
-fDA
-lrf
-oPL
-agy
-pZq
-pZq
-anv
-pZq
-pze
-aem
+mZE
+mZE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
 aaa
-aem
-ukW
-eLP
-ukW
-aem
+ycE
+ycE
+ycE
+ycE
+rmD
 aaa
-aaa
-aby
-abI
-abI
+agP
+dBd
+uiQ
+gWI
 ahL
 ail
 aiN
@@ -86693,7 +86041,7 @@ atD
 auz
 avA
 keD
-axG
+wNj
 ayM
 axG
 aBd
@@ -86893,43 +86241,43 @@ aaa
 aaa
 aaa
 aaa
-rNl
-aht
-aem
-dat
-bqP
-bqP
-dat
-aig
-kKt
-aem
-sbr
-ula
-aiC
-akM
-gOH
-agy
-dvB
-obf
-jnr
-agy
-kHc
-rUC
-anD
-rUC
-rUC
-aem
+mZE
+mZE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
 aaa
-aem
-ukW
-lcY
-ukW
-aem
-aaa
-aaa
-aby
-abI
-sdk
+ycE
+ycE
+ycE
+ycE
+rmD
+wHu
+agP
+ahq
+ahq
+ahq
 ahL
 aim
 aiO
@@ -86950,7 +86298,7 @@ ajM
 ajM
 ajM
 akA
-axJ
+kCU
 ayM
 axG
 aBd
@@ -87150,43 +86498,43 @@ aaa
 aaa
 aaa
 aaa
-rNl
-aht
-aem
-hKq
-dat
-cSZ
-hKq
-xdK
-cRH
-aem
-eeu
-iJz
-oIx
-qEG
-vUr
-agy
-xEc
-hqU
-rcK
-pPr
-uSx
-uSx
-ifS
-uSx
-rke
-aem
+mZE
+mZE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
 aaa
-aem
-ukW
-ukW
-ukW
-aem
+ycE
+ycE
+ycE
+ycE
+rmD
 abI
 agP
-agQ
-agQ
-agP
+upd
+dGt
+dGt
 ahL
 ahL
 ahL
@@ -87407,38 +86755,38 @@ aaa
 aaa
 aaa
 aaa
-rNl
-aht
-aem
-aem
-aem
-aem
-aem
-aem
-pCe
-aem
-agy
-tCX
-agy
-agy
-dEU
-agy
-jnP
-amW
-rcK
-uJe
-uSx
-uSx
-anE
-uSx
-uSx
-aem
+mZE
+mZE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
 aaa
-aem
-aem
-aem
-aem
-aem
+ycE
+ycE
+ycE
+ycE
+rmD
 aaa
 agP
 cnJ
@@ -87664,35 +87012,35 @@ aaa
 aaa
 aaa
 aaa
-rNl
-aht
+mZE
+mZE
 aaa
 aaa
-aht
-aht
-aem
-mpt
-pjS
-aem
-rai
-haP
-xfT
-tMI
-qqB
-agy
-lTB
-rcK
-rcK
-pIn
-uSx
-uSx
-uSx
-uSx
-uSx
-aem
-gJF
-abI
-aby
+mZE
+mZE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+mZE
+mZE
+mZE
 aht
 aaa
 aby
@@ -87700,17 +87048,17 @@ aaa
 agQ
 ahd
 ahq
-ahq
+bpm
 ahN
 aio
 agP
 ajl
-ajV
+alE
 ajV
 alC
 alE
+ajV
 alC
-alE
 aou
 apb
 agP
@@ -87925,47 +87273,47 @@ aaa
 aaa
 aaa
 aaa
-gYo
-nze
-aem
-mpt
-pjS
-aem
-xvj
-vsy
-vsy
-smj
-lNU
-agy
-lvR
-rcK
-rcK
-knW
-uSx
-uSx
-uSx
-uSx
-mkZ
-aem
-abI
-abI
-bzy
+mZE
+mZE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+mZE
+mZE
+mZE
 aht
 aaa
 aby
 aaa
 agQ
-ahd
-ahq
+amn
+amn
 cnT
 amn
-ahd
+amn
 agP
 ajm
-ajW
-ajV
-alD
+alE
+dxC
 anM
+alE
 anc
 anM
 aou
@@ -88182,49 +87530,49 @@ aaa
 aaa
 aaa
 aaa
-gYo
-aht
-aem
-cIn
-pjS
-aem
-nsQ
-uwE
-hrT
-lxp
-mRP
-agy
-lDf
-daM
-qmK
-agy
-rox
-jxi
-tsn
-vDn
-vDn
-aem
-abI
-abI
+mZE
+mZE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+mZE
+mZE
 aaa
 aaa
 aaa
 aby
 aaa
 agQ
-ahd
+rEZ
+rEZ
+cnT
 ahq
 ahq
-amn
-ahd
 agP
 ajn
-amo
-ajV
 alE
+alE
+xWm
 amp
-alE
-alE
+xea
+hHA
 aov
 apc
 apP
@@ -88439,30 +87787,30 @@ aaa
 aaa
 aaa
 aaa
-gYo
-aht
-aem
-mam
-ahA
-aem
-aem
-aem
-aem
-aem
-aem
-aem
-aem
-aem
-aem
-aem
-aem
-aem
-aem
-aem
-aem
-aem
-aby
-aby
+mZE
+mZE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+mZE
+mZE
 aaa
 aaa
 aaa
@@ -88472,16 +87820,16 @@ agP
 cnN
 ahq
 cnT
-amn
-ahd
+ahq
+rEZ
 agP
 ajo
-ajX
+alE
 ajV
-alC
+hki
 alE
+cCL
 alC
-alE
 aow
 apd
 agQ
@@ -88696,28 +88044,28 @@ aaa
 aaa
 aaa
 aaa
-gYo
-aht
-aem
-agY
-pjS
-aem
-wNU
-gVK
-aig
-wNU
-wNU
-aem
-exJ
-aht
-aht
-aht
-aht
-aht
-aht
-aht
-aht
-abI
+mZE
+mZE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+mZE
+mZE
+mZE
+mZE
+mZE
+mZE
+mZE
+mZE
+mZE
 aaa
 aaa
 aaa
@@ -88726,15 +88074,15 @@ aaa
 aby
 aaa
 agQ
-ahd
-ahq
-ahq
+aro
+aro
+pOx
 aro
 aip
 agP
 ajp
-ajY
-ajV
+alE
+xNu
 alF
 amq
 ane
@@ -88769,7 +88117,7 @@ aOv
 aKJ
 aQF
 aRK
-aRL
+aLL
 aRL
 aUQ
 aVU
@@ -88953,28 +88301,28 @@ aaa
 aaa
 aaa
 aaa
-gYo
-aht
-aem
-wHX
-pQP
-aem
-aig
-aig
-dOw
-aig
-aig
-aem
-exJ
-rNl
-rNl
-rNl
-rNl
-rNl
-rNl
-rNl
-rNl
-aby
+mZE
+mZE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+mZE
+mZE
+mZE
+mZE
+mZE
+mZE
+mZE
+mZE
+mZE
 aaa
 aaa
 aaa
@@ -88985,8 +88333,8 @@ aaa
 agQ
 cnP
 ahq
-ahq
-ahO
+qXa
+aiq
 aiq
 aiQ
 ajq
@@ -89210,19 +88558,19 @@ aaa
 aaa
 aaa
 aaa
-gYo
-aht
-aem
-mpt
-ahB
-qWf
-ahm
-dxg
-aiD
-akO
-hUC
-aem
-osF
+mZE
+mZE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
 aaa
 aaa
 aaa
@@ -89242,7 +88590,7 @@ aaa
 agQ
 cnQ
 ahq
-cnV
+ahq
 ahq
 air
 agP
@@ -89467,20 +88815,20 @@ aaa
 aaa
 aaa
 aaa
-gYo
-aht
-aem
-cIn
-vZE
-aem
-aig
-aig
-qKY
-aig
-aig
-aem
-exJ
-fon
+mZE
+mZE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+mZE
 mZE
 aaa
 aaa
@@ -89724,28 +89072,28 @@ aaa
 aaa
 aaa
 aaa
-gYo
-aht
-aem
-lyl
-mpt
-aem
-dRV
-wfd
-guD
-ood
-ood
-aem
-exJ
-fon
+mZE
+mZE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+mZE
 mZE
 aaa
 aaa
 aaa
 aaa
 aaa
-bBW
-bBW
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -89981,20 +89329,20 @@ aaa
 aaa
 aaa
 aaa
-gYo
-aht
-aem
-aem
-aem
-aem
-aem
-aem
-aem
-aem
-aem
-aem
-exJ
-fon
+mZE
+mZE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+ycE
+mZE
 mZE
 aaa
 aaa
@@ -90238,28 +89586,28 @@ aaa
 aaa
 aaa
 aaa
-gYo
-aht
-aht
-aht
-aht
-aht
-suV
-aht
-aht
-aht
-aht
-aht
-aht
-fon
+mZE
+mZE
+mZE
+mZE
+mZE
+mZE
+mZE
+mZE
+mZE
+mZE
+mZE
+mZE
+mZE
+mZE
 mZE
 aaa
 aaa
 aaa
 aaa
-bBW
-bBW
-bBW
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -90305,8 +89653,8 @@ jYe
 aIS
 aDZ
 aKQ
-aKQ
-aKQ
+hFv
+xQl
 aKQ
 aLL
 aQK
@@ -90331,10 +89679,10 @@ bil
 biY
 ble
 ble
-bmq
-boA
-boC
-bpI
+ble
+ble
+ble
+bpH
 biY
 bsC
 buc
@@ -90495,20 +89843,20 @@ aaa
 aaa
 aaa
 aaa
-fon
-fon
-fon
-fon
-fon
-fon
-fon
-fon
-aht
-gYo
-gYo
-gYo
-gYo
-gYo
+mZE
+mZE
+mZE
+mZE
+mZE
+mZE
+mZE
+mZE
+mZE
+mZE
+mZE
+mZE
+mZE
+mZE
 mZE
 aaa
 aaa
@@ -90587,10 +89935,10 @@ bvH
 bim
 biY
 bjU
-bld
-bld
-bld
-bld
+ble
+sQe
+mlP
+iQQ
 bpJ
 biY
 bsC
@@ -91338,7 +90686,7 @@ aKQ
 aKQ
 aLL
 aQN
-aRN
+xBf
 aRN
 aTX
 aUX
@@ -94709,7 +94057,7 @@ bsL
 bul
 bwU
 bsK
-bsK
+epU
 bAg
 bpY
 bOG
@@ -96227,7 +95575,7 @@ aPE
 cpb
 bcv
 bah
-aYg
+drj
 aHH
 bag
 bbr
@@ -96244,13 +95592,13 @@ aGV
 blu
 bvH
 aDZ
-bjm
+bgC
 mhn
-cqi
-cqi
-cqi
+vNK
+vNK
+vNK
 bwb
-cqi
+vNK
 imE
 kYM
 bmC
@@ -96739,8 +96087,8 @@ aKY
 aQN
 aPE
 aVj
-aWm
 bck
+sqz
 aYi
 cpk
 bag
@@ -97516,7 +96864,7 @@ aUf
 aUf
 aPE
 bbu
-bcs
+bah
 bag
 beG
 aPE
@@ -97772,7 +97120,7 @@ aXm
 aYk
 aUf
 bao
-bbv
+bbx
 bag
 bah
 aZe
@@ -99778,8 +99126,8 @@ aaa
 aaa
 aaa
 aiT
-plA
-oMN
+xbJ
+qDe
 akf
 gxe
 akf
@@ -100292,9 +99640,9 @@ aaa
 aaa
 aiS
 aiS
-aiS
-aiS
-epJ
+xbJ
+fAM
+akf
 uaC
 cBv
 cBw
@@ -100554,7 +99902,7 @@ cBo
 alQ
 xjg
 cBw
-noC
+alb
 aiS
 aiS
 aiS
@@ -100578,7 +99926,7 @@ aBL
 aBL
 apX
 aET
-rYC
+aET
 aET
 aET
 aDZ
@@ -100811,7 +100159,7 @@ ajt
 alQ
 mnG
 alb
-tap
+alb
 aiS
 anY
 apt
@@ -101091,11 +100439,11 @@ apX
 aBN
 aDc
 apX
+ljq
+jOB
+jOB
 aET
-cor
-aET
-aET
-hFy
+aDZ
 aJh
 aDZ
 lAs
@@ -102121,7 +101469,7 @@ aDf
 cop
 aEW
 aPR
-aGC
+aPR
 aPR
 aPR
 aJj

--- a/_maps/map_files/PubbyStation/PubbyStation_Lumos.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation_Lumos.dmm
@@ -3,14 +3,10 @@
 /turf/open/space/basic,
 /area/space)
 "aab" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/computer/security,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 5
+	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
 "aac" = (
@@ -25,18 +21,6 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/science)
-"aae" = (
-/obj/machinery/button/flasher{
-	id = "permalock";
-	pixel_x = 6;
-	pixel_y = 36;
-	req_access_txt = "3"
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aaf" = (
 /mob/living/simple_animal/pet/dog/cheems,
 /turf/open/floor/plasteel,
@@ -51,6 +35,7 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aah" = (
+/obj/machinery/seed_extractor,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "abf" = (
@@ -1053,39 +1038,21 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aeH" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/structure/table/reinforced,
-/obj/item/clothing/under/rank/prisoner/skirt,
-/obj/item/clothing/under/rank/prisoner/skirt,
-/obj/item/clothing/under/rank/prisoner/skirt,
-/obj/item/clothing/shoes/sneakers/orange,
-/obj/item/clothing/shoes/sneakers/orange,
-/obj/item/clothing/shoes/sneakers/orange,
 /obj/machinery/camera{
 	c_tag = "Permabrig Prisoner Processing";
 	dir = 8;
 	network = list("ss13","prison");
 	start_active = 1
 	},
-/obj/item/radio/headset{
-	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
-	name = "prisoner headset";
-	prison_radio = 1
+/obj/machinery/airalarm/directional/east,
+/obj/structure/rack,
+/obj/item/tank/internals/plasmaman/belt,
+/obj/item/tank/internals/plasmaman/belt,
+/obj/item/tank/internals/plasmaman/belt,
+/obj/item/tank/internals/plasmaman/belt,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
 	},
-/obj/item/radio/headset{
-	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
-	name = "prisoner headset";
-	prison_radio = 1
-	},
-/obj/item/radio/headset{
-	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
-	name = "prisoner headset";
-	prison_radio = 1
-	},
-/obj/item/radio/off,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aeJ" = (
@@ -1364,35 +1331,21 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "afo" = (
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "outerbrig";
-	name = "Perma Wing";
-	req_access_txt = "63"
+/obj/structure/lattice,
+/obj/machinery/camera{
+	c_tag = "Permabrig Space Northeast";
+	dir = 1;
+	name = "aft camera"
 	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/preopen{
-	id = "locklock"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/floor/plasteel,
-/area/security/prison)
+/turf/open/space/basic,
+/area/space/nearstation)
 "afq" = (
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "outerbrig";
-	name = "Perma Wing";
-	req_access_txt = "63"
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/preopen{
-	id = "locklock"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
-/turf/open/floor/plasteel,
+/turf/closed/wall,
 /area/security/prison)
 "afr" = (
 /obj/structure/table/reinforced,
@@ -1476,6 +1429,17 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/structure/table/reinforced,
+/obj/item/clothing/shoes/sneakers/orange,
+/obj/item/clothing/shoes/sneakers/orange,
+/obj/item/clothing/shoes/sneakers/orange,
+/obj/item/clothing/shoes/sneakers/orange,
+/obj/item/clothing/shoes/sneakers/orange,
+/obj/item/clothing/shoes/sneakers/orange,
+/obj/item/clothing/under/rank/prisoner,
+/obj/item/clothing/under/rank/prisoner,
+/obj/item/clothing/under/rank/prisoner,
+/obj/item/clothing/under/rank/prisoner,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "afE" = (
@@ -1486,36 +1450,21 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "afG" = (
-/obj/machinery/airalarm/directional/north,
-/obj/structure/chair{
-	dir = 4
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-4"
 	},
-/turf/open/floor/plasteel,
+/obj/machinery/door/poddoor/preopen{
+	id = "permalock2"
+	},
+/turf/open/floor/plating,
 /area/security/prison)
 "afH" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/structure/table/reinforced,
-/obj/item/clothing/head/helmet/space/plasmaman/prisoner,
-/obj/item/clothing/head/helmet/space/plasmaman/prisoner,
-/obj/item/clothing/under/plasmaman/prisoner,
-/obj/item/clothing/under/plasmaman/prisoner,
-/obj/item/clothing/shoes/sneakers/orange,
-/obj/item/clothing/shoes/sneakers/orange,
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/item/radio/headset{
-	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
-	name = "prisoner headset";
-	prison_radio = 1
-	},
-/obj/item/radio/headset{
-	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
-	name = "prisoner headset";
-	prison_radio = 1
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -1598,13 +1547,13 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden/layer1{
 	dir = 4
 	},
 /obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "agd" = (
@@ -1681,20 +1630,13 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "ago" = (
-/obj/machinery/light,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "agp" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "agq" = (
@@ -1751,33 +1693,29 @@
 /turf/closed/wall,
 /area/security/prison)
 "agz" = (
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "outerbrig";
-	name = "Prisoner Processing";
-	req_access_txt = "63"
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-2"
 	},
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "0-4"
 	},
-/turf/open/floor/plasteel,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "permalock2"
+	},
+/turf/open/floor/plating,
 /area/security/prison)
 "agA" = (
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "outerbrig";
-	name = "Prisoner Processing";
-	req_access_txt = "63"
-	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
-/turf/open/floor/plasteel,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/security/prison)
 "agC" = (
 /obj/machinery/door/airlock/security/glass{
@@ -1789,6 +1727,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/obj/effect/turf_decal/lumos/tile/red/fulltile,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "agD" = (
@@ -1820,28 +1759,31 @@
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
 "agK" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/button/door{
 	id = "locklock";
 	name = "Perma Airlock Lockdown";
 	pixel_y = 26;
 	req_access_txt = "3"
 	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "agN" = (
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/camera,
+/obj/machinery/power/apc/highcap/five_k{
+	dir = 1;
+	name = "Prison Wing APC";
+	pixel_x = 1;
+	pixel_y = 24
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/camera,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "agP" = (
@@ -1891,40 +1833,29 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden/layer1{
 	dir = 1
 	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/effect/turf_decal/lumos/tile/red/checker,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aha" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4;
-	layer = 2.9
-	},
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/lumos/tile/red/checker,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "ahd" = (
@@ -1948,14 +1879,11 @@
 "ahj" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/straight_jacket,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
 /obj/item/razor,
+/obj/effect/turf_decal/lumos/tile/red/half{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
 "ahk" = (
@@ -1976,14 +1904,11 @@
 	pixel_x = 6;
 	pixel_y = 36
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
+	},
+/obj/effect/turf_decal/lumos/tile/red/half{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
@@ -1992,46 +1917,29 @@
 	name = "Station Intercom (General)";
 	pixel_x = 28
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 4
+	},
+/obj/effect/turf_decal/lumos/tile/red/half{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
 "ahm" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aho" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"ahp" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
+/obj/effect/turf_decal/lumos/tile/red/checker,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "ahq" = (
@@ -2060,14 +1968,8 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/lumos/tile/red/fullcorner{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/security/execution/transfer)
@@ -2075,13 +1977,10 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/white,
 /area/security/execution/transfer)
 "ahw" = (
@@ -2123,11 +2022,10 @@
 	pixel_x = 24;
 	pixel_y = 4
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
 "ahD" = (
@@ -2147,14 +2045,7 @@
 /area/security/warden)
 "ahG" = (
 /obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
 	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 8
@@ -2162,56 +2053,25 @@
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/turf_decal/lumos/tile/red/checker,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "ahH" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4;
-	layer = 2.9
-	},
-/obj/structure/window/reinforced,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"ahI" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"ahJ" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
+/obj/effect/turf_decal/lumos/tile/red/checker,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "ahK" = (
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/machinery/power/apc/highcap/five_k{
-	dir = 1;
-	name = "Prison Wing APC";
-	pixel_x = 1;
-	pixel_y = 24
+/obj/machinery/door/poddoor/preopen{
+	id = "permalock2"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/security/prison)
 "ahL" = (
 /turf/closed/wall/r_wall,
@@ -2232,10 +2092,11 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
 "ahO" = (
-/obj/structure/grille,
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/station_ruins)
+/obj/structure/sign/warning/electricshock{
+	pixel_y = 32
+	},
+/turf/open/floor/plating/asteroid,
+/area/security/prison)
 "ahQ" = (
 /obj/machinery/light{
 	dir = 4
@@ -2251,15 +2112,12 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "ahS" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/structure/table/glass,
 /obj/item/melee/chainofcommand,
 /obj/item/melee/baton,
+/obj/effect/turf_decal/lumos/tile/red/half{
+	dir = 8
+	},
 /turf/open/floor/plasteel/white,
 /area/security/execution/transfer)
 "ahT" = (
@@ -2343,16 +2201,13 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/turf_decal/lumos/tile/red/checker,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aid" = (
@@ -2362,16 +2217,13 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/turf_decal/lumos/tile/red/checker,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aig" = (
@@ -2470,12 +2322,9 @@
 /area/maintenance/department/security/brig)
 "aiv" = (
 /obj/structure/table/glass,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/item/electropack,
 /obj/item/assembly/signaler,
+/obj/effect/turf_decal/lumos/tile/red/half,
 /turf/open/floor/plasteel/white,
 /area/security/execution/transfer)
 "aiw" = (
@@ -2493,10 +2342,7 @@
 /turf/open/floor/plating,
 /area/security/execution/transfer)
 "aix" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -2508,8 +2354,7 @@
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
 "aiz" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -2518,18 +2363,8 @@
 /turf/closed/wall/r_wall,
 /area/security/execution/transfer)
 "aiB" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"aiE" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/light,
+/obj/machinery/airalarm/directional/south,
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aiG" = (
@@ -2545,16 +2380,12 @@
 	dir = 1;
 	pixel_y = -22
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aiK" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/station_ruins)
+/turf/open/floor/plating/asteroid,
+/area/security/prison)
 "aiL" = (
 /obj/structure/table,
 /obj/item/storage/box/flashbangs{
@@ -2663,10 +2494,7 @@
 	dir = 4;
 	pixel_x = -23
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/red/half,
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
 "aja" = (
@@ -2676,10 +2504,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/red/half,
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
 "ajb" = (
@@ -2692,14 +2517,15 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
 "ajc" = (
-/obj/structure/closet/secure_closet/brig,
+/obj/structure/chair{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "aje" = (
@@ -2714,16 +2540,7 @@
 /area/security/prison)
 "ajf" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/red/fulltile,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "ajg" = (
@@ -2795,16 +2612,7 @@
 /turf/open/floor/plasteel/dark,
 /area/security/armory)
 "ajk" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/red/fulltile,
 /turf/open/floor/plasteel,
 /area/security/main)
 "ajl" = (
@@ -2814,11 +2622,8 @@
 	departmentType = 5;
 	pixel_y = 30
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
@@ -2830,11 +2635,8 @@
 /obj/structure/noticeboard{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
@@ -2850,11 +2652,8 @@
 	pixel_x = 1;
 	pixel_y = 3
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
@@ -2863,11 +2662,8 @@
 /obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
@@ -2876,11 +2672,8 @@
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
@@ -2888,18 +2681,9 @@
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/obj/effect/turf_decal/lumos/tile/red/fulltile,
 /turf/open/floor/plasteel,
 /area/security/main)
 "ajr" = (
@@ -3039,16 +2823,10 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 9
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "ajO" = (
@@ -3058,12 +2836,8 @@
 /obj/structure/sign/poster/official/safety_report{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -3139,10 +2913,7 @@
 	name = "Security Office APC";
 	pixel_x = -24
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -3156,35 +2927,36 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "ajW" = (
-/obj/structure/lattice,
-/obj/machinery/camera{
-	c_tag = "Permabrig Space North";
-	dir = 1;
-	name = "aft camera"
-	},
-/turf/open/space/basic,
-/area/space/station_ruins)
-"ajX" = (
-/obj/structure/sign/warning/electricshock,
-/turf/closed/wall/r_wall,
-/area/space/station_ruins)
-"ajY" = (
-/obj/effect/spawner/structure/window/reinforced,
+/obj/effect/turf_decal/sand,
 /obj/structure/cable{
-	icon_state = "0-4"
+	icon_state = "1-2"
 	},
-/turf/open/floor/plating,
-/area/space/station_ruins)
+/turf/open/floor/plasteel,
+/area/security/prison)
+"ajX" = (
+/turf/open/floor/plating/smooth/grass{
+	desc = "A lush patch for moss commonly found growing in inhabited asteroids.";
+	name = "asteroid moss"
+	},
+/area/security/prison)
+"ajY" = (
+/obj/structure/sign/warning/electricshock{
+	pixel_y = 32
+	},
+/turf/open/floor/plating/smooth/grass{
+	desc = "A lush patch for moss commonly found growing in inhabited asteroids.";
+	name = "asteroid moss"
+	},
+/area/security/prison)
 "ajZ" = (
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/security/main)
 "aka" = (
@@ -3423,14 +3195,8 @@
 /obj/item/clothing/mask/surgical,
 /obj/item/reagent_containers/spray/cleaner,
 /obj/structure/table/glass,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/lumos/tile/red/fullcorner{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/security/brig)
@@ -3444,11 +3210,8 @@
 /obj/machinery/airalarm{
 	pixel_y = 22
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/security/brig)
@@ -3459,11 +3222,8 @@
 	},
 /obj/structure/table/glass,
 /obj/machinery/computer/med_data/laptop,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/security/brig)
@@ -3472,15 +3232,11 @@
 	dir = 4
 	},
 /obj/machinery/iv_drip,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/item/bedsheet/medical,
 /obj/structure/bed,
+/obj/effect/turf_decal/lumos/tile/red/fullcorner{
+	dir = 8
+	},
 /turf/open/floor/plasteel/white,
 /area/security/brig)
 "akG" = (
@@ -3500,22 +3256,13 @@
 	name = "Evidence Room";
 	req_access_txt = "63"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/turf_decal/lumos/tile/red/fulltile,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "akJ" = (
@@ -3524,6 +3271,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
 	dir = 9
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -3535,8 +3285,7 @@
 	c_tag = "Brig Evidence Room";
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -3579,27 +3328,17 @@
 /obj/machinery/newscaster{
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
 "akR" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/security/main)
 "akT" = (
@@ -3613,9 +3352,9 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/effect/turf_decal/tile/red,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /obj/vehicle/ridden/secway,
+/obj/effect/turf_decal/trimline/red/filled/corner,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "akV" = (
@@ -3623,25 +3362,16 @@
 	pixel_x = -22;
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "akW" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "akX" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "akZ" = (
@@ -3703,15 +3433,11 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "ali" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating,
-/area/space/station_ruins)
+/obj/structure/lattice,
+/obj/structure/grille,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "alj" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
 	dir = 8
@@ -3771,12 +3497,8 @@
 	},
 /obj/item/reagent_containers/glass/bottle/charcoal,
 /obj/item/reagent_containers/glass/bottle/epinephrine,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/lumos/tile/red/fullcorner{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/security/brig)
@@ -3795,8 +3517,7 @@
 	dir = 4;
 	name = "Brig Infirmary"
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -3809,15 +3530,11 @@
 /area/security/brig)
 "aly" = (
 /obj/machinery/light/small,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -3825,12 +3542,8 @@
 /obj/structure/closet{
 	name = "Evidence Closet"
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -3856,10 +3569,7 @@
 	dir = 4;
 	pixel_x = -27
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -3871,18 +3581,9 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "alD" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating,
-/area/space/station_ruins)
+/obj/effect/turf_decal/sand,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "alE" = (
 /turf/open/floor/plasteel,
 /area/security/main)
@@ -3897,12 +3598,11 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "alG" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -3915,6 +3615,9 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "alJ" = (
@@ -4030,13 +3733,10 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel/white,
 /area/security/brig)
 "amb" = (
@@ -4056,8 +3756,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -4068,6 +3767,9 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -4098,12 +3800,11 @@
 	name = "Brig APC";
 	pixel_x = 24
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -4200,10 +3901,7 @@
 	name = "Station Intercom (General)";
 	pixel_x = -31
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -4217,14 +3915,28 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
 "amo" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-8"
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/turf/open/floor/plating,
-/area/space/station_ruins)
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/sand,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "amp" = (
 /obj/machinery/holopad,
+/obj/effect/turf_decal/trimline/red,
+/obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/security/main)
 "amq" = (
@@ -4240,15 +3952,14 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden/layer1{
 	dir = 8
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
@@ -4442,29 +4153,22 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/turf_decal/lumos/tile/red/fullcorner{
+	dir = 1
+	},
 /turf/open/floor/plasteel/white,
 /area/security/brig)
 "amN" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/structure/closet/secure_closet/brig_phys,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden/layer1,
+/obj/effect/turf_decal/lumos/tile/red/half,
 /turf/open/floor/plasteel/white,
 /area/security/brig)
 "amO" = (
@@ -4475,33 +4179,24 @@
 	},
 /obj/item/reagent_containers/blood/OMinus,
 /obj/item/reagent_containers/blood/OMinus,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/turf_decal/lumos/tile/red/fullcorner,
 /turf/open/floor/plasteel/white,
 /area/security/brig)
 "amP" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -4518,8 +4213,7 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "amR" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -4603,10 +4297,7 @@
 	dir = 9;
 	pixel_x = -22
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -4616,6 +4307,9 @@
 /obj/machinery/recharger{
 	pixel_x = 5;
 	pixel_y = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
@@ -4634,23 +4328,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
-"anf" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
-/turf/open/floor/plasteel,
-/area/security/main)
 "ang" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/trimline/red/filled/corner,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "anh" = (
@@ -4696,12 +4379,16 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "anq" = (
-/obj/structure/punching_bag,
+/obj/structure/holohoop,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/sand,
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
-/area/space/station_ruins)
+/area/security/prison)
 "anr" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -4713,7 +4400,6 @@
 /area/maintenance/department/security/brig)
 "ans" = (
 /obj/item/wirecutters,
-/obj/effect/spawner/lootdrop/maintenance,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -4778,10 +4464,7 @@
 	icon_state = "map-pubby";
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -4798,12 +4481,11 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "2-4"
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -4858,11 +4540,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -4886,15 +4564,11 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/security/main)
 "anP" = (
@@ -4910,14 +4584,14 @@
 /obj/machinery/light_switch{
 	pixel_y = -24
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
 	},
 /obj/structure/bed/dogbed,
 /mob/living/simple_animal/hostile/retaliate/samak/mcchonks,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "anS" = (
@@ -4927,11 +4601,8 @@
 /obj/machinery/keycard_auth{
 	pixel_y = -24
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
@@ -4939,14 +4610,11 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/structure/table/wood,
 /obj/machinery/photocopier/faxmachine,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "anU" = (
@@ -4962,11 +4630,8 @@
 	name = "Station Intercom (General)";
 	pixel_y = -27
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
@@ -4981,11 +4646,8 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
@@ -5087,12 +4749,11 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aoo" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -5150,10 +4811,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -5206,12 +4864,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/security/main)
 "aoz" = (
@@ -5219,16 +4876,7 @@
 /area/maintenance/fore)
 "aoA" = (
 /obj/effect/turf_decal/bot_white/right,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/gateway)
 "aoB" = (
@@ -5236,30 +4884,12 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/bot_white,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/gateway)
 "aoC" = (
 /obj/effect/turf_decal/bot_white/left,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/gateway)
 "aoH" = (
@@ -5281,12 +4911,15 @@
 /turf/open/space,
 /area/solar/port)
 "aoJ" = (
-/obj/structure/weightmachine/weightlifter,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/sand,
 /turf/open/floor/plasteel,
-/area/space/station_ruins)
+/area/security/prison)
 "aoK" = (
 /obj/item/target/clown,
 /turf/open/floor/plating,
@@ -5428,26 +5061,14 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/red/fulltile,
 /turf/open/floor/plasteel,
 /area/security/main)
 "apb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/main)
 "apc" = (
@@ -5461,19 +5082,20 @@
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden/layer1{
 	dir = 8
 	},
+/obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/security/main)
 "apd" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/main)
 "ape" = (
@@ -5481,16 +5103,13 @@
 	dir = 1;
 	pixel_y = -22
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/main)
 "apf" = (
@@ -5504,22 +5123,13 @@
 	pixel_x = 32;
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
 	dir = 9
 	},
+/obj/effect/turf_decal/lumos/tile/red/fulltile,
 /turf/open/floor/plasteel,
 /area/security/main)
 "apg" = (
@@ -5622,16 +5232,7 @@
 /area/space/nearstation)
 "apq" = (
 /obj/effect/turf_decal/bot_white,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/gateway)
 "apr" = (
@@ -5741,7 +5342,7 @@
 	pixel_x = 4;
 	pixel_y = 4
 	},
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plating,
 /area/security/warden)
 "apM" = (
 /obj/machinery/door/airlock/security/glass{
@@ -5758,15 +5359,14 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "apN" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	icon_state = "2-4"
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -5792,6 +5392,17 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/red,
 /turf/open/floor/plasteel,
 /area/security/main)
 "apQ" = (
@@ -5830,14 +5441,14 @@
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/solar/port)
 "aqb" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/lattice,
+/obj/machinery/camera{
+	c_tag = "Permabrig Space North";
+	dir = 1;
+	name = "aft camera"
 	},
-/obj/machinery/jukebox{
-	req_one_access = null
-	},
-/turf/open/floor/plasteel,
-/area/space/station_ruins)
+/turf/open/space/basic,
+/area/space/nearstation)
 "aqd" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -5849,18 +5460,10 @@
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/solar/port)
 "aqe" = (
-/obj/structure/punching_bag,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
+/obj/effect/turf_decal/sand,
+/obj/structure/weightmachine/stacklifter,
 /turf/open/floor/plasteel,
-/area/space/station_ruins)
+/area/security/prison)
 "aqg" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
@@ -5885,9 +5488,6 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aqn" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
@@ -5897,17 +5497,14 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aqo" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -5921,20 +5518,20 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aqp" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -5942,56 +5539,38 @@
 /obj/machinery/camera{
 	c_tag = "Brig Cells"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden/layer1{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"aqr" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 4
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aqs" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden/layer1{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aqt" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -5999,6 +5578,9 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/manifold4w/cyan/hidden/layer1,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aqv" = (
@@ -6009,17 +5591,14 @@
 	name = "Station Intercom (General)";
 	pixel_y = 29
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -6027,17 +5606,14 @@
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_y = 30
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -6045,17 +5621,14 @@
 /obj/machinery/airalarm/unlocked{
 	pixel_y = 23
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -6067,14 +5640,17 @@
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aqz" = (
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -6083,12 +5659,8 @@
 	dir = 8;
 	pixel_x = 30
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -6163,16 +5735,7 @@
 /area/bridge)
 "aqL" = (
 /obj/machinery/computer/bank_machine,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
 "aqM" = (
@@ -6210,16 +5773,7 @@
 "aqP" = (
 /obj/structure/filingcabinet,
 /obj/item/folder/documents,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
 "aqQ" = (
@@ -6294,8 +5848,12 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "ara" = (
-/turf/closed/wall/r_wall,
-/area/space/station_ruins)
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/sand,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "arc" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -6337,9 +5895,6 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "ark" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
@@ -6407,14 +5962,13 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "art" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -6659,44 +6213,17 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "arS" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
 "arU" = (
 /obj/machinery/nuclearbomb/selfdestruct,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
 "arW" = (
 /obj/machinery/ore_silo,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
 "arX" = (
@@ -6858,17 +6385,12 @@
 /turf/open/floor/plating,
 /area/crew_quarters/dorms)
 "ask" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/cyan/hidden/layer1{
-	dir = 1
-	},
+/obj/effect/turf_decal/sand,
 /turf/open/floor/plasteel,
-/area/space/station_ruins)
+/area/security/prison)
 "asl" = (
 /obj/structure/grille/broken,
 /obj/structure/cable{
@@ -6911,12 +6433,8 @@
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "asu" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -6926,13 +6444,10 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "asw" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "asx" = (
@@ -6942,25 +6457,19 @@
 	name = "Cell 1";
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "asy" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "asz" = (
@@ -6969,13 +6478,10 @@
 	name = "Cell 2";
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "asB" = (
@@ -6985,45 +6491,29 @@
 	name = "Cell 3";
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "asC" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "asD" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "asE" = (
 /obj/machinery/light,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "asF" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -7138,16 +6628,7 @@
 /area/bridge)
 "asV" = (
 /obj/structure/closet/crate/goldcrate,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
 "asX" = (
@@ -7165,16 +6646,7 @@
 /area/ai_monitored/nuke_storage)
 "asZ" = (
 /obj/structure/closet/crate/silvercrate,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
 "ata" = (
@@ -7323,12 +6795,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/obj/effect/turf_decal/lumos/tile/blue/fulltile,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "atx" = (
@@ -7372,21 +6841,12 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/obj/effect/turf_decal/lumos/tile/green/fulltile,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "atB" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
@@ -7395,6 +6855,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -7406,12 +6869,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/obj/effect/turf_decal/lumos/tile/yellow/fulltile,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "atD" = (
@@ -7477,6 +6937,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
 	dir = 9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -7599,16 +7062,7 @@
 /obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
 /obj/item/clothing/head/bearpelt,
 /obj/item/skub,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
 "aub" = (
@@ -7653,16 +7107,7 @@
 /obj/item/disk/nuclear/fake,
 /obj/item/stack/ore/diamond,
 /obj/item/gun/energy/disabler,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
 "auf" = (
@@ -7803,6 +7248,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "auz" = (
@@ -7811,6 +7259,9 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
+	},
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -7821,6 +7272,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
 	dir = 9
+	},
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -8041,18 +7495,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
 "auZ" = (
@@ -8126,14 +7571,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "avi" = (
@@ -8144,11 +7586,8 @@
 	icon_state = "map-pubby";
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
@@ -8164,9 +7603,6 @@
 	name = "Monastery Monitor";
 	network = list("monastery");
 	pixel_y = 32
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
@@ -8237,17 +7673,11 @@
 	pixel_x = -28
 	},
 /obj/item/bedsheet/blue,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "avt" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "avu" = (
@@ -8255,13 +7685,10 @@
 	id = "Cell 1";
 	name = "Cell 1 Locker"
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "avv" = (
@@ -8271,20 +7698,14 @@
 	pixel_x = -28
 	},
 /obj/item/bedsheet/green,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/turf_decal/trimline/green/filled/line,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "avw" = (
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
+/obj/effect/turf_decal/trimline/green/filled/line,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "avx" = (
@@ -8292,10 +7713,7 @@
 	id = "Cell 2";
 	name = "Cell 2 Locker"
 	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
+/obj/effect/turf_decal/trimline/green/filled/line,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "avy" = (
@@ -8305,20 +7723,14 @@
 	pixel_x = -28
 	},
 /obj/item/bedsheet/orange,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "avz" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
+/obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "avA" = (
@@ -8326,10 +7738,7 @@
 	id = "Cell 3";
 	name = "Cell 3 Locker"
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
+/obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "avB" = (
@@ -8698,22 +8107,13 @@
 	id_tag = "Dorm3";
 	name = "Dorm 3"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/dorms)
 "awr" = (
@@ -9343,11 +8743,8 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/captain)
@@ -9359,6 +8756,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/captain)
@@ -9613,12 +9013,12 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "ayy" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-2"
+/obj/effect/turf_decal/sand,
+/obj/structure/sign/warning/electricshock{
+	pixel_y = 32
 	},
-/turf/open/floor/plating,
-/area/space/station_ruins)
+/turf/open/floor/plasteel,
+/area/security/prison)
 "ayz" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/vacuum/external{
@@ -9885,17 +9285,11 @@
 	name = "Chief Engineer RC";
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
 /obj/item/phone{
 	pixel_x = 17
+	},
+/obj/effect/turf_decal/lumos/tile/yellow/fullcorner{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
@@ -10133,22 +9527,13 @@
 	id_tag = "Dorm2";
 	name = "Dorm 2"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/dorms)
 "azv" = (
@@ -10244,9 +9629,15 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "azG" = (
-/obj/structure/sign/poster/official/random,
-/turf/closed/wall/r_wall,
-/area/space/station_ruins)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "permalock2"
+	},
+/turf/open/floor/plating,
+/area/security/prison)
 "azH" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -10255,28 +9646,31 @@
 /turf/open/space,
 /area/solar/port)
 "azI" = (
+/obj/effect/turf_decal/sand,
+/obj/structure/weightmachine/weightlifter,
 /turf/open/floor/plasteel,
-/area/space/station_ruins)
+/area/security/prison)
 "azJ" = (
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "0-2"
 	},
-/turf/open/floor/plasteel,
-/area/space/station_ruins)
+/obj/structure/cable,
+/obj/machinery/door/poddoor/preopen{
+	id = "permalock2"
+	},
+/turf/open/floor/plating,
+/area/security/prison)
 "azK" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/solar/port)
 "azL" = (
-/obj/machinery/computer/arcade,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/bed{
+	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel,
-/area/space/station_ruins)
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "azN" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -10324,16 +9718,11 @@
 	},
 /area/maintenance/department/security/brig)
 "azZ" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#cee5d2"
+/obj/machinery/light/small{
+	dir = 1
 	},
-/obj/machinery/computer/arcade,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/space/station_ruins)
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "aAa" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating{
@@ -10487,15 +9876,17 @@
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/heads/captain)
 "aAr" = (
-/obj/structure/chair/comfy/brown{
-	dir = 4
+/obj/structure/bed,
+/obj/item/radio/intercom{
+	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_y = 24;
+	prison_radio = 1
 	},
-/turf/open/floor/plasteel/grimy,
-/area/crew_quarters/heads/captain)
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "aAs" = (
-/obj/structure/table/wood,
-/obj/item/kitchen/fork,
-/obj/item/card/id/captains_spare,
+/obj/machinery/vending/wardrobe/cap_wardrobe,
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/heads/captain)
 "aAt" = (
@@ -10531,6 +9922,7 @@
 /area/crew_quarters/heads/captain)
 "aAx" = (
 /obj/structure/table/wood,
+/obj/item/card/id/captains_spare,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain)
 "aAy" = (
@@ -10539,6 +9931,9 @@
 	dir = 4
 	},
 /obj/machinery/recharger,
+/obj/item/phone{
+	pixel_x = -11
+	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain)
 "aAz" = (
@@ -10714,11 +10109,16 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "aAV" = (
+/obj/item/toy/beach_ball/holoball,
+/obj/effect/turf_decal/sand,
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel,
-/area/space/station_ruins)
+/area/security/prison)
 "aAW" = (
 /obj/structure/rack,
 /obj/item/clothing/mask/gas,
@@ -10802,7 +10202,11 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -24
 	},
-/obj/machinery/vending/wardrobe/cap_wardrobe,
+/obj/structure/bed/dogbed,
+/mob/living/simple_animal/hostile/retaliate/simbu{
+	desc = "The Captain's pet Simbu. He's fluffy.";
+	name = "Pubbsy"
+	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/captain)
 "aBl" = (
@@ -11164,17 +10568,15 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "aCa" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/sand,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/space/station_ruins)
+/turf/open/floor/plasteel,
+/area/security/prison)
 "aCc" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
@@ -11551,6 +10953,9 @@
 /obj/item/paper_bin{
 	layer = 2.9
 	},
+/obj/item/phone{
+	pixel_y = 13
+	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
 "aCQ" = (
@@ -11667,22 +11072,13 @@
 	id_tag = "Dorm1";
 	name = "Dorm 1"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/dorms)
 "aDf" = (
@@ -11864,13 +11260,13 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain)
 "aDF" = (
-/obj/structure/disposalpipe/junction{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -11879,13 +11275,13 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/disposalpipe/junction{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -12809,18 +12205,12 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain)
 "aFy" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/captain)
 "aFz" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/captain)
 "aFA" = (
@@ -12853,7 +12243,7 @@
 	id = "hop";
 	name = "privacy shutters"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/crew_quarters/heads/hop)
 "aFC" = (
 /obj/machinery/vending/snack,
@@ -13150,49 +12540,21 @@
 /area/storage/primary)
 "aGk" = (
 /obj/machinery/vending/boozeomat/pubby_captain,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/captain)
 "aGl" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
+/obj/structure/table/glass,
+/obj/item/storage/box/drinkingglasses,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/captain)
 "aGm" = (
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
+/obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/computer/arcade{
-	dir = 1
-	},
+/obj/machinery/disposal/bin,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/captain)
 "aGn" = (
@@ -13299,15 +12661,12 @@
 /turf/open/floor/plating,
 /area/storage/emergency/starboard)
 "aGC" = (
-/obj/structure/holohoop,
+/obj/effect/turf_decal/sand,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/space/station_ruins)
+/turf/open/floor/plasteel,
+/area/security/prison)
 "aGD" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -13444,31 +12803,13 @@
 /area/hallway/secondary/exit/departure_lounge)
 "aHb" = (
 /obj/machinery/computer/arcade,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
 "aHc" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
 "aHd" = (
@@ -14020,23 +13361,19 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "aIr" = (
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
+	icon_state = "0-8"
 	},
 /obj/structure/cable{
-	icon_state = "2-4"
+	icon_state = "0-2"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/structure/cable,
+/obj/machinery/door/poddoor/preopen{
+	id = "permalock2"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/space/station_ruins)
+/turf/open/floor/plating,
+/area/security/prison)
 "aIC" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -14784,6 +14121,7 @@
 /area/maintenance/department/cargo)
 "aKp" = (
 /obj/machinery/plate_press,
+/obj/item/stack/license_plates/empty/fifty,
 /turf/open/floor/plasteel/checker,
 /area/security/prison)
 "aKq" = (
@@ -15279,14 +14617,8 @@
 	pixel_y = 30
 	},
 /obj/machinery/computer/security,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
@@ -15301,11 +14633,8 @@
 /obj/machinery/airalarm{
 	pixel_y = 22
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
@@ -15315,12 +14644,8 @@
 	name = "Station Intercom (General)";
 	pixel_y = 26
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
@@ -15728,13 +15053,10 @@
 	},
 /area/maintenance/department/crew_quarters/bar)
 "aNj" = (
-/obj/effect/turf_decal/tile/purple{
+/obj/machinery/atmospherics/pipe/simple/violet/hidden,
+/obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/violet/hidden,
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "aNm" = (
@@ -15854,10 +15176,7 @@
 "aND" = (
 /obj/structure/table,
 /obj/item/book/manual/wiki/security_space_law,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -15870,8 +15189,7 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
 "aNF" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -16135,11 +15453,8 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "aOz" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/violet/hidden,
+/obj/effect/turf_decal/lumos/tile/purple/half,
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "aOA" = (
@@ -16196,10 +15511,7 @@
 	pixel_x = -26
 	},
 /obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -16296,14 +15608,11 @@
 /obj/machinery/recharger{
 	pixel_y = 4
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
@@ -16317,12 +15626,11 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
 "aOQ" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
@@ -16331,12 +15639,7 @@
 	name = "Cargo Security Post";
 	req_access_txt = "63"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/red/fulltile,
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "aOS" = (
@@ -16624,12 +15927,8 @@
 /obj/structure/table,
 /obj/item/beacon,
 /obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/fullcorner{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/teleporter)
@@ -16638,39 +15937,27 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/blue/half,
 /turf/open/floor/plasteel/dark,
 /area/teleporter)
 "aPO" = (
 /obj/machinery/teleport/station,
 /obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/blue/half,
 /turf/open/floor/plasteel/dark,
 /area/teleporter)
 "aPP" = (
 /obj/machinery/teleport/hub,
 /obj/machinery/light,
 /obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/blue/half,
 /turf/open/floor/plasteel/dark,
 /area/teleporter)
 "aPQ" = (
 /obj/structure/closet/crate,
 /obj/item/crowbar,
 /obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/blue/half,
 /turf/open/floor/plasteel/dark,
 /area/teleporter)
 "aPR" = (
@@ -16685,32 +15972,21 @@
 	pixel_x = -24
 	},
 /obj/structure/closet/secure_closet/security/cargo,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
 "aPU" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
 "aPV" = (
 /obj/structure/filingcabinet/security,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
@@ -17191,14 +16467,9 @@
 	name = "Cargo Security Post";
 	req_access_txt = "63"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/lumos/tile/red/fulltile,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
 "aRh" = (
@@ -17515,12 +16786,9 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "aRV" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/lumos/tile/blue/half,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "aRW" = (
@@ -18195,13 +17463,14 @@
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/solar/starboard)
 "aTG" = (
-/obj/structure/table,
-/obj/machinery/microwave,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/structure/lattice,
+/obj/machinery/camera{
+	c_tag = "Permabrig Space Northwest";
+	dir = 1;
+	name = "aft camera"
 	},
-/turf/open/floor/plasteel/white,
-/area/space/station_ruins)
+/turf/open/space/basic,
+/area/space/nearstation)
 "aTH" = (
 /obj/docking_port/stationary{
 	dir = 8;
@@ -18951,10 +18220,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "aVt" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -18974,8 +18240,7 @@
 /obj/machinery/conveyor_switch{
 	id = "cargodeliver"
 	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -19275,15 +18540,11 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "aWm" = (
-/obj/machinery/computer/arcade,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/toilet{
+	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel,
-/area/space/station_ruins)
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "aWn" = (
 /obj/machinery/power/apc{
 	dir = 8;
@@ -19382,8 +18643,7 @@
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/office)
 "aWw" = (
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -19716,7 +18976,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/quartermaster/office)
 "aXt" = (
 /obj/structure/table/reinforced,
@@ -19726,7 +18986,7 @@
 	name = "Cargo Desk";
 	req_access_txt = "50"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/quartermaster/office)
 "aXu" = (
 /obj/machinery/door/firedoor,
@@ -19741,8 +19001,7 @@
 	c_tag = "Cargo Foyer";
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -20075,6 +19334,10 @@
 /obj/item/bikehorn,
 /obj/item/toy/cattoy,
 /obj/effect/turf_decal/lumos/tile/neutral/fulltile,
+/obj/item/phone/broken{
+	desc = "Hello? Based department?";
+	pixel_x = -4
+	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/theatre)
 "aYm" = (
@@ -20093,11 +19356,8 @@
 /obj/machinery/computer/cargo{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/brown{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
@@ -20105,14 +19365,11 @@
 /obj/structure/chair/office/dark{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "aYp" = (
@@ -20120,11 +19377,8 @@
 	dir = 1
 	},
 /obj/effect/landmark/start/cargo_technician,
-/obj/effect/turf_decal/tile/brown{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
@@ -20138,31 +19392,22 @@
 	pixel_y = -2
 	},
 /obj/structure/table,
-/obj/effect/turf_decal/tile/brown{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "aYr" = (
-/obj/effect/turf_decal/tile/brown{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "aYs" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
-/obj/effect/turf_decal/tile/brown{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
@@ -20174,8 +19419,7 @@
 	dir = 8;
 	pixel_x = 28
 	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -20968,6 +20212,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "baC" = (
@@ -21271,9 +20516,8 @@
 /turf/open/floor/plating,
 /area/crew_quarters/bar)
 "bbv" = (
-/obj/effect/landmark/start/prisoner/prilate,
-/turf/open/floor/circuit/green,
-/area/space/station_ruins)
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "bbw" = (
 /obj/effect/landmark/start/assistant,
 /obj/structure/chair/stool,
@@ -21345,12 +20589,9 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/lumos/tile/brown/fulltile,
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "bbH" = (
@@ -21366,20 +20607,14 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/lumos/tile/brown/half,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "bbK" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/brown/half,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "bbL" = (
@@ -21439,9 +20674,12 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "bbT" = (
-/obj/structure/chair/stool,
-/turf/open/floor/wood,
-/area/space/station_ruins)
+/obj/structure/toilet{
+	contents = newlist(/obj/item/toy/snappop/phoenix);
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "bbU" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -21607,8 +20845,11 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "bcs" = (
-/turf/open/floor/circuit/green,
-/area/space/station_ruins)
+/obj/machinery/door/airlock/public/glass{
+	name = "Cell"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "bct" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -21671,14 +20912,8 @@
 	pixel_x = -23
 	},
 /obj/item/storage/belt/fannypack/yellow,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
@@ -21689,14 +20924,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "bcC" = (
@@ -21704,12 +20936,8 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
@@ -21719,14 +20947,8 @@
 	dir = 4;
 	pixel_x = -28
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
+/obj/effect/turf_decal/lumos/tile/brown/fullcorner{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
@@ -21735,22 +20957,16 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/lumos/tile/brown/half{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "bcF" = (
-/obj/effect/turf_decal/tile/brown{
+/obj/effect/turf_decal/lumos/tile/brown/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
@@ -21760,12 +20976,8 @@
 	dir = 8;
 	pixel_x = 23
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
+/obj/effect/turf_decal/lumos/tile/brown/fullcorner{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
@@ -22089,14 +21301,11 @@
 	name = "Quartermaster APC";
 	pixel_x = -24
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
 /obj/structure/table,
 /obj/machinery/photocopier/faxmachine,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "bdG" = (
@@ -22113,8 +21322,7 @@
 /obj/machinery/computer/bounty{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -22539,14 +21747,11 @@
 /area/science/robotics/mechbay)
 "beJ" = (
 /obj/structure/filingcabinet,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
 /obj/machinery/keycard_auth{
 	pixel_x = -23
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
@@ -22564,8 +21769,7 @@
 /obj/machinery/computer/cargo{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -22853,15 +22057,11 @@
 	departmentType = 2;
 	pixel_x = -30
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
 /obj/machinery/computer/card/minor/qm{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
@@ -22887,11 +22087,8 @@
 	},
 /obj/item/coin/silver,
 /obj/item/stamp/qm,
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
 /obj/item/phone,
+/obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "bfD" = (
@@ -22902,12 +22099,8 @@
 /obj/machinery/computer/security/qm{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
@@ -23598,18 +22791,14 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
+	},
+/obj/effect/turf_decal/lumos/tile/brown/fullcorner{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
@@ -23621,25 +22810,19 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 9
 	},
+/obj/effect/turf_decal/lumos/tile/brown/half,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "bhu" = (
 /obj/structure/closet/secure_closet/miner,
 /obj/machinery/light,
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/brown/half,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "bhv" = (
@@ -23647,13 +22830,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
 	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/brown/fullcorner,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "bhB" = (
@@ -24061,10 +23238,7 @@
 /obj/structure/sign/poster/official/random{
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/blue/half,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "biP" = (
@@ -24077,10 +23251,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/blue/half,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "biR" = (
@@ -24089,10 +23260,7 @@
 	c_tag = "Central Primary Hallway Genetics";
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/blue/half,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "biS" = (
@@ -24137,30 +23305,21 @@
 /area/medical/medbay/central)
 "bjg" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/lumos/tile/blue/half,
 /turf/open/floor/plasteel,
 /area/medical/medbay/central)
 "bjh" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/blue/half,
 /turf/open/floor/plasteel,
 /area/medical/medbay/central)
 "bji" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-10"
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/blue/half,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bjj" = (
@@ -24170,10 +23329,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/purple/half,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bjk" = (
@@ -24182,35 +23338,23 @@
 	dir = 1
 	},
 /obj/machinery/light,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/blue/half,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bjl" = (
 /obj/machinery/light,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/purple/half,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bjm" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/purple/half,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bjn" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-10"
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/purple/half,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bjp" = (
@@ -24401,24 +23545,15 @@
 /obj/machinery/airalarm{
 	pixel_y = 22
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/fullcorner{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bkd" = (
 /obj/structure/chair,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -24427,22 +23562,16 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bkf" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -24453,11 +23582,8 @@
 /obj/machinery/shower{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -24492,16 +23618,7 @@
 "bkp" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/aft)
 "bkq" = (
@@ -24735,10 +23852,9 @@
 	dir = 1
 	},
 /obj/effect/landmark/start/psychologist,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/white,
 /area/medical/psych)
 "blc" = (
@@ -24819,11 +23935,8 @@
 	pixel_x = 3;
 	pixel_y = 2
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -24831,11 +23944,8 @@
 /obj/structure/table,
 /obj/item/folder/white,
 /obj/item/healthanalyzer,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -25064,16 +24174,7 @@
 /obj/structure/sign/warning/securearea{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
 "blU" = (
@@ -25085,16 +24186,7 @@
 /obj/machinery/computer/security/telescreen/circuitry{
 	pixel_y = 30
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
 "blV" = (
@@ -25102,16 +24194,7 @@
 /obj/item/clothing/glasses/science,
 /obj/item/clothing/glasses/science,
 /obj/item/stack/sheet/metal/ten,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
 "blW" = (
@@ -25123,16 +24206,7 @@
 /obj/machinery/computer/security/telescreen/circuitry{
 	pixel_y = 30
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
 "blX" = (
@@ -25140,11 +24214,8 @@
 /area/science/xenobiology)
 "blZ" = (
 /obj/machinery/computer/camera_advanced/xenobio,
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
@@ -25234,19 +24305,13 @@
 /obj/machinery/firealarm{
 	pixel_y = 26
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable{
 	icon_state = "0-2";
 	pixel_y = 1
+	},
+/obj/effect/turf_decal/lumos/tile/blue/fullcorner{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/psych)
@@ -25257,13 +24322,7 @@
 	dir = 1;
 	network = list("ss13","medbay")
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/blue/fullcorner,
 /turf/open/floor/plasteel/white,
 /area/medical/psych)
 "bmn" = (
@@ -25280,13 +24339,13 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "bmq" = (
-/obj/machinery/camera{
-	c_tag = "Permabrig Lounge West";
+/obj/effect/turf_decal/sand,
+/obj/machinery/firealarm{
 	dir = 4;
-	network = list("ss13","prison")
+	pixel_x = -24
 	},
 /turf/open/floor/plasteel,
-/area/space/station_ruins)
+/area/security/prison)
 "bmr" = (
 /obj/machinery/camera{
 	c_tag = "Morgue";
@@ -25371,10 +24430,7 @@
 /area/medical/medbay/central)
 "bmA" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -25527,16 +24583,7 @@
 	pixel_x = -28;
 	pixel_y = 3
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bna" = (
@@ -25544,16 +24591,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/box/red,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bnb" = (
@@ -25565,16 +24603,7 @@
 /obj/item/stock_parts/cell/high,
 /obj/item/stock_parts/cell/high,
 /obj/item/stock_parts/cell/high,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bnc" = (
@@ -25722,10 +24751,7 @@
 /obj/item/reagent_containers/food/drinks/britcup{
 	desc = "Kingston's personal cup."
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/blue/half,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bnD" = (
@@ -25743,12 +24769,8 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bnG" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/obj/effect/turf_decal/lumos/tile/blue/fullcorner{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -25888,16 +24910,7 @@
 /obj/item/kirbyplants{
 	icon_state = "plant-10"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
 "boa" = (
@@ -25999,24 +25012,18 @@
 /area/medical/genetics)
 "bov" = (
 /obj/structure/closet/secure_closet/personal/patient,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "bow" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/structure/window/reinforced{
 	dir = 4;
 	layer = 2.9
+	},
+/obj/effect/turf_decal/lumos/tile/blue/half{
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
@@ -26025,12 +25032,6 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/machinery/door/window/southleft{
 	name = "Medbay Delivery";
 	req_access_txt = "28"
@@ -26043,18 +25044,18 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/lumos/tile/blue/half{
+	dir = 1
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "boy" = (
 /obj/structure/closet/wardrobe/mixed,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/structure/window/reinforced{
 	dir = 8
+	},
+/obj/effect/turf_decal/lumos/tile/blue/half{
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
@@ -26063,20 +25064,19 @@
 /obj/machinery/firealarm{
 	pixel_y = 27
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "boA" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/machinery/door/poddoor/preopen{
+	id = "permalock2"
 	},
-/turf/open/floor/wood,
-/area/space/station_ruins)
+/turf/open/floor/plating,
+/area/security/prison)
 "boB" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -26087,23 +25087,27 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "boC" = (
-/turf/open/floor/wood,
-/area/space/station_ruins)
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "boD" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/holopad,
 /turf/open/floor/plasteel/checker,
-/area/space/nearstation)
+/area/security/prison)
 "boE" = (
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 4
+	},
+/obj/effect/turf_decal/lumos/tile/blue/half{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -26142,11 +25146,8 @@
 	name = "Station Intercom (Medbay)";
 	pixel_y = 26
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -26155,12 +25156,8 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/medical_doctor,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/obj/effect/turf_decal/lumos/tile/blue/fullcorner{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -26168,10 +25165,7 @@
 /obj/structure/table/reinforced,
 /obj/item/folder/white,
 /obj/item/pen,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -26188,16 +25182,13 @@
 /area/medical/medbay/central)
 "boL" = (
 /obj/structure/bed/roller,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/turf_decal/lumos/tile/blue/half,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "boM" = (
@@ -26207,33 +25198,25 @@
 	dir = 1;
 	network = list("ss13","medbay")
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
 	},
+/obj/effect/turf_decal/lumos/tile/blue/half,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "boN" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/blue/half,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "boO" = (
 /obj/structure/table/glass,
 /obj/item/stack/medical/gauze,
 /obj/item/reagent_containers/glass/bottle/epinephrine,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/blue/half,
+/obj/effect/turf_decal/lumos/tile/blue/half,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "boP" = (
@@ -26357,16 +25340,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/general/visible,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bpe" = (
@@ -26374,16 +25348,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bpf" = (
@@ -26398,16 +25363,7 @@
 	},
 /obj/item/paper_bin,
 /obj/item/pen,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bph" = (
@@ -26428,17 +25384,8 @@
 	c_tag = "Experimentation Lab Central";
 	network = list("ss13","rd")
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/structure/table/reinforced,
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bpi" = (
@@ -26453,16 +25400,7 @@
 /obj/item/gun/energy/laser/practice,
 /obj/item/clothing/ears/earmuffs,
 /obj/item/clothing/ears/earmuffs,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bpm" = (
@@ -26541,16 +25479,7 @@
 	name = "Station Intercom (Medbay)";
 	pixel_x = -30
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/blue/fulltile,
 /turf/open/floor/plasteel,
 /area/medical/genetics)
 "bpz" = (
@@ -26571,10 +25500,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "bpD" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -26591,8 +25517,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -26615,14 +25540,9 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "bpI" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/space/station_ruins)
+/obj/machinery/vending/hydronutrients/prisoner,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "bpJ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -26677,17 +25597,14 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
+	},
+/obj/effect/turf_decal/lumos/tile/blue/half{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -26723,18 +25640,14 @@
 /obj/structure/chair/office/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bpS" = (
 /obj/structure/table/reinforced,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -26768,16 +25681,7 @@
 	},
 /obj/item/folder/white,
 /obj/item/pen,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/yellow/fulltile,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bpX" = (
@@ -26927,37 +25831,25 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -24
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/lumos/tile/purple/fullcorner{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/science/explab)
 "bqp" = (
 /obj/structure/chair/stool,
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/explab)
 "bqq" = (
 /obj/effect/landmark/start/scientist,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/lumos/tile/purple/half{
+	dir = 1
+	},
 /turf/open/floor/plasteel/white,
 /area/science/explab)
 "bqs" = (
@@ -26981,13 +25873,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/science/explab)
 "bqx" = (
@@ -27006,11 +25895,8 @@
 /obj/item/stack/sheet/mineral/plasma{
 	pixel_y = 4
 	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/explab)
@@ -27036,10 +25922,7 @@
 /obj/structure/window/reinforced,
 /obj/item/clothing/gloves/color/latex,
 /obj/item/clothing/glasses/science,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/purple/half,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "bqF" = (
@@ -27047,10 +25930,7 @@
 	dir = 1
 	},
 /obj/structure/window/reinforced,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/purple/half,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "bqG" = (
@@ -27197,16 +26077,7 @@
 /obj/machinery/computer/cloning{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/blue/fulltile,
 /turf/open/floor/plasteel,
 /area/medical/genetics)
 "bqX" = (
@@ -27290,17 +26161,14 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
+	},
+/obj/effect/turf_decal/lumos/tile/blue/half{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/zone3)
@@ -27337,7 +26205,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -27370,35 +26238,20 @@
 /obj/machinery/computer/med_data{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/blue/half,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bri" = (
 /obj/machinery/computer/crew{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/blue/fullcorner,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "brj" = (
 /obj/machinery/chem_master,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/fullcorner{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
@@ -27407,11 +26260,8 @@
 	dir = 1
 	},
 /obj/effect/landmark/start/chemist,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
@@ -27423,11 +26273,8 @@
 /obj/item/reagent_containers/dropper,
 /obj/item/reagent_containers/dropper,
 /obj/structure/table,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
@@ -27439,12 +26286,8 @@
 	pixel_x = 32;
 	receive_ore_updates = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
+/obj/effect/turf_decal/lumos/tile/yellow/fullcorner{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
@@ -27633,10 +26476,7 @@
 	pixel_x = -25
 	},
 /obj/machinery/portable_atmospherics/pump,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -27685,14 +26525,11 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
+	},
+/obj/effect/turf_decal/lumos/tile/purple/half{
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
@@ -27703,16 +26540,13 @@
 /obj/structure/sign/departments/xenobio{
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/lumos/tile/purple/half{
+	dir = 1
+	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "brV" = (
@@ -27731,23 +26565,17 @@
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "brW" = (
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "brX" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/lumos/tile/blue/half{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "bsa" = (
@@ -27835,11 +26663,8 @@
 /obj/structure/sign/departments/xenobio{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
@@ -27894,16 +26719,7 @@
 	dir = 4;
 	pixel_x = -23
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/blue/fulltile,
 /turf/open/floor/plasteel,
 /area/medical/genetics)
 "bss" = (
@@ -27968,31 +26784,13 @@
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/blue/fulltile,
 /turf/open/floor/plasteel,
 /area/medical/sleeper)
 "bsC" = (
 /obj/machinery/atmospherics/components/unary/cryo_cell,
 /obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/blue/fulltile,
 /turf/open/floor/plasteel,
 /area/medical/sleeper)
 "bsD" = (
@@ -28005,16 +26803,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/blue/fulltile,
 /turf/open/floor/plasteel,
 /area/medical/sleeper)
 "bsE" = (
@@ -28029,16 +26818,7 @@
 	pixel_y = 22
 	},
 /obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/blue/fulltile,
 /turf/open/floor/plasteel,
 /area/medical/sleeper)
 "bsF" = (
@@ -28094,10 +26874,7 @@
 /obj/structure/sign/poster/official/safety_eye_protection{
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -28118,8 +26895,7 @@
 	name = "Station Intercom (General)";
 	pixel_x = 29
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -28266,13 +27042,10 @@
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
 "bte" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
 	},
+/obj/effect/turf_decal/lumos/tile/purple/half,
 /turf/open/floor/plasteel/white,
 /area/science/explab)
 "btf" = (
@@ -28301,10 +27074,7 @@
 	},
 /obj/item/multitool,
 /obj/item/multitool,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -28354,14 +27124,13 @@
 /turf/open/floor/plasteel/white,
 /area/science/explab)
 "bts" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -28384,25 +27153,19 @@
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "btw" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /obj/machinery/atmospherics/pipe/simple/violet/hidden,
+/obj/effect/turf_decal/lumos/tile/purple/half{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "btx" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/violet/hidden,
+/obj/effect/turf_decal/lumos/tile/purple/half,
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "btA" = (
@@ -28564,29 +27327,20 @@
 /obj/item/kirbyplants{
 	icon_state = "plant-21"
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/blue/half,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "btV" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/blue/half,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "btW" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/lumos/tile/blue/half,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "btX" = (
@@ -28595,10 +27349,7 @@
 	pixel_y = 6
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/blue/half,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "btY" = (
@@ -28617,10 +27368,7 @@
 	pixel_x = 24;
 	pixel_y = 8
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/blue/half,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "btZ" = (
@@ -28734,13 +27482,6 @@
 	dir = 8;
 	pixel_x = 28
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
 /obj/structure/table/glass,
 /obj/item/stack/sheet/mineral/plasma{
 	amount = 2;
@@ -28751,6 +27492,9 @@
 /obj/item/grenade/chem_grenade,
 /obj/item/screwdriver,
 /obj/item/grenade/chem_grenade,
+/obj/effect/turf_decal/lumos/tile/yellow/half{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bup" = (
@@ -28826,10 +27570,7 @@
 /obj/item/kirbyplants/photosynthetic{
 	pixel_y = 10
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -28838,8 +27579,7 @@
 /obj/item/kirbyplants/photosynthetic{
 	pixel_y = 10
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -28849,12 +27589,9 @@
 /turf/open/floor/plating,
 /area/science/explab)
 "buA" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/lumos/tile/purple/half,
 /turf/open/floor/plasteel/white,
 /area/science/explab)
 "buB" = (
@@ -28879,46 +27616,31 @@
 /obj/item/kirbyplants{
 	icon_state = "plant-11"
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/purple/half,
 /turf/open/floor/plasteel/white,
 /area/science/explab)
 "buE" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
 	},
+/obj/effect/turf_decal/lumos/tile/purple/half,
 /turf/open/floor/plasteel/white,
 /area/science/explab)
 "buG" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/turf_decal/lumos/tile/purple/half,
 /turf/open/floor/plasteel/white,
 /area/science/explab)
 "buH" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
+/obj/effect/turf_decal/lumos/tile/purple/fullcorner,
 /turf/open/floor/plasteel/white,
 /area/science/explab)
 "buJ" = (
@@ -28935,14 +27657,11 @@
 /area/science/xenobiology)
 "buK" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 4
 	},
+/obj/effect/turf_decal/lumos/tile/purple/half,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "buN" = (
@@ -29007,10 +27726,7 @@
 	dir = 1;
 	pixel_y = -29
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/purple/half,
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "bva" = (
@@ -29034,18 +27750,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/lumos/tile/blue/fulltile,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "bve" = (
@@ -29376,11 +28083,8 @@
 	dir = 4;
 	pixel_x = -28
 	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
@@ -29409,41 +28113,29 @@
 	pixel_y = 30
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bvQ" = (
-/obj/effect/turf_decal/tile/purple{
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bvR" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/lumos/tile/purple/half{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bvS" = (
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
@@ -29453,12 +28145,8 @@
 	layer = 2.9
 	},
 /obj/structure/closet/emcloset,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
+/obj/effect/turf_decal/lumos/tile/purple/fullcorner{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
@@ -29484,16 +28172,7 @@
 /obj/machinery/magnetic_module,
 /obj/effect/landmark/blobstart,
 /obj/structure/target_stake,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bvY" = (
@@ -29531,17 +28210,11 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/purple/half,
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "bwh" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/purple/half,
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "bwm" = (
@@ -29606,34 +28279,22 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -26
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 9
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "bww" = (
 /obj/machinery/computer/scan_consolenew,
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "bwx" = (
 /obj/machinery/dna_scannernew,
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
@@ -29641,14 +28302,11 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "bwz" = (
@@ -29656,11 +28314,8 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
@@ -29671,12 +28326,8 @@
 	pixel_y = 4
 	},
 /obj/item/storage/box/bodybags,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 5
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
@@ -29716,11 +28367,8 @@
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "bwF" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/machinery/bloodbankgen,
+/obj/effect/turf_decal/lumos/tile/blue/half,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "bwG" = (
@@ -29740,13 +28388,10 @@
 /obj/structure/chair{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
 	},
+/obj/effect/turf_decal/lumos/tile/blue/half,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "bwK" = (
@@ -29805,13 +28450,7 @@
 /obj/item/hand_labeler,
 /obj/item/clothing/glasses/science,
 /obj/item/clothing/glasses/science,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/yellow/fullcorner,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bxa" = (
@@ -30268,16 +28907,7 @@
 /area/hallway/primary/aft)
 "bxH" = (
 /obj/effect/turf_decal/box/corners,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bxJ" = (
@@ -30344,9 +28974,11 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "bxP" = (
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/department/science)
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "bxQ" = (
 /obj/machinery/door/window/northleft{
 	base_state = "right";
@@ -30471,10 +29103,7 @@
 /obj/item/storage/box/disks,
 /obj/item/flashlight/pen,
 /obj/item/flashlight/pen,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -30499,8 +29128,7 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -30548,17 +29176,19 @@
 /turf/open/floor/plating,
 /area/medical/sleeper)
 "byp" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 8
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
+/turf/open/floor/plasteel,
+/area/security/prison)
 "byr" = (
-/turf/closed/wall/r_wall,
-/area/space)
+/obj/structure/chair/stool,
+/obj/effect/landmark/start/prisoner,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "byt" = (
 /obj/machinery/light{
 	dir = 4
@@ -30594,10 +29224,7 @@
 	icon_state = "0-4"
 	},
 /obj/item/radio/headset/headset_med,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -30800,20 +29427,14 @@
 /obj/item/kirbyplants/photosynthetic{
 	pixel_y = 4
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/purple/half,
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
 "byU" = (
 /obj/structure/chair/comfy{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/purple/half,
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
 "byV" = (
@@ -30821,20 +29442,14 @@
 /obj/item/folder,
 /obj/item/pen,
 /obj/machinery/light,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/purple/half,
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
 "byW" = (
 /obj/structure/chair/comfy{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/purple/half,
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
 "byX" = (
@@ -30843,10 +29458,7 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/purple/half,
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
 "byY" = (
@@ -30865,13 +29477,7 @@
 	dir = 4;
 	layer = 2.9
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/purple/fullcorner,
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bzc" = (
@@ -30903,12 +29509,9 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "bzg" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/lumos/tile/purple/half,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "bzh" = (
@@ -31130,17 +29733,14 @@
 /turf/open/floor/grass,
 /area/medical/genetics)
 "bzG" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
@@ -31177,8 +29777,7 @@
 /obj/structure/mirror{
 	pixel_x = 28
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -31187,30 +29786,21 @@
 /obj/item/kirbyplants{
 	icon_state = "plant-10"
 	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/green/half,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/zone3)
 "bzN" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/green/half,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/zone3)
 "bzO" = (
 /obj/structure/chair{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/green/half,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/zone3)
 "bzP" = (
@@ -31223,16 +29813,7 @@
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/blue/fulltile,
 /turf/open/floor/plasteel,
 /area/medical/sleeper)
 "bzQ" = (
@@ -31271,17 +29852,14 @@
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "bzU" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
+	},
+/obj/effect/turf_decal/lumos/tile/blue/half{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -31289,6 +29867,7 @@
 /obj/effect/turf_decal/lumos/tile/blue/checker{
 	dir = 4
 	},
+/obj/machinery/washing_machine,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "bzW" = (
@@ -31371,16 +29950,12 @@
 /area/crew_quarters/heads/cmo)
 "bAe" = (
 /obj/machinery/vending/wardrobe/chem_wardrobe,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
 /obj/machinery/airalarm{
 	dir = 1;
 	pixel_y = -22
+	},
+/obj/effect/turf_decal/lumos/tile/yellow/fullcorner{
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
@@ -31389,10 +29964,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/yellow/half,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bAg" = (
@@ -31543,10 +30115,7 @@
 /area/hallway/primary/aft)
 "bAC" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -31562,8 +30131,7 @@
 /area/science/explab)
 "bAE" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -31644,10 +30212,7 @@
 /obj/item/reagent_containers/glass/beaker,
 /obj/item/reagent_containers/dropper,
 /obj/item/storage/pill_bottle/mutadone,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -31678,8 +30243,7 @@
 	name = "Genetics Requests Console";
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -31747,17 +30311,14 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
+	},
+/obj/effect/turf_decal/lumos/tile/blue/half{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -32048,10 +30609,7 @@
 	dir = 4;
 	pixel_x = -28
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -32065,12 +30623,11 @@
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bBJ" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
+	},
+/obj/effect/turf_decal/lumos/tile/purple/half{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
@@ -32096,10 +30653,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -32108,8 +30662,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -32146,16 +30699,7 @@
 	pixel_y = 32
 	},
 /obj/machinery/portable_atmospherics/canister,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "bBS" = (
@@ -32167,16 +30711,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "bBT" = (
@@ -32191,16 +30726,7 @@
 	pixel_x = 27
 	},
 /obj/machinery/portable_atmospherics/pump,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "bBU" = (
@@ -32212,7 +30738,19 @@
 /area/science/xenobiology)
 "bBV" = (
 /obj/structure/table,
-/turf/open/floor/plasteel/checker,
+/obj/machinery/requests_console{
+	department = "Prison";
+	departmentType = 1;
+	pixel_y = -30
+	},
+/obj/item/stack/license_plates/empty/fifty,
+/obj/item/stack/license_plates/empty/fifty{
+	pixel_y = 8
+	},
+/obj/item/stack/license_plates/empty/fifty{
+	pixel_y = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "bBW" = (
 /turf/open/space,
@@ -32236,12 +30774,8 @@
 /obj/item/paper_bin{
 	layer = 2.9
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 10
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
@@ -32249,10 +30783,7 @@
 /obj/machinery/computer/scan_consolenew{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
+/obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "bCb" = (
@@ -32262,17 +30793,14 @@
 	dir = 1;
 	network = list("ss13","medbay")
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
+/obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "bCc" = (
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -32292,8 +30820,7 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -32339,32 +30866,14 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -24
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/blue/fulltile,
 /turf/open/floor/plasteel,
 /area/medical/sleeper)
 "bCj" = (
 /obj/machinery/sleeper{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/blue/fulltile,
 /turf/open/floor/plasteel,
 /area/medical/sleeper)
 "bCl" = (
@@ -32376,13 +30885,10 @@
 	pixel_x = -2;
 	pixel_y = -27
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
 	},
+/obj/effect/turf_decal/lumos/tile/blue/half,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "bCm" = (
@@ -32390,24 +30896,9 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/blue/half,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"bCn" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
 "bCo" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -32424,14 +30915,13 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -32742,10 +31232,7 @@
 /turf/closed/wall,
 /area/science/storage)
 "bCT" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -32799,14 +31286,8 @@
 /obj/machinery/atmospherics/components/trinary/mixer/flipped{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -32815,16 +31296,7 @@
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 9
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "bDd" = (
@@ -32840,16 +31312,7 @@
 	dir = 4
 	},
 /obj/item/wrench,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "bDe" = (
@@ -32860,8 +31323,13 @@
 /area/science/xenobiology)
 "bDf" = (
 /obj/structure/chair/stool,
-/turf/open/floor/plasteel/checker,
-/area/space/nearstation)
+/obj/machinery/light,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "bDg" = (
 /obj/machinery/atmospherics/components/unary/tank/air,
 /turf/open/floor/plating,
@@ -32888,12 +31356,8 @@
 /area/maintenance/department/engine)
 "bDl" = (
 /obj/structure/closet/secure_closet/medical1,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 10
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
@@ -32904,20 +31368,13 @@
 	dir = 1;
 	pixel_y = -22
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
+/obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "bDn" = (
 /obj/machinery/vending/wardrobe/gene_wardrobe,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 6
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
@@ -32935,7 +31392,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/plaque,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bDq" = (
@@ -32954,10 +31410,7 @@
 	dir = 4;
 	pixel_x = -22
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -33193,17 +31646,14 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
+	},
+/obj/effect/turf_decal/lumos/tile/purple/half{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
@@ -33222,14 +31672,13 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -33305,32 +31754,14 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "bEc" = (
 /obj/machinery/atmospherics/components/binary/valve{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "bEd" = (
@@ -33347,16 +31778,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "bEf" = (
@@ -33366,16 +31788,7 @@
 /obj/item/storage/bag/ore,
 /obj/item/pickaxe,
 /obj/structure/closet/crate,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "bEj" = (
@@ -33479,13 +31892,10 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -26
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/machinery/rnd/production/techfab/department/medical,
+/obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/machinery/rnd/production/techfab/department/medical,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bEw" = (
@@ -33503,11 +31913,8 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -33526,11 +31933,8 @@
 	name = "First-Aid Supplies";
 	req_access_txt = "5"
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -33549,11 +31953,8 @@
 	name = "First-Aid Supplies";
 	req_access_txt = "5"
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -33569,11 +31970,8 @@
 	pixel_y = -3
 	},
 /obj/structure/window/reinforced,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -33679,6 +32077,9 @@
 /area/maintenance/department/engine)
 "bEL" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
 /turf/open/floor/plating,
 /area/security/prison)
 "bEM" = (
@@ -33845,8 +32246,7 @@
 /turf/open/floor/plasteel/dark,
 /area/science/storage)
 "bFf" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -33901,16 +32301,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "bFp" = (
@@ -33918,47 +32309,29 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "bFr" = (
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "bFs" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
+	},
+/obj/effect/turf_decal/lumos/tile/purple/half{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bFt" = (
-/obj/effect/turf_decal/tile/purple{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "bFu" = (
@@ -33967,13 +32340,10 @@
 	id = "toxinsdriver";
 	pixel_x = 28
 	},
-/obj/effect/turf_decal/tile/purple{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "bFx" = (
@@ -34096,6 +32466,10 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/green/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/green/filled/corner,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bFN" = (
@@ -34166,6 +32540,7 @@
 /area/maintenance/department/engine)
 "bFY" = (
 /obj/effect/turf_decal/bot,
+/obj/effect/landmark/start/prisoner,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "bFZ" = (
@@ -34257,10 +32632,7 @@
 /area/science/storage)
 "bGj" = (
 /obj/machinery/vending/coffee,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -34272,8 +32644,7 @@
 /area/science/explab)
 "bGl" = (
 /obj/machinery/portable_atmospherics/scrubber,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -34285,18 +32656,12 @@
 	pixel_x = -24;
 	pixel_y = 8
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/purple/half,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "bGn" = (
 /obj/machinery/vending/wardrobe/science_wardrobe,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/purple/half,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "bGo" = (
@@ -34316,10 +32681,7 @@
 	pixel_y = -2
 	},
 /obj/structure/table/reinforced,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/purple/half,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "bGp" = (
@@ -34344,10 +32706,7 @@
 	network = list("ss13","rd")
 	},
 /obj/machinery/light,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/purple/half,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "bGq" = (
@@ -34365,29 +32724,20 @@
 	},
 /obj/item/assembly/timer,
 /obj/structure/table/reinforced,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/purple/half,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "bGr" = (
 /obj/structure/tank_dispenser,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/purple/half,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "bGs" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/lumos/tile/purple/half,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "bGt" = (
@@ -34396,29 +32746,11 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "bGu" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "bGv" = (
@@ -34429,16 +32761,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "bGw" = (
@@ -34581,14 +32904,8 @@
 	pixel_x = -4;
 	pixel_y = 24
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 9
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -34597,6 +32914,12 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/trimline/green/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/green/filled/corner{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bGU" = (
@@ -34612,12 +32935,8 @@
 /obj/machinery/light_switch{
 	pixel_x = 22
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 5
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -34654,38 +32973,25 @@
 	dir = 8;
 	pixel_x = 28
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bHb" = (
 /obj/structure/closet/crate/freezer/blood,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/machinery/light_switch{
 	pixel_x = -22
 	},
+/obj/effect/turf_decal/lumos/tile/blue/fulltile,
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "bHc" = (
 /obj/structure/sink{
 	pixel_y = 28
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
@@ -34700,13 +33006,10 @@
 /obj/machinery/airalarm{
 	pixel_y = 22
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/machinery/limbgrower,
+/obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/machinery/limbgrower,
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "bHf" = (
@@ -34882,16 +33185,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "bHA" = (
@@ -34911,16 +33205,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "bHC" = (
@@ -34930,20 +33215,14 @@
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "bHD" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/purple/half,
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "bHE" = (
 /obj/structure/window/reinforced,
 /obj/machinery/doppler_array/research/science,
 /obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/purple/half,
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "bHI" = (
@@ -35004,14 +33283,8 @@
 /area/maintenance/department/engine)
 "bHU" = (
 /obj/machinery/vending/medical,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 9
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -35019,11 +33292,8 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -35031,11 +33301,8 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -35050,11 +33317,8 @@
 /obj/machinery/airalarm/unlocked{
 	pixel_y = 23
 	},
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -35062,7 +33326,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -35085,25 +33349,19 @@
 	dir = 4;
 	pixel_x = 11
 	},
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bIc" = (
 /obj/machinery/vending/medical,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/blue/half,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bId" = (
 /obj/structure/closet/secure_closet/medical3,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/blue/half,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bIe" = (
@@ -35114,18 +33372,12 @@
 	dir = 1;
 	network = list("ss13","medbay")
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/blue/half,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bIf" = (
 /obj/machinery/vending/wardrobe/medi_wardrobe,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/blue/half,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bIg" = (
@@ -35151,10 +33403,7 @@
 /obj/machinery/light_switch{
 	pixel_y = -24
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/blue/half,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bIh" = (
@@ -35179,20 +33428,18 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/turf/open/floor/plasteel/freezer,
+/obj/effect/turf_decal/lumos/tile/blue/fulltile,
+/turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "bIk" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
+	},
+/obj/effect/turf_decal/lumos/tile/blue/half{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
@@ -35218,8 +33465,7 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -35433,13 +33679,10 @@
 	network = list("toxins");
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
+/obj/effect/turf_decal/lumos/tile/purple/half,
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "bIP" = (
@@ -35532,89 +33775,35 @@
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/engine)
 "bJb" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/engine)
 "bJc" = (
 /obj/structure/chair/comfy/black,
 /obj/item/trash/pistachios,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/engine)
 "bJd" = (
 /obj/structure/chair/comfy/black,
 /obj/item/stack/spacecash/c100,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/engine)
 "bJe" = (
 /obj/structure/chair/comfy/black,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/engine)
 "bJf" = (
 /obj/structure/chair/comfy/black,
 /obj/item/cigbutt,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/engine)
 "bJg" = (
 /obj/item/trash/popcorn,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/engine)
 "bJh" = (
@@ -35651,10 +33840,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -35680,6 +33866,9 @@
 	dir = 8;
 	pixel_x = 28
 	},
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bJo" = (
@@ -35689,24 +33878,8 @@
 	name = "Medbay RC";
 	pixel_x = -30
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
-"bJp" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -35715,10 +33888,7 @@
 /turf/closed/wall,
 /area/medical/surgery)
 "bJr" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -35730,8 +33900,7 @@
 	pixel_x = 26
 	},
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -35755,6 +33924,7 @@
 /area/security/prison)
 "bJA" = (
 /obj/effect/turf_decal/bot_red,
+/obj/machinery/holopad,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "bJD" = (
@@ -35987,16 +34157,7 @@
 /area/maintenance/department/engine)
 "bKl" = (
 /obj/item/stack/medical/gauze,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/engine)
 "bKm" = (
@@ -36043,13 +34204,15 @@
 /area/medical/virology)
 "bKt" = (
 /obj/machinery/computer/pandemic,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bKu" = (
 /obj/machinery/smartfridge/chemistry/virology/preloaded,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 5
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -36115,14 +34278,11 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bKB" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/structure/table/reinforced,
 /obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/effect/turf_decal/lumos/tile/blue/half{
+	dir = 8
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "bKD" = (
@@ -36133,12 +34293,11 @@
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "bKE" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/structure/table/reinforced,
 /obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/effect/turf_decal/lumos/tile/blue/half{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "bKF" = (
@@ -36149,14 +34308,24 @@
 /obj/machinery/door/poddoor/preopen{
 	id = "visitexit"
 	},
+/obj/effect/turf_decal/lumos/tile/red/fulltile,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "bKG" = (
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -36234,11 +34403,8 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -36252,11 +34418,8 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -36274,11 +34437,8 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -36296,11 +34456,8 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -36314,14 +34471,11 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/lumos/tile/yellow/half{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bKX" = (
@@ -36335,12 +34489,8 @@
 	dir = 8;
 	name = "Mix Outlet Pump"
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
+/obj/effect/turf_decal/lumos/tile/yellow/fullcorner{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -36398,6 +34548,9 @@
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/science/mixing)
@@ -36528,8 +34681,7 @@
 	layer = 2.9
 	},
 /obj/item/pen/red,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -36570,10 +34722,7 @@
 /turf/open/floor/plating,
 /area/medical/medbay/central)
 "bLJ" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -36582,66 +34731,55 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
+	},
+/obj/effect/turf_decal/lumos/tile/blue/half{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bLL" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/structure/table/optable,
+/obj/effect/turf_decal/lumos/tile/blue/fulltile,
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "bLM" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/machinery/computer/operating{
 	dir = 8
 	},
+/obj/effect/turf_decal/lumos/tile/blue/fulltile,
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "bLO" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	pixel_y = 29
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "bLQ" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /obj/machinery/flasher{
 	id = "visitflash";
 	pixel_y = 25
+	},
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#cee5d2"
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -36676,11 +34814,8 @@
 	dir = 4
 	},
 /obj/machinery/portable_atmospherics/scrubber,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/lumos/tile/red/checker{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
 	},
 /turf/open/floor/plasteel/white/corner{
 	dir = 1
@@ -36719,11 +34854,8 @@
 	pixel_x = -3;
 	pixel_y = -3
 	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -36732,11 +34864,8 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -36748,22 +34877,16 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bMb" = (
 /obj/machinery/meter/atmos/distro_loop,
 /obj/machinery/atmospherics/pipe/manifold/supply/visible,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -36771,11 +34894,8 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/visible{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -36784,11 +34904,8 @@
 	dir = 8;
 	name = "Mix to Distro"
 	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -36815,8 +34932,7 @@
 	output_tag = "mix_in";
 	sensors = list("mix_sensor" = "Tank")
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -36880,6 +34996,9 @@
 	dir = 8
 	},
 /obj/structure/fans/tiny,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/science/mixing)
 "bMr" = (
@@ -36980,16 +35099,7 @@
 /area/maintenance/department/engine)
 "bMC" = (
 /obj/item/stack/spacecash/c10,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/engine)
 "bMD" = (
@@ -37038,12 +35148,8 @@
 /obj/item/clothing/gloves/color/latex,
 /obj/item/clothing/glasses/hud/health,
 /obj/item/reagent_containers/dropper,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -37052,42 +35158,25 @@
 /obj/item/clothing/neck/stethoscope,
 /obj/item/gun/syringe,
 /obj/structure/table/glass,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/fullcorner{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bMM" = (
 /obj/structure/closet/l3closet,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/blue/fullcorner,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bMP" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#cee5d2"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /obj/machinery/camera{
 	c_tag = "Permabrig Visitations Prisoner-side";
 	dir = 8;
 	network = list("ss13","prison");
 	start_active = 1
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -37095,16 +35184,16 @@
 /obj/machinery/conveyor/auto{
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "bMR" = (
-/obj/machinery/light,
-/obj/machinery/button/door{
-	id = "permalock2";
-	name = "Perma Secure Airlock";
-	pixel_y = -26;
-	req_access_txt = "3"
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
 	},
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "bMS" = (
@@ -37148,10 +35237,7 @@
 	dir = 4;
 	name = "External to Filter"
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -37167,8 +35253,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -37253,8 +35338,7 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -37477,30 +35561,21 @@
 /obj/structure/table,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/reagentgrinder,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
+/obj/effect/turf_decal/trimline/green/filled/line,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bNQ" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /obj/machinery/vending/wardrobe/viro_wardrobe,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
+/obj/effect/turf_decal/trimline/green/filled/line,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bNR" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-21"
 	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
+/obj/effect/turf_decal/trimline/green/filled/line,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bNS" = (
@@ -37519,8 +35594,12 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bNV" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "sexroom"
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/obj/machinery/camera{
+	c_tag = "Permabrig North Hallway";
+	network = list("ss13","prison")
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -37531,10 +35610,6 @@
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
-/area/maintenance/department/engine)
-"bNX" = (
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bOa" = (
 /obj/effect/turf_decal/tile/yellow{
@@ -37556,11 +35631,8 @@
 	dir = 4
 	},
 /obj/machinery/portable_atmospherics/pump,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/checker{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
 	},
 /turf/open/floor/plasteel/white/corner{
 	dir = 1
@@ -37578,10 +35650,7 @@
 	dir = 8;
 	name = "Air to External"
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -37597,8 +35666,7 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -37733,16 +35801,7 @@
 /obj/structure/chair/comfy/black{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/engine)
 "bOA" = (
@@ -37870,10 +35929,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -37888,8 +35944,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bOQ" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -37912,10 +35967,7 @@
 	dir = 1
 	},
 /obj/machinery/space_heater,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/yellow/half,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bOT" = (
@@ -37944,10 +35996,7 @@
 /obj/item/multitool{
 	layer = 4
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/yellow/half,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bOW" = (
@@ -37957,10 +36006,7 @@
 /obj/item/t_scanner,
 /obj/item/t_scanner,
 /obj/item/t_scanner,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/yellow/half,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bOX" = (
@@ -37973,10 +36019,7 @@
 /obj/item/stack/sheet/glass,
 /obj/item/stack/rods/fifty,
 /obj/item/pipe_dispenser,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/yellow/half,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bOY" = (
@@ -38024,8 +36067,7 @@
 	dir = 8;
 	name = "N2O Outlet Pump"
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -38238,10 +36280,7 @@
 /obj/machinery/conveyor_switch{
 	id = "atmosdeliver"
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -38252,8 +36291,7 @@
 /area/engine/atmos)
 "bPP" = (
 /obj/structure/tank_dispenser,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -38277,13 +36315,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "bPT" = (
@@ -38323,8 +36358,7 @@
 	output_tag = "n2o_out";
 	sensors = list("n2o_sensor" = "Tank")
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -38357,7 +36391,10 @@
 	dir = 4;
 	network = list("ss13","monastery")
 	},
-/turf/open/floor/plating/asteroid,
+/turf/open/floor/plating/smooth/grass{
+	desc = "A lush patch for moss commonly found growing in inhabited asteroids.";
+	name = "asteroid moss"
+	},
 /area/chapel/asteroid/monastery)
 "bQd" = (
 /obj/structure/flora/ausbushes/leafybush,
@@ -38387,7 +36424,10 @@
 	dir = 8;
 	network = list("ss13","monastery")
 	},
-/turf/open/floor/plating/asteroid,
+/turf/open/floor/plating/smooth/grass{
+	desc = "A lush patch for moss commonly found growing in inhabited asteroids.";
+	name = "asteroid moss"
+	},
 /area/chapel/asteroid/monastery)
 "bQi" = (
 /obj/structure/window/reinforced{
@@ -38458,16 +36498,7 @@
 /obj/item/aicard,
 /obj/item/aiModule/reset,
 /obj/item/assembly/flash/handheld,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/green/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "bQu" = (
@@ -38479,16 +36510,7 @@
 /obj/machinery/firealarm{
 	pixel_y = 29
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/green/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "bQv" = (
@@ -38497,16 +36519,7 @@
 	pixel_y = 32
 	},
 /obj/effect/spawner/lootdrop/techstorage/engineering,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/green/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "bQw" = (
@@ -38523,31 +36536,13 @@
 /obj/machinery/airalarm{
 	pixel_y = 22
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/green/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "bQx" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/techstorage/rnd,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/green/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "bQy" = (
@@ -38561,44 +36556,17 @@
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/green/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "bQz" = (
 /obj/machinery/computer/arcade,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/green/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "bQA" = (
 /obj/machinery/vending/assist,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/green/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "bQB" = (
@@ -38655,10 +36623,7 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/atmospheric_technician,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -38667,8 +36632,7 @@
 /obj/machinery/computer/atmos_control{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -38754,8 +36718,7 @@
 	},
 /area/maintenance/department/engine)
 "bQT" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/trash_pile,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bQU" = (
@@ -38948,8 +36911,7 @@
 /obj/machinery/computer/atmos_alert{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -39000,8 +36962,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -39143,64 +37104,37 @@
 "bRO" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/techstorage/medical,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
+/obj/effect/turf_decal/lumos/tile/green/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "bRP" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/techstorage/tcomms,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
+/obj/effect/turf_decal/lumos/tile/green/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "bRQ" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/techstorage/security,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
+/obj/effect/turf_decal/lumos/tile/green/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "bRR" = (
@@ -39319,10 +37253,7 @@
 	freq = 1400;
 	location = "Atmospherics"
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/yellow/half,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bSc" = (
@@ -39333,10 +37264,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/yellow/half,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bSd" = (
@@ -39344,10 +37272,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/yellow/half,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bSe" = (
@@ -39379,8 +37304,7 @@
 	dir = 8;
 	name = "Plasma Outlet Pump"
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -39455,7 +37379,7 @@
 /area/maintenance/department/engine)
 "bSu" = (
 /obj/item/broken_bottle,
-/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/trash_pile,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bSv" = (
@@ -39654,8 +37578,7 @@
 	output_tag = "tox_out";
 	sensors = list("tox_sensor" = "Tank")
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -39857,16 +37780,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/green/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "bTx" = (
@@ -39878,16 +37792,7 @@
 /obj/machinery/light{
 	light_color = "#cee5d2"
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/green/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "bTy" = (
@@ -39896,16 +37801,7 @@
 /obj/item/stock_parts/subspace/amplifier,
 /obj/item/stock_parts/subspace/analyzer,
 /obj/item/stock_parts/subspace/analyzer,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/green/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "bTz" = (
@@ -39916,16 +37812,7 @@
 	},
 /obj/item/clothing/gloves/color/yellow,
 /obj/item/t_scanner,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/green/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "bTA" = (
@@ -39940,16 +37827,7 @@
 	pixel_y = -32
 	},
 /obj/item/clothing/glasses/meson/engine,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/green/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "bTB" = (
@@ -39960,16 +37838,7 @@
 	},
 /obj/structure/cable,
 /obj/structure/closet/crate/solarpanel_small,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/green/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "bTC" = (
@@ -39996,11 +37865,8 @@
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bTH" = (
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -40009,11 +37875,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 6
 	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -40021,11 +37884,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -40042,11 +37902,8 @@
 /obj/machinery/camera{
 	c_tag = "Atmospherics Entrance"
 	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -40057,11 +37914,8 @@
 /obj/machinery/firealarm{
 	pixel_y = 29
 	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -40085,11 +37939,8 @@
 	dir = 4
 	},
 /obj/machinery/vending/wardrobe/atmos_wardrobe,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -40101,11 +37952,8 @@
 /obj/structure/fireaxecabinet{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -40117,11 +37965,8 @@
 /obj/machinery/camera{
 	c_tag = "Atmospherics Mixing"
 	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -40220,24 +38065,15 @@
 	dir = 4;
 	pixel_x = -23
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
 "bUj" = (
 /obj/machinery/computer/secure_data,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
@@ -40370,8 +38206,7 @@
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -40426,14 +38261,11 @@
 /turf/closed/wall/r_wall,
 /area/crew_quarters/heads/chief)
 "bUI" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
 /obj/structure/table/reinforced,
 /obj/machinery/photocopier/faxmachine,
+/obj/effect/turf_decal/lumos/tile/yellow/half{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
 "bUJ" = (
@@ -40447,11 +38279,8 @@
 /obj/machinery/computer/security/telescreen/ce{
 	pixel_y = 30
 	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
@@ -40460,11 +38289,8 @@
 	pixel_y = 22
 	},
 /obj/machinery/computer/apc_control,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
@@ -40473,22 +38299,15 @@
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
 "bUM" = (
 /obj/machinery/computer/card/minor/ce,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
+/obj/effect/turf_decal/lumos/tile/yellow/fullcorner{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
@@ -40511,11 +38330,8 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/smes/engineering,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
@@ -40530,11 +38346,8 @@
 /obj/machinery/camera{
 	c_tag = "Engineering Power Storage"
 	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
@@ -40543,11 +38356,8 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/smes/engineering,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
@@ -40571,10 +38381,7 @@
 /obj/item/paper_bin{
 	layer = 2.9
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -40599,14 +38406,13 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -40619,22 +38425,13 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
+/obj/effect/turf_decal/lumos/tile/red/fulltile,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
 "bUZ" = (
@@ -40771,8 +38568,7 @@
 	dir = 8;
 	name = "CO2 Outlet Pump"
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -40893,8 +38689,7 @@
 	icon_state = "0-8"
 	},
 /obj/item/clothing/glasses/meson/engine,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -40945,10 +38740,7 @@
 	dir = 4;
 	pixel_x = -23
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -40967,8 +38759,7 @@
 /area/engine/engine_smes)
 "bVN" = (
 /obj/machinery/suit_storage_unit/engine,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -40987,10 +38778,7 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -41006,8 +38794,7 @@
 /area/security/checkpoint/engineering)
 "bVQ" = (
 /obj/structure/closet/wardrobe/red,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -41095,8 +38882,7 @@
 /obj/machinery/computer/atmos_control/tank/carbon_tank{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -41193,13 +38979,10 @@
 /obj/item/folder/yellow,
 /obj/item/paper/monitorkey,
 /obj/item/pen,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
+/mob/living/simple_animal/parrot/Poly,
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 8
 	},
-/mob/living/simple_animal/parrot/Poly,
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
 "bWo" = (
@@ -41236,8 +39019,7 @@
 /obj/machinery/light_switch{
 	pixel_x = 22
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -41245,16 +39027,7 @@
 "bWs" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/techstorage/RnD_secure,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/red/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "bWt" = (
@@ -41264,31 +39037,13 @@
 	dir = 1
 	},
 /obj/effect/spawner/lootdrop/techstorage/command,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/red/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "bWu" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/techstorage/AI,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/red/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "bWv" = (
@@ -41322,10 +39077,7 @@
 	network = list("engine");
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -41363,8 +39115,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -41378,20 +39129,13 @@
 	network = list("engine");
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
 "bWB" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
 "bWC" = (
@@ -41399,12 +39143,8 @@
 	pixel_x = 32
 	},
 /obj/structure/closet/secure_closet/security/engine,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
@@ -41581,18 +39321,8 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"bXf" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow,
-/turf/open/floor/plasteel,
-/area/crew_quarters/heads/chief)
 "bXg" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/yellow/half,
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
 "bXh" = (
@@ -41607,12 +39337,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/lumos/tile/yellow/half,
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
 "bXj" = (
@@ -41630,13 +39357,7 @@
 	pixel_x = 24;
 	req_access_txt = "11"
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/yellow/fullcorner,
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
 "bXk" = (
@@ -41657,10 +39378,7 @@
 /obj/structure/cable,
 /obj/item/stack/sheet/metal/fifty,
 /obj/item/stack/cable_coil,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -41720,73 +39438,49 @@
 "bXr" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/yellow/half,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bXs" = (
 /obj/machinery/portable_atmospherics/pump,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/yellow/half,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bXt" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/yellow/half,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bXu" = (
 /obj/machinery/computer/atmos_control/tank/nitrogen_tank{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/yellow/half,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bXv" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/yellow/half,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bXw" = (
 /obj/machinery/light,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
+/obj/effect/turf_decal/lumos/tile/yellow/half,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bXx" = (
 /obj/machinery/computer/atmos_control/tank/oxygen_tank{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/yellow/half,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bXy" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/yellow/half,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bXz" = (
@@ -41794,28 +39488,19 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/yellow/half,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bXA" = (
 /obj/machinery/atmospherics/components/trinary/mixer/airmix,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/yellow/half,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bXB" = (
 /obj/machinery/computer/atmos_control/tank/air_tank{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/yellow/half,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bXC" = (
@@ -41824,10 +39509,7 @@
 	dir = 4;
 	name = "Air Outlet Pump"
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/yellow/half,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bXD" = (
@@ -41837,10 +39519,7 @@
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/yellow/half,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bXE" = (
@@ -41851,23 +39530,14 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/yellow/half,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bXF" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/yellow/fullcorner,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bXG" = (
@@ -41915,16 +39585,16 @@
 	},
 /area/maintenance/department/engine)
 "bXT" = (
-/obj/machinery/holopad,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/manifold/cyan/hidden/layer1{
-	dir = 8
+/obj/machinery/requests_console{
+	department = "Prison";
+	departmentType = 1;
+	pixel_y = 30
 	},
 /turf/open/floor/plasteel,
-/area/space/station_ruins)
+/area/security/prison)
 "bXU" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -41986,6 +39656,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/lumos/tile/yellow/fulltile,
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
 "bYb" = (
@@ -42152,11 +39823,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -42167,11 +39835,8 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -42186,14 +39851,11 @@
 	dir = 8;
 	sortType = 5
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/lumos/tile/yellow/half{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "bYN" = (
@@ -42210,11 +39872,8 @@
 	icon_state = "map-pubby";
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -42228,11 +39887,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -42249,11 +39905,8 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -42270,14 +39923,11 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/lumos/tile/yellow/half{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -42294,24 +39944,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"bYV" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -42326,11 +39961,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -42347,11 +39979,8 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -42369,11 +39998,8 @@
 	name = "Station Intercom (General)";
 	pixel_y = 26
 	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -42435,10 +40061,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -42469,8 +40092,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -42545,11 +40167,8 @@
 /obj/item/flashlight,
 /obj/item/flashlight,
 /obj/item/clothing/glasses/meson/engine,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -42658,10 +40277,7 @@
 	pixel_x = -27
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -42685,8 +40301,7 @@
 	pixel_x = 24;
 	pixel_y = -6
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -42876,10 +40491,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -42900,8 +40512,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -43176,10 +40787,7 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -43201,8 +40809,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -43381,10 +40988,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -43398,8 +41002,7 @@
 /obj/machinery/atmospherics/components/binary/pump/on{
 	name = "Incinerator Output Pump"
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -43519,26 +41122,18 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cdf" = (
-/obj/structure/rack,
-/obj/machinery/light/small{
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
-/obj/item/tank/internals/nitrogen/belt,
-/obj/item/tank/internals/nitrogen/belt,
-/obj/item/tank/internals/plasmaman/belt,
-/obj/item/tank/internals/plasmaman/belt,
-/turf/open/floor/plating,
-/area/space/station_ruins)
+/turf/open/floor/plasteel,
+/area/security/prison)
 "cdg" = (
 /obj/structure/table/glass,
 /obj/item/paper_bin,
 /obj/item/pen,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/fullcorner{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
@@ -43548,21 +41143,12 @@
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 5
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/yellow/half,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "cdi" = (
 /obj/machinery/atmospherics/pipe/manifold4w/general/visible,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/yellow/fullcorner,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "cdj" = (
@@ -43679,33 +41265,24 @@
 /area/maintenance/department/engine)
 "cdI" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/yellow/half,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cdK" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
 /obj/structure/reagent_dispensers/fueltank,
+/obj/effect/turf_decal/lumos/tile/yellow/half,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cdL" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/lumos/tile/yellow/half,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cdM" = (
@@ -43714,10 +41291,7 @@
 	dir = 1;
 	pixel_x = 23
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/yellow/half,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cdO" = (
@@ -43861,29 +41435,16 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "cet" = (
 /obj/structure/closet/radiation,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
+/obj/effect/turf_decal/lumos/tile/yellow/half,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "ceu" = (
@@ -44023,13 +41584,10 @@
 /area/engine/engineering)
 "ceX" = (
 /obj/structure/closet/secure_closet/engineering_welding,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/obj/effect/turf_decal/lumos/tile/yellow/half,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cfa" = (
@@ -44079,46 +41637,19 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "cfo" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "cfp" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "cfr" = (
@@ -44159,16 +41690,7 @@
 /area/chapel/main/monastery)
 "cfE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "cfF" = (
@@ -44183,32 +41705,14 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "cfG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "cfH" = (
@@ -44346,16 +41850,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "cgj" = (
@@ -44587,16 +42082,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "cho" = (
@@ -44820,18 +42306,15 @@
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "cil" = (
-/obj/structure/table,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/hatchet,
+/obj/machinery/camera{
+	c_tag = "Permabrig East Hallway";
+	network = list("ss13","prison")
+	},
 /turf/open/floor/plasteel,
-/area/space/station_ruins)
+/area/security/prison)
 "cio" = (
 /obj/structure/closet/cabinet,
 /obj/item/clothing/suit/chaplain/holidaypriest,
@@ -44895,16 +42378,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "ciE" = (
@@ -45365,16 +42839,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "ckF" = (
@@ -46342,12 +43807,11 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
 "cnV" = (
-/obj/machinery/requests_console{
-	department = "Prison";
-	departmentType = 1
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 5
 	},
-/turf/closed/wall/r_wall,
-/area/space/station_ruins)
+/turf/open/floor/plasteel,
+/area/security/prison)
 "cnX" = (
 /obj/structure/trash_pile,
 /turf/open/floor/plating,
@@ -46450,8 +43914,12 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "cor" = (
-/turf/open/floor/plasteel/elevatorshaft,
-/area/space/station_ruins)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating,
+/area/security/prison)
 "cos" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -46901,48 +44369,30 @@
 /area/hallway/primary/central)
 "cpT" = (
 /obj/item/kirbyplants,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/blue/half,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "cpU" = (
 /obj/item/kirbyplants,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/purple/half,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "cpX" = (
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "cpY" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/lumos/tile/blue/half{
+	dir = 1
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "cpZ" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/blue/fullcorner,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "cqa" = (
@@ -46961,8 +44411,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "cqd" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -47093,11 +44542,8 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -47429,6 +44875,7 @@
 /area/chapel/office)
 "cso" = (
 /obj/structure/table/wood,
+/obj/item/phone,
 /obj/item/nullrod,
 /turf/open/floor/carpet/black,
 /area/chapel/office)
@@ -47442,12 +44889,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/lumos/tile/red/fullcorner{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
@@ -47456,12 +44899,8 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/lumos/tile/red/fullcorner{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
@@ -47469,12 +44908,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/lumos/tile/red/fullcorner{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
@@ -47516,48 +44951,21 @@
 /turf/open/floor/carpet/black,
 /area/chapel/office)
 "csE" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/red/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "csF" = (
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/red/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "csG" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/red/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "csM" = (
@@ -47642,14 +45050,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/lumos/tile/red/fullcorner{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
@@ -47657,14 +45059,8 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/lumos/tile/red/fullcorner{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
@@ -47742,16 +45138,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "ctM" = (
@@ -47761,16 +45148,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "ctN" = (
@@ -47784,16 +45162,7 @@
 	c_tag = "Monastery Cloister Fore";
 	network = list("ss13","monastery")
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "ctO" = (
@@ -47803,16 +45172,7 @@
 /obj/machinery/airalarm{
 	pixel_y = 22
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "ctP" = (
@@ -47853,10 +45213,7 @@
 	dir = 1;
 	pixel_y = -29
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/purple/half,
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "cui" = (
@@ -48064,16 +45421,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "cuQ" = (
@@ -48132,32 +45480,14 @@
 /obj/machinery/door/airlock{
 	name = "Garden"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "cuY" = (
 /obj/machinery/door/airlock{
 	name = "Garden"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "cuZ" = (
@@ -48174,16 +45504,7 @@
 /area/hydroponics/garden/monastery)
 "cvc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "cvd" = (
@@ -48294,48 +45615,21 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "cvw" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "cvy" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "cvA" = (
@@ -48379,16 +45673,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "cvH" = (
@@ -48401,16 +45686,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "cvI" = (
@@ -48427,16 +45703,7 @@
 	dir = 1;
 	network = list("ss13","monastery")
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "cvJ" = (
@@ -48447,16 +45714,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "cvK" = (
@@ -48467,16 +45725,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "cvR" = (
@@ -48743,10 +45992,7 @@
 /area/library/lounge)
 "cxb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/purple/half,
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "cxe" = (
@@ -48799,16 +46045,7 @@
 /obj/effect/turf_decal/box/corners{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
 "cxz" = (
@@ -49176,14 +46413,13 @@
 /turf/open/floor/plasteel/dark,
 /area/library)
 "czx" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
-/area/space/station_ruins)
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/sand,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "czB" = (
 /obj/structure/table/wood/fancy,
 /obj/item/storage/fancy/candle_box,
@@ -49691,19 +46927,19 @@
 	pixel_y = 12
 	},
 /obj/item/restraints/handcuffs,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/security/main)
 "cCO" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "cCP" = (
@@ -49796,9 +47032,16 @@
 /turf/open/space/basic,
 /area/space)
 "cHS" = (
-/obj/structure/grille,
-/turf/open/space/basic,
-/area/space/station_ruins)
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/holohoop{
+	dir = 1
+	},
+/obj/effect/turf_decal/sand,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "cKV" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -49810,23 +47053,22 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "cLq" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/sand,
+/turf/open/floor/plasteel,
 /area/security/prison)
 "cLt" = (
-/obj/machinery/holopad,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
+/obj/structure/sign/warning/electricshock{
+	pixel_x = 32
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
+/turf/open/floor/plating/smooth/grass{
+	desc = "A lush patch for moss commonly found growing in inhabited asteroids.";
+	name = "asteroid moss"
 	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/space/station_ruins)
+/area/security/prison)
 "cLw" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -49834,16 +47076,12 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cMk" = (
-/obj/machinery/camera{
-	c_tag = "Permabrig Showers";
-	dir = 4;
-	network = list("ss13","prison")
-	},
-/obj/structure/sign/poster/official/random{
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/space/station_ruins)
+/obj/structure/table,
+/obj/item/hatchet,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/glass/bucket,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "cOp" = (
 /obj/item/clothing/mask/gas,
 /obj/item/clothing/mask/gas,
@@ -49854,43 +47092,20 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "cPc" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/machinery/camera{
-	c_tag = "Permabrig Garden";
-	dir = 4;
-	network = list("ss13","prison")
-	},
-/obj/structure/sign/poster/official/random{
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel,
-/area/space/station_ruins)
+/obj/machinery/biogenerator/prisoner,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "cPn" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/wood,
-/area/space/station_ruins)
+/obj/machinery/vending/hydroseeds,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "cPx" = (
-/obj/structure/chair/stool,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/closet/crate/bin,
+/obj/machinery/firealarm{
+	pixel_y = 29
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/space/station_ruins)
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "cPy" = (
 /obj/machinery/atmospherics/components/binary/pump,
 /obj/structure/sign/warning/nosmoking{
@@ -49917,10 +47132,7 @@
 /obj/structure/window/reinforced,
 /obj/item/storage/box/monkeycubes,
 /obj/item/storage/box/monkeycubes,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/purple/half,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "cSJ" = (
@@ -49952,10 +47164,7 @@
 	pixel_x = 24
 	},
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/blue/half,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "cSK" = (
@@ -49975,22 +47184,19 @@
 /turf/open/floor/plasteel/dark,
 /area/science/lab)
 "cUu" = (
-/obj/structure/table,
-/obj/machinery/computer/libraryconsole,
-/turf/open/floor/wood,
-/area/space/station_ruins)
-"cWb" = (
-/obj/machinery/hydroponics/constructable,
-/obj/machinery/light,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
+/obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/space/station_ruins)
+/area/security/prison)
+"cWb" = (
+/obj/structure/table,
+/obj/item/toy/cards/deck,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "cXS" = (
 /obj/structure/chair,
 /turf/open/floor/plating,
@@ -50001,9 +47207,10 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "cYF" = (
-/obj/machinery/hydroponics/constructable,
+/obj/structure/chair/stool,
+/obj/effect/landmark/start/prisoner,
 /turf/open/floor/plasteel,
-/area/space/station_ruins)
+/area/security/prison)
 "cZt" = (
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
@@ -50028,16 +47235,29 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "dci" = (
-/obj/structure/lattice,
-/obj/structure/grille,
-/turf/open/space/basic,
-/area/space/station_ruins)
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "dcp" = (
-/obj/machinery/reagentgrinder,
-/obj/structure/table,
-/obj/item/reagent_containers/dropper,
-/turf/open/floor/plasteel/white,
-/area/space/station_ruins)
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "dcL" = (
 /obj/item/target/alien,
 /turf/open/floor/plating,
@@ -50103,16 +47323,7 @@
 /obj/effect/turf_decal/box/corners{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
 "dmP" = (
@@ -50147,19 +47358,18 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "dop" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24;
-	pixel_y = 28
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
-/area/space/station_ruins)
+/area/security/prison)
 "dpa" = (
 /obj/machinery/light{
 	dir = 1
@@ -50247,6 +47457,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/obj/effect/turf_decal/trimline/green/filled/line,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "dtm" = (
@@ -50290,14 +47501,11 @@
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/exit/departure_lounge)
 "dvw" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "dxc" = (
@@ -50364,37 +47572,35 @@
 /turf/open/floor/plating,
 /area/security/main)
 "dBT" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/condiment/flour,
-/obj/item/reagent_containers/food/condiment/flour,
-/obj/item/reagent_containers/food/condiment/flour,
-/turf/open/floor/plasteel/white,
-/area/space/station_ruins)
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "dCE" = (
 /obj/machinery/light{
 	dir = 8;
 	light_color = "#e8eaff"
 	},
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
+/obj/structure/closet/secure_closet/genpop,
+/obj/effect/turf_decal/lumos/tile/red/checker,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "dDo" = (
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
-/area/space/station_ruins)
+/area/security/prison)
 "dEy" = (
 /obj/machinery/airalarm{
 	dir = 1;
@@ -50440,11 +47646,8 @@
 	pixel_y = 4;
 	req_access_txt = "5; 33"
 	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
@@ -50479,20 +47682,31 @@
 	},
 /area/maintenance/department/science)
 "dKx" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
-/turf/open/floor/wood,
-/area/space/station_ruins)
-"dLt" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/machinery/door/airlock/external{
+	name = "Brig Courtyard"
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"dLt" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/effect/turf_decal/lumos/tile/red/checker,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "dLv" = (
@@ -50539,8 +47753,9 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "dOw" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 4
+/obj/effect/turf_decal/sand,
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -50555,17 +47770,11 @@
 /turf/open/floor/wood,
 /area/maintenance/department/engine)
 "dUt" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 9
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/table,
-/obj/item/clothing/suit/straight_jacket,
-/obj/item/clothing/suit/straight_jacket,
 /turf/open/floor/plasteel,
-/area/space/station_ruins)
+/area/security/prison)
 "dVH" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -50619,18 +47828,20 @@
 /turf/open/floor/plating,
 /area/lawoffice)
 "eca" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Sleepers"
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
 /turf/open/floor/plasteel,
-/area/space/station_ruins)
+/area/security/prison)
 "ecj" = (
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/wood,
-/area/space/station_ruins)
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "ecx" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/item/wrench/medical,
@@ -50659,14 +47870,14 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "efs" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "efu" = (
@@ -50680,16 +47891,11 @@
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "ehK" = (
-/obj/machinery/airalarm/directional/east,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 5
 	},
 /turf/open/floor/plasteel,
-/area/space/station_ruins)
+/area/security/prison)
 "ehM" = (
 /obj/effect/decal/remains/human,
 /obj/structure/disposaloutlet,
@@ -50726,6 +47932,7 @@
 /obj/effect/decal/cleanable/cobweb{
 	icon_state = "cobweb2"
 	},
+/obj/structure/trash_pile,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "elk" = (
@@ -50733,20 +47940,19 @@
 /turf/open/floor/wood,
 /area/lawoffice)
 "enN" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
 	},
-/turf/open/floor/plasteel/cafeteria,
-/area/space/station_ruins)
+/turf/open/floor/plasteel,
+/area/security/prison)
 "enT" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#cee5d2"
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/machinery/vending/cola/random,
-/turf/open/floor/plasteel/cafeteria,
-/area/space/station_ruins)
+/turf/open/floor/plasteel,
+/area/security/prison)
 "epg" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -50761,14 +47967,10 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/dorms)
 "epJ" = (
-/obj/structure/lattice,
-/obj/machinery/camera{
-	c_tag = "Permabrig Space Northwest";
-	dir = 1;
-	name = "aft camera"
-	},
-/turf/open/space/basic,
-/area/space/station_ruins)
+/obj/structure/chair/stool,
+/obj/effect/turf_decal/trimline/red/filled/corner,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "epU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -50789,18 +47991,10 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "eqA" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Library"
-	},
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/space/station_ruins)
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "eqD" = (
 /obj/structure/sign/poster/contraband/random{
 	pixel_x = -32
@@ -50857,12 +48051,10 @@
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "eAy" = (
-/obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
+/obj/structure/chair/stool,
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
-/area/space/station_ruins)
+/area/security/prison)
 "eAH" = (
 /obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
 	dir = 4
@@ -50929,18 +48121,16 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "eFR" = (
-/obj/structure/lattice,
-/obj/machinery/camera{
-	c_tag = "Permabrig Space East";
-	dir = 4;
-	name = "aft camera"
-	},
-/turf/open/space/basic,
-/area/space/station_ruins)
+/obj/structure/table,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "eGB" = (
-/obj/machinery/deepfryer,
-/turf/open/floor/plasteel/white,
-/area/space/station_ruins)
+/obj/structure/chair/stool,
+/obj/machinery/light,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "eHI" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
@@ -50948,14 +48138,10 @@
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
 "eIw" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
+/obj/structure/closet/secure_closet/psychologist,
+/obj/effect/turf_decal/lumos/tile/blue/fullcorner{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/structure/closet/secure_closet/psychologist,
 /turf/open/floor/plasteel/white,
 /area/medical/psych)
 "eIL" = (
@@ -50978,24 +48164,17 @@
 /turf/open/space,
 /area/solar/port)
 "eKC" = (
-/obj/structure/table,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 8
 	},
-/obj/item/camera,
-/obj/item/camera_film,
-/obj/item/storage/photo_album,
 /turf/open/floor/plasteel,
-/area/space/station_ruins)
+/area/security/prison)
 "eKN" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
-/area/space/station_ruins)
+/area/security/prison)
 "eLt" = (
 /obj/structure/closet/firecloset,
 /obj/effect/turf_decal/tile/neutral{
@@ -51011,15 +48190,10 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
 "eNc" = (
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 3;
-	name = "3maintenance loot spawner"
-	},
-/obj/structure/rack,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/maintenance/department/chapel/monastery)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/prison)
 "eNq" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -51027,14 +48201,8 @@
 /turf/open/floor/plasteel,
 /area/science/explab)
 "eNz" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/space/station_ruins)
+/turf/closed/mineral,
+/area/security/prison)
 "eNF" = (
 /obj/structure/grille,
 /obj/structure/lattice,
@@ -51078,25 +48246,19 @@
 	},
 /area/maintenance/department/security/brig)
 "eSB" = (
-/obj/structure/chair{
-	dir = 4
+/obj/structure/lattice,
+/obj/machinery/camera{
+	c_tag = "Permabrig Space West";
+	dir = 8;
+	name = "aft camera"
 	},
-/turf/open/floor/plasteel,
-/area/security/prison)
+/turf/open/space/basic,
+/area/space/nearstation)
 "eSL" = (
 /obj/item/beacon,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
 "eVy" = (
@@ -51119,11 +48281,8 @@
 /turf/open/floor/engine,
 /area/science/explab)
 "eYr" = (
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/explab)
@@ -51132,17 +48291,16 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "faI" = (
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 4
+/obj/machinery/camera{
+	c_tag = "Permabrig Garden";
+	dir = 4;
+	network = list("ss13","prison")
 	},
 /turf/open/floor/plasteel,
-/area/space/station_ruins)
+/area/security/prison)
 "fdS" = (
 /obj/machinery/door/window/southleft{
 	dir = 4;
@@ -51178,29 +48336,17 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "feH" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/manifold/cyan/hidden/layer1{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/space/station_ruins)
+/obj/machinery/hydroponics/constructable,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "ffJ" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
 	},
+/obj/effect/turf_decal/lumos/tile/yellow/half,
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
 "ffQ" = (
@@ -51223,15 +48369,11 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/disposal/bin,
+/obj/effect/turf_decal/lumos/tile/purple/fullcorner{
+	dir = 1
+	},
 /turf/open/floor/plasteel/white,
 /area/science/explab)
 "fjD" = (
@@ -51241,31 +48383,18 @@
 /turf/closed/wall/r_wall,
 /area/engine/supermatter)
 "fkz" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/loading_area{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4;
-	layer = 2.9
-	},
-/obj/machinery/conveyor/auto{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/space/station_ruins)
-"fkG" = (
+/obj/effect/landmark/start/prisoner,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
-/area/space/station_ruins)
+/area/security/prison)
+"fkG" = (
+/obj/machinery/hydroponics/constructable,
+/obj/item/seeds/plump,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "fkH" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -51292,9 +48421,11 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "fnl" = (
-/obj/structure/closet/secure_closet/freezer/fridge/open,
-/turf/open/floor/plasteel/white,
-/area/space/station_ruins)
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "fon" = (
 /obj/structure/lattice,
 /obj/structure/grille,
@@ -51329,9 +48460,9 @@
 	},
 /area/maintenance/department/engine)
 "ftO" = (
-/obj/structure/chair/stool,
-/turf/open/floor/plasteel/cafeteria,
-/area/space/station_ruins)
+/obj/machinery/smartfridge/food,
+/turf/closed/wall,
+/area/security/prison)
 "ftW" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -51361,14 +48492,14 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "fvX" = (
-/obj/machinery/holopad,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/chair/stool,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
-/area/space/station_ruins)
+/area/security/prison)
 "fwe" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -51382,18 +48513,9 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "fxz" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 4
-	},
+/obj/effect/turf_decal/trimline/red/filled/corner,
 /turf/open/floor/plasteel,
-/area/space/station_ruins)
+/area/security/prison)
 "fxC" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/closed/wall/r_wall,
@@ -51434,24 +48556,16 @@
 	pixel_x = -27
 	},
 /obj/item/clothing/glasses/meson/gar,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
 "fzv" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/machinery/vending/hydronutrients/prisoner,
+/obj/machinery/prize_counter,
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
-/area/space/station_ruins)
+/area/security/prison)
 "fAx" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -51482,23 +48596,17 @@
 /obj/effect/turf_decal/loading_area{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "fBH" = (
-/obj/machinery/hydroponics/constructable,
-/obj/machinery/holopad,
+/obj/machinery/computer/arcade/tetris{
+	dir = 1
+	},
+/obj/machinery/light,
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
-/area/space/station_ruins)
+/area/security/prison)
 "fBZ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -51527,27 +48635,21 @@
 /turf/open/floor/plasteel/dark,
 /area/science/storage)
 "fGY" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/structure/table,
-/obj/structure/bedsheetbin,
-/turf/open/floor/plasteel,
-/area/space/station_ruins)
-"fIo" = (
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/computer/arcade{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
-/area/space/station_ruins)
+/area/security/prison)
+"fIo" = (
+/obj/machinery/computer/arcade{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "fIu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -51558,38 +48660,49 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/dorms)
 "fIN" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/manifold/cyan/hidden/layer1{
+	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/structure/cable{
-	icon_state = "1-4"
+	icon_state = "1-2"
 	},
-/obj/machinery/vending/kink,
 /turf/open/floor/plasteel,
-/area/space/station_ruins)
+/area/security/prison)
 "fIT" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/chapel/main/monastery)
 "fJn" = (
-/obj/machinery/airalarm/directional/north,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 28
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"fJq" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 8
+	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
-/area/space/station_ruins)
-"fJq" = (
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel,
-/area/space/station_ruins)
+/area/security/prison)
 "fJx" = (
-/obj/structure/table,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/machinery/hydroponics/constructable,
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
-/area/space/station_ruins)
+/obj/item/seeds/potato,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "fKj" = (
 /obj/machinery/door/airlock/maintenance/abandoned{
 	name = "Mineral Room"
@@ -51607,10 +48720,21 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "fON" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/white,
-/area/space/station_ruins)
+/obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "fQf" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -51624,43 +48748,65 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 6
 	},
+/mob/living/simple_animal/opossum/poppy,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "fQk" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/machinery/button/flasher{
 	id = "visitflash";
-	pixel_x = 24;
-	pixel_y = 5;
+	pixel_x = -6;
+	pixel_y = -34;
 	req_access_txt = "3"
 	},
 /obj/machinery/button/door{
 	id = "visit";
 	name = "Visitation Shutters";
+	pixel_x = 6;
 	pixel_y = -26;
 	req_access_txt = "3"
 	},
+/obj/effect/turf_decal/lumos/tile/red/fulltile,
+/obj/machinery/button/door{
+	id = "visitexit";
+	name = "Visitation Prisoner Lockdown";
+	pixel_x = -6;
+	pixel_y = -26;
+	req_access_txt = "3"
+	},
+/obj/structure/chair/stool,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "fRc" = (
-/obj/machinery/camera{
-	c_tag = "Permabrig Cell Hallway 1";
-	dir = 4;
-	network = list("ss13","prison")
+/obj/machinery/hydroponics/constructable,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/space/station_ruins)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "fRs" = (
 /turf/closed/wall,
 /area/crew_quarters/heads/hor)
 "fTo" = (
-/obj/structure/chair/stool,
-/obj/machinery/light,
-/turf/open/floor/plasteel/cafeteria,
-/area/space/station_ruins)
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "fTY" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -51691,21 +48837,12 @@
 /area/library/lounge)
 "fXa" = (
 /obj/machinery/light,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/machinery/computer/med_data/laptop{
 	dir = 1;
 	pixel_y = 4
 	},
 /obj/structure/table/reinforced,
+/obj/effect/turf_decal/lumos/tile/blue/fulltile,
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "fZK" = (
@@ -51740,23 +48877,42 @@
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "gbM" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass{
+	name = "Garden"
+	},
+/obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 4
+	},
+/obj/effect/turf_decal/lumos/tile/green/half{
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
-/area/space/station_ruins)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "gca" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 5
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/checker,
-/area/space/station_ruins)
+/turf/open/floor/plasteel,
+/area/security/prison)
 "gcj" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -51774,10 +48930,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/purple/half,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "gdL" = (
@@ -51786,14 +48939,8 @@
 	dir = 4;
 	pixel_x = -28
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/lumos/tile/purple/fullcorner{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
@@ -51890,16 +49037,7 @@
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "gmp" = (
@@ -51930,11 +49068,8 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
 /obj/machinery/portable_atmospherics/pump,
+/obj/effect/turf_decal/lumos/tile/yellow/half,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "gpC" = (
@@ -51959,17 +49094,12 @@
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
 "gsF" = (
-/obj/structure/chair{
-	dir = 4
-	},
 /obj/structure/window/reinforced{
 	dir = 1;
 	pixel_y = 2
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
+/obj/structure/closet/secure_closet/genpop,
+/obj/effect/turf_decal/lumos/tile/red/checker,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "gue" = (
@@ -51999,14 +49129,19 @@
 	},
 /area/hallway/secondary/exit/departure_lounge)
 "gvS" = (
-/obj/structure/lattice,
-/obj/machinery/camera{
-	c_tag = "Permabrig Space southwest";
-	dir = 8;
-	name = "aft camera"
+/obj/structure/chair/stool,
+/obj/effect/landmark/start/prisoner,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 4
 	},
-/turf/open/space/basic,
-/area/space/station_ruins)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "gwn" = (
 /obj/structure/sign/warning{
 	pixel_y = 32
@@ -52062,9 +49197,22 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "gAr" = (
-/obj/structure/sign/nanotrasen,
-/turf/closed/wall,
-/area/space/station_ruins)
+/obj/structure/table,
+/obj/item/storage/pill_bottle/dice,
+/obj/machinery/atmospherics/pipe/manifold/cyan/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "gAG" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green,
@@ -52098,16 +49246,7 @@
 /obj/effect/turf_decal/box/corners{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
 "gEj" = (
@@ -52156,19 +49295,15 @@
 /turf/open/floor/plasteel/dark,
 /area/science/lab)
 "gGy" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/shower{
+	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/space/station_ruins)
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/prison)
 "gGA" = (
 /obj/structure/table/glass,
 /obj/machinery/reagentgrinder,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -52184,14 +49319,11 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "gIo" = (
-/obj/structure/table,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/item/toy/cards/deck,
-/turf/open/floor/plasteel,
-/area/space/station_ruins)
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/prison)
 "gIC" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -52206,20 +49338,18 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "gIG" = (
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "gJF" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/shower{
+	dir = 8;
+	pixel_y = -4
 	},
-/turf/open/floor/wood,
-/area/space/station_ruins)
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/prison)
 "gKc" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -52259,41 +49389,28 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
 "gLY" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
+	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
 /turf/open/floor/plasteel,
-/area/space/station_ruins)
+/area/security/prison)
 "gMO" = (
 /obj/structure/plasticflaps/opaque,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "gMP" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24;
-	pixel_y = 28
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/cyan/hidden/layer1{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/space/station_ruins)
+/area/security/prison)
 "gNv" = (
 /obj/structure/sign/poster/contraband/random{
 	pixel_x = 32
@@ -52339,37 +49456,20 @@
 /area/space/nearstation)
 "gTJ" = (
 /obj/structure/closet/secure_closet/medical2,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = 28
 	},
+/obj/effect/turf_decal/lumos/tile/blue/fulltile,
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "gTP" = (
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 4
-	},
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/plasteel,
-/area/space/station_ruins)
+/area/security/prison)
 "gUb" = (
 /obj/structure/chair/office/dark{
 	dir = 4
@@ -52382,14 +49482,11 @@
 	},
 /area/maintenance/department/engine)
 "gVH" = (
-/obj/structure/table,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
 	},
-/obj/item/instrument/accordion,
 /turf/open/floor/plasteel,
-/area/space/station_ruins)
+/area/security/prison)
 "gWI" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -52420,30 +49517,25 @@
 /obj/item/stack/sheet/metal/fifty,
 /obj/item/stack/rods/fifty,
 /obj/item/clothing/glasses/welding,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
 /obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/lumos/tile/yellow/half,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "hcf" = (
-/obj/machinery/airalarm/directional/west,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/structure/chair/stool,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/manifold/cyan/hidden/layer1{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
-/area/space/station_ruins)
+/area/security/prison)
 "hcS" = (
-/obj/machinery/camera{
-	c_tag = "Permabrig Space Southeast"
-	},
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/station_ruins)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/security/prison)
 "heC" = (
 /obj/machinery/power/apc/highcap/five_k{
 	dir = 8;
@@ -52456,16 +49548,9 @@
 	},
 /area/maintenance/department/science)
 "hfp" = (
-/obj/machinery/holopad,
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/cyan/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/space/station_ruins)
+/obj/machinery/cryopod,
+/turf/open/floor/circuit/green,
+/area/security/prison)
 "hfZ" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/machinery/requests_console{
@@ -52478,20 +49563,12 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "hiw" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/shower{
 	dir = 4
 	},
-/turf/open/floor/wood,
-/area/space/station_ruins)
+/obj/item/soap/homemade,
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/prison)
 "hiY" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=Sci4";
@@ -52511,11 +49588,8 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
 /obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/lumos/tile/yellow/half,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "hki" = (
@@ -52524,6 +49598,9 @@
 /obj/item/pen,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
@@ -52566,9 +49643,8 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "hoC" = (
-/obj/machinery/door/airlock/public,
-/turf/open/floor/plasteel/dark,
-/area/space/station_ruins)
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/prison)
 "hoS" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 6
@@ -52595,15 +49671,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "hue" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 10
 	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/machinery/vending/clothing,
 /turf/open/floor/plasteel,
-/area/space/station_ruins)
+/area/security/prison)
 "hvW" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio4";
@@ -52727,12 +49799,9 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/auxiliary)
 "hFy" = (
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
-	},
-/turf/open/floor/circuit/green,
-/area/space/station_ruins)
+/obj/effect/turf_decal/trimline/green/filled/line,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "hGB" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -52823,6 +49892,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
 	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "hQy" = (
@@ -52904,16 +49976,16 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "hUl" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/requests_console{
+	department = "Prison";
+	departmentType = 1;
+	pixel_y = -30
 	},
-/obj/machinery/airalarm/directional/east,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 4
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 6
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/plasteel,
-/area/space/station_ruins)
+/area/security/prison)
 "hUt" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
@@ -52944,16 +50016,7 @@
 /area/engine/engineering)
 "hYe" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/red/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "hZB" = (
@@ -52987,18 +50050,11 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
 "ibA" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/space/station_ruins)
+/area/security/prison)
 "ick" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -53039,24 +50095,27 @@
 /area/maintenance/department/engine)
 "ihk" = (
 /obj/structure/chair/office/light,
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "iid" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/preopen{
-	id = "permalock2"
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
-/area/space/station_ruins)
+/area/security/prison)
 "iiX" = (
-/turf/open/floor/plasteel/white,
-/area/space/station_ruins)
+/obj/machinery/door/airlock/public/glass{
+	name = "Sleepers"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "ijF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
@@ -53144,75 +50203,49 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "ioG" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/space/station_ruins)
-"ipj" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/space/station_ruins)
-"ipu" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel,
-/area/space/station_ruins)
-"ipP" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
 /obj/machinery/camera{
-	c_tag = "Permabrig East Hallway 2";
+	c_tag = "Permabrig Sleepers";
+	dir = 1;
+	network = list("ss13","prison")
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
+"ipj" = (
+/obj/machinery/light{
+	light_color = "#cee5d2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
+"ipu" = (
+/obj/machinery/computer/cryopod{
 	dir = 8;
-	network = list("ss13","prison");
-	start_active = 1
+	pixel_x = 26
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
+"ipP" = (
+/obj/machinery/camera{
+	c_tag = "Permabrig Showers";
+	dir = 4;
+	network = list("ss13","prison")
 	},
-/turf/open/floor/plasteel,
-/area/space/station_ruins)
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/prison)
 "iqx" = (
-/obj/machinery/atmospherics/components/binary/valve/on{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/space/station_ruins)
+/turf/open/floor/plasteel/showroomfloor/shower,
+/area/security/prison)
 "isH" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 9
+/obj/machinery/door/airlock/public/glass{
+	name = "Showers"
 	},
-/obj/machinery/atmospherics/pipe/manifold/cyan/hidden/layer1{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/space/station_ruins)
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/prison)
 "itl" = (
 /obj/structure/sign/departments/xenobio{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
@@ -53225,13 +50258,10 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
+/obj/machinery/atmospherics/pipe/simple/violet/hidden{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/violet/hidden{
+/obj/effect/turf_decal/lumos/tile/green/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -53316,15 +50346,15 @@
 /turf/open/floor/plating,
 /area/security/execution/transfer)
 "iEH" = (
-/obj/machinery/light,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
+/obj/machinery/door/airlock/public/glass{
+	name = "Diner"
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/obj/effect/turf_decal/lumos/tile/green/half{
+	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/space/station_ruins)
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel/white/side,
+/area/security/prison)
 "iEQ" = (
 /obj/structure/table,
 /obj/item/storage/box/lights/mixed,
@@ -53374,19 +50404,24 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "iMx" = (
-/obj/structure/mopbucket,
-/obj/item/mop,
-/obj/item/reagent_containers/glass/bucket,
-/turf/open/floor/plating,
-/area/space/station_ruins)
+/obj/structure/table,
+/obj/item/paper_bin{
+	pixel_y = 4
+	},
+/obj/item/pen,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "iOi" = (
-/obj/machinery/door/poddoor{
-	id = "soli2"
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
 	},
-/turf/open/floor/mineral/titanium/white{
-	name = "secure isolation floor"
+/obj/machinery/camera{
+	c_tag = "Permabrig Common Room";
+	dir = 8;
+	network = list("ss13","prison")
 	},
-/area/space/station_ruins)
+/turf/open/floor/plasteel,
+/area/security/prison)
 "iPj" = (
 /obj/machinery/igniter{
 	id = "xenoigniter";
@@ -53408,21 +50443,17 @@
 	dir = 4;
 	network = list("xeno","rd")
 	},
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/lumos/tile/green/fullcorner{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "iPH" = (
 /obj/structure/table/reinforced,
-/obj/machinery/door/window,
 /obj/machinery/door/poddoor/shutters{
 	id = "visit"
 	},
+/obj/structure/window/reinforced,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "iPU" = (
@@ -53441,12 +50472,13 @@
 /turf/open/floor/plating,
 /area/security/execution/transfer)
 "iQz" = (
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
+/obj/machinery/shower{
+	dir = 8;
+	pixel_y = -4
 	},
-/turf/open/floor/plasteel/grimy,
-/area/space/station_ruins)
+/obj/item/soap/homemade,
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/prison)
 "iQQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -53454,20 +50486,17 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "iRm" = (
-/obj/machinery/light{
+/obj/machinery/atmospherics/pipe/manifold/cyan/hidden/layer1{
 	dir = 8
 	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
-/area/space/station_ruins)
+/area/security/prison)
 "iSz" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -53482,23 +50511,30 @@
 /turf/closed/wall/r_wall,
 /area/engine/supermatter)
 "iVl" = (
-/obj/machinery/light,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/space/station_ruins)
-"iVw" = (
-/obj/machinery/seed_extractor,
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/space/station_ruins)
+/area/security/prison)
+"iVw" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass{
+	name = "Pressing Room"
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel/checker,
+/area/security/prison)
 "iVJ" = (
 /obj/effect/spawner/lootdrop/organ_spawner,
 /turf/open/floor/plating{
@@ -53551,15 +50587,14 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "jfc" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/space/station_ruins)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
+/turf/open/floor/plasteel/checker,
+/area/security/prison)
 "jfy" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/transit_tube/horizontal{
@@ -53579,12 +50614,14 @@
 /turf/open/floor/plasteel/dark,
 /area/library)
 "jgH" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+/obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/cyan/hidden/layer1,
-/turf/open/floor/plasteel,
-/area/space/station_ruins)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8
+	},
+/turf/open/floor/plasteel/checker,
+/area/security/prison)
 "jhk" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -53611,18 +50648,15 @@
 	},
 /area/maintenance/department/crew_quarters/dorms)
 "jia" = (
-/obj/machinery/cryopod{
-	dir = 8
+/obj/structure/table/reinforced,
+/obj/item/storage/box/monkeycubes{
+	pixel_y = 6
 	},
-/turf/open/floor/circuit/green,
-/area/space/station_ruins)
+/turf/open/floor/plasteel/freezer,
+/area/security/prison)
 "jiV" = (
-/obj/structure/window/reinforced,
-/obj/machinery/conveyor/auto{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/space/station_ruins)
+/turf/open/floor/plasteel/freezer,
+/area/security/prison)
 "jjC" = (
 /obj/structure/rack,
 /obj/item/storage/briefcase{
@@ -53646,13 +50680,20 @@
 /turf/open/space,
 /area/solar/port)
 "jkW" = (
-/obj/machinery/camera{
-	c_tag = "Permabrig Kitchen";
-	network = list("ss13","prison")
+/obj/structure/table,
+/obj/item/reagent_containers/food/condiment/rice,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/condiment/enzyme{
+	layer = 5;
+	pixel_x = -1;
+	pixel_y = 6
 	},
-/obj/machinery/processor,
+/obj/item/reagent_containers/food/condiment/sugar{
+	pixel_x = 1;
+	pixel_y = 5
+	},
 /turf/open/floor/plasteel/white,
-/area/space/station_ruins)
+/area/security/prison)
 "jrG" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -53671,11 +50712,8 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "jsf" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/circuit/green,
-/area/space/station_ruins)
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "jsj" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -53705,18 +50743,15 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/violet/hidden,
+/obj/effect/turf_decal/lumos/tile/green/fullcorner,
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "juv" = (
 /obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -53729,36 +50764,36 @@
 	dir = 1;
 	pixel_y = -26
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "jwm" = (
-/obj/machinery/computer/cryopod{
-	dir = 8;
-	pixel_x = 26
+/obj/structure/closet/secure_closet/freezer/gulag_fridge,
+/obj/machinery/camera{
+	c_tag = "Permabrig Kitchen";
+	network = list("ss13","prison")
 	},
-/turf/open/floor/plasteel,
-/area/space/station_ruins)
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "jwo" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#cee5d2"
+/obj/structure/table,
+/obj/machinery/reagentgrinder{
+	pixel_x = -5;
+	pixel_y = 12
 	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/space/station_ruins)
+/obj/machinery/firealarm{
+	pixel_y = 29
+	},
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "jxl" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/blue/half,
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "jzz" = (
@@ -53820,14 +50855,12 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "jCM" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 4
+/obj/structure/table,
+/obj/machinery/microwave{
+	pixel_y = 6
 	},
-/obj/machinery/atmospherics/pipe/manifold/cyan/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/space/station_ruins)
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "jDA" = (
 /obj/item/chair,
 /turf/open/floor/plating{
@@ -53835,23 +50868,24 @@
 	},
 /area/maintenance/department/science)
 "jDZ" = (
-/obj/structure/rack,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/tank/internals/emergency_oxygen,
-/obj/item/tank/internals/emergency_oxygen,
-/obj/item/tank/internals/emergency_oxygen,
-/obj/item/tank/internals/emergency_oxygen,
-/turf/open/floor/plating,
-/area/space/station_ruins)
-"jEd" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 1
+/obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
 	},
-/turf/open/floor/wood,
-/area/space/station_ruins)
+/obj/machinery/washing_machine,
+/obj/machinery/firealarm{
+	pixel_y = 29
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"jEd" = (
+/obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
+	},
+/obj/structure/sink{
+	pixel_y = 28
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "jEX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -53878,40 +50912,26 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "jIn" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/camera{
-	c_tag = "Permabrig West Hallway 2";
-	dir = 4;
-	network = list("ss13","prison")
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/space/station_ruins)
+/obj/machinery/light,
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/prison)
 "jIO" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/wood,
-/area/space/station_ruins)
+/obj/machinery/plate_chute/inputchute{
+	pixel_y = -25
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "jLW" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
 "jMl" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/machinery/light/small{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
-/turf/open/floor/plasteel,
-/area/space/station_ruins)
+/turf/open/floor/plasteel/freezer,
+/area/security/prison)
 "jNW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -53919,6 +50939,7 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/turf_decal/lumos/tile/red/checker,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "jOB" = (
@@ -53931,19 +50952,13 @@
 /turf/open/floor/plasteel,
 /area/maintenance/department/engine)
 "jPQ" = (
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/door/airlock/freezer{
+	desc = "Consult with the Warden for access.";
+	name = "prison freezer";
+	req_access_txt = "63;3"
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24;
-	pixel_y = 28
-	},
-/obj/machinery/vr_sleeper{
-	dir = 4
-	},
-/turf/open/floor/circuit,
-/area/space/station_ruins)
+/turf/open/floor/plasteel/freezer,
+/area/security/prison)
 "jQh" = (
 /obj/item/stack/sheet/animalhide/xeno,
 /turf/open/floor/plating{
@@ -54009,16 +51024,11 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "jWW" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
-/turf/open/floor/plasteel,
-/area/space/station_ruins)
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "jXh" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -54052,13 +51062,21 @@
 	},
 /area/maintenance/department/engine)
 "jYk" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/drinks/drinkingglass,
-/turf/open/floor/plasteel/cafeteria,
-/area/space/station_ruins)
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/holopad,
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "jYW" = (
-/turf/open/floor/plating,
-/area/space/station_ruins)
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "jZG" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "chemistry_shutters";
@@ -54077,14 +51095,14 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "kdo" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/wood,
-/area/space/station_ruins)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "keD" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -54121,24 +51139,30 @@
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "khD" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/machinery/door/airlock/public/glass{
+	name = "Diner"
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/security/prison)
+"kjy" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
-/turf/open/floor/plasteel,
-/area/space/station_ruins)
-"kjy" = (
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/space/station_ruins)
+/area/security/prison)
 "kjK" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "MiniSat Maintenance";
@@ -54195,21 +51219,14 @@
 /turf/open/space/basic,
 /area/space)
 "koU" = (
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/structure/cable{
-	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
-/area/space/station_ruins)
+/area/security/prison)
 "kpK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
@@ -54217,19 +51234,10 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "krC" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/machinery/computer/operating{
 	dir = 4
 	},
+/obj/effect/turf_decal/lumos/tile/blue/fulltile,
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "krU" = (
@@ -54244,15 +51252,13 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "kul" = (
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
+/obj/machinery/atmospherics/pipe/manifold4w/cyan/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/machinery/cryopod{
-	dir = 8
-	},
-/turf/open/floor/circuit/green,
-/area/space/station_ruins)
+/turf/open/floor/plasteel,
+/area/security/prison)
 "kvj" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -54270,14 +51276,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/lumos/tile/red/fullcorner{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
@@ -54294,17 +51294,33 @@
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "kxv" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8
+/obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
 	},
-/turf/open/floor/plasteel/white,
-/area/space/station_ruins)
+/obj/machinery/door/airlock/public/glass{
+	name = "Laundry"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "kxC" = (
-/obj/structure/sign/poster/official/random{
-	pixel_y = -32
+/obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
 	},
-/turf/open/floor/plasteel/cafeteria,
-/area/space/station_ruins)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/cyan/hidden/layer1{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "kyv" = (
 /obj/structure/closet/secure_closet/engineering_personal,
 /obj/effect/turf_decal/stripes/line{
@@ -54313,21 +51329,23 @@
 /obj/machinery/airalarm{
 	pixel_y = 22
 	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "kzd" = (
-/obj/structure/rack,
-/obj/item/flashlight,
-/obj/item/storage/bag/trash,
-/obj/item/radio/off,
-/turf/open/floor/plating,
-/area/space/station_ruins)
+/obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "kAa" = (
 /obj/structure/chair{
 	dir = 8
@@ -54388,18 +51406,14 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "kDR" = (
-/obj/structure/table,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+/obj/effect/turf_decal/lumos/tile/blue/checker{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/space/station_ruins)
+/area/security/prison)
 "kDY" = (
 /obj/item/shard{
 	icon_state = "small"
@@ -54468,14 +51482,8 @@
 	dir = 4;
 	pixel_x = -27
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/lumos/tile/green/fullcorner{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
@@ -54525,24 +51533,29 @@
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "kJw" = (
-/obj/structure/lattice,
-/obj/machinery/camera{
-	c_tag = "Permabrig Space Northeast";
-	dir = 1;
-	name = "aft camera"
+/obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
 	},
-/turf/open/space/basic,
-/area/space/station_ruins)
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "kJx" = (
-/obj/machinery/camera{
-	c_tag = "Permabrig Iso Cell 1";
-	network = list("ss13","prison")
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass{
+	name = "Library"
 	},
-/obj/structure/bed,
-/turf/open/floor/mineral/titanium/white{
-	name = "secure isolation floor"
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
-/area/space/station_ruins)
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/wood,
+/area/security/prison)
 "kKv" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -54554,19 +51567,12 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "kML" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 11
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-8"
 	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/space/station_ruins)
+/turf/open/floor/plating,
+/area/security/prison)
 "kNf" = (
 /obj/machinery/door/window/northleft{
 	base_state = "right";
@@ -54626,14 +51632,8 @@
 "kRK" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/machinery/portable_atmospherics/canister/bz,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/lumos/tile/green/fullcorner{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
@@ -54658,14 +51658,11 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "kSO" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "1-8"
+	},
+/obj/effect/turf_decal/lumos/tile/blue/half{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/psych)
@@ -54680,9 +51677,9 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "kTE" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
-/turf/open/floor/wood,
-/area/space/station_ruins)
+/obj/structure/closet/secure_closet/freezer/meat,
+/turf/open/floor/plasteel/freezer,
+/area/security/prison)
 "kTR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
@@ -54691,16 +51688,25 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "kUq" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/snacks/hotdog,
-/turf/open/floor/plasteel/cafeteria,
-/area/space/station_ruins)
-"kUE" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4
+/obj/structure/sink/kitchen{
+	dir = 4;
+	pixel_x = -11
 	},
-/turf/open/floor/plasteel,
-/area/space/station_ruins)
+/turf/open/floor/plasteel/white,
+/area/security/prison)
+"kUE" = (
+/obj/structure/closet/crate/bin,
+/obj/machinery/requests_console{
+	department = "Prison";
+	departmentType = 1;
+	pixel_y = -30
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 28
+	},
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "kVy" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
@@ -54709,14 +51715,14 @@
 /area/hallway/secondary/entry)
 "kWw" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/machinery/door/airlock/public/glass{
+	name = "Common Room"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
-/area/space/station_ruins)
+/area/security/prison)
 "kWQ" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /obj/structure/cable/yellow{
@@ -54732,19 +51738,10 @@
 /area/engine/engineering)
 "kXx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/item/kirbyplants{
 	icon_state = "plant-10"
 	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "kYM" = (
@@ -54755,19 +51752,36 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "kZm" = (
-/obj/machinery/airalarm/directional/east,
-/obj/structure/closet/crate/bin,
-/turf/open/floor/plasteel/cafeteria,
-/area/space/station_ruins)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating,
+/area/security/prison)
 "law" = (
 /obj/structure/lattice/catwalk,
 /obj/item/stack/cable_coil,
 /turf/open/space,
 /area/solar/port)
 "lcU" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/structure/bedsheetbin,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 5
+	},
 /turf/open/floor/plasteel,
-/area/space/station_ruins)
+/area/security/prison)
 "lcZ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -54847,43 +51861,27 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "lkz" = (
-/obj/effect/turf_decal/tile/red{
+/obj/structure/rack,
+/obj/item/clothing/under/plasmaman/prisoner,
+/obj/item/clothing/under/plasmaman/prisoner,
+/obj/item/clothing/head/helmet/space/plasmaman/prisoner,
+/obj/item/clothing/head/helmet/space/plasmaman/prisoner,
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/structure/table/reinforced,
-/obj/item/clothing/under/rank/prisoner,
-/obj/item/clothing/under/rank/prisoner,
-/obj/item/clothing/under/rank/prisoner,
-/obj/item/clothing/shoes/sneakers/orange,
-/obj/item/clothing/shoes/sneakers/orange,
-/obj/item/clothing/shoes/sneakers/orange,
-/obj/item/radio/headset{
-	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
-	name = "prisoner headset";
-	prison_radio = 1
-	},
-/obj/item/radio/headset{
-	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
-	name = "prisoner headset";
-	prison_radio = 1
-	},
-/obj/item/radio/headset{
-	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
-	name = "prisoner headset";
-	prison_radio = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "llv" = (
-/obj/machinery/plate_chute/inputchute{
-	pixel_y = -25
+/obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 5
+/obj/structure/table,
+/obj/structure/bedsheetbin/towel,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 4
 	},
-/turf/open/floor/plasteel/checker,
-/area/space/station_ruins)
+/turf/open/floor/plasteel,
+/area/security/prison)
 "lms" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
@@ -54909,13 +51907,10 @@
 /area/engine/engineering)
 "loz" = (
 /obj/structure/closet/radiation,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/obj/effect/turf_decal/lumos/tile/yellow/half,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "lqc" = (
@@ -54933,14 +51928,14 @@
 /turf/open/floor/plasteel/dark,
 /area/library/lounge)
 "lrk" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 8
+/obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/space/station_ruins)
+/area/security/prison)
 "lrM" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -54956,11 +51951,11 @@
 /obj/machinery/door/airlock/glass{
 	name = "Storage"
 	},
-/obj/machinery/atmospherics/pipe/layer_manifold{
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/space/station_ruins)
+/area/security/prison)
 "lvA" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -55001,11 +51996,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/explab)
@@ -55025,15 +52017,11 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "lEY" = (
-/obj/machinery/light,
-/obj/structure/sign/poster/official/random{
-	pixel_y = -32
-	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 5
+	dir = 10
 	},
-/turf/open/floor/wood,
-/area/space/station_ruins)
+/turf/open/floor/plating,
+/area/security/prison)
 "lFh" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -55048,14 +52036,10 @@
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "lGd" = (
-/obj/machinery/button/door{
-	id = "permalock2";
-	name = "Perma Secure Airlock";
-	pixel_y = -26;
-	req_access_txt = "3"
-	},
-/turf/open/floor/plasteel,
-/area/space/station_ruins)
+/obj/structure/closet/crate/trashcart,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plating,
+/area/security/prison)
 "lGv" = (
 /obj/machinery/door/airlock/atmos/abandoned{
 	name = "Atmospherics Maintenance";
@@ -55067,16 +52051,17 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "lGA" = (
-/turf/open/floor/plasteel/showroomfloor/shower,
-/area/space/station_ruins)
+/obj/structure/table,
+/obj/machinery/computer/libraryconsole{
+	pixel_y = 8
+	},
+/turf/open/floor/wood,
+/area/security/prison)
 "lGS" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/lumos/tile/green/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -55085,6 +52070,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
+/obj/structure/trash_pile,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "lHX" = (
@@ -55093,13 +52079,9 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "lIi" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
-/turf/open/floor/plasteel,
-/area/space/station_ruins)
+/obj/structure/filingcabinet,
+/turf/open/floor/wood,
+/area/security/prison)
 "lIr" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -55122,26 +52104,19 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "lJY" = (
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/machinery/cryopod{
-	dir = 8
-	},
-/turf/open/floor/circuit/green,
-/area/space/station_ruins)
-"lKk" = (
-/turf/closed/wall,
-/area/space/station_ruins)
-"lKw" = (
-/obj/structure/closet/crate/bin,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/wood,
-/area/space/station_ruins)
+/area/security/prison)
+"lKk" = (
+/obj/structure/bookcase/random/religion,
+/turf/open/floor/wood,
+/area/security/prison)
+"lKw" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
+/area/security/prison)
 "lKL" = (
 /obj/machinery/door/airlock/abandoned{
 	name = "Starboard Emergency Storage"
@@ -55149,12 +52124,9 @@
 /turf/open/floor/plating,
 /area/storage/emergency/starboard)
 "lMU" = (
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
 /turf/open/floor/plating,
-/area/maintenance/department/security/brig)
+/area/security/prison)
 "lNr" = (
 /obj/structure/lattice,
 /obj/structure/grille/broken,
@@ -55165,26 +52137,16 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "lOU" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/structure/sink/kitchen{
-	dir = 8;
-	pixel_x = 11
-	},
-/turf/open/floor/plasteel/white,
-/area/space/station_ruins)
+/obj/structure/mopbucket,
+/obj/item/mop,
+/obj/item/reagent_containers/glass/bucket,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plating,
+/area/security/prison)
 "lPt" = (
-/obj/machinery/holopad,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/space/station_ruins)
+/obj/structure/chair/stool,
+/turf/open/floor/wood,
+/area/security/prison)
 "lQn" = (
 /obj/machinery/light/small{
 	dir = 1;
@@ -55218,9 +52180,12 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "lRM" = (
-/obj/machinery/newscaster,
-/turf/closed/wall,
-/area/space/station_ruins)
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/security/prison)
 "lRX" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
@@ -55245,9 +52210,9 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "lTQ" = (
-/obj/structure/lattice,
-/turf/open/space,
-/area/space/station_ruins)
+/obj/machinery/vending/dinnerware/prisoner,
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
 "lUt" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -55259,30 +52224,9 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "lUw" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/preopen{
-	id = "permalock2"
-	},
-/obj/machinery/button/door{
-	id = "soli1";
-	name = "Solitary Cell 1";
-	pixel_x = 26;
-	pixel_y = 10;
-	req_access_txt = "3"
-	},
-/obj/machinery/door_timer{
-	id = "soli1";
-	name = "Solitary 1 door timer";
-	pixel_x = 31;
-	pixel_y = -5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
-/turf/open/floor/plasteel,
-/area/space/station_ruins)
+/obj/machinery/vending/sustenance,
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
 "lUO" = (
 /obj/structure/sign/warning/radiation,
 /turf/closed/wall/r_wall,
@@ -55322,9 +52266,8 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "lXc" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
-/turf/open/floor/plasteel,
-/area/space/station_ruins)
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
 "lXJ" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
@@ -55333,13 +52276,9 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "lYx" = (
-/obj/structure/chair/stool,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/space/station_ruins)
+/obj/structure/closet/crate/bin,
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
 "mau" = (
 /obj/structure/lattice,
 /obj/structure/grille/broken,
@@ -55358,11 +52297,8 @@
 	dir = 1
 	},
 /obj/machinery/vending/wardrobe/engi_wardrobe,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -55371,6 +52307,37 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/table/reinforced,
+/obj/item/radio/headset{
+	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
+	name = "prisoner headset";
+	prison_radio = 1
+	},
+/obj/item/radio/headset{
+	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
+	name = "prisoner headset";
+	prison_radio = 1
+	},
+/obj/item/radio/headset{
+	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
+	name = "prisoner headset";
+	prison_radio = 1
+	},
+/obj/item/radio/headset{
+	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
+	name = "prisoner headset";
+	prison_radio = 1
+	},
+/obj/item/radio/headset{
+	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
+	name = "prisoner headset";
+	prison_radio = 1
+	},
+/obj/item/radio/headset{
+	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
+	name = "prisoner headset";
+	prison_radio = 1
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "mci" = (
@@ -55378,10 +52345,15 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "mcP" = (
-/obj/structure/table,
-/obj/item/reagent_containers/glass/bowl,
-/turf/open/floor/plasteel/cafeteria,
-/area/space/station_ruins)
+/obj/effect/turf_decal/bot,
+/obj/effect/landmark/start/prisoner,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "mdL" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -55400,17 +52372,8 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/box/red,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/effect/landmark/start/scientist,
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
 "mgz" = (
@@ -55489,8 +52452,10 @@
 /turf/open/floor/wood,
 /area/maintenance/department/crew_quarters/dorms)
 "mor" = (
-/turf/open/floor/plasteel/dark,
-/area/space/station_ruins)
+/obj/machinery/space_heater,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plating,
+/area/security/prison)
 "mpd" = (
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
@@ -55514,11 +52479,8 @@
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 9
 	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
@@ -55576,36 +52538,31 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "mwa" = (
-/obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/space/station_ruins)
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/turf/open/floor/plating,
+/area/security/prison)
 "mwg" = (
-/obj/machinery/camera{
-	c_tag = "Permabrig Lounge East";
-	dir = 8;
-	network = list("ss13","prison");
-	start_active = 1
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 12
 	},
-/turf/open/floor/plasteel,
-/area/space/station_ruins)
+/turf/open/floor/plating,
+/area/security/prison)
 "mwG" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/lumos/tile/yellow/half,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "mxc" = (
-/obj/structure/table,
-/obj/machinery/chem_dispenser/drinks/beer,
-/turf/open/floor/plasteel/white,
-/area/space/station_ruins)
+/obj/machinery/camera{
+	c_tag = "Permabrig Library";
+	dir = 4;
+	network = list("ss13","prison")
+	},
+/turf/open/floor/carpet,
+/area/security/prison)
 "mxy" = (
 /obj/machinery/power/terminal{
 	dir = 4
@@ -55664,15 +52621,9 @@
 /turf/open/floor/plating,
 /area/security/checkpoint/engineering)
 "mCD" = (
-/obj/machinery/airalarm/directional/west,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/space/station_ruins)
+/obj/structure/chair/stool,
+/turf/open/floor/carpet,
+/area/security/prison)
 "mDW" = (
 /obj/machinery/power/smes{
 	charge = 5e+006
@@ -55717,11 +52668,11 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "mJX" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
 	},
-/turf/open/floor/plasteel/cafeteria,
-/area/space/station_ruins)
+/turf/open/floor/carpet,
+/area/security/prison)
 "mKc" = (
 /obj/structure/bookcase/random/nonfiction,
 /turf/open/floor/plasteel/dark,
@@ -55745,11 +52696,9 @@
 	},
 /area/maintenance/department/security/brig)
 "mLU" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/space/station_ruins)
+/obj/structure/bookcase/random/reference,
+/turf/open/floor/wood,
+/area/security/prison)
 "mMz" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -55771,12 +52720,11 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "mSf" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
+	},
+/obj/effect/turf_decal/lumos/tile/blue/half{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -55793,18 +52741,13 @@
 	},
 /area/chapel/dock)
 "mTk" = (
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/structure/lattice,
+/obj/machinery/camera{
+	c_tag = "Permabrig Space Southeast";
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
-/turf/open/floor/plasteel,
-/area/space/station_ruins)
+/turf/open/space/basic,
+/area/space/nearstation)
 "mTs" = (
 /obj/structure/girder,
 /turf/open/floor/plating{
@@ -55862,11 +52805,11 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "ncM" = (
-/obj/machinery/shower{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/space/station_ruins)
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
 "ndI" = (
 /obj/item/reagent_containers/food/drinks/bottle/vodka,
 /turf/open/floor/plating{
@@ -55889,12 +52832,14 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "ney" = (
-/obj/machinery/shower{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/item/soap/homemade,
-/turf/open/floor/plasteel/showroomfloor,
-/area/space/station_ruins)
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
 "nfi" = (
 /obj/structure/sign/directions/evac{
 	dir = 1;
@@ -55908,17 +52853,17 @@
 	},
 /area/hallway/secondary/exit/departure_lounge)
 "nfk" = (
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 6
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/space/station_ruins)
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
 "nfz" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -55927,14 +52872,17 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "nfB" = (
-/obj/structure/lattice,
-/obj/machinery/camera{
-	c_tag = "Permabrig Space West";
-	dir = 8;
-	name = "aft camera"
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 4
 	},
-/turf/open/space/basic,
-/area/space/station_ruins)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
 "nge" = (
 /obj/structure/grille/broken,
 /obj/structure/lattice,
@@ -55982,13 +52930,10 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "nkF" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "nnh" = (
@@ -55999,18 +52944,39 @@
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/crew_quarters/dorms)
 "noC" = (
-/obj/machinery/plate_press,
-/obj/item/stack/license_plates/empty/fifty,
-/turf/open/floor/plasteel/checker,
-/area/space/station_ruins)
+/obj/machinery/door/airlock/public/glass{
+	name = "Diner"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
 "noE" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24;
-	pixel_y = 28
+/obj/machinery/atmospherics/pipe/manifold/cyan/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
-/area/space/station_ruins)
+/area/security/prison)
 "noM" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -56019,8 +52985,14 @@
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "npo" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/machinery/button/flasher{
+	id = "permalock";
+	pixel_x = 6;
+	pixel_y = 26;
+	req_access_txt = "3"
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -56036,18 +53008,21 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "nqT" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
-/obj/machinery/camera{
-	c_tag = "Permabrig Cell Hallway 2";
-	dir = 8;
-	network = list("ss13","prison");
-	start_active = 1
+/mob/living/simple_animal/chicken{
+	desc = "A dumb hen, kept in the Brig to boost Prisoner morale... For more mushroom wine.;
+	name = "Broiler"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
-/area/space/station_ruins)
+/area/security/prison)
 "nqV" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -56058,10 +53033,7 @@
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "nqY" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
+/obj/effect/turf_decal/lumos/tile/red/checker,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "nrg" = (
@@ -56109,13 +53081,20 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "nxz" = (
-/obj/structure/chair/stool,
-/obj/machinery/camera{
-	c_tag = "Permabrig Cafeteria";
-	network = list("ss13","prison")
+/obj/machinery/atmospherics/pipe/manifold/cyan/hidden/layer1{
+	dir = 4
 	},
-/turf/open/floor/plasteel/cafeteria,
-/area/space/station_ruins)
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "nxT" = (
 /obj/machinery/smartfridge/extract/preloaded,
 /turf/open/floor/plasteel,
@@ -56137,19 +53116,11 @@
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "nze" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#cee5d2"
+/obj/machinery/door/window/westleft{
+	name = "Tele-Reception Center"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/structure/closet/crate/bin,
-/turf/open/floor/plasteel,
-/area/space/station_ruins)
+/turf/open/floor/circuit/green,
+/area/security/prison)
 "nzD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
@@ -56170,19 +53141,14 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "nAK" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/machinery/atmospherics/components/unary/tank/air{
 	dir = 4
 	},
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
 	},
-/turf/open/floor/plasteel,
-/area/space/station_ruins)
+/turf/open/floor/plating,
+/area/security/prison)
 "nAY" = (
 /obj/structure/chair/stool,
 /obj/effect/landmark/start/station_engineer,
@@ -56237,12 +53203,14 @@
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "nEl" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+/obj/machinery/atmospherics/components/binary/valve/on{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/space/station_ruins)
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/security/prison)
 "nGi" = (
 /obj/structure/chair{
 	dir = 4
@@ -56343,18 +53311,17 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "nPq" = (
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/space/station_ruins)
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/security/prison)
 "nPA" = (
 /obj/item/chair,
 /turf/open/floor/plating,
@@ -56370,13 +53337,11 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "nRs" = (
-/obj/structure/table,
-/obj/structure/sign/poster/official/random{
-	pixel_y = -32
-	},
-/obj/item/reagent_containers/food/drinks/drinkingglass,
-/turf/open/floor/plasteel/cafeteria,
-/area/space/station_ruins)
+/obj/structure/rack,
+/obj/item/radio/off,
+/obj/item/flashlight,
+/turf/open/floor/plating,
+/area/security/prison)
 "nSj" = (
 /obj/structure/grille/broken,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -56393,17 +53358,13 @@
 /turf/open/floor/wood,
 /area/lawoffice)
 "nSr" = (
-/obj/machinery/shower{
-	dir = 8
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/space/station_ruins)
+/obj/structure/table,
+/turf/open/floor/carpet,
+/area/security/prison)
 "nSt" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/space/station_ruins)
+/obj/structure/bookcase/random/fiction,
+/turf/open/floor/wood,
+/area/security/prison)
 "nTr" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -56486,23 +53447,10 @@
 	},
 /area/maintenance/department/science)
 "oco" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/space/station_ruins)
+/obj/structure/chair/stool,
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
 "odM" = (
 /obj/effect/landmark/barthpot,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -56511,30 +53459,18 @@
 "oep" = (
 /obj/structure/table/glass,
 /obj/item/paper_bin,
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/lumos/tile/green/fullcorner{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "oeQ" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/space/station_ruins)
+/obj/structure/table,
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
 "ofN" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/blue/half,
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "ofX" = (
@@ -56547,18 +53483,22 @@
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "ohQ" = (
-/obj/structure/lattice,
-/obj/structure/grille,
-/turf/open/space,
-/area/space/station_ruins)
+/obj/structure/chair/stool,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
 "ohR" = (
 /obj/item/chair,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "ojn" = (
-/obj/machinery/vending/dinnerware/prisoner,
-/turf/open/floor/plasteel/white,
-/area/space/station_ruins)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
 "olc" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Bedroom";
@@ -56570,11 +53510,10 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "olO" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Laundry"
-	},
-/turf/open/floor/plasteel,
-/area/space/station_ruins)
+/obj/structure/chair/stool,
+/obj/effect/landmark/start/prisoner,
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
 "onX" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -56632,11 +53571,8 @@
 	pixel_y = -24;
 	req_access_txt = "11"
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
 /obj/structure/reagent_dispensers/watertank,
+/obj/effect/turf_decal/lumos/tile/yellow/half,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "ouv" = (
@@ -56646,15 +53582,9 @@
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "ovc" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
-	},
-/obj/machinery/portable_atmospherics/canister/air,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/space/station_ruins)
+/obj/structure/chair/stool,
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
 "ovM" = (
 /obj/machinery/camera{
 	c_tag = "Arrivals Port Fore"
@@ -56667,12 +53597,8 @@
 	},
 /area/hallway/secondary/entry)
 "owS" = (
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/lumos/tile/red/fullcorner{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
@@ -56684,18 +53610,15 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "oxy" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green{
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
 	},
-/obj/machinery/biogenerator/prisoner,
-/turf/open/floor/plasteel,
-/area/space/station_ruins)
+/turf/open/floor/plating,
+/area/security/prison)
 "oyF" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
@@ -56753,8 +53676,7 @@
 /turf/open/floor/carpet,
 /area/medical/psych)
 "oDP" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -56794,9 +53716,12 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "oFf" = (
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/space/station_ruins)
+/obj/machinery/atmospherics/components/binary/valve{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating,
+/area/security/prison)
 "oFl" = (
 /obj/structure/chair/office/light{
 	dir = 8
@@ -56821,19 +53746,11 @@
 /turf/open/floor/plasteel,
 /area/maintenance/department/engine)
 "oGN" = (
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
-/turf/open/floor/plasteel,
-/area/space/station_ruins)
+/turf/open/floor/plating,
+/area/security/prison)
 "oHa" = (
 /obj/machinery/power/emitter/anchored{
 	dir = 8;
@@ -56879,10 +53796,15 @@
 /turf/open/floor/plasteel/stairs/left,
 /area/maintenance/department/crew_quarters/dorms)
 "oMR" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
-/turf/open/floor/circuit,
-/area/space/station_ruins)
+/obj/structure/rack,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/tank/internals/emergency_oxygen,
+/obj/item/tank/internals/emergency_oxygen,
+/obj/item/tank/internals/emergency_oxygen,
+/turf/open/floor/plating,
+/area/security/prison)
 "oNE" = (
 /obj/structure/chair/office/light,
 /obj/structure/sign/warning/deathsposal{
@@ -57027,12 +53949,8 @@
 /obj/structure/table/glass,
 /obj/item/mmi,
 /obj/item/clothing/mask/balaclava,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/lumos/tile/red/fullcorner{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/security/execution/transfer)
@@ -57097,10 +54015,8 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "pdq" = (
-/obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel,
-/area/space/station_ruins)
+/turf/open/floor/carpet,
+/area/security/prison)
 "pfz" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -57122,20 +54038,13 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "pfY" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/structure/chair/stool,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/cyan/hidden/layer1{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/space/station_ruins)
+/turf/open/floor/carpet,
+/area/security/prison)
 "pgH" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/effect/turf_decal/stripes/line{
@@ -57157,15 +54066,11 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "pia" = (
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/structure/rack,
-/obj/machinery/light/small{
-	dir = 4
+/obj/machinery/newscaster{
+	pixel_y = -30
 	},
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/maintenance/department/chapel/monastery)
+/turf/open/floor/carpet,
+/area/security/prison)
 "pjH" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -57174,10 +54079,9 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "pkg" = (
-/obj/item/caution,
-/obj/item/caution,
-/turf/open/floor/plating,
-/area/space/station_ruins)
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/wood,
+/area/security/prison)
 "pkM" = (
 /obj/machinery/door/airlock/external{
 	req_access_txt = "22"
@@ -57185,10 +54089,9 @@
 /turf/open/floor/plating,
 /area/chapel/office)
 "plA" = (
-/obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
-/turf/open/floor/plasteel,
-/area/space/station_ruins)
+/obj/structure/bookcase/random/nonfiction,
+/turf/open/floor/wood,
+/area/security/prison)
 "pmB" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
@@ -57197,12 +54100,14 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "pny" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 4
+/obj/structure/lattice,
+/obj/machinery/camera{
+	c_tag = "Permabrig Space southwest";
+	dir = 8;
+	name = "aft camera"
 	},
-/turf/open/floor/plasteel/grimy,
-/area/space/station_ruins)
+/turf/open/space/basic,
+/area/space/nearstation)
 "pnU" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
 	dir = 4;
@@ -57264,14 +54169,25 @@
 /turf/closed/wall/r_wall,
 /area/engine/supermatter)
 "pvl" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8
+/obj/structure/chair/stool,
+/obj/effect/landmark/start/prisoner,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel,
-/area/space/station_ruins)
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
 "pvq" = (
-/turf/open/floor/circuit,
-/area/space/station_ruins)
+/obj/machinery/camera{
+	c_tag = "Permabrig Cafeteria";
+	dir = 1;
+	network = list("ss13","prison")
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -29
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
 "pvK" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -57312,14 +54228,14 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "pxw" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/space/station_ruins)
+/area/security/prison)
 "pyw" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -57330,11 +54246,11 @@
 /turf/open/floor/plasteel/white,
 /area/hallway/secondary/entry)
 "pzx" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/lumos/tile/red/checker,
+/obj/structure/chair{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -57364,26 +54280,13 @@
 /area/engine/engineering)
 "pDP" = (
 /obj/machinery/vending/assist,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
 "pFe" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/lumos/tile/red/fullcorner{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
@@ -57416,27 +54319,23 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
 "pJX" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 10
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 10
-	},
-/turf/open/floor/plasteel/grimy,
-/area/space/station_ruins)
+/obj/machinery/airalarm/directional/west,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "pKd" = (
 /obj/structure/trash_pile,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "pLr" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 9
+/obj/effect/turf_decal/lumos/loading_area{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 5
-	},
-/turf/open/floor/circuit,
-/area/space/station_ruins)
+/turf/open/floor/plasteel,
+/area/security/prison)
 "pMG" = (
 /obj/structure/sink{
 	dir = 8;
@@ -57457,16 +54356,7 @@
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "pOx" = (
@@ -57485,10 +54375,15 @@
 /turf/closed/wall/r_wall,
 /area/medical/virology)
 "pTF" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8
+	},
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/plasteel,
-/area/space/station_ruins)
+/area/security/prison)
 "pVD" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -57546,10 +54441,7 @@
 	},
 /obj/item/extinguisher,
 /obj/machinery/light,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/purple/half,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "pXT" = (
@@ -57597,46 +54489,18 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "qbV" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/camera{
-	c_tag = "Permabrig Entrance";
-	dir = 8;
-	network = list("ss13","prison");
-	start_active = 1
-	},
-/obj/machinery/button/door{
-	id = "soli2";
-	name = "Solitary Cell 2";
-	pixel_x = 26;
-	pixel_y = -10;
-	req_access_txt = "3"
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/door_timer{
-	id = "soli2";
-	name = "Solitary 2 door timer";
-	pixel_x = 31;
-	pixel_y = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
-/turf/open/floor/plasteel,
-/area/space/station_ruins)
+/obj/structure/lattice,
+/obj/machinery/camera,
+/turf/open/space/basic,
+/area/space/nearstation)
 "qbZ" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
 /area/storage/emergency/starboard)
 "qcD" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/lumos/tile/green/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
@@ -57644,10 +54508,7 @@
 /obj/structure/table/glass,
 /obj/item/folder/blue,
 /obj/item/pen,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/green/half,
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "qdi" = (
@@ -57689,24 +54550,22 @@
 /turf/closed/wall/r_wall,
 /area/engine/supermatter)
 "qio" = (
-/obj/machinery/airalarm/directional/north,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/machinery/button/door{
+	id = "permalock2";
+	name = "Perma Secure Airlock";
+	pixel_y = -26;
+	req_access_txt = "3"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8
+/obj/machinery/camera{
+	c_tag = "Permabrig Assembly Room";
+	dir = 1;
+	network = list("ss13","prison")
 	},
 /turf/open/floor/plasteel,
-/area/space/station_ruins)
+/area/security/prison)
 "qjx" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/yellow/half,
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
 "qkM" = (
@@ -57772,18 +54631,21 @@
 /area/science/xenobiology)
 "qtO" = (
 /obj/machinery/light,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/yellow/half,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "qwm" = (
-/obj/machinery/vr_sleeper{
-	dir = 4
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -29
 	},
-/turf/open/floor/circuit,
-/area/space/station_ruins)
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "qxq" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	name = "Air Out"
@@ -57802,12 +54664,16 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "qzM" = (
-/obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+/obj/machinery/requests_console{
+	department = "Prison";
+	departmentType = 1;
+	pixel_y = -30
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
-/area/space/station_ruins)
+/turf/open/floor/plasteel,
+/area/security/prison)
 "qAM" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/item/cigbutt,
@@ -57835,16 +54701,7 @@
 /obj/structure/sign/warning/securearea{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
 "qEN" = (
@@ -57923,22 +54780,28 @@
 /turf/open/space,
 /area/solar/port)
 "qLf" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/plating,
-/area/space/station_ruins)
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "outerbrig";
+	name = "Perma Wing";
+	req_access_txt = "63"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/preopen{
+	id = "locklock"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "qLI" = (
 /obj/structure/table,
 /obj/item/stack/sheet/glass/fifty{
 	layer = 4
 	},
 /obj/item/stack/cable_coil,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
+/obj/effect/turf_decal/lumos/tile/yellow/half,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "qMi" = (
@@ -58005,19 +54868,27 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "qTw" = (
-/obj/structure/lattice,
-/obj/machinery/camera,
-/turf/open/space,
-/area/space/station_ruins)
-"qTM" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "outerbrig";
+	name = "Perma Wing";
+	req_access_txt = "63"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/manifold/cyan/hidden/layer1,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/preopen{
+	id = "locklock"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
 /turf/open/floor/plasteel,
-/area/space/station_ruins)
+/area/security/prison)
+"qTM" = (
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "qTV" = (
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
@@ -58037,16 +54908,8 @@
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "qVX" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/button/door{
-	id = "visitexit";
-	name = "Visitation Prisoner Lockdown";
-	pixel_y = -26;
-	req_access_txt = "3"
-	},
+/obj/machinery/light,
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "qWa" = (
@@ -58070,10 +54933,7 @@
 /obj/item/storage/toolbox/electrical{
 	pixel_x = -2
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/yellow/half,
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
 "qXa" = (
@@ -58086,17 +54946,18 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
 "qXb" = (
-/obj/structure/table,
-/obj/item/paicard,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "outerbrig";
+	name = "Prisoner Processing";
+	req_access_txt = "63"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/cyan/hidden/layer1,
+/obj/effect/turf_decal/lumos/tile/red/fulltile,
 /turf/open/floor/plasteel,
-/area/space/station_ruins)
+/area/security/prison)
 "qXq" = (
 /obj/machinery/door/airlock/maintenance/abandoned,
 /obj/structure/cable{
@@ -58127,12 +54988,8 @@
 	icon_state = "2-4"
 	},
 /obj/item/wrench,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
+/obj/effect/turf_decal/lumos/tile/green/fullcorner{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
@@ -58164,12 +55021,8 @@
 /area/maintenance/department/engine)
 "reV" = (
 /obj/machinery/suit_storage_unit/ce,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/fullcorner{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
@@ -58204,22 +55057,23 @@
 	},
 /area/maintenance/department/engine)
 "riD" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "outerbrig";
+	name = "Prisoner Processing";
+	req_access_txt = "63"
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/machinery/camera{
-	c_tag = "Permabrig Laundry";
-	dir = 4;
-	network = list("ss13","prison")
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
 	},
-/obj/structure/sign/poster/official/random{
-	pixel_x = -32
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/obj/effect/turf_decal/lumos/tile/red/fulltile,
 /turf/open/floor/plasteel,
-/area/space/station_ruins)
+/area/security/prison)
 "riF" = (
 /obj/machinery/computer/arcade,
 /obj/effect/turf_decal/tile/neutral{
@@ -58235,44 +55089,48 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
 "rjC" = (
-/obj/machinery/camera{
-	c_tag = "Permabrig Sleeper Hallway";
-	dir = 1;
-	network = list("ss13","prison")
+/obj/machinery/button/flasher{
+	id = "permalock";
+	pixel_x = -6;
+	pixel_y = 26;
+	req_access_txt = "3"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/cyan/hidden/layer1,
-/turf/open/floor/plasteel/grimy,
-/area/space/station_ruins)
-"rlD" = (
-/obj/structure/bookcase/random,
-/turf/open/floor/wood,
-/area/space/station_ruins)
-"rlL" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#cee5d2"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/structure/closet/crate/bin,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/space/station_ruins)
+/area/security/prison)
+"rlD" = (
+/obj/structure/closet/secure_closet/genpop,
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 2
+	},
+/obj/structure/window/reinforced{
+	dir = 4;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/lumos/tile/red/checker,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"rlL" = (
+/obj/structure/closet/secure_closet/genpop,
+/obj/structure/window/reinforced{
+	dir = 4;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/lumos/tile/red/checker,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "rmC" = (
 /turf/open/space/basic,
 /area/space/station_ruins)
 "rmD" = (
-/obj/structure/lattice,
-/obj/structure/grille,
-/turf/open/space/basic,
+/obj/effect/turf_decal/lumos/tile/red/checker,
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/security/prison)
 "rnr" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -58288,8 +55146,15 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "rnG" = (
-/turf/open/floor/plasteel/showroomfloor,
-/area/space/station_ruins)
+/obj/structure/closet/secure_closet/genpop,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/lumos/tile/red/checker,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "roc" = (
 /obj/structure/cable,
 /obj/structure/lattice/catwalk,
@@ -58321,14 +55186,8 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "rrU" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/lumos/tile/red/fullcorner{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
@@ -58377,12 +55236,8 @@
 	pixel_y = 25;
 	req_access_txt = "71"
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
+/obj/effect/turf_decal/lumos/tile/blue/fullcorner{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/psych)
@@ -58449,16 +55304,14 @@
 	},
 /area/maintenance/department/science)
 "rFY" = (
-/obj/machinery/camera{
-	c_tag = "Permabrig Sleepers";
-	dir = 1;
-	network = list("ss13","prison")
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/machinery/light{
-	light_color = "#cee5d2"
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
-/area/space/station_ruins)
+/area/security/prison)
 "rHA" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
@@ -58504,14 +55357,11 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port)
 "rKv" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/space/station_ruins)
+/turf/open/floor/plasteel,
+/area/security/brig)
 "rKL" = (
 /obj/item/trash/cheesie,
 /turf/open/floor/plating{
@@ -58519,14 +55369,13 @@
 	},
 /area/maintenance/department/science)
 "rLi" = (
-/obj/machinery/camera{
-	c_tag = "Permabrig Prisoner Arrivals";
-	dir = 8;
-	name = "aft camera"
+/obj/structure/chair/office/dark{
+	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/obj/effect/landmark/start/security_officer,
+/obj/effect/turf_decal/trimline/red/filled/corner,
 /turf/open/floor/plasteel,
-/area/space/station_ruins)
+/area/security/main)
 "rMV" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -58535,8 +55384,12 @@
 /turf/open/floor/plating/airless,
 /area/maintenance/department/engine)
 "rNl" = (
-/turf/open/floor/plasteel/grimy,
-/area/space/station_ruins)
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner,
+/turf/open/floor/plasteel,
+/area/security/main)
 "rNB" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -58554,38 +55407,28 @@
 /turf/closed/wall/r_wall,
 /area/science/mixing)
 "rRM" = (
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
 /turf/open/floor/plasteel,
-/area/space/station_ruins)
+/area/security/main)
 "rSH" = (
 /obj/item/trash/can,
 /turf/open/floor/wood,
 /area/maintenance/department/engine)
 "rTp" = (
-/obj/machinery/requests_console{
-	department = "Prison";
-	departmentType = 1
-	},
-/turf/closed/wall,
-/area/space/station_ruins)
+/obj/structure/trash_pile,
+/turf/open/floor/plating,
+/area/maintenance/department/security/brig)
 "rVa" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/structure/table,
 /obj/item/restraints/handcuffs,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "rWE" = (
@@ -58605,15 +55448,20 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "rYC" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/grimy,
-/area/space/station_ruins)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "rZi" = (
-/obj/machinery/vending/snack/random,
-/turf/open/floor/plasteel/cafeteria,
-/area/space/station_ruins)
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "sbk" = (
 /obj/structure/girder,
 /turf/open/floor/plating,
@@ -58649,15 +55497,37 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "sdk" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
-/turf/open/floor/plasteel/grimy,
-/area/space/station_ruins)
-"sfB" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+/obj/item/radio/intercom{
+	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_x = -25;
+	pixel_y = -2;
+	prison_radio = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
-/turf/open/floor/wood,
-/area/space/station_ruins)
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"sfB" = (
+/obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "sgc" = (
 /obj/machinery/vending/cigarette,
 /obj/effect/turf_decal/tile/neutral{
@@ -58673,12 +55543,17 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
 "sge" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 11
+/obj/machinery/light/small{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/space/station_ruins)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "shH" = (
 /turf/closed/wall/r_wall,
 /area/space/nearstation)
@@ -58689,20 +55564,14 @@
 /area/maintenance/department/engine)
 "sjC" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
 /obj/machinery/power/port_gen/pacman,
+/obj/effect/turf_decal/lumos/tile/yellow/half,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "skm" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/trimline/brown/filled/corner,
 /turf/open/floor/plasteel,
-/area/space/station_ruins)
+/area/quartermaster/storage)
 "skw" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /turf/closed/wall,
@@ -58767,15 +55636,14 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "ssO" = (
-/obj/machinery/camera{
-	c_tag = "Permabrig Iso Cell 2";
-	network = list("ss13","prison")
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/structure/bed,
-/turf/open/floor/mineral/titanium/white{
-	name = "secure isolation floor"
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 8
 	},
-/area/space/station_ruins)
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "sty" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/white,
@@ -58797,9 +55665,14 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard)
 "suV" = (
-/obj/machinery/holopad,
-/turf/open/floor/plasteel/grimy,
-/area/space/station_ruins)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4
+	},
+/obj/effect/turf_decal/lumos/tile/blue/half{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "svA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 6
@@ -58867,17 +55740,14 @@
 /obj/machinery/firealarm{
 	pixel_y = 29
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -58895,23 +55765,33 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "sCA" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#cee5d2"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
 	},
-/obj/structure/table,
-/obj/machinery/chem_dispenser/drinks,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
+	},
 /turf/open/floor/plasteel/white,
-/area/space/station_ruins)
+/area/medical/medbay/central)
 "sDI" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 10
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
-/turf/open/floor/wood,
-/area/space/station_ruins)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/turf_decal/lumos/tile/blue/half{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "sEB" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
@@ -58924,9 +55804,12 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "sGr" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
-/turf/open/floor/plasteel/grimy,
-/area/space/station_ruins)
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
+/obj/effect/turf_decal/trimline/green/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "sHY" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/transit_tube/curved{
@@ -58947,26 +55830,17 @@
 	dir = 5
 	},
 /obj/structure/closet/secure_closet/engineering_personal,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "sKG" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/turf/open/floor/plating/smooth/grass{
+	desc = "A lush patch for moss commonly found growing in inhabited asteroids.";
+	name = "asteroid moss"
 	},
-/obj/structure/table,
-/obj/item/storage/box/hug,
-/obj/item/razor{
-	pixel_x = -6
-	},
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/plasteel,
-/area/space/station_ruins)
+/area/chapel/asteroid/monastery)
 "sNz" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -58984,12 +55858,12 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "sQi" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#cee5d2"
+/obj/structure/flora/ausbushes/fernybush,
+/turf/open/floor/plating/smooth/grass{
+	desc = "A lush patch for moss commonly found growing in inhabited asteroids.";
+	name = "asteroid moss"
 	},
-/turf/open/floor/wood,
-/area/space/station_ruins)
+/area/chapel/asteroid/monastery)
 "sQt" = (
 /obj/machinery/door/airlock/external{
 	name = "Supply Dock Airlock";
@@ -59050,24 +55924,22 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "sXP" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/condiment/rice,
-/obj/item/reagent_containers/food/condiment/rice,
-/obj/item/reagent_containers/food/condiment/rice,
-/turf/open/floor/plasteel/white,
-/area/space/station_ruins)
+/obj/item/flashlight/lantern{
+	icon_state = "lantern-on"
+	},
+/turf/open/floor/plating/smooth/grass{
+	desc = "A lush patch for moss commonly found growing in inhabited asteroids.";
+	name = "asteroid moss"
+	},
+/area/chapel/asteroid/monastery)
 "sXR" = (
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall/r_wall,
 /area/science/xenobiology)
 "sYN" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/space/station_ruins)
+/mob/living/simple_animal/hostile/asteroid/basilisk,
+/turf/closed/mineral/random/low_chance,
+/area/asteroid/nearstation/bomb_site)
 "sYQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -59106,12 +55978,9 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "tap" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
-	},
-/turf/open/floor/plasteel/grimy,
-/area/space/station_ruins)
+/mob/living/simple_animal/hostile/asteroid/basilisk,
+/turf/open/floor/plating/asteroid/airless,
+/area/asteroid/nearstation/bomb_site)
 "taA" = (
 /obj/structure/chair/office/light,
 /turf/open/floor/plasteel/dark,
@@ -59147,19 +56016,6 @@
 /obj/effect/turf_decal/lumos/tile/purple/fulltile,
 /turf/open/floor/plasteel/white,
 /area/hallway/secondary/entry)
-"tcg" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/camera{
-	c_tag = "Permabrig East";
-	dir = 8;
-	network = list("ss13","prison");
-	start_active = 1
-	},
-/turf/open/floor/plasteel,
-/area/space/station_ruins)
 "tcY" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -59186,12 +56042,8 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
+/obj/effect/turf_decal/lumos/tile/purple/fullcorner{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/science/explab)
@@ -59199,11 +56051,8 @@
 /obj/structure/table,
 /obj/item/reagent_containers/glass/beaker,
 /obj/item/reagent_containers/dropper,
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
@@ -59227,16 +56076,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall,
 /area/maintenance/department/security/brig)
-"thm" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Garden"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/space/station_ruins)
 "thA" = (
 /obj/machinery/atmospherics/pipe/simple/general/hidden,
 /turf/closed/wall/r_wall,
@@ -59275,15 +56114,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"tlc" = (
-/obj/machinery/camera{
-	c_tag = "Permabrig Pressing Room";
-	dir = 4;
-	network = list("ss13","prison")
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
-/turf/open/floor/plasteel/checker,
-/area/space/station_ruins)
 "tlw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
@@ -59311,16 +56141,9 @@
 	req_one_access_txt = "32;47;48"
 	},
 /obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/yellow/half,
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
-"tpb" = (
-/obj/machinery/holopad,
-/turf/open/floor/plasteel/checker,
-/area/space/station_ruins)
 "tqO" = (
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
@@ -59341,20 +56164,6 @@
 	},
 /turf/open/floor/plating,
 /area/science/xenobiology)
-"tru" = (
-/obj/machinery/shower{
-	dir = 4
-	},
-/obj/item/soap,
-/turf/open/floor/plasteel/showroomfloor,
-/area/space/station_ruins)
-"trD" = (
-/obj/structure/closet/crate/trashcart,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/space/station_ruins)
 "ttS" = (
 /obj/structure/chair/stool,
 /mob/living/simple_animal/pet/bumbles,
@@ -59387,16 +56196,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/crew_quarters/dorms)
-"tvn" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/machinery/washing_machine,
-/turf/open/floor/plasteel,
-/area/space/station_ruins)
 "tvP" = (
 /obj/item/storage/toolbox/mechanical,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -59490,22 +56289,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/lab)
-"tLc" = (
-/turf/open/space,
-/area/space/station_ruins)
 "tLv" = (
 /obj/structure/cable{
 	icon_state = "1-4"
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
 	dir = 5
+	},
+/obj/effect/turf_decal/lumos/tile/red/checker,
+/obj/structure/chair{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -59526,13 +56322,6 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/department/engine)
-"tRx" = (
-/obj/machinery/shower{
-	dir = 4
-	},
-/obj/item/soap/homemade,
-/turf/open/floor/plasteel/showroomfloor,
-/area/space/station_ruins)
 "tSL" = (
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
@@ -59543,11 +56332,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"tVx" = (
-/obj/machinery/light,
-/obj/structure/reagent_dispensers/cooking_oil,
-/turf/open/floor/plasteel/white,
-/area/space/station_ruins)
 "tXn" = (
 /obj/structure/sink{
 	dir = 4;
@@ -59556,12 +56340,8 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
+/obj/effect/turf_decal/lumos/tile/purple/fullcorner{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
@@ -59574,29 +56354,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/hallway/secondary/entry)
-"tZG" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel/grimy,
-/area/space/station_ruins)
 "uaC" = (
 /obj/structure/chair/comfy/black{
 	dir = 8
 	},
 /turf/open/floor/carpet,
 /area/maintenance/department/crew_quarters/dorms)
-"uaE" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
-/turf/open/floor/plasteel/checker,
-/area/space/station_ruins)
 "uaO" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 6
@@ -59613,19 +56376,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"uaS" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Pressing Room"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel/checker,
-/area/space/station_ruins)
 "ubW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
@@ -59680,45 +56430,15 @@
 "ufa" = (
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
-"ufu" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/space/station_ruins)
-"ugw" = (
-/obj/structure/toilet{
-	dir = 8
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/space/station_ruins)
 "ugC" = (
 /obj/structure/chair/office/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"uhM" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
-/turf/open/floor/plasteel,
-/area/space/station_ruins)
 "uiP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -59908,15 +56628,6 @@
 	},
 /turf/open/floor/circuit/telecomms,
 /area/science/xenobiology)
-"uwH" = (
-/mob/living/simple_animal/opossum/poppy,
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
-/area/maintenance/department/engine)
-"uwL" = (
-/turf/open/floor/plasteel/cafeteria,
-/area/space/station_ruins)
 "uwX" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical,
@@ -59973,15 +56684,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/white,
 /area/medical/psych)
-"uAv" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
-/turf/open/floor/plasteel,
-/area/space/station_ruins)
 "uAU" = (
 /obj/structure/table/wood,
 /obj/item/folder/blue,
@@ -60017,10 +56719,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
-"uHM" = (
-/obj/machinery/smartfridge/food,
-/turf/closed/wall,
-/area/space/station_ruins)
 "uIn" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -60033,28 +56731,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engine/engineering)
-"uJr" = (
-/obj/machinery/door/poddoor{
-	id = "soli1"
-	},
-/turf/open/floor/mineral/titanium/white{
-	name = "secure isolation floor"
-	},
-/area/space/station_ruins)
-"uLj" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/camera{
-	c_tag = "Permabrig West Hallway 1";
-	dir = 4;
-	network = list("ss13","prison")
-	},
-/turf/open/floor/plasteel,
-/area/space/station_ruins)
 "uLF" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -60073,11 +56749,8 @@
 /area/maintenance/department/engine)
 "uMo" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
 /obj/structure/closet/crate/solarpanel_small,
+/obj/effect/turf_decal/lumos/tile/yellow/half,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "uMt" = (
@@ -60085,18 +56758,14 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "uMQ" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /obj/machinery/airalarm{
 	pixel_y = 23
 	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"uNt" = (
-/obj/structure/grille,
-/turf/open/space,
-/area/space/station_ruins)
 "uOM" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -60107,22 +56776,10 @@
 	},
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/solar/port)
-"uPf" = (
-/turf/open/floor/plasteel/vaporwave,
-/area/space/station_ruins)
 "uPg" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"uQR" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/space/station_ruins)
 "uRk" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 5
@@ -60158,17 +56815,6 @@
 /obj/item/stamp/law,
 /turf/open/floor/carpet,
 /area/lawoffice)
-"uVx" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/wood,
-/area/space/station_ruins)
 "uWo" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/transit_tube/horizontal,
@@ -60210,23 +56856,6 @@
 /obj/structure/window/reinforced,
 /turf/open/space,
 /area/space/nearstation)
-"uZz" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/delivery,
-/obj/structure/sign/poster/official/random{
-	pixel_x = -32
-	},
-/obj/structure/plasticflaps,
-/obj/machinery/conveyor/auto{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/space/station_ruins)
 "vay" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -60267,16 +56896,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "vgp" = (
@@ -60302,35 +56922,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
-"vhd" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/structure/closet/crate/bin,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel,
-/area/space/station_ruins)
 "vhk" = (
 /obj/structure/chair,
 /turf/open/floor/carpet,
 /area/lawoffice)
-"vhA" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/manifold/cyan/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/space/station_ruins)
 "vim" = (
 /mob/living/simple_animal/pet/roro/roboticsroro,
 /turf/open/floor/plasteel,
@@ -60382,16 +56977,7 @@
 "vmG" = (
 /obj/structure/table/reinforced,
 /obj/item/integrated_electronics/analyzer,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
 "vmY" = (
@@ -60421,19 +57007,6 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
-"voE" = (
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/structure/closet/crate/bin,
-/obj/machinery/requests_console{
-	department = "Prison";
-	departmentType = 1;
-	pixel_y = -30
-	},
-/turf/open/floor/plasteel,
-/area/space/station_ruins)
 "vpz" = (
 /obj/structure/girder,
 /turf/open/floor/plating{
@@ -60441,28 +57014,12 @@
 	luminosity = 2
 	},
 /area/maintenance/department/science)
-"vqQ" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Showers"
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/space/station_ruins)
 "vqV" = (
-/obj/structure/chair{
-	dir = 4
-	},
 /obj/structure/window/reinforced,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
+/obj/structure/closet/secure_closet/genpop,
+/obj/effect/turf_decal/lumos/tile/red/checker,
 /turf/open/floor/plasteel,
 /area/security/prison)
-"vrX" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/snacks/fortunecookie,
-/turf/open/floor/plasteel/cafeteria,
-/area/space/station_ruins)
 "vsk" = (
 /obj/machinery/atmospherics/pipe/simple/general/hidden,
 /obj/structure/cable{
@@ -60517,26 +57074,6 @@
 /obj/item/clothing/mask/gas,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"vvq" = (
-/obj/machinery/holopad,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/manifold/cyan/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/space/station_ruins)
-"vvI" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/space/station_ruins)
 "vxp" = (
 /obj/machinery/door/window/eastright{
 	base_state = "left";
@@ -60644,15 +57181,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"vGo" = (
-/obj/structure/closet/crate/bin,
-/obj/machinery/requests_console{
-	department = "Prison";
-	departmentType = 1;
-	pixel_y = -30
-	},
-/turf/open/floor/plasteel/white,
-/area/space/station_ruins)
 "vIc" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -60662,14 +57190,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
-"vJC" = (
-/obj/structure/filingcabinet,
-/obj/machinery/camera{
-	c_tag = "Permabrig Library";
-	network = list("ss13","prison")
-	},
-/turf/open/floor/wood,
-/area/space/station_ruins)
 "vKq" = (
 /obj/machinery/door/firedoor,
 /obj/structure/sign/poster/official/random{
@@ -60739,27 +57259,11 @@
 /obj/machinery/camera{
 	c_tag = "Engineering Port Storage"
 	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"vRQ" = (
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/space/station_ruins)
 "vTx" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -60786,16 +57290,7 @@
 	req_access_txt = "8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "vVO" = (
@@ -60823,16 +57318,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"waW" = (
-/obj/machinery/light,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/space/station_ruins)
 "wbB" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	name = "External Gas to Loop"
@@ -60909,11 +57394,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -60925,31 +57407,12 @@
 	dir = 4;
 	name = "emergency shower"
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
 	},
+/obj/effect/turf_decal/lumos/tile/purple/half,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"wlJ" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/conveyor/auto{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4;
-	layer = 2.9
-	},
-/turf/open/floor/plasteel,
-/area/space/station_ruins)
 "wnJ" = (
 /obj/structure/sign/warning,
 /turf/closed/wall,
@@ -60965,40 +57428,12 @@
 	},
 /turf/open/floor/plating,
 /area/engine/supermatter)
-"woq" = (
-/obj/structure/chair/stool,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/space/station_ruins)
 "wqu" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 8
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
-"wri" = (
-/obj/machinery/light,
-/obj/machinery/requests_console{
-	department = "Prison";
-	departmentType = 1;
-	pixel_y = -30
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/plasteel/checker,
-/area/space/station_ruins)
-"wrn" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/item/reagent_containers/food/condiment/saltshaker,
-/turf/open/floor/plasteel/white,
-/area/space/station_ruins)
 "wrU" = (
 /obj/machinery/photocopier,
 /obj/machinery/firealarm{
@@ -61007,14 +57442,6 @@
 	},
 /turf/open/floor/wood,
 /area/lawoffice)
-"wtt" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/manifold4w/cyan/hidden/layer1,
-/turf/open/floor/plasteel,
-/area/space/station_ruins)
 "wtE" = (
 /obj/effect/landmark/start/paramedic,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -61040,10 +57467,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"wvK" = (
-/obj/machinery/vending/cola/random,
-/turf/open/floor/plasteel/cafeteria,
-/area/space/station_ruins)
 "wwr" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -61053,16 +57476,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"wwG" = (
-/obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/pen/blue,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/space/station_ruins)
 "wxb" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -61105,10 +57518,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "wBb" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/purple/half,
 /turf/open/floor/plasteel/white,
 /area/science/explab)
 "wBg" = (
@@ -61118,19 +57528,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
-"wCj" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Diner"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/space/station_ruins)
 "wCR" = (
 /obj/machinery/light/small,
 /obj/structure/closet/firecloset,
@@ -61148,17 +57545,6 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"wDm" = (
-/obj/structure/table,
-/obj/item/storage/pill_bottle/dice,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/space/station_ruins)
 "wDZ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -61204,14 +57590,6 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
-"wIm" = (
-/obj/machinery/atmospherics/components/binary/valve{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/plating,
-/area/space/station_ruins)
 "wIo" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /obj/structure/lattice,
@@ -61229,21 +57607,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"wIX" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#cee5d2"
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/machinery/vending/hydroseeds,
-/turf/open/floor/plasteel,
-/area/space/station_ruins)
 "wJP" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
@@ -61255,14 +57618,6 @@
 /obj/machinery/light/small,
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
-"wKI" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/condiment/enzyme{
-	layer = 5
-	},
-/obj/item/reagent_containers/food/condiment/sugar,
-/turf/open/floor/plasteel/white,
-/area/space/station_ruins)
 "wLo" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -61316,12 +57671,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"wOt" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/item/reagent_containers/food/condiment/peppermill,
-/turf/open/floor/plasteel/white,
-/area/space/station_ruins)
 "wOS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/machinery/light/small{
@@ -61329,10 +57678,6 @@
 	},
 /turf/open/floor/plating,
 /area/science/mixing)
-"wPE" = (
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/plasteel/white,
-/area/space/station_ruins)
 "wPW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 6
@@ -61433,20 +57778,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"wWU" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
-/turf/open/floor/plasteel,
-/area/space/station_ruins)
 "wXu" = (
 /obj/machinery/disposal/bin,
 /obj/structure/window/reinforced{
@@ -61458,22 +57789,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
-"wYs" = (
-/obj/machinery/space_heater,
-/turf/open/floor/plating,
-/area/space/station_ruins)
-"wYu" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/space/station_ruins)
 "wYK" = (
 /obj/machinery/power/supermatter_crystal/engine,
 /turf/open/floor/engine,
@@ -61528,6 +57843,12 @@
 /area/maintenance/department/crew_quarters/dorms)
 "xea" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/security/main)
 "xee" = (
@@ -61589,13 +57910,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"xiy" = (
-/obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/space/station_ruins)
 "xja" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -61640,11 +57954,8 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
@@ -61762,31 +58073,9 @@
 	},
 /area/maintenance/department/security/brig)
 "xzp" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/blue/half,
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
-"xzB" = (
-/obj/machinery/atmospherics/components/unary/tank/air{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/space/station_ruins)
-"xzQ" = (
-/obj/structure/toilet{
-	contents = newlist(/obj/item/toy/snappop/phoenix);
-	dir = 4
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/space/station_ruins)
 "xzR" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible,
 /obj/effect/turf_decal/stripes/line{
@@ -61794,19 +58083,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"xAM" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Diner"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/space/station_ruins)
 "xBf" = (
 /obj/machinery/light/small{
 	brightness = 3;
@@ -61844,18 +58120,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"xEb" = (
-/obj/structure/bed,
-/obj/effect/landmark/start/prisoner,
-/obj/item/radio/intercom{
-	desc = "Talk through this. It looks like it has been modified to not broadcast.";
-	name = "Prison Intercom (General)";
-	pixel_y = 24;
-	prison_radio = 1
-	},
-/obj/item/bedsheet/orange,
-/turf/open/floor/plasteel/dark,
-/area/space/station_ruins)
 "xFl" = (
 /obj/machinery/power/apc/highcap/five_k{
 	areastring = "/area/tcommsat/server";
@@ -61973,15 +58237,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
-"xVt" = (
-/obj/effect/spawner/lootdrop/maintenance{
-	name = "2maintenance loot spawner"
-	},
-/obj/structure/rack,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/maintenance/department/chapel/monastery)
 "xWl" = (
 /obj/item/pen,
 /obj/item/paper_bin{
@@ -61997,19 +58252,12 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner,
 /turf/open/floor/plasteel,
 /area/security/main)
-"xWy" = (
-/obj/structure/bed,
-/obj/item/radio/intercom{
-	desc = "Talk through this. It looks like it has been modified to not broadcast.";
-	name = "Prison Intercom (General)";
-	pixel_y = 24;
-	prison_radio = 1
-	},
-/obj/item/bedsheet/orange,
-/turf/open/floor/plasteel/dark,
-/area/space/station_ruins)
 "xYR" = (
 /mob/living/simple_animal/opossum,
 /turf/open/floor/plating{
@@ -62027,53 +58275,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"yaF" = (
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/space/station_ruins)
-"ybI" = (
-/obj/machinery/door/airlock/public/glass,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/space/station_ruins)
 "ybX" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"ycr" = (
-/obj/item/toy/beach_ball/holoball,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/space/station_ruins)
 "ycx" = (
 /turf/open/floor/wood{
 	icon_state = "wood-broken5"
 	},
 /area/maintenance/department/engine)
 "ycE" = (
+/obj/structure/grille,
+/obj/structure/lattice,
 /turf/open/space/basic,
-/area/security/prison)
+/area/space/nearstation)
 "ydf" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -62081,14 +58297,11 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "yfO" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 10
 	},
+/obj/effect/turf_decal/lumos/tile/yellow/half,
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
 "ygZ" = (
@@ -62103,14 +58316,11 @@
 /obj/machinery/vending/wallmed{
 	pixel_y = 28
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/structure/closet/crate/freezer/surplus_limbs,
 /obj/item/reagent_containers/glass/beaker/synthflesh,
+/obj/effect/turf_decal/lumos/tile/blue/half{
+	dir = 1
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "ymb" = (
@@ -65510,17 +61720,17 @@ rmC
 rmC
 rmC
 rmC
-ahO
-ahO
-ahO
-ahO
-ahO
-ahO
-ahO
-ahO
-ahO
-ahO
-ahO
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
 rmC
 rmC
 rmC
@@ -65767,17 +61977,17 @@ rmC
 rmC
 rmC
 rmC
-ahO
-aiK
-aiK
-aiK
-aiK
-aiK
-aiK
-aiK
-gvS
-aiK
-ahO
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
 rmC
 rmC
 rmC
@@ -66010,31 +62220,31 @@ rmC
 rmC
 rmC
 rmC
-ahO
-ahO
-ahO
-ahO
-ahO
-ahO
-ahO
-ahO
-ahO
-ahO
-ahO
-ahO
-ahO
-ahO
-ahO
-aiK
-ara
-ara
-ara
-ara
-ara
-ara
-ara
-aiK
-ahO
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
 rmC
 rmC
 rmC
@@ -66267,31 +62477,31 @@ rmC
 rmC
 rmC
 rmC
-ahO
-aiK
-aiK
-aiK
-aiK
-aiK
-aiK
-aiK
-aiK
-aiK
-aiK
-nfB
-aiK
-aiK
-aiK
-aiK
-ara
-oxy
-lrk
-cPc
-mCD
-cWb
-ara
-aiK
-ahO
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
 rmC
 rmC
 rmC
@@ -66524,31 +62734,31 @@ rmC
 rmC
 rmC
 rmC
-ahO
-epJ
-ara
-ara
-ara
-ara
-ara
-ara
-ara
-ara
-ara
-ara
-ara
-ara
-ara
-ara
-ara
-iVw
-azI
-cYF
-azI
-sYN
-ara
-aiK
-ahO
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
 rmC
 rmC
 rmC
@@ -66781,31 +62991,31 @@ rmC
 rmC
 rmC
 rmC
-ahO
-aiK
-ara
-noC
-tlc
-llv
-ara
-ncM
-tRx
-cMk
-ncM
-tru
-lKk
-nAK
-riD
-fGY
-lKk
-fzv
-azI
-fBH
-kUE
-sYN
-ara
-aiK
-ahO
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
 rmC
 rmC
 rmC
@@ -67038,31 +63248,31 @@ rmC
 rmC
 rmC
 rmC
-ahO
-aiK
-ara
-noC
-tpb
-wri
-ara
-jwo
-rnG
-lGA
-rnG
-iVl
-lKk
-tvn
-lPt
-iEH
-lKk
-cil
-azI
-azI
-oeQ
-voE
-ara
-aiK
-ahO
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
 rmC
 rmC
 rmC
@@ -67293,33 +63503,33 @@ rmC
 rmC
 rmC
 rmC
-ahO
-ahO
-ahO
-aiK
-ara
-noC
-uaE
-gca
-ara
-nSr
-nSr
-rnG
-ney
-nSr
-lKk
-tvn
-pxw
-vhd
-lKk
-wIX
-dDo
-kjy
-yaF
-kML
-ara
-aiK
-aiK
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
 rmC
 rmC
 rmC
@@ -67550,32 +63760,32 @@ rmC
 rmC
 rmC
 rmC
-ahO
-aiK
-aiK
-aiK
-ara
-ara
-ara
-uaS
-ara
-lKk
-lKk
-vqQ
-lKk
-lKk
-lKk
-lKk
-olO
-lKk
-lKk
-lKk
-lKk
-uHM
-thm
-ara
-ara
-aiK
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
 rmC
 rmC
 rmC
@@ -67805,34 +64015,34 @@ rmC
 rmC
 rmC
 rmC
-ahO
-ahO
-ahO
-aiK
-ajX
-ajY
-azG
-nze
-ufu
-gTP
-kWw
-ufu
-hcf
-ufu
-jIn
-faI
-dop
-ufu
-ufu
-ufu
-uLj
-ufu
-kWw
-ufu
-gTP
-ara
-ara
-aiK
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
 rmC
 rmC
 rmC
@@ -68062,34 +64272,34 @@ rmC
 rmC
 rmC
 rmC
-ahO
-aiK
-aiK
-aiK
-ayy
-fIN
-azI
-azI
-uQR
-hfp
-jMl
-uhM
-uhM
-mTk
-vhA
-jWW
-uhM
-uhM
-uhM
-mTk
-uhM
-uhM
-jMl
-bXT
-qTM
-ara
-aiK
-aiK
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
 rmC
 rmC
 rmC
@@ -68317,36 +64527,36 @@ rmC
 rmC
 rmC
 rmC
-ahO
-ahO
-ahO
-aiK
-ara
-ajY
-ara
-fJn
-azI
-oFf
-woq
-lYx
-gAr
-lKk
-lKk
-lKk
-lKk
-lKk
-lKk
-lKk
-lKk
-lKk
-lKk
-lKk
-lKk
-qio
-waW
-ara
-aiK
-aiK
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
 rmC
 rmC
 rmC
@@ -68574,37 +64784,37 @@ rmC
 rmC
 rmC
 rmC
-ahO
-aiK
-aiK
-aiK
-ayy
-azL
-bmq
-aAV
-lcU
-pdq
-wwG
-gIo
-lKk
-xWy
-xzQ
-lKk
-xEb
-xzQ
-lKk
-xWy
-xzQ
-lKk
-xEb
-xzQ
-lKk
-eNz
-ioG
-ara
-ara
-ara
-ara
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
 rmC
 rmC
 rmC
@@ -68831,37 +65041,37 @@ rmC
 rmC
 rmC
 rmC
-ahO
-ajW
-ajX
-ajY
-azG
-azZ
-azI
-aAV
-azI
-oFf
-wDm
-fJx
-lKk
-mor
-mor
-lKk
-mor
-mor
-lKk
-mor
-mor
-lKk
-mor
-mor
-lKk
-eNz
-ioG
-lKk
-uZz
-fkz
-wlJ
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
 rmC
 rmC
 rmC
@@ -69088,37 +65298,37 @@ rmC
 rmC
 rmC
 rmC
-ahO
-aiK
-ajY
-anq
-azI
-aAV
-azI
-aAV
-azI
-oFf
-woq
-lYx
-lKk
-lKk
-hoC
-lKk
-lKk
-hoC
-lKk
-lKk
-hoC
-lKk
-lKk
-hoC
-gAr
-ipj
-jfc
-rTp
-jiV
-dUt
-sKG
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
 rmC
 rmC
 rmC
@@ -69345,37 +65555,37 @@ rmC
 rmC
 rmC
 rmC
-ahO
-aiK
-ali
-aoJ
-azI
-aCa
-boA
-gGy
-boA
-boA
-wYu
-cPn
-fJq
-azI
-azI
-mLU
-azI
-azI
-nSt
-noE
-azI
-fRc
-azI
-azI
-fJq
-eNz
-ioG
-iid
-nPq
-azI
-azI
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
 rmC
 rmC
 rmC
@@ -69602,37 +65812,37 @@ rmC
 rmC
 rmC
 rmC
-ahO
-aiK
-ali
-aqb
-azI
-aGC
-boC
-gJF
-boC
-boC
-ycr
-jIO
-fJq
-azI
-azI
-azI
-azI
-azI
-eAy
-azI
-azI
-azI
-azI
-azI
-fJq
-eNz
-ioG
-iid
-azI
-azI
-lGd
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
 rmC
 rmC
 rmC
@@ -69859,37 +66069,37 @@ rmC
 rmC
 rmC
 rmC
-ahO
-aiK
-alD
-aqe
-azJ
-aIr
-bpI
-hiw
-bpI
-bpI
-oco
-uVx
-eKN
-fkG
-fkG
-nqT
-fkG
-fkG
-hUl
-lIi
-lIi
-gLY
-lIi
-lIi
-uAv
-wWU
-wtt
-lUw
-lIi
-qbV
-lIi
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
 rmC
 rmC
 rmC
@@ -70116,37 +66326,37 @@ rmC
 rmC
 rmC
 rmC
-ahO
-aiK
-amo
-aoJ
-azI
-aAV
-azI
-aAV
-azI
-oFf
-cPx
-lYx
-gAr
-lKk
-hoC
-lKk
-lKk
-hoC
-lKk
-lKk
-hoC
-lKk
-lKk
-hoC
-lKk
-ipj
-jfc
-lKk
-uJr
-lKk
-iOi
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
 rmC
 rmC
 rmC
@@ -70373,37 +66583,37 @@ rmC
 rmC
 rmC
 rmC
-ahO
-aiK
-ajX
-amo
-azG
-azZ
-azI
-aAV
-azI
-oFf
-kDR
-eKC
-lKk
-mor
-mor
-lKk
-mor
-mor
-lKk
-mor
-mor
-lKk
-mor
-mor
-lKk
-eNz
-ioG
-lKk
-kJx
-lKk
-ssO
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
 rmC
 rmC
 rmC
@@ -70630,33 +66840,33 @@ rmC
 rmC
 rmC
 rmC
-ahO
-aiK
-aiK
-aiK
-ayy
-aWm
-azI
-aAV
-lXc
-plA
-qXb
-gVH
-lKk
-xEb
-ugw
-lKk
-xWy
-ugw
-lKk
-xEb
-ugw
-lKk
-xWy
-ugw
-lKk
-eNz
-fxz
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
 rmC
 rmC
 rmC
@@ -70887,33 +67097,33 @@ rmC
 rmC
 rmC
 rmC
-ahO
-ahO
-ahO
-aiK
-ara
-amo
-cnV
-aAV
-azI
-oFf
-cPx
-lYx
-lKk
-lKk
-lKk
-lKk
-lKk
-lKk
-lKk
-lKk
-lKk
-lKk
-lKk
-lKk
-gAr
-nfk
-waW
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
 rmC
 rmC
 rmC
@@ -71146,31 +67356,31 @@ rmC
 rmC
 rmC
 rmC
-ahO
-aiK
-aiK
-aiK
-ayy
-hue
-mwg
-azI
-ask
-fvX
-khD
-fIo
-gMP
-oGN
-feH
-rRM
-fIo
-pfY
-fIo
-iRm
-fIo
-fIo
-pfY
-vvq
-jCM
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
 rmC
 rmC
 rmC
@@ -71403,31 +67613,31 @@ rmC
 rmC
 rmC
 rmC
-ahO
-ahO
-ahO
-aiK
-ajX
-amo
-azG
-rlL
-koU
-skm
-ipu
-skm
-ibA
-skm
-ipP
-ehK
-skm
-ibA
-skm
-ipu
-tcg
-skm
-ibA
-skm
-skm
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
 rmC
 rmC
 rmC
@@ -71662,29 +67872,29 @@ rmC
 rmC
 rmC
 rmC
-ahO
-aiK
-aiK
-aiK
-ara
-ara
-ioG
-ara
-lKk
-lKk
-eqA
-lKk
-lKk
-lKk
-lKk
-xAM
-lKk
-lKk
-lKk
-lKk
-wCj
-lKk
-lKk
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
 rmC
 rmC
 rmC
@@ -71917,31 +68127,31 @@ rmC
 rmC
 rmC
 rmC
-ahO
-aiK
-ara
-ara
-ara
-ara
-ara
-ara
-ybI
-ara
-rlD
-rlD
-kdo
-rlD
-rlD
-lKk
-aTG
-gbM
-tVx
-lKk
-ftO
-ftO
-rKv
-ftO
-fTo
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
 rmC
 rmC
 rmC
@@ -72174,31 +68384,31 @@ rmC
 rmC
 rmC
 rmC
-ahO
-aiK
-ara
-bbv
-bcs
-hFy
-bbv
-lcU
-nEl
-ara
-sQi
-kTE
-isH
-jEd
-boC
-lKk
-eGB
-gbM
-sXP
-lKk
-jYk
-kUq
-rKv
-jYk
-nRs
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
 rmC
 rmC
 rmC
@@ -72431,35 +68641,35 @@ rmC
 rmC
 rmC
 rmC
-ahO
-aiK
-ara
-bcs
-cor
-cor
-bcs
-azI
-cLt
-ara
-rlD
-rlD
-mwa
-rlD
-rlD
-lKk
-dcp
-gbM
-dBT
-lKk
-mcP
-mcP
-rKv
-mcP
-vrX
-ara
 rmC
-ara
-uPf
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
 rmC
 rmC
 rmC
@@ -72688,35 +68898,35 @@ rmC
 rmC
 rmC
 rmC
-ahO
-aiK
-ara
-bcs
-cor
-cor
-bcs
-azI
-vRQ
-ara
-vJC
-boC
-sDI
-dKx
-lEY
-lKk
-fnl
-czx
-vGo
-lKk
-nxz
-ftO
-vvI
-ftO
-ftO
-ara
 rmC
-ara
-uPf
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
 rmC
 rmC
 rmC
@@ -72945,35 +69155,35 @@ rmC
 rmC
 rmC
 rmC
-ahO
-aiK
-ara
-bbv
-bcs
-jsf
-bbv
-rLi
-jgH
-ara
-cUu
-bbT
-ecj
-lKw
-sfB
-lKk
-jkW
-qzM
-iiX
-uHM
-uwL
-uwL
-xiy
-uwL
-enN
-ara
 rmC
-ara
-uPf
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
 rmC
 rmC
 rmC
@@ -73202,35 +69412,35 @@ rmC
 rmC
 rmC
 rmC
-ahO
-aiK
-ara
-ara
-ara
-ara
-ara
-ara
-ybI
-ara
-lKk
-lRM
-lKk
-lKk
-luY
-lKk
-wKI
-kxv
-iiX
-wrn
-uwL
-uwL
-mJX
-uwL
-uwL
-ara
 rmC
-ara
-ara
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
 rmC
 rmC
 rmC
@@ -73459,35 +69669,35 @@ rmC
 rmC
 rmC
 rmC
-ahO
-aiK
 rmC
 rmC
-aiK
-aiK
-ara
-rNl
-tZG
-ara
-kzd
-pkg
-iMx
-trD
-qLf
-lKk
-ojn
-iiX
-iiX
-fON
-uwL
-uwL
-uwL
-uwL
-uwL
-ara
-qTw
-lTQ
-ohQ
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
 rmC
 rmC
 rmC
@@ -73720,31 +69930,31 @@ rmC
 rmC
 rmC
 rmC
-cHS
-kJw
-ara
-rNl
-tZG
-ara
-cdf
-jYW
-jYW
-iqx
-wIm
-lKk
-mxc
-iiX
-iiX
-wOt
-uwL
-uwL
-uwL
-uwL
-kxC
-ara
-lTQ
-lTQ
-uNt
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
 rmC
 rmC
 rmC
@@ -73977,30 +70187,30 @@ rmC
 rmC
 rmC
 rmC
-cHS
-aiK
-ara
-rYC
-tZG
-ara
-jDZ
-sge
-wYs
-xzB
-ovc
-lKk
-sCA
-wPE
-lOU
-lKk
-enT
-wvK
-kZm
-rZi
-rZi
-ara
-lTQ
-lTQ
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
 rmC
 rmC
 rmC
@@ -74234,30 +70444,30 @@ rmC
 rmC
 rmC
 rmC
-cHS
-aiK
-ara
-sdk
-pny
-ara
-ara
-ara
-ara
-ara
-ara
-ara
-ara
-ara
-ara
-ara
-ara
-ara
-ara
-ara
-ara
-ara
-ohQ
-ohQ
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
 rmC
 rmC
 rmC
@@ -74491,28 +70701,28 @@ rmC
 rmC
 rmC
 rmC
-cHS
-aiK
-ara
-suV
-tZG
-ara
-qwm
-jPQ
-azI
-qwm
-qwm
-ara
-aiK
-aiK
-aiK
-aiK
-aiK
-aiK
-aiK
-aiK
-aiK
-lTQ
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
 rmC
 rmC
 rmC
@@ -74748,28 +70958,28 @@ rmC
 rmC
 rmC
 rmC
-cHS
-aiK
-ara
-sGr
-rjC
-ara
-azI
-azI
-nSt
-azI
-azI
-ara
-aiK
-ahO
-ahO
-ahO
-ahO
-ahO
-ahO
-ahO
-ahO
-ohQ
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
 rmC
 rmC
 rmC
@@ -75005,19 +71215,19 @@ rmC
 rmC
 rmC
 rmC
-cHS
-aiK
-ara
-rNl
-pJX
-eca
-pTF
-oMR
-pLr
-pvq
-rFY
-ara
-hcS
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
 rmC
 rmC
 rmC
@@ -75262,20 +71472,20 @@ rmC
 rmC
 rmC
 rmC
-cHS
-aiK
-ara
-rYC
-iQz
-ara
-azI
-azI
-pvl
-azI
-azI
-ara
-aiK
-dci
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
 rmC
 rmC
 rmC
@@ -75519,28 +71729,28 @@ rmC
 rmC
 rmC
 rmC
-cHS
-aiK
-ara
-tap
-rNl
-ara
-lJY
-kul
-jwm
-jia
-jia
-ara
-aiK
-dci
 rmC
 rmC
 rmC
 rmC
 rmC
 rmC
-tLc
-tLc
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
 rmC
 rmC
 rmC
@@ -75776,20 +71986,20 @@ rmC
 rmC
 rmC
 rmC
-cHS
-aiK
-ara
-ara
-ara
-ara
-ara
-ara
-ara
-ara
-ara
-ara
-aiK
-dci
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
 rmC
 rmC
 rmC
@@ -76033,28 +72243,28 @@ rmC
 rmC
 rmC
 rmC
-cHS
-aiK
-aiK
-aiK
-aiK
-aiK
-eFR
-aiK
-aiK
-aiK
-aiK
-aiK
-aiK
-dci
 rmC
 rmC
 rmC
 rmC
 rmC
-tLc
-tLc
-tLc
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
 rmC
 rmC
 rmC
@@ -76290,20 +72500,20 @@ rmC
 rmC
 rmC
 rmC
-dci
-dci
-dci
-dci
-dci
-dci
-dci
-dci
-aiK
-cHS
-cHS
-cHS
-cHS
-cHS
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
+rmC
 rmC
 rmC
 rmC
@@ -76432,7 +72642,7 @@ bOw
 bOw
 bQg
 bUC
-bOw
+sKG
 cbG
 csM
 ceB
@@ -76689,7 +72899,7 @@ bQg
 bQg
 bQg
 bOw
-bOw
+sKG
 cbG
 cee
 ceB
@@ -76945,8 +73155,8 @@ bOw
 bOw
 bOw
 bSm
-bOw
-bUC
+sKG
+sQi
 cbG
 cef
 ceB
@@ -77193,14 +73403,14 @@ bNr
 bNs
 bNs
 bNs
-bOw
+sKG
 bOw
 bQg
 bQg
 bOw
 bOw
 bOw
-bQe
+sXP
 bWV
 bWV
 bWV
@@ -77448,14 +73658,14 @@ bOv
 bQQ
 bNs
 bNs
-bOw
-bOw
-bOw
+sKG
+sKG
+sKG
 bOw
 bQg
 bOw
 bOw
-bOw
+sKG
 bWV
 bWV
 bWV
@@ -77704,15 +73914,15 @@ bNs
 bNs
 bNs
 bNs
-bSm
-bOw
+sKG
+sKG
 bOw
 bOw
 bOw
 bQg
 bOw
 bOw
-bUC
+sQi
 bWV
 cdC
 caT
@@ -77957,9 +74167,9 @@ aby
 bGH
 bNs
 bNs
-bOw
+sKG
 bQc
-bOw
+sKG
 bOw
 bOw
 bOw
@@ -78213,9 +74423,9 @@ bJZ
 bIT
 bMr
 bNs
-bOw
-bOw
-bOw
+sKG
+sKG
+sKG
 bOw
 bOw
 bOw
@@ -78368,17 +74578,17 @@ aaa
 aaa
 aaa
 aaa
-mZE
-mZE
-mZE
-mZE
-mZE
-mZE
-mZE
-mZE
-mZE
-mZE
-mZE
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -78397,9 +74607,9 @@ aiu
 aht
 aht
 ait
-lMU
+aoe
 aiu
-ajD
+rTp
 apB
 cXS
 egK
@@ -78625,17 +74835,17 @@ aaa
 aaa
 aaa
 aaa
-mZE
-mZE
-mZE
-mZE
-mZE
-mZE
-mZE
-mZE
-mZE
-mZE
-mZE
+fon
+fon
+fon
+fon
+fon
+fon
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -78868,31 +75078,31 @@ aaa
 aaa
 aaa
 aaa
-mZE
-mZE
-mZE
-mZE
-mZE
-mZE
-mZE
-mZE
-mZE
-mZE
-mZE
-mZE
-mZE
-mZE
-mZE
-mZE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-mZE
-mZE
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aht
+aht
+aht
+aht
+aht
+aht
+fon
+fon
+fon
+fon
+fon
 aaa
 aaa
 aaa
@@ -79125,32 +75335,32 @@ aaa
 aaa
 aaa
 aaa
-mZE
-mZE
-mZE
-mZE
-mZE
-mZE
-mZE
-mZE
-mZE
-mZE
-mZE
-mZE
-mZE
-mZE
-mZE
-mZE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-mZE
-mZE
 aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+fon
+fon
+aem
+aem
+aem
+aem
+aem
+aht
+aht
+aht
+pny
+aht
+aht
+fon
 aaa
 aaa
 aaa
@@ -79382,32 +75592,32 @@ aaa
 aaa
 aaa
 aaa
-mZE
-mZE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-mZE
-mZE
 aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+fon
+fon
+fon
+fon
+fon
+fon
+aht
+aht
+aem
+jia
+jMl
+kTE
+aem
+aem
+afG
+aem
+aem
+aem
+aht
+fon
 aaa
 aaa
 aaa
@@ -79639,32 +75849,32 @@ aaa
 aaa
 aaa
 aaa
-mZE
-mZE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-mZE
-mZE
 aaa
+aaa
+aaa
+aaa
+aaa
+fon
+aht
+aht
+aht
+aht
+eSB
+aht
+aht
+aht
+aem
+jiV
+jiV
+kTE
+agy
+lTQ
+ncM
+oco
+ovc
+aem
+aht
+fon
 aaa
 aaa
 aaa
@@ -79896,33 +76106,33 @@ aaa
 aaa
 aaa
 aaa
-mZE
-mZE
-ycE
-ycE
-ycE
-ycE
-ycE
-aem
-aem
-aem
-aem
-ycE
-aem
-aem
-aem
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-mZE
-mZE
 aaa
 aaa
+aaa
+aaa
+fon
+aht
+aht
+aem
+aem
+aem
+aem
+afG
+aem
+aem
+aem
+agy
+jPQ
+agy
+agy
+lUw
+ncM
+oeQ
+oeQ
+aem
+aht
+fon
+fon
 afU
 agi
 agi
@@ -80013,7 +76223,7 @@ bLr
 bMw
 bNx
 bNw
-bOw
+sKG
 bOw
 bOw
 bOw
@@ -80151,35 +76361,35 @@ aaa
 aaa
 aaa
 aaa
-mZE
-mZE
-mZE
-mZE
-ycE
-ycE
-ycE
-ycE
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+fon
+aht
 aem
 aem
-aah
-aig
-aig
-aig
-aig
-aig
+cMk
+dUt
+faI
+fJq
+gTP
+hue
 agy
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-mZE
-mZE
+jkW
+jsf
+kUq
+ftO
+lXc
+ney
+ohQ
+pvl
+boA
+aht
 aaa
-aaa
+aht
 afU
 szG
 sOC
@@ -80270,10 +76480,10 @@ mSY
 bMw
 bNy
 bNw
-bOw
+sKG
 bQh
-bOw
-bOw
+sKG
+sKG
 bOw
 bSm
 bOw
@@ -80408,35 +76618,35 @@ aaa
 aaa
 aaa
 aaa
-mZE
-mZE
-mZE
-mZE
-ycE
-ycE
-ycE
-ycE
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+fon
+aTG
 aem
 aah
-aah
-aig
-aig
-aig
-aig
-aig
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-mZE
-aaa
-aaa
-aaa
+cPc
+eca
+feH
+fJx
+feH
+hFy
+iEH
+jsf
+jWW
+jsf
+lKw
+lXc
+nfk
+ojn
+pvq
+aem
+aht
+aht
+aht
 afU
 lem
 mzl
@@ -80531,8 +76741,8 @@ bNs
 bNs
 bNs
 bNs
-bOw
-bOw
+sKG
+sKG
 bOw
 bOw
 bQg
@@ -80663,37 +76873,37 @@ aaa
 aaa
 aaa
 aaa
-mZE
-mZE
-mZE
-mZE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-aem
-aah
-aah
-aig
-aig
-aig
-aig
-aig
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+fon
+aht
+azG
+boC
+boC
+ecj
+fkz
+fON
+gVH
+hFy
 agy
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-mZE
+jwm
+jYk
+jsf
+lKw
+lXc
+nfB
+olO
+ovc
+aem
+aht
 aaa
-aaa
-aaa
+aht
 afU
 agj
 agv
@@ -80789,8 +76999,8 @@ bQi
 bQR
 bNs
 bNs
-bOw
-bOw
+sKG
+sKG
 bOw
 bOw
 bQg
@@ -80798,9 +77008,9 @@ bOw
 bOw
 bOw
 bOw
-bOw
-bUC
-bOw
+sKG
+sQi
+sKG
 bQg
 cbR
 bXJ
@@ -80920,37 +77130,37 @@ aaa
 aaa
 aaa
 aaa
-mZE
-mZE
-mZE
-mZE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+fon
+fon
+fon
+aht
 aem
-aah
-aah
-aig
-aig
-aig
-aig
-aig
+bpI
+cPn
+eca
+fkG
+fRc
+feH
+hFy
 agy
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-mZE
-mZE
-aaa
-aaa
-aaa
+jwo
+jYW
+jsf
+lKw
+lXc
+nfB
+oeQ
+oeQ
+aem
+aht
+aht
+aht
 afU
 afU
 agw
@@ -81038,7 +77248,7 @@ tbF
 aZx
 bIY
 bLs
-bcX
+aZx
 bNB
 bMy
 abI
@@ -81175,39 +77385,39 @@ aaa
 aaa
 aaa
 aaa
-mZE
-mZE
-mZE
-mZE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+fon
+aht
+aht
+aht
+aht
 aem
 aem
-aah
-aig
-aig
-aig
-aig
-aig
+cPx
+ehK
+fnl
+fTo
+fnl
+hUl
 agy
-ycE
-ycE
-ycE
+jCM
+kdo
+kUE
 agy
-ycE
-ycE
-ycE
-mZE
-mZE
+lYx
+nfB
+ovc
+ovc
+aem
+aht
 aaa
-aaa
-aaa
+aht
 afX
 agl
 agx
@@ -81432,34 +77642,34 @@ aaa
 aaa
 aaa
 aaa
-mZE
-mZE
-mZE
-mZE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+fon
+aht
 aem
 aem
+aem
+aem
+aem
 agy
 agy
-apu
-aig
-apu
+ftO
+gbM
+eNc
 agy
 agy
 agy
-aig
+khD
 agy
 agy
-bEL
-ycE
-bEL
+cor
+noC
+eNc
 aem
 aem
 aem
@@ -81689,36 +77899,36 @@ aaa
 aaa
 aaa
 aaa
-mZE
-mZE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-aig
-aig
-aig
-aig
-aig
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+fon
+aht
+aem
+azL
+aWm
 agy
-aig
-aig
-aig
-aig
-aig
-aig
+bxP
+cUu
+enN
+enN
+gca
+enN
+cUu
+enN
+enN
+kjy
+agy
+cUu
+enN
+gca
+enN
+cUu
+pJX
 bMQ
 afn
 aeT
@@ -81730,7 +77940,7 @@ gsF
 dCE
 vqV
 aib
-aiB
+ago
 ajc
 agy
 akB
@@ -81946,48 +78156,48 @@ aaa
 aaa
 aaa
 aaa
-mZE
-mZE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+fon
+aht
+aem
+azZ
+bbv
+bcs
+byp
+vbG
 aig
 aig
+dcp
 aig
 aig
+vbG
 aig
+koU
 agy
 aig
 bFY
+noE
+gVH
 aig
-aig
-aig
-aig
-aig
+pLr
+pLr
 agy
 afC
 mbU
 eiL
 agy
-aae
+juv
 nqY
 nqY
 nqY
 aib
-aiB
+ago
 ajc
 agy
 akC
@@ -82203,48 +78413,48 @@ aaa
 aaa
 aaa
 aaa
-mZE
-mZE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+fon
+aht
+aem
+aAr
+bbv
+agy
+byr
+cWb
+vbG
 aig
+dcp
 aig
-aig
-aig
-aig
-aig
+vbG
+iMx
+vbG
+koU
+bEL
 aig
 bFY
+dcp
 aig
 aig
 aig
+qio
+agy
+qTM
 aig
-aig
-afo
-aig
-dOw
 aga
-agz
+agy
 npo
 nqY
 nqY
 nqY
 aib
-aiB
+ago
 ajc
 agy
 akD
@@ -82460,48 +78670,48 @@ aaa
 aaa
 aaa
 aaa
-mZE
-mZE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+fon
+aht
+aem
+agy
+agy
+agy
+bMR
+cYF
 aig
 aig
+gvS
+ark
+ibA
+cYF
 aig
-aig
-aig
-aig
+koU
+kWw
 aig
 bFY
-aig
+nqT
 aig
 bJA
 aig
-bMR
-agy
+aig
+qLf
 afE
 ark
 aig
-agy
+qXb
 agK
-nqY
-nqY
-nqY
+rlD
+rlL
+rnG
 aib
-aiE
+qVX
 agy
 agy
 akE
@@ -82717,37 +78927,37 @@ aaa
 aaa
 aaa
 aaa
-mZE
-mZE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-aig
-aig
-aig
-aig
-aig
-aig
-aig
-bFY
-aig
-aig
-aig
-aig
-aig
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+fon
+aht
+aem
+azL
+bbT
+agy
+byp
+dci
+enT
+fvX
+gAr
+hcf
+iid
+enT
+enT
+kul
+kZm
+enT
+mcP
+nxz
+gLY
+enT
+iRm
+qwm
 afq
 aiG
 agb
@@ -82755,22 +78965,22 @@ aiG
 agA
 efs
 tLv
-nqY
+rmD
 pzx
 aib
-aig
+ago
 ajf
 ajL
-avB
-aon
+rKv
+rKv
 amd
 amP
 any
-avB
-avB
-avB
-avB
-aon
+rKv
+rKv
+rKv
+rKv
+rKv
 asu
 atv
 aux
@@ -82974,48 +79184,48 @@ aaa
 aaa
 aaa
 aaa
-mZE
-mZE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+fon
+aht
+aem
+azZ
+bbv
+bcs
+byp
+dcp
+aig
+aig
+cYF
 aig
 aig
 aig
 aig
-aig
+koU
 agy
 aig
 bFY
 aig
+arl
 aig
+koU
 aig
+qTw
 aig
+arl
 aig
-agy
-afG
-eSB
-eSB
-agy
-aig
+riD
+byp
 agZ
 aho
 ahG
 aid
-aiG
+rFY
 aje
 ajK
 akG
@@ -83028,7 +79238,7 @@ asv
 asv
 aqm
 asv
-asv
+rYC
 atw
 atI
 avt
@@ -83133,7 +79343,7 @@ cfN
 cfN
 xYV
 cjm
-koE
+aht
 aaa
 aaa
 aaa
@@ -83231,51 +79441,51 @@ aaa
 aaa
 aaa
 aaa
-mZE
-mZE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-aig
-aig
-aig
-aig
-aig
-aig
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+fon
+aht
+aem
+aAr
+bbv
 agy
+bNV
+dcp
 aig
-aig
-aig
-aig
-aig
-aig
-aig
+fxz
+eKN
+eKN
+eKN
+iOi
+eKN
+iVl
+agy
+eKN
+eKN
+eKN
+eKN
+pxw
+iVl
+qzM
 agy
 afH
 aeH
 lkz
 agy
-npo
+rjC
 aha
-ahp
+nqY
 ahH
 nqY
-aig
+ago
 ajf
 ajL
-aqr
+art
 amR
 amf
 amR
@@ -83390,8 +79600,8 @@ cfN
 cfN
 qWo
 cjm
-cjm
-koE
+aht
+aht
 aaa
 aaa
 aaa
@@ -83488,33 +79698,33 @@ aaa
 aaa
 aaa
 aaa
-mZE
-mZE
-mZE
-mZE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+fon
+aht
+aem
 agy
 agy
-bzV
+agy
+bXT
+dcp
+aig
+fzv
+agy
+hcS
+iiX
+agy
+agy
+kxv
 agy
 agy
 bIr
-bIs
+nze
 bIr
 aem
 bKF
@@ -83527,9 +79737,9 @@ agy
 agN
 dLt
 nqY
-ahI
 nqY
-aiB
+nqY
+ago
 agy
 ajM
 akI
@@ -83646,8 +79856,8 @@ bNE
 xYV
 qWo
 lxI
-xVt
 cjm
+aht
 aht
 aaa
 aaa
@@ -83745,30 +79955,30 @@ aaa
 aaa
 aaa
 aaa
-mZE
-mZE
-mZE
-mZE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+fon
+aht
+aem
+azL
+aWm
+agy
+byp
+dcp
+vbG
+fBH
+agy
+hfp
+bbv
 agy
 bzV
-bzV
-bzV
+kxC
+lcU
 agy
 bIs
 bJy
@@ -83783,9 +79993,9 @@ ago
 agy
 uMQ
 jNW
-aig
-ahJ
-aig
+nqY
+nqY
+nqY
 aiJ
 agy
 ajN
@@ -83902,9 +80112,9 @@ cjm
 cjm
 cjm
 cjm
-eNc
-pia
 cjm
+cjm
+aht
 aht
 aaa
 aaa
@@ -84004,28 +80214,28 @@ aaa
 aaa
 aaa
 aaa
-mZE
-mZE
-mZE
-mZE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
+aaa
+aaa
+aaa
+aaa
+aaa
+fon
+aht
+aem
+azZ
+bbv
+bcs
+byp
+dcp
+vbG
+fGY
+agy
+hfp
+ioG
 agy
 bzV
-bzV
-bzV
+kzd
+llv
 agy
 bJv
 bJz
@@ -84040,10 +80250,10 @@ agp
 agC
 ahm
 aag
-aem
-ahK
+aig
+aig
 aih
-aiB
+ago
 agy
 ajO
 akK
@@ -84158,10 +80368,10 @@ fon
 aht
 aht
 aht
-cjm
-cjm
-cjm
-cjm
+aht
+aht
+aht
+aht
 aht
 aaa
 aaa
@@ -84261,28 +80471,28 @@ aaa
 aaa
 aaa
 aaa
-mZE
-mZE
-mZE
-mZE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
+aaa
+aaa
+aaa
+aaa
+aaa
+fon
+aht
+aem
+aAr
+bbv
 agy
-bzV
-bzV
-bzV
+byp
+dcp
+vbG
+fGY
+agy
+hfp
+ipj
+agy
+jDZ
+kDR
+lrk
 agy
 agy
 agy
@@ -84297,7 +80507,7 @@ qVX
 agy
 juv
 aig
-aem
+aig
 ahL
 ahL
 ahL
@@ -84311,7 +80521,7 @@ amX
 amX
 aoT
 apK
-aqr
+aqp
 aon
 nkF
 atD
@@ -84520,32 +80730,32 @@ aaa
 aaa
 aaa
 aaa
-mZE
-mZE
-mZE
-mZE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-agy
-bzV
-bzV
-bzV
-agy
-apu
-apu
-apu
+aaa
+aaa
+aaa
+fon
+aqb
 aem
-bKG
+agy
+agy
+agy
+byp
+dcp
+epJ
+fIo
+agy
+hfp
+ipu
+agy
+jEd
+kJw
+lrk
+agy
+mor
+nAK
+oxy
+aem
+pTF
 vbG
 iPH
 vbG
@@ -84775,32 +80985,32 @@ aaa
 aaa
 aaa
 aaa
-mZE
-mZE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
+aaa
+aaa
+aaa
+aaa
+aaa
+fon
+aht
+aem
+azL
+aWm
+agy
+cdf
+dop
+eqA
 agy
 agy
 agy
-apu
+agy
+agy
+agy
+agy
+luY
 agy
 apu
-apu
-apu
+nEl
+oFf
 aem
 bMP
 vbG
@@ -84829,7 +81039,7 @@ aqt
 arm
 cCO
 qPT
-sCk
+sdk
 avy
 awK
 wNj
@@ -85032,35 +81242,35 @@ aaa
 aaa
 aaa
 aaa
-mZE
-mZE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
+aaa
+aaa
+aaa
+aaa
+aaa
+fon
+aht
+aem
+azZ
+bbv
+bcs
+byp
+dcp
+ago
 agy
-apu
-apu
-apu
-apu
-apu
+gGy
+hiw
+ipP
+gGy
+gGy
+agy
+lEY
+lMU
+mwa
+nPq
+oGN
 aem
 aem
-bNV
+aem
 aem
 aem
 aem
@@ -85084,9 +81294,9 @@ aoW
 apM
 aqu
 arn
-dtd
+rZi
 atC
-auA
+sfB
 avz
 awJ
 wNj
@@ -85289,38 +81499,38 @@ aaa
 aaa
 aaa
 aaa
-mZE
-mZE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
+aaa
+aaa
+aaa
+aaa
+aaa
+fon
+aht
+aem
+aAr
+bbv
 agy
-apu
-apu
-apu
-apu
-apu
-byr
-ycE
-ycE
-ycE
-ycE
-cLq
+byp
+dcp
+eAy
+agy
+gIo
+hoC
+iqx
+hoC
+jIn
+agy
+lGd
+lOU
+mwg
+nRs
+oMR
+aem
+aht
+fon
+aaa
+aaa
+aht
 aaa
 agP
 dBd
@@ -85343,7 +81553,7 @@ aqp
 arp
 nkF
 atD
-auz
+sge
 avA
 keD
 wNj
@@ -85423,7 +81633,7 @@ bWj
 bWZ
 bXS
 bva
-bNX
+bQT
 bva
 cab
 jPf
@@ -85546,38 +81756,38 @@ aaa
 aaa
 aaa
 aaa
-mZE
-mZE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
+aaa
+aaa
+aaa
+aaa
+aaa
+fon
+aht
+aem
+agy
+agy
+agy
+byp
+dcp
+eFR
+agy
+gJF
+gJF
+hoC
+iQz
+gJF
 agy
 agy
 agy
 agy
 agy
 agy
-byr
-ycE
-ycE
-ycE
-ycE
-cLq
+aem
+aht
+fon
+aaa
+aaa
+aht
 wHu
 agP
 ahq
@@ -85803,38 +82013,38 @@ aaa
 aaa
 aaa
 aaa
-mZE
-mZE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
+aaa
+aaa
+aaa
+aaa
+aaa
+fon
+aht
+aem
+azL
+aWm
+agy
+cil
+dcp
+eGB
 agy
 agy
 agy
-bEM
-bEM
-bEM
-bEM
-bEM
-byr
-ycE
-ycE
-cLq
-cLq
-rmD
+isH
+agy
+agy
+agy
+lGA
+lPt
+mxc
+mCD
+pdq
+aem
+aht
+fon
+aht
+aht
+fon
 abI
 agP
 upd
@@ -86060,38 +82270,38 @@ aaa
 aaa
 aaa
 aaa
-mZE
-mZE
+aaa
+aaa
+aaa
 ycE
 ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
+fon
+aht
+aem
+azZ
+bbv
+bcs
+byp
+dcp
+eKC
+enN
+enN
+enN
+enN
+enN
+enN
 bEL
+lIi
 bEM
-bEM
-bEM
-bEM
-bEM
-byr
-ycE
-ycE
-cLq
-ycE
-rmD
+mCD
+nSr
+pfY
+aem
+aht
+fon
+aht
+aaa
+fon
 aaa
 agP
 cnJ
@@ -86317,35 +82527,35 @@ aaa
 aaa
 aaa
 aaa
-mZE
-mZE
 aaa
 aaa
-mZE
-mZE
 ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-bEM
-bEM
-bEM
-bEM
-bEM
-bEM
-shH
-mZE
-mZE
+aht
+aht
+aht
+aht
+aem
+aAr
+bbv
+agy
+bMR
+dBT
+enT
+fIN
+gLY
+enT
+enT
+iRm
+enT
+kJx
+lJY
+lRM
+mJX
+mCD
+pia
+aem
+qbV
+fon
 aht
 aaa
 aby
@@ -86576,33 +82786,33 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-mZE
-mZE
 ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-bEL
+aht
+aht
+aem
+aem
+aem
+aem
+aem
+aem
+cnV
+dDo
+eKN
+fJn
+gMP
+eKN
+eKN
+iVl
+eKN
+kML
 bEM
 bEM
 bEM
 bEM
-bEM
-shH
-mZE
-mZE
+pkg
+aem
+aht
+fon
 aht
 aaa
 aby
@@ -86617,8 +82827,8 @@ agP
 ajm
 alE
 dxC
-anM
-alE
+rLi
+rNl
 anc
 anM
 aou
@@ -86832,35 +83042,35 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-mZE
-mZE
 ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
+aht
+aht
+aem
+aem
+ajX
+ajX
+alD
+alD
+aem
+cor
+dKx
+eNc
 aem
 aem
 aem
-aOe
+aem
+iVw
 aem
 aem
-bEM
-bEM
-bEM
-bEM
-bEM
-shH
-mZE
-aaa
-koE
+lKk
+lKk
+mLU
+nSt
+plA
+aem
+aht
+fon
+aht
 aaa
 aby
 aaa
@@ -87089,24 +83299,24 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-mZE
-mZE
 ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
+aht
+aem
+aem
+ajX
+aqe
+alD
+aqe
+alD
+bmq
+aiK
+aGC
+ajX
+ajX
 aem
 aKp
 aOe
-aOe
+jfc
 bBV
 aem
 aem
@@ -87114,11 +83324,11 @@ aem
 aem
 aem
 aem
-shH
-mZE
-aaa
-koE
-koE
+aem
+aht
+fon
+aht
+aht
 aby
 abI
 agP
@@ -87132,7 +83342,7 @@ ajo
 alE
 ajV
 hki
-alE
+rRM
 cCL
 alC
 aow
@@ -87346,34 +83556,34 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-mZE
-mZE
 ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
+aht
+aem
+ahO
+alD
+alD
+alD
+alD
+aiK
+aiK
+aiK
+aGC
+ajX
+ajX
 aem
 aKp
-boD
+aOe
 boD
 bDf
-shH
-mZE
-mZE
-mZE
-mZE
-mZE
-aaa
-aaa
-aaa
+aem
+aht
+aht
+mTk
+aht
+aht
+aht
+aht
+fon
 aaa
 aaa
 aby
@@ -87475,7 +83685,7 @@ bPC
 bDi
 bva
 bPA
-uwH
+bSw
 bSw
 nNJ
 bDi
@@ -87603,33 +83813,33 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-mZE
-mZE
 ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
+aht
+afG
+aiK
+amo
+ara
+ara
+ara
+ara
+ara
+czx
+aGC
+aiK
+ajX
 aem
 aKp
-boD
-boD
-boD
-shH
-mZE
-mZE
-mZE
-mZE
-mZE
-aaa
-aaa
+aOe
+jgH
+jIO
+aem
+fon
+fon
+fon
+fon
+fon
+fon
+fon
 aaa
 aaa
 aaa
@@ -87647,7 +83857,7 @@ ajZ
 akR
 alG
 amr
-anf
+anO
 anO
 aoy
 apf
@@ -87860,26 +84070,26 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-mZE
-mZE
 ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
+aht
+agz
+ajW
+anq
+ajW
+ajW
+aAV
+ajW
+ajW
+cHS
+dOw
+aiK
+eNz
 aem
 aem
-byr
-byr
-byr
-byr
+aem
+aem
+aem
+aem
 aaa
 aaa
 aaa
@@ -88117,25 +84327,25 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-mZE
-mZE
 ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-mZE
-mZE
-aaa
+aht
+ahK
+ajX
+aoJ
+ask
+ask
+aCa
+ask
+ask
+cLq
+aiK
+ajX
+eNz
+eNz
+eNz
+eNz
+eNz
+fon
 aaa
 aaa
 aaa
@@ -88232,7 +84442,7 @@ bFN
 bGU
 bIb
 bJn
-bKs
+sGr
 bKs
 bMI
 bNQ
@@ -88374,25 +84584,25 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-mZE
-mZE
 ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-mZE
-mZE
-aaa
+aht
+aem
+ajY
+ajX
+aiK
+aiK
+aGC
+aiK
+aiK
+aiK
+ajX
+ajX
+eNz
+eNz
+eNz
+eNz
+shH
+fon
 aaa
 aaa
 aaa
@@ -88631,25 +84841,25 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-mZE
-mZE
 ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-ycE
-mZE
-mZE
-aaa
+afo
+aem
+aem
+alD
+alD
+azI
+aGC
+azI
+aiK
+aiK
+ajX
+eNz
+eNz
+eNz
+eNz
+eNz
+aht
+fon
 aaa
 aaa
 aaa
@@ -88689,7 +84899,7 @@ avK
 auH
 axP
 ayU
-aAr
+axO
 aBj
 aCx
 oyF
@@ -88752,7 +84962,7 @@ bMJ
 bEr
 bEr
 bPA
-bNX
+bQT
 bQX
 bKH
 bKH
@@ -88888,24 +85098,24 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-mZE
-mZE
-mZE
-mZE
-mZE
-mZE
-mZE
-mZE
-mZE
-mZE
-mZE
-mZE
-mZE
-mZE
-mZE
+ycE
+aht
+aht
+aem
+aem
+ayy
+alD
+aGC
+alD
+alD
+cLt
+ajX
+eNz
+eNz
+eNz
+aem
+aht
+fon
 aaa
 aaa
 aaa
@@ -89146,23 +85356,23 @@ aaa
 aaa
 aaa
 aaa
+ycE
+aht
+aht
+aem
+azG
+azJ
+aIr
+azJ
+boA
+aem
+aem
+eNz
+aem
+fon
+fon
+fon
 aaa
-aaa
-mZE
-mZE
-mZE
-mZE
-mZE
-mZE
-mZE
-mZE
-mZE
-mZE
-mZE
-mZE
-mZE
-mZE
-mZE
 aaa
 aaa
 aaa
@@ -89403,18 +85613,18 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+ycE
+aht
+aht
+aht
+aht
+aht
+aht
+aht
+aht
+aht
+aht
+aht
 aaa
 aaa
 aaa
@@ -89661,16 +85871,16 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+ycE
+ali
+ali
+ali
+ali
+ali
+ali
+ali
+ali
+ali
 aaa
 aaa
 aaa
@@ -90285,8 +86495,8 @@ bLJ
 bDs
 bEA
 bFS
+suV
 bLJ
-bCn
 bJo
 bzU
 bLJ
@@ -90303,7 +86513,7 @@ bPB
 bUI
 bVE
 bVE
-bXf
+bXg
 bUH
 bYI
 jrG
@@ -90492,7 +86702,7 @@ aAx
 aBo
 aCB
 aDF
-aAt
+aBm
 aFy
 aGl
 awR
@@ -90542,9 +86752,9 @@ bCo
 buf
 bEB
 bwK
-buf
 bIh
-byp
+sCA
+buf
 bKz
 bnH
 aRV
@@ -90749,7 +86959,7 @@ aAy
 aBp
 aCC
 aDG
-aBm
+aAt
 aFz
 aGm
 awR
@@ -90800,8 +87010,8 @@ cqd
 bug
 cqm
 bHa
+sDI
 cqd
-bJp
 cqd
 bLK
 bMM
@@ -91319,7 +87529,7 @@ bJr
 bKB
 krC
 bFU
-bDi
+bQT
 hZB
 bPD
 bPB
@@ -93646,7 +89856,7 @@ bVM
 bWy
 bXo
 bYi
-bYV
+bYW
 bZD
 cam
 ccW
@@ -101564,7 +97774,7 @@ aYw
 aYw
 aYw
 aZo
-aTm
+skm
 bbH
 bcA
 bdF
@@ -102078,7 +98288,7 @@ aTm
 aaf
 aTm
 aZo
-wDZ
+ssO
 bbH
 bcC
 bdH
@@ -104104,14 +100314,14 @@ aiS
 akn
 atn
 atn
-avm
-avm
-axy
-avm
+atn
 avm
 axy
 avm
 avm
+axy
+avm
+atn
 atn
 atn
 aFM
@@ -104469,7 +100679,7 @@ cju
 ckK
 cju
 ckK
-ckK
+sYN
 ckK
 ckK
 cju
@@ -105253,7 +101463,7 @@ cju
 cju
 ckK
 ckK
-ckK
+sYN
 ckK
 ckK
 cju
@@ -105646,14 +101856,14 @@ aiS
 akn
 atn
 atn
-avm
-avm
-vzz
-avm
+atn
 avm
 vzz
 avm
 avm
+vzz
+avm
+atn
 atn
 atn
 aEj
@@ -106213,7 +102423,7 @@ bkF
 bkF
 bkF
 bkF
-bxP
+lTb
 nev
 bwm
 bEf
@@ -106293,7 +102503,7 @@ cju
 ckK
 ckK
 cju
-cjx
+tap
 cnp
 cnq
 cju
@@ -107299,13 +103509,13 @@ ckK
 cju
 cju
 ckK
-ckK
+sYN
 ckK
 ckK
 ckK
 cju
 cju
-ckK
+sYN
 ckK
 ckK
 cju


### PR DESCRIPTION
## About The Pull Request

Pubby rework for your health

## Why It's Good For The Game

Pubby needed some attention, and this should be a good starting point. The map is generally unmaintained across most codebases, so a good little spring cleaning and facelift is in order. The biggest change is the new Perma, since I adamantly dislike copy-pasting entire swathes of stations unless needed.

## Changelog
:cl:
tweak: updated decals
tweak: new perma (same as the one proposed)
add: asteroid moss in some spots
tweak: HoS pet is now the long-awaited (by me alone) McChonks
add: Captain didn't have a pet so I gave him a Simbu
add: garbage piles to maint
add: more telephones to heads and such
tweak: Laundry room now has more laundry and room
del: kinkmate (there is a singular hidden one on the station now)
tweak: Warden Office gets a little shuffle
add: shooting range to Sec Equip
del: shooting range in maint
del: recovery room in Medbay, door goes directly into Surgery
/:cl: