### PR TITLE
The start of a new round is now announced in discord + some other commands

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -336,6 +336,7 @@ SUBSYSTEM_DEF(ticker)
 	var/list/adm = get_admin_counts()
 	var/list/allmins = adm["present"]
 	send2irc("Server", "Round [GLOB.round_id ? "#[GLOB.round_id]:" : "of"] [hide_mode ? "secret":"[mode.name]"] has started[allmins.len ? ".":" with no active admins online!"]")
+	world.TgsTargetedChatBroadcast("Round #[GLOB.round_id] has begun on [SSmapping.config.map_name].", FALSE)
 	setup_done = TRUE
 
 	for(var/i in GLOB.start_landmarks_list)

--- a/code/modules/admin/chat_commands.dm
+++ b/code/modules/admin/chat_commands.dm
@@ -28,7 +28,7 @@
 		return
 	last_irc_check = rtod
 	var/server = CONFIG_GET(string/server)
-	return "[GLOB.round_id ? "Round #[GLOB.round_id]: " : ""][GLOB.clients.len] players on [SSmapping.config.map_name]; Round [SSticker.HasRoundStarted() ? (SSticker.IsRoundInProgress() ? "Active" : "Finishing") : "Starting"] -- [server ? server : "[world.internet_address]:[world.port]"]"
+	return "[GLOB.round_id ? "Round #[GLOB.round_id]: " : ""][GLOB.clients.len] players on [SSmapping.config.map_name]; Round [SSticker.HasRoundStarted() ? (SSticker.IsRoundInProgress() ? "Active" : "Finishing") : "Starting"], Round Time: [DisplayTimeText(world.time - SSticker.round_start_time, 1)] -- [server ? server : "[world.internet_address]:[world.port]"]"
 	//CIT CHANGE obfuscates the gamemode for TGS bot commands on discord by removing Mode:[GLOB.master_mode]
 /datum/tgs_chat_command/ahelp
 	name = "ahelp"

--- a/modular_lumos/code/modules/tgs/chatcommands.dm
+++ b/modular_lumos/code/modules/tgs/chatcommands.dm
@@ -1,0 +1,25 @@
+/datum/tgs_chat_command/who
+	name = "who"
+	help_text = "Lists everyone currently on the server"
+	admin_only = FALSE
+
+/datum/tgs_chat_command/who/Run(datum/tgs_chat_user/sender, params)
+	return tgswho()
+
+/datum/tgs_chat_command/awho
+	name = "awho"
+	help_text = "Lists everyone + sneaky admins currently on the server"
+	admin_only = TRUE
+
+/datum/tgs_chat_command/awho/Run(datum/tgs_chat_user/sender, params)
+	return tgsadminwho()
+
+/datum/tgs_chat_command/restart
+	name = "restart"
+	help_text = "Forces a restart on the server"
+	admin_only = TRUE
+
+/datum/tgs_chat_command/restart/Run(datum/tgs_chat_user/sender)
+	to_chat(world, "<span class='boldwarning'>Server restart - Initialized by [sender.friendly_name]</span>")
+	send2irc("Server", "[sender.friendly_name] forced a restart.")
+	return world.TgsEndProcess()

--- a/modular_lumos/code/modules/tgs/custom_procs.dm
+++ b/modular_lumos/code/modules/tgs/custom_procs.dm
@@ -3,7 +3,7 @@
 	var/list/player_keys = list()
 	for(var/player in GLOB.clients)
 		var/client/C = player
-		player_keys += "[C.?holder.fakekey ? "[C.holder.fakekey]" : "[C]"]"
+		player_keys += "[C?.holder.fakekey ? "[C.holder.fakekey]" : "[C]"]"
 
 	for(var/verified_player in player_keys)
 		message += "- [verified_player]\n"

--- a/modular_lumos/code/modules/tgs/custom_procs.dm
+++ b/modular_lumos/code/modules/tgs/custom_procs.dm
@@ -1,0 +1,41 @@
+/proc/tgswho()
+	var/list/message = list("Players: \n")
+	var/list/player_keys = list()
+	for(var/player in GLOB.clients)
+		var/client/C = player
+		player_keys += "[C.holder.fakekey ? "[C.holder.fakekey]" : "[C]"]"
+
+	for(var/verified_player in player_keys)
+		message += "- [verified_player]\n"
+
+	return jointext(message, "")
+
+/proc/tgsadminwho()
+	var/list/full_message = list("Connected clients: \n")
+	var/list/message = list("Players: \n")
+	var/list/message_admin = list("Admins: \n")
+	var/list/player_keys = list()
+	var/list/admin_keys = list()
+	for(var/player in GLOB.clients)
+		var/client/C = player
+		player_keys += "[C]"
+
+	for(var/verified_player in player_keys)
+		message += "- [verified_player]\n"
+
+	for(var/adm in GLOB.admins)
+		var/client/C = adm
+		admin_keys += "[C.holder.fakekey ? "[C] disguised as [C.holder.fakekey]" : "[C]"]"
+
+	for(var/verified_admin in admin_keys)
+		message_admin += "- [verified_admin]\n"
+
+	if(message_admin)
+		var/finished_admin_message = "[jointext(message_admin, "")]"
+		full_message += finished_admin_message
+
+	if(message)
+		var/finished_message = "[jointext(message, "")]"
+		full_message += finished_message
+
+	return jointext(full_message, "")

--- a/modular_lumos/code/modules/tgs/custom_procs.dm
+++ b/modular_lumos/code/modules/tgs/custom_procs.dm
@@ -3,7 +3,7 @@
 	var/list/player_keys = list()
 	for(var/player in GLOB.clients)
 		var/client/C = player
-		player_keys += "[C.holder.fakekey ? "[C.holder.fakekey]" : "[C]"]"
+		player_keys += "[C.?holder.fakekey ? "[C.holder.fakekey]" : "[C]"]"
 
 	for(var/verified_player in player_keys)
 		message += "- [verified_player]\n"

--- a/modular_lumos/code/modules/tgs/custom_procs.dm
+++ b/modular_lumos/code/modules/tgs/custom_procs.dm
@@ -1,5 +1,5 @@
 /proc/tgswho()
-	var/list/message = list("Players: \n")
+	var/list/message = list("[GLOB.clients.len] Players: \n")
 	var/list/player_keys = list()
 	for(var/player in GLOB.clients)
 		var/client/C = player
@@ -11,7 +11,7 @@
 	return jointext(message, "")
 
 /proc/tgsadminwho()
-	var/list/full_message = list("Connected clients: \n")
+	var/list/full_message = list("[GLOB.clients.len] Connected clients: \n")
 	var/list/message = list("Players: \n")
 	var/list/message_admin = list("Admins: \n")
 	var/list/player_keys = list()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3597,6 +3597,8 @@
 #include "modular_lumos\code\modules\research\techweb\nodes\weaponry_nodes.dm"
 #include "modular_lumos\code\modules\research\xenobiology\crossbreeding\warping.dm"
 #include "modular_lumos\code\modules\respawn\respawnrequest.dm"
+#include "modular_lumos\code\modules\tgs\chatcommands.dm"
+#include "modular_lumos\code\modules\tgs\custom_procs.dm"
 #include "modular_lumos\plushes\plushes.dm"
 #include "modular_skyrat\_DEFINES\role_preferences.dm"
 #include "modular_skyrat\code\_DEFINES\access.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Admins were notified when the round begun via discord, but not players for some reason. This fixes that. Also ports who, awho and restart commands from https://github.com/Sandstorm-Station/Sandstorm-Station-13/pull/58 that I found.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Players should know when a round starts as well :)
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: The start of a new round is now announced in discord
add: Added a who command to the bot from discord (and an admin variant)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
