### PR TITLE
Relayers all of snaxi's pipes + adds beautifications and new xenoarch 

### DIFF
--- a/_maps/map_files/Snaxi/IcemoonUnderground_Above_Lumos.dmm
+++ b/_maps/map_files/Snaxi/IcemoonUnderground_Above_Lumos.dmm
@@ -46,13 +46,15 @@
 	},
 /area/icemoon/underground/unexplored/rivers)
 "au" = (
-/obj/effect/turf_decal/trimline/purple/filled/line,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/effect/turf_decal/tile/neutral{
+/obj/structure/table,
+/obj/item/strangerock,
+/obj/machinery/light,
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel/median/whitetodark/fullcorner{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
 "aw" = (
 /obj/machinery/door/firedoor/border_only{
@@ -105,6 +107,15 @@
 	},
 /turf/open/floor/plating,
 /area/security/execution/education)
+"aI" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
+	},
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/xenoarch/arch)
 "aJ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -137,9 +148,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"aU" = (
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "aW" = (
 /obj/structure/table_frame,
 /obj/item/storage/box/papersack,
@@ -184,16 +192,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
-"bi" = (
-/obj/machinery/computer/rdconsole/core,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/arch)
 "bj" = (
 /obj/machinery/door/airlock/glass_large,
 /turf/open/floor/plating,
@@ -207,6 +205,11 @@
 "bl" = (
 /turf/closed/wall/r_wall,
 /area/science/storage)
+"bm" = (
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/machinery/light,
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "bo" = (
 /turf/closed/wall/r_wall,
 /area/science/misc_lab)
@@ -234,34 +237,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
-"bz" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/lumos/loading_area/white,
-/obj/structure/railing/corner{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
-"bB" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 4
-	},
-/obj/structure/chair/sofa/corp/left{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "bG" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
@@ -277,17 +252,6 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/primary/port)
-"bV" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 6
-	},
-/obj/structure/table,
-/obj/item/paper_bin{
-	pixel_y = 6
-	},
-/obj/item/pen,
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "bZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
@@ -299,6 +263,13 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/plasteel/cafeteria,
 /area/chapel/main)
+"cb" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/obj/machinery/power/terminal,
+/turf/open/floor/plating,
+/area/xenoarch/arch)
 "cd" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/structure/closet,
@@ -320,16 +291,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"ch" = (
-/obj/machinery/suit_storage_unit/mining,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/arch)
 "ci" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -362,20 +323,12 @@
 /turf/open/floor/plasteel,
 /area/science/circuit)
 "cv" = (
-/obj/structure/table,
-/obj/item/gps/mining{
-	gpstag = "XENOARCH";
-	pixel_x = -6
-	},
-/obj/item/gps/mining{
-	gpstag = "XENOARCH";
-	pixel_x = 6
+/obj/machinery/suit_storage_unit/mining,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
@@ -422,16 +375,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"cG" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel/median/whitetodark{
-	dir = 1
-	},
-/area/xenoarch/arch)
 "cH" = (
 /obj/machinery/mass_driver{
 	dir = 1;
@@ -439,6 +382,21 @@
 	},
 /turf/open/floor/plating,
 /area/science/test_area)
+"cJ" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "cM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
@@ -536,36 +494,22 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/test_area)
-"ds" = (
-/obj/effect/spawner/structure/window/reinforced/tinted/electrochromatic{
-	electrochromatic_id = xenoarch
-	},
-/turf/open/floor/plating,
-/area/xenoarch/arch)
-"dw" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 1
-	},
-/obj/structure/railing/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "dx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
 	},
 /turf/open/floor/plating,
 /area/security/execution/education)
+"dB" = (
+/obj/item/radio/intercom{
+	dir = 4;
+	name = "Station Intercom (General)";
+	pixel_x = 27
+	},
+/turf/open/floor/plasteel/median/whitetodark{
+	dir = 4
+	},
+/area/xenoarch/arch)
 "dC" = (
 /obj/machinery/door/airlock/security/glass{
 	id_tag = null;
@@ -631,6 +575,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/misc_lab)
+"dU" = (
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "dW" = (
 /turf/closed/wall,
 /area/mine/eva)
@@ -643,6 +597,18 @@
 /obj/item/bedsheet/blue,
 /turf/open/floor/plating,
 /area/hallway/primary/aft)
+"ea" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/xenoarch/arch)
 "ec" = (
 /obj/structure/table,
 /obj/item/clothing/glasses/science,
@@ -654,10 +620,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/test_area)
-"eh" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner,
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "ei" = (
 /obj/structure/table,
 /obj/item/pickaxe,
@@ -711,10 +673,6 @@
 /obj/structure/grille/broken,
 /turf/open/floor/plating,
 /area/icemoon/surface/outdoors)
-"eo" = (
-/obj/structure/chair/office/dark,
-/turf/open/floor/plating/asteroid/snow/icemoon,
-/area/xenoarch/arch)
 "eq" = (
 /turf/closed/wall,
 /area/mine/production)
@@ -771,14 +729,6 @@
 	},
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors)
-"ey" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
-	},
-/obj/machinery/space_heater,
-/turf/open/floor/plating,
-/area/xenoarch/arch)
 "eB" = (
 /obj/machinery/firealarm{
 	pixel_y = 24
@@ -887,17 +837,6 @@
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel,
 /area/mine/eva)
-"eU" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/xenoarch/arch)
 "eV" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -1095,6 +1034,44 @@
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"fq" = (
+/obj/structure/chair/office/dark{
+	dir = 1
+	},
+/obj/machinery/newscaster{
+	pixel_x = 32;
+	pixel_y = 1
+	},
+/turf/open/floor/plasteel/median/whitetodark{
+	dir = 4
+	},
+/area/xenoarch/arch)
+"fv" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
+/obj/structure/railing/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/status_display/evac{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
+"fw" = (
+/obj/structure/chair/office/dark{
+	dir = 1
+	},
+/turf/open/floor/plasteel/median/whitetodark{
+	dir = 8
+	},
+/area/xenoarch/arch)
 "fy" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -1187,6 +1164,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/eva)
+"fL" = (
+/obj/machinery/atmospherics/pipe/simple/multiz{
+	piping_layer = 1
+	},
+/turf/open/floor/plating,
+/area/xenoarch/arch)
 "fM" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -1242,6 +1225,10 @@
 /obj/item/clothing/head/cone,
 /turf/open/floor/plating,
 /area/icemoon/surface/outdoors)
+"ga" = (
+/obj/structure/chair/office/dark,
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/xenoarch/arch)
 "gb" = (
 /obj/structure/chair/comfy/black{
 	dir = 8
@@ -1477,6 +1464,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/production)
+"hA" = (
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "hD" = (
 /obj/machinery/button/door{
 	id = "misclab";
@@ -1506,28 +1505,9 @@
 /obj/structure/barricade/wooden/crude/snow,
 /turf/open/floor/plating,
 /area/icemoon/surface/outdoors)
-"hQ" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 6
-	},
-/obj/machinery/vending/cola/random,
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "hS" = (
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors)
-"hV" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "hY" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plasteel,
@@ -1542,18 +1522,6 @@
 	},
 /turf/open/floor/carpet,
 /area/hallway/primary/port)
-"ie" = (
-/obj/effect/turf_decal/trimline/brown/filled/corner{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "ig" = (
 /obj/structure/table,
 /obj/item/stack/sheet/mineral/plasma,
@@ -1637,15 +1605,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/xenoarch/arch)
-"iP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 5
-	},
-/turf/open/floor/plating/asteroid/snow/icemoon,
-/area/xenoarch/arch)
 "iY" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio6";
@@ -1697,10 +1656,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
-"jm" = (
-/obj/effect/turf_decal/trimline/brown,
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "jn" = (
 /obj/machinery/light/small,
 /turf/open/floor/plasteel/dark,
@@ -1741,18 +1696,15 @@
 /obj/machinery/holopad,
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
+"jv" = (
+/obj/machinery/door/firedoor/border_only{
+	name = "south facing firelock"
+	},
+/turf/open/floor/plasteel/stairs/medium,
+/area/xenoarch/arch)
 "jy" = (
 /turf/open/openspace,
 /area/mine/eva)
-"jz" = (
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating,
-/area/xenoarch/arch)
 "jA" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -1765,6 +1717,16 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
 /area/hallway/primary/port)
+"jF" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
+/obj/machinery/quantumpad{
+	map_pad_id = "xenoarch";
+	map_pad_link_id = "miningbase"
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "jH" = (
 /obj/structure/table/reinforced,
 /obj/item/integrated_electronics/analyzer,
@@ -1778,6 +1740,14 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
+"jI" = (
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "jK" = (
 /obj/machinery/door/window/northleft{
 	dir = 2;
@@ -1798,18 +1768,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/eva)
-"jM" = (
-/obj/structure/closet/wardrobe/xenoarch,
-/obj/item/clothing/shoes/winterboots/ice_boots,
-/obj/item/clothing/glasses/meson,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/arch)
 "jN" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -1855,6 +1813,19 @@
 	},
 /turf/open/floor/plasteel/stairs/left,
 /area/chapel/main)
+"ks" = (
+/obj/machinery/door/airlock/research{
+	name = "Xenoarchaeology Lab";
+	req_access_txt = "47"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1;
+	name = "north facing firelock"
+	},
+/turf/open/floor/plasteel/dark,
+/area/xenoarch/arch)
 "ku" = (
 /obj/machinery/portable_atmospherics/canister,
 /obj/effect/turf_decal/bot,
@@ -1894,6 +1865,30 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/science/xenobiology)
+"kM" = (
+/obj/effect/spawner/structure/window/reinforced/tinted/electrochromatic{
+	electrochromatic_id = xenoarch
+	},
+/turf/open/floor/plating,
+/area/xenoarch/arch)
+"kQ" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/plasteel/median/whitetodark{
+	dir = 1
+	},
+/area/xenoarch/arch)
+"kR" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/machinery/space_heater,
+/turf/open/floor/plating,
+/area/xenoarch/arch)
 "kS" = (
 /turf/closed/wall/mineral/iron,
 /area/chapel/main)
@@ -1939,6 +1934,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/icemoon/surface/outdoors)
+"lf" = (
+/obj/structure/table,
+/obj/item/gps/mining{
+	gpstag = "XENOARCH";
+	pixel_x = -6
+	},
+/obj/item/gps/mining{
+	gpstag = "XENOARCH";
+	pixel_x = 6
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/xenoarch/arch)
 "lg" = (
 /obj/structure/stairs,
 /turf/open/floor/plasteel,
@@ -1966,12 +1979,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/storage)
-"ly" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "lB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/cafeteria,
@@ -2009,6 +2016,14 @@
 /obj/structure/frame/machine,
 /turf/open/floor/plating,
 /area/icemoon/surface/outdoors)
+"lM" = (
+/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -6;
+	pixel_y = -31
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "lN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -2044,16 +2059,6 @@
 "lV" = (
 /turf/open/floor/plasteel/grimy,
 /area/chapel/main)
-"lY" = (
-/obj/effect/turf_decal/trimline/brown/filled/line,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "ma" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 5
@@ -2077,6 +2082,22 @@
 /obj/item/storage/box/flashes,
 /turf/open/floor/plating,
 /area/security/execution/education)
+"mf" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/lumos/loading_area/white,
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "mg" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -2184,6 +2205,15 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/misc_lab)
+"mR" = (
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "mS" = (
 /turf/open/floor/plating,
 /area/mine/production)
@@ -2205,18 +2235,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"mW" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/machinery/airalarm{
-	pixel_y = 24
-	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/arch)
 "mY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -2363,6 +2381,11 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"ob" = (
+/turf/open/floor/plasteel/median/whitetodark{
+	dir = 8
+	},
+/area/xenoarch/arch)
 "oc" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -2373,6 +2396,16 @@
 "oe" = (
 /turf/open/floor/plasteel,
 /area/science/circuit)
+"oi" = (
+/obj/effect/turf_decal/trimline/brown/filled/corner,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/xenoarch/arch)
 "oj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -2453,16 +2486,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"oJ" = (
-/obj/machinery/suit_storage_unit/mining,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/arch)
 "oK" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/heater,
 /obj/machinery/light{
@@ -2483,18 +2506,6 @@
 	},
 /turf/open/floor/plating,
 /area/mine/living_quarters)
-"oM" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "oO" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/structure/cable{
@@ -2544,16 +2555,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/production)
-"oY" = (
+"oZ" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
+	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 1
-	},
+/obj/item/kirbyplants/random,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "pc" = (
@@ -2620,16 +2626,6 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/plasteel,
 /area/science/test_area)
-"ps" = (
-/obj/item/radio/intercom{
-	dir = 4;
-	name = "Station Intercom (General)";
-	pixel_x = 27
-	},
-/turf/open/floor/plasteel/median/whitetodark{
-	dir = 4
-	},
-/area/xenoarch/arch)
 "pu" = (
 /obj/machinery/mineral/mint,
 /turf/open/floor/plasteel,
@@ -2663,6 +2659,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
+"pH" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "pJ" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -2672,15 +2674,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/production)
-"pM" = (
-/obj/structure/table,
-/obj/machinery/light,
-/obj/structure/sign/poster/official/random{
-	pixel_x = -32
+"pK" = (
+/obj/structure/railing{
+	dir = 8
 	},
-/turf/open/floor/plasteel/median/whitetodark/fullcorner{
-	dir = 1
+/obj/machinery/door/firedoor/border_only{
+	name = "south facing firelock"
 	},
+/turf/open/floor/plasteel/stairs/left,
 /area/xenoarch/arch)
 "pN" = (
 /obj/structure/table/glass,
@@ -2753,6 +2754,20 @@
 "qm" = (
 /turf/open/floor/plating,
 /area/chapel/main)
+"qo" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/lumos/loading_area/white{
+	dir = 1
+	},
+/obj/structure/railing/corner,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 28
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "qq" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
@@ -2768,6 +2783,14 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/mine/production)
+"qy" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating,
+/area/xenoarch/arch)
 "qz" = (
 /obj/structure/trash_pile,
 /turf/open/floor/plating,
@@ -2792,6 +2815,18 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"qI" = (
+/obj/machinery/door/airlock/research{
+	name = "Xenoarchaeology Equipment Room";
+	req_access_txt = "47"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/door/firedoor/border_only{
+	name = "south facing firelock"
+	},
+/turf/open/floor/plasteel/dark,
+/area/xenoarch/arch)
 "qL" = (
 /obj/machinery/airalarm{
 	pixel_y = 22
@@ -2829,6 +2864,19 @@
 	},
 /turf/open/floor/plating,
 /area/chapel/main)
+"qS" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 5
+	},
+/obj/structure/chair/sofa/corp/right{
+	dir = 8
+	},
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "qT" = (
 /obj/structure/sink/kitchen{
 	dir = 4;
@@ -2872,12 +2920,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"qY" = (
-/obj/machinery/door/firedoor/border_only{
-	name = "south facing firelock"
-	},
-/turf/open/floor/plasteel/stairs/medium,
-/area/xenoarch/arch)
 "rb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -2919,6 +2961,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/circuit)
+"rp" = (
+/obj/structure/closet/wardrobe/xenoarch,
+/obj/item/clothing/shoes/winterboots/ice_boots,
+/obj/item/clothing/glasses/meson,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/xenoarch/arch)
 "rq" = (
 /obj/machinery/power/port_gen/pacman{
 	anchored = 1
@@ -2988,6 +3042,16 @@
 /obj/effect/decal/remains/human,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/security/execution/education)
+"rZ" = (
+/obj/machinery/suit_storage_unit/mining,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/xenoarch/arch)
 "sa" = (
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
@@ -3111,21 +3175,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel/white,
 /area/mine/living_quarters)
-"sB" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 6
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/arch)
 "sD" = (
 /obj/machinery/light/small,
 /turf/open/floor/plating,
@@ -3152,13 +3201,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/mine/living_quarters)
-"sI" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 5
-	},
-/obj/machinery/power/terminal,
-/turf/open/floor/plating,
-/area/xenoarch/arch)
 "sJ" = (
 /obj/item/transfer_valve{
 	pixel_x = -5
@@ -3301,6 +3343,13 @@
 /obj/item/beacon,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/underground/unexplored/rivers)
+"tp" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 10
+	},
+/obj/item/kirbyplants/random,
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "ts" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -3344,12 +3393,13 @@
 	},
 /turf/open/floor/plating,
 /area/mine/living_quarters)
-"tK" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 10
+"tJ" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 1
 	},
-/obj/machinery/vending/snack/random,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/median/whitetodark{
+	dir = 1
+	},
 /area/xenoarch/arch)
 "tL" = (
 /obj/machinery/atmospherics/components/unary/tank/air{
@@ -3357,6 +3407,26 @@
 	},
 /turf/open/floor/plating,
 /area/mine/living_quarters)
+"tP" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/xenoarch/arch)
+"tV" = (
+/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/xenoarch/arch)
 "tY" = (
 /obj/item/assembly/prox_sensor{
 	pixel_x = -4;
@@ -3425,6 +3495,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/explab)
+"ur" = (
+/obj/effect/turf_decal/lumos/loading_area/white,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "uv" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 8
@@ -3443,11 +3523,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"uy" = (
-/turf/open/floor/plasteel/median/whitetodark{
-	dir = 8
-	},
-/area/xenoarch/arch)
 "uD" = (
 /obj/machinery/door/airlock{
 	id_tag = "Cell2";
@@ -3470,18 +3545,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/production)
-"uH" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/arch)
 "uI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -3530,20 +3593,6 @@
 /obj/machinery/vending/wardrobe/science_wardrobe,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
-"uW" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/lumos/loading_area/white{
-	dir = 1
-	},
-/obj/structure/railing/corner,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "vb" = (
 /obj/machinery/mineral/equipment_vendor,
 /obj/effect/turf_decal/tile/purple,
@@ -3584,14 +3633,6 @@
 /obj/machinery/suit_storage_unit/rd,
 /turf/open/floor/engine,
 /area/science/test_area)
-"vp" = (
-/obj/effect/turf_decal/trimline/brown/filled/line,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "vq" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -3617,6 +3658,22 @@
 /obj/structure/grille,
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors)
+"vu" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/lumos/loading_area/white,
+/obj/structure/railing/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "vw" = (
 /obj/effect/turf_decal/loading_area,
 /turf/open/floor/plasteel,
@@ -3632,6 +3689,18 @@
 	},
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/mine/production)
+"vB" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/median/whitetodark{
+	dir = 1
+	},
+/area/xenoarch/arch)
+"vD" = (
+/obj/effect/turf_decal/trimline/brown,
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "vG" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 4
@@ -3725,19 +3794,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/engine,
 /area/science/mixing)
-"wo" = (
-/obj/structure/tank_dispenser/oxygen,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/arch)
 "wp" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/food/snacks/sugarcookie/spookycoffin,
@@ -3780,6 +3836,18 @@
 	},
 /turf/open/floor/carpet,
 /area/chapel/main)
+"wA" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
+/obj/structure/chair/sofa/corp/left{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "wF" = (
 /obj/structure/frame/machine,
 /turf/open/floor/plating,
@@ -3936,6 +4004,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"xy" = (
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "xE" = (
 /obj/machinery/button/door{
 	id = "xenobio1";
@@ -3949,7 +4027,7 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "xF" = (
-/obj/effect/turf_decal/lumos/loading_area/white{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -3986,6 +4064,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/mine/living_quarters)
+"ye" = (
+/obj/effect/turf_decal/trimline/purple,
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "yf" = (
 /obj/structure/table,
 /obj/item/storage/firstaid/regular,
@@ -3995,6 +4077,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/mine/living_quarters)
+"yg" = (
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "yh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -4062,6 +4153,18 @@
 	},
 /turf/open/floor/engine,
 /area/science/misc_lab)
+"yB" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "yD" = (
 /obj/machinery/light{
 	dir = 4
@@ -4081,17 +4184,25 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/production)
-"yL" = (
-/obj/machinery/atmospherics/pipe/simple/multiz{
-	piping_layer = 1
-	},
-/turf/open/floor/plating,
-/area/xenoarch/arch)
-"yM" = (
+"yH" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
+	dir = 6
 	},
+/obj/structure/table,
+/obj/item/paper_bin{
+	pixel_y = 6
+	},
+/obj/item/pen,
 /turf/open/floor/plasteel,
+/area/xenoarch/arch)
+"yI" = (
+/obj/structure/table,
+/obj/item/strangerock,
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -23
+	},
+/turf/open/floor/plasteel/median/whitetodark/fullcorner,
 /area/xenoarch/arch)
 "yQ" = (
 /obj/effect/turf_decal/stripes/line{
@@ -4122,9 +4233,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/mine/production)
-"yZ" = (
-/turf/open/floor/plating/asteroid/snow/icemoon,
-/area/xenoarch/arch)
 "zd" = (
 /obj/machinery/airalarm/unlocked{
 	dir = 4;
@@ -4154,18 +4262,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel,
 /area/mine/production)
-"zm" = (
-/obj/structure/table,
-/obj/machinery/camera/autoname{
-	dir = 8
-	},
-/obj/machinery/status_display/evac{
-	pixel_x = 32
-	},
-/turf/open/floor/plasteel/median/whitetodark/fullcorner{
-	dir = 8
-	},
-/area/xenoarch/arch)
 "zn" = (
 /obj/machinery/camera{
 	c_tag = "Processing Area Room";
@@ -4231,21 +4327,6 @@
 /obj/machinery/shieldwallgen/xenobiologyaccess,
 /turf/open/floor/plating,
 /area/science/misc_lab)
-"zC" = (
-/obj/machinery/button/electrochromatic{
-	id = "xenoarch";
-	pixel_y = -26
-	},
-/turf/open/floor/plasteel/median/whitetodark,
-/area/xenoarch/arch)
-"zD" = (
-/obj/structure/chair/office/dark{
-	dir = 1
-	},
-/turf/open/floor/plasteel/median/whitetodark{
-	dir = 8
-	},
-/area/xenoarch/arch)
 "zE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -4255,18 +4336,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"zG" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/arch)
 "zH" = (
 /obj/machinery/power/apc/auto_name/south,
 /obj/machinery/light,
@@ -4275,6 +4344,11 @@
 	},
 /turf/open/floor/engine,
 /area/science/storage)
+"zL" = (
+/obj/structure/table,
+/obj/item/relic,
+/turf/open/floor/plasteel/median/whitetodark,
+/area/xenoarch/arch)
 "zQ" = (
 /obj/machinery/mineral/unloading_machine{
 	dir = 1;
@@ -4374,6 +4448,12 @@
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plating,
 /area/hallway/primary/port)
+"Av" = (
+/obj/structure/table,
+/turf/open/floor/plasteel/median/whitetodark{
+	dir = 1
+	},
+/area/xenoarch/arch)
 "Aw" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Mining Station Communications";
@@ -4410,11 +4490,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"AI" = (
-/obj/effect/turf_decal/trimline/brown/filled/line,
-/obj/machinery/light,
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "AN" = (
 /obj/structure/ladder,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
@@ -4434,13 +4509,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"AU" = (
-/obj/structure/stairs{
-	dir = 4;
-	icon_state = "stairs_t"
-	},
-/turf/closed/wall,
-/area/xenoarch/arch)
 "AV" = (
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_toxmix,
 /turf/open/floor/engine,
@@ -4626,15 +4694,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/grimy,
 /area/chapel/main)
-"BX" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "BY" = (
 /turf/closed/wall/r_wall,
 /area/hallway/primary/port)
@@ -4650,25 +4709,10 @@
 	},
 /turf/open/floor/circuit/telecomms,
 /area/science/xenobiology)
-"Ca" = (
-/obj/machinery/door/airlock/external,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/structure/fans/tiny,
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "Cb" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/plasteel,
 /area/science/test_area)
-"Cc" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 10
-	},
-/obj/item/kirbyplants/random,
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "Cd" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
@@ -4776,6 +4820,25 @@
 	},
 /turf/open/floor/plating,
 /area/icemoon/surface/outdoors)
+"CC" = (
+/obj/structure/table,
+/obj/machinery/light,
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel/median/whitetodark/fullcorner{
+	dir = 1
+	},
+/area/xenoarch/arch)
+"CD" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "CG" = (
 /obj/structure/chair{
 	dir = 1
@@ -4836,6 +4899,18 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
+"Df" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel/dark,
+/area/xenoarch/arch)
 "Dh" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
@@ -4871,15 +4946,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
-"Dp" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	name = "south facing firelock"
-	},
-/turf/open/floor/plasteel/stairs/left,
-/area/xenoarch/arch)
 "Ds" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 4;
@@ -4919,6 +4985,7 @@
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
 "DC" = (
+/obj/machinery/computer/rdconsole/core,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
@@ -4936,6 +5003,21 @@
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/underground/unexplored/rivers)
+"DE" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/xenoarch/arch)
 "DF" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio1";
@@ -5171,16 +5253,13 @@
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
-"EW" = (
-/obj/structure/table,
-/obj/item/relic,
-/turf/open/floor/plasteel/median/whitetodark,
-/area/xenoarch/arch)
 "Fa" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/cable{
-	icon_state = "2-8"
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
+"Fb" = (
+/obj/machinery/atmospherics/pipe/simple/multiz{
+	piping_layer = 3
 	},
 /turf/open/floor/plating,
 /area/xenoarch/arch)
@@ -5202,6 +5281,22 @@
 /obj/structure/chair/wood/normal,
 /turf/open/floor/plasteel/grimy,
 /area/chapel/main)
+"Fg" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc/auto_name/north,
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "Fo" = (
 /obj/structure/table/reinforced,
 /obj/item/stack/sheet/glass/fifty,
@@ -5266,6 +5361,15 @@
 "FK" = (
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/underground/unexplored/rivers)
+"FL" = (
+/obj/machinery/power/smes{
+	charge = 5e+006
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/xenoarch/arch)
 "FM" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -5274,12 +5378,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/icemoon/surface/outdoors)
-"FO" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "FQ" = (
 /obj/machinery/light{
 	dir = 4
@@ -5293,12 +5391,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/production)
-"FR" = (
-/obj/effect/turf_decal/trimline/brown/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "FT" = (
 /obj/structure/punching_bag,
 /obj/machinery/light/small{
@@ -5431,6 +5523,12 @@
 /obj/item/book/manual/wiki/experimentor,
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
+"GD" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "GI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -5470,10 +5568,10 @@
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
 "GQ" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+/obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 8
 	},
-/turf/open/floor/plating/asteroid/snow/icemoon,
+/turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "GS" = (
 /obj/effect/turf_decal/stripes/line{
@@ -5614,14 +5712,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/icemoon/surface/outdoors)
-"HC" = (
-/obj/effect/turf_decal/trimline/purple/filled/line,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -6;
-	pixel_y = -31
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "HD" = (
 /obj/machinery/door/window/southleft{
 	dir = 1;
@@ -5658,19 +5748,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
-"HK" = (
-/obj/machinery/door/airlock/research{
-	name = "Xenoarchaeology Lab";
-	req_access_txt = "47"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1;
-	name = "north facing firelock"
-	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/arch)
 "HM" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
@@ -5928,6 +6005,15 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/xenobiology)
+"IJ" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	name = "south facing firelock"
+	},
+/turf/open/floor/plasteel/stairs/right,
+/area/xenoarch/arch)
 "IK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -5996,6 +6082,19 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/science/circuit)
+"IZ" = (
+/obj/structure/tank_dispenser/oxygen,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/xenoarch/arch)
 "Jc" = (
 /obj/machinery/atmospherics/components/binary/valve{
 	dir = 4;
@@ -6012,12 +6111,6 @@
 "Ji" = (
 /turf/closed/wall,
 /area/icemoon/underground/unexplored/rivers)
-"Jj" = (
-/obj/structure/table,
-/turf/open/floor/plasteel/median/whitetodark{
-	dir = 1
-	},
-/area/xenoarch/arch)
 "Jl" = (
 /obj/structure/railing/corner{
 	dir = 4
@@ -6079,6 +6172,18 @@
 "Jz" = (
 /turf/open/floor/carpet,
 /area/chapel/main)
+"JB" = (
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
+"JC" = (
+/obj/effect/turf_decal/lumos/loading_area/white{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "JD" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 8
@@ -6166,15 +6271,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/production)
-"Ki" = (
-/obj/effect/turf_decal/trimline/brown/filled/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/arch)
 "Kk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
@@ -6212,6 +6308,9 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"Kt" = (
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "KE" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
@@ -6239,21 +6338,18 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/primary/port)
-"KL" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/lumos/loading_area/white,
-/obj/structure/railing/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+"KO" = (
+/obj/machinery/rnd/production/protolathe/department/science,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
 "KP" = (
 /obj/machinery/door/airlock/maintenance{
@@ -6273,14 +6369,24 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/chapel/main)
-"KZ" = (
-/obj/structure/table,
-/obj/item/strangerock,
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -23
+"KV" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 10
 	},
-/turf/open/floor/plasteel/median/whitetodark/fullcorner,
+/obj/machinery/vending/snack/random,
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
+"La" = (
+/obj/structure/table,
+/obj/machinery/camera/autoname{
+	dir = 8
+	},
+/obj/machinery/status_display/evac{
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel/median/whitetodark/fullcorner{
+	dir = 8
+	},
 /area/xenoarch/arch)
 "Le" = (
 /obj/effect/decal/cleanable/dirt,
@@ -6448,18 +6554,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/visible,
 /turf/open/floor/plating,
 /area/hallway/primary/port)
-"LZ" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/lumos/loading_area/white{
-	dir = 1
-	},
-/obj/structure/railing/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "Ma" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -6512,15 +6606,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/execution/education)
-"Mj" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	name = "south facing firelock"
-	},
-/turf/open/floor/plasteel/stairs/right,
-/area/xenoarch/arch)
 "Mm" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -6540,6 +6625,9 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"Ms" = (
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/xenoarch/arch)
 "Mt" = (
 /obj/machinery/light/small,
 /obj/effect/turf_decal/tile/purple{
@@ -6547,6 +6635,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
+"Mx" = (
+/obj/structure/stairs{
+	dir = 4;
+	icon_state = "stairs_t"
+	},
+/turf/closed/wall,
+/area/xenoarch/arch)
 "MG" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -6576,15 +6671,6 @@
 /obj/structure/closet/radiation,
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
-"MO" = (
-/obj/effect/turf_decal/trimline/brown/filled/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "MP" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -6595,6 +6681,10 @@
 /obj/machinery/door/airlock/research/glass/incinerator/toxmix_exterior,
 /turf/open/floor/engine,
 /area/science/mixing)
+"MR" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner,
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "MT" = (
 /obj/machinery/vending/assist,
 /obj/structure/cable{
@@ -6637,31 +6727,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
-"Nk" = (
-/obj/effect/turf_decal/trimline/brown/filled/line,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
-"Nq" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "Nr" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
@@ -6736,12 +6801,6 @@
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel,
 /area/mine/production)
-"NL" = (
-/obj/effect/turf_decal/trimline/brown/filled/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "NO" = (
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
@@ -6945,6 +7004,24 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
+"OG" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/lumos/loading_area/white{
+	dir = 1
+	},
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
+"OJ" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/xenoarch/arch)
 "OO" = (
 /obj/machinery/sparker/toxmix{
 	pixel_x = 25
@@ -6961,26 +7038,20 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/primary/port)
-"OR" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 5
+"OT" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
 	},
-/obj/structure/chair/sofa/corp/right{
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/xenoarch/arch)
-"OW" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel/median/whitetodark{
-	dir = 1
-	},
 /area/xenoarch/arch)
 "OY" = (
 /obj/structure/sign/warning/vacuum/external{
@@ -7059,10 +7130,6 @@
 /obj/structure/flora/rock/icy,
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors)
-"PC" = (
-/obj/effect/turf_decal/trimline/brown/filled/line,
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "PD" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/monkeycubes,
@@ -7190,25 +7257,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
-"Qi" = (
-/obj/effect/turf_decal/trimline/brown/filled/corner,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/arch)
-"Qn" = (
-/obj/effect/turf_decal/trimline/brown/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "Qp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
@@ -7220,6 +7268,18 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/carpet,
 /area/chapel/main)
+"Qw" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/xenoarch/arch)
 "Qx" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
@@ -7229,31 +7289,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
-"QA" = (
-/obj/machinery/door/airlock/research{
-	name = "Xenoarchaeology Equipment Room";
-	req_access_txt = "47"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/door/firedoor/border_only{
-	name = "south facing firelock"
-	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/arch)
-"QE" = (
-/obj/machinery/rnd/production/protolathe/department/science,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/arch)
 "QH" = (
 /obj/effect/decal/remains/human,
 /obj/item/pipe{
@@ -7269,6 +7304,15 @@
 	},
 /turf/open/floor/plating,
 /area/icemoon/surface/outdoors)
+"QI" = (
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/xenoarch/arch)
 "QJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 9
@@ -7327,14 +7371,6 @@
 "QY" = (
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/plasteel,
-/area/xenoarch/arch)
-"Ra" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel/median/whitetodark{
-	dir = 1
-	},
 /area/xenoarch/arch)
 "Rb" = (
 /obj/structure/table,
@@ -7551,6 +7587,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/test_area)
+"RZ" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "Sa" = (
 /obj/item/flashlight/lantern,
 /obj/item/mining_scanner,
@@ -7645,15 +7690,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/science/xenobiology)
-"SN" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "SO" = (
 /obj/machinery/sparker{
 	id = "testigniter";
@@ -7702,18 +7738,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"Th" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 1
-	},
-/obj/structure/railing/corner{
+"Td" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 8
+	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
+"Tg" = (
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
@@ -7821,6 +7862,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
+"TK" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
+	},
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/xenoarch/arch)
 "TN" = (
 /obj/structure/trash_pile,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
@@ -7926,10 +7973,6 @@
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/chapel/main)
-"Uo" = (
-/obj/structure/table,
-/turf/open/floor/plasteel/median/whitetodark,
-/area/xenoarch/arch)
 "Up" = (
 /turf/open/floor/plating,
 /area/security/execution/education)
@@ -8116,13 +8159,6 @@
 /obj/effect/spawner/structure/window/ice,
 /turf/open/floor/plating,
 /area/chapel/main)
-"Vk" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 9
-	},
-/obj/item/kirbyplants/random,
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "Vm" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -8207,18 +8243,6 @@
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/security/execution/education)
-"VG" = (
-/obj/structure/chair/office/dark{
-	dir = 1
-	},
-/obj/machinery/newscaster{
-	pixel_x = 32;
-	pixel_y = 1
-	},
-/turf/open/floor/plasteel/median/whitetodark{
-	dir = 4
-	},
-/area/xenoarch/arch)
 "VH" = (
 /obj/structure/stairs,
 /obj/structure/railing{
@@ -8288,25 +8312,9 @@
 	},
 /turf/open/floor/carpet,
 /area/mine/living_quarters)
-"VZ" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+"VY" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 8
-	},
-/obj/machinery/quantumpad{
-	map_pad_id = "xenoarch";
-	map_pad_link_id = "miningbase"
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
-"Wb" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4
-	},
-/turf/open/floor/plating/asteroid/snow/icemoon,
-/area/xenoarch/arch)
-"Wc" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
@@ -8314,10 +8322,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/power/apc/auto_name/north,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "Wd" = (
@@ -8368,12 +8372,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/hallway/primary/aft)
-"Wt" = (
-/obj/machinery/atmospherics/pipe/simple/multiz{
-	piping_layer = 3
-	},
-/turf/open/floor/plating,
-/area/xenoarch/arch)
 "Wz" = (
 /obj/structure/grille,
 /turf/closed/mineral/random/snow,
@@ -8531,10 +8529,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/explab)
-"Xj" = (
-/obj/effect/turf_decal/trimline/purple,
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "Xl" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -8585,6 +8579,12 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/mine/living_quarters)
+"Xz" = (
+/obj/effect/turf_decal/trimline/brown,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "XA" = (
 /obj/machinery/shieldwallgen/xenobiologyaccess,
 /obj/structure/sign/poster/official/safety_eye_protection{
@@ -8632,6 +8632,13 @@
 	},
 /turf/open/floor/carpet,
 /area/hallway/primary/port)
+"XQ" = (
+/obj/machinery/button/electrochromatic{
+	id = "xenoarch";
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel/median/whitetodark,
+/area/xenoarch/arch)
 "XR" = (
 /turf/closed/wall/r_wall,
 /area/science/explab)
@@ -8660,12 +8667,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"Yc" = (
-/obj/effect/turf_decal/trimline/brown,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "Yf" = (
 /obj/structure/table,
 /obj/item/strangerock,
@@ -8674,6 +8675,15 @@
 	},
 /turf/open/floor/plating,
 /area/icemoon/surface/outdoors)
+"Yi" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/xenoarch/arch)
 "Ym" = (
 /obj/structure/sink{
 	dir = 4;
@@ -8807,15 +8817,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/test_area)
-"YN" = (
-/obj/effect/turf_decal/lumos/loading_area/white,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
+"YL" = (
+/obj/structure/table,
+/turf/open/floor/plasteel/median/whitetodark,
 /area/xenoarch/arch)
 "YP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -8941,6 +8945,13 @@
 "Zu" = (
 /turf/closed/wall/r_wall,
 /area/security/execution/education)
+"Zw" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 6
+	},
+/obj/machinery/vending/cola/random,
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "Zy" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
@@ -8951,17 +8962,6 @@
 /obj/structure/chair/stool,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
-"ZB" = (
-/obj/structure/table,
-/obj/item/strangerock,
-/obj/machinery/light,
-/obj/structure/sign/poster/official/random{
-	pixel_x = 32
-	},
-/turf/open/floor/plasteel/median/whitetodark/fullcorner{
-	dir = 4
-	},
-/area/xenoarch/arch)
 "ZF" = (
 /obj/machinery/atmospherics/pipe/simple/multiz,
 /obj/effect/turf_decal/stripes/box,
@@ -46520,9 +46520,9 @@ ah
 VE
 hS
 cl
-oJ
-wo
-ch
+rZ
+IZ
+cv
 cl
 cl
 cl
@@ -46777,13 +46777,13 @@ VE
 VE
 hS
 cl
-mW
-DC
-DC
+Df
+Yi
+Yi
 iO
-Vk
-SN
-Cc
+oZ
+CD
+tp
 cl
 cl
 VE
@@ -47034,14 +47034,14 @@ VE
 hS
 hS
 iO
-jM
-uH
-Qi
+rp
+ea
+oi
 iO
-NL
-Xj
-FR
-tK
+JB
+ye
+GQ
+KV
 cl
 VE
 VE
@@ -47291,14 +47291,14 @@ hS
 hS
 hS
 iO
-jM
-sB
-au
-QA
-oM
-aU
-eh
-hQ
+rp
+DE
+tV
+qI
+Td
+Kt
+MR
+Zw
 cl
 hS
 hS
@@ -47548,13 +47548,13 @@ hS
 hS
 hS
 iO
-QE
-zG
-Ki
+KO
+Qw
+QI
 iO
-ie
-jm
-vp
+hA
+vD
+Tg
 cl
 cl
 hS
@@ -47805,13 +47805,13 @@ hS
 hS
 hS
 cl
-bi
 DC
-cv
+Yi
+lf
 iO
-oY
-ly
-HC
+yB
+GD
+lM
 cl
 hS
 hS
@@ -48066,13 +48066,13 @@ iO
 iO
 iO
 cl
-dw
-Xj
-AI
+fv
+ye
+bm
 cl
 cl
-ds
-ds
+kM
+kM
 cl
 cl
 hS
@@ -48319,18 +48319,18 @@ iO
 nN
 JK
 iO
-MO
-VZ
-LZ
-Dp
-bz
-FO
+yg
+jF
+OG
+pK
+mf
+pH
 QY
 iO
-KZ
-zD
-uy
-pM
+yI
+fw
+ob
+CC
 cl
 hS
 hS
@@ -48575,20 +48575,20 @@ hS
 lU
 Gt
 QY
-Ca
-yM
-aU
+jI
 xF
-qY
-YN
-jm
-PC
+Kt
+JC
+jv
+ur
+vD
+Fa
 iO
-Jj
-yZ
-eo
-Uo
-ds
+Av
+Ms
+ga
+YL
+kM
 hS
 hS
 hS
@@ -48831,21 +48831,21 @@ hS
 hS
 iO
 Jl
-FR
+GQ
 iO
-Qn
-BX
-uW
-Mj
-KL
-aU
-eh
+mR
+RZ
+qo
+IJ
+vu
+Kt
+MR
 iO
-Ra
-Wb
-yZ
-EW
-ds
+vB
+TK
+Ms
+zL
+kM
 hS
 hS
 hS
@@ -49088,20 +49088,20 @@ VE
 hS
 cl
 Jv
-AU
+Mx
 cl
 cl
 cl
 cl
 cl
-Th
-Xj
-lY
-HK
-cG
-iP
-yZ
-zC
+OT
+ye
+xy
+ks
+kQ
+aI
+Ms
+XQ
 cl
 hS
 hS
@@ -49347,19 +49347,19 @@ cl
 cl
 cl
 cl
-yL
-sI
-jz
+fL
+cb
+FL
 cl
-Wc
-aU
-hV
+Fg
+Kt
+VY
 iO
-OW
-GQ
-yZ
-Uo
-ds
+tJ
+OJ
+Ms
+YL
+kM
 hS
 hS
 VE
@@ -49604,19 +49604,19 @@ VE
 VE
 VE
 cl
-Wt
-ey
-Fa
-eU
-Nq
-Yc
-Nk
+Fb
+kR
+qy
+tP
+cJ
+Xz
+dU
 iO
-Jj
-yZ
-eo
-Uo
-ds
+Av
+Ms
+ga
+YL
+kM
 hS
 hS
 VE
@@ -49865,14 +49865,14 @@ cl
 cl
 cl
 cl
-OR
-bB
-bV
+qS
+wA
+yH
 iO
-zm
-VG
-ps
-ZB
+La
+fq
+dB
+au
 cl
 hS
 hS

--- a/_maps/map_files/Snaxi/IcemoonUnderground_Above_Lumos.dmm
+++ b/_maps/map_files/Snaxi/IcemoonUnderground_Above_Lumos.dmm
@@ -479,6 +479,15 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/test_area)
+"dq" = (
+/obj/structure/table,
+/obj/item/strangerock,
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -23
+	},
+/turf/open/floor/plasteel/median/whitetodark/fullcorner,
+/area/xenoarch/arch)
 "dx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
@@ -504,14 +513,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/execution/education)
-"dD" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel/median/whitetodark{
-	dir = 1
-	},
-/area/xenoarch/arch)
 "dF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 1
@@ -1251,16 +1252,6 @@
 	},
 /turf/open/floor/plating,
 /area/science/misc_lab)
-"gq" = (
-/obj/effect/turf_decal/trimline/brown/filled/line,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "gu" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -1270,6 +1261,11 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/primary/aft)
+"gy" = (
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/machinery/light,
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "gz" = (
 /obj/structure/table,
 /obj/item/radio/off,
@@ -1479,10 +1475,6 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/plasteel,
 /area/mine/eva)
-"ia" = (
-/obj/effect/turf_decal/trimline/brown/filled/line,
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "id" = (
 /obj/structure/table/wood,
 /obj/structure/window/reinforced{
@@ -1769,14 +1761,6 @@
 /obj/machinery/light/small,
 /turf/open/floor/plasteel,
 /area/mine/eva)
-"jZ" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel/median/whitetodark{
-	dir = 1
-	},
-/area/xenoarch/arch)
 "kb" = (
 /obj/structure/ore_box,
 /turf/open/floor/plasteel,
@@ -1817,6 +1801,14 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/misc_lab)
+"kA" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/median/whitetodark{
+	dir = 1
+	},
+/area/xenoarch/arch)
 "kC" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
@@ -2461,13 +2453,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"oI" = (
-/obj/machinery/button/electrochromatic{
-	id = "xenoarch";
-	pixel_y = -26
-	},
-/turf/open/floor/plasteel/median/whitetodark,
-/area/xenoarch/arch)
 "oK" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/heater,
 /obj/machinery/light{
@@ -2716,6 +2701,13 @@
 	},
 /turf/closed/wall/mineral/iron,
 /area/chapel/main)
+"qg" = (
+/obj/machinery/button/electrochromatic{
+	id = "xenoarch";
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel/median/whitetodark,
+/area/xenoarch/arch)
 "qh" = (
 /obj/machinery/atmospherics/components/binary/valve{
 	dir = 4;
@@ -2943,18 +2935,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/circuit)
-"rl" = (
-/obj/structure/table,
-/obj/machinery/camera/autoname{
-	dir = 8
-	},
-/obj/machinery/status_display/evac{
-	pixel_x = 32
-	},
-/turf/open/floor/plasteel/median/whitetodark/fullcorner{
-	dir = 8
-	},
-/area/xenoarch/arch)
 "rp" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
@@ -3011,6 +2991,10 @@
 /mob/living/simple_animal/slime,
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"rP" = (
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "rQ" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/turf_decal/bot,
@@ -3258,15 +3242,6 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/primary/aft)
-"sT" = (
-/obj/structure/table,
-/obj/item/strangerock,
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -23
-	},
-/turf/open/floor/plasteel/median/whitetodark/fullcorner,
-/area/xenoarch/arch)
 "sW" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/plasteel/dark,
@@ -4470,6 +4445,18 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"AI" = (
+/obj/structure/table,
+/obj/machinery/camera/autoname{
+	dir = 8
+	},
+/obj/machinery/status_display/evac{
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel/median/whitetodark/fullcorner{
+	dir = 8
+	},
+/area/xenoarch/arch)
 "AN" = (
 /obj/structure/ladder,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
@@ -4511,6 +4498,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"Bc" = (
+/obj/structure/table,
+/obj/item/relic,
+/turf/open/floor/plasteel/median/whitetodark,
+/area/xenoarch/arch)
 "Bd" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Mining Station Maintenance";
@@ -4877,6 +4869,8 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "Df" = (
+/obj/item/relic,
+/obj/structure/table,
 /turf/open/floor/plating,
 /area/xenoarch/arch)
 "Dh" = (
@@ -4900,6 +4894,14 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/engine,
 /area/science/storage)
+"Dk" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/median/whitetodark{
+	dir = 1
+	},
+/area/xenoarch/arch)
 "Dl" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -4953,19 +4955,8 @@
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
 "DC" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 6
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/plating,
 /area/xenoarch/arch)
 "DD" = (
 /obj/structure/chair{
@@ -5221,14 +5212,11 @@
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
 "Fa" = (
-/obj/structure/table,
-/obj/item/gps/mining{
-	gpstag = "XENOARCH";
-	pixel_x = -6
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
 	},
-/obj/item/gps/mining{
-	gpstag = "XENOARCH";
-	pixel_x = 6
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -5327,11 +5315,22 @@
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/underground/unexplored/rivers)
 "FL" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 9
+/obj/structure/table,
+/obj/item/gps/mining{
+	gpstag = "XENOARCH";
+	pixel_x = -6
 	},
-/obj/item/kirbyplants/random,
-/turf/open/floor/plasteel,
+/obj/item/gps/mining{
+	gpstag = "XENOARCH";
+	pixel_x = 6
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
 "FM" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -5845,18 +5844,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
-"Ij" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "Ik" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plating,
@@ -6162,9 +6149,10 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "JK" = (
-/obj/effect/turf_decal/trimline/brown/filled/corner{
-	dir = 4
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 9
 	},
+/obj/item/kirbyplants/random,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "JL" = (
@@ -6275,6 +6263,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"Kq" = (
+/obj/structure/table,
+/turf/open/floor/plasteel/median/whitetodark{
+	dir = 1
+	},
+/area/xenoarch/arch)
 "Kt" = (
 /obj/effect/turf_decal/lumos/loading_area/white{
 	dir = 1
@@ -6340,12 +6334,6 @@
 /area/chapel/main)
 "KV" = (
 /obj/effect/turf_decal/trimline/brown/filled/corner{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -6410,6 +6398,18 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/primary/port)
+"Lo" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "Lp" = (
 /obj/structure/table/wood,
 /obj/machinery/light/small,
@@ -6611,14 +6611,14 @@
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
 "Mx" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
@@ -7265,20 +7265,14 @@
 /turf/open/floor/plating,
 /area/icemoon/surface/outdoors)
 "QI" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
-	},
-/obj/structure/railing/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
-/obj/machinery/status_display/evac{
-	pixel_y = 32
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
@@ -7724,13 +7718,16 @@
 	dir = 1
 	},
 /obj/structure/railing/corner{
-	dir = 1
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
+/obj/machinery/status_display/evac{
+	pixel_y = 32
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
@@ -7995,11 +7992,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
-"UG" = (
-/obj/structure/table,
-/obj/item/relic,
-/turf/open/floor/plasteel/median/whitetodark,
-/area/xenoarch/arch)
 "UH" = (
 /obj/structure/table,
 /obj/item/storage/box/donkpockets,
@@ -8094,6 +8086,16 @@
 /obj/machinery/meter,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"UU" = (
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "UW" = (
 /obj/machinery/airalarm{
 	dir = 1;
@@ -8291,7 +8293,10 @@
 /turf/open/floor/carpet,
 /area/mine/living_quarters)
 "VY" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
+/obj/structure/railing/corner{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -8300,10 +8305,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/power/apc/auto_name/north,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "Wd" = (
@@ -8620,15 +8621,18 @@
 /area/hallway/primary/port)
 "XQ" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 5
+	dir = 1
 	},
-/obj/structure/chair/sofa/corp/right{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc/auto_name/north,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "XR" = (
@@ -8810,7 +8814,16 @@
 /turf/open/floor/plasteel,
 /area/science/test_area)
 "YL" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 5
+	},
+/obj/structure/chair/sofa/corp/right{
+	dir = 8
+	},
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "YP" = (
@@ -8934,18 +8947,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/test_area)
-"Zs" = (
-/obj/structure/table,
-/turf/open/floor/plasteel/median/whitetodark{
-	dir = 1
-	},
-/area/xenoarch/arch)
 "Zu" = (
 /turf/closed/wall/r_wall,
 /area/security/execution/education)
 "Zw" = (
-/obj/effect/turf_decal/trimline/brown/filled/line,
-/obj/machinery/light,
+/obj/effect/turf_decal/trimline/purple/filled/corner,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "Zy" = (
@@ -46776,7 +46782,7 @@ lM
 Yi
 Yi
 iO
-FL
+JK
 oZ
 CD
 cl
@@ -47033,7 +47039,7 @@ oi
 rp
 ea
 iO
-JK
+KV
 OT
 Jl
 GQ
@@ -47287,12 +47293,12 @@ hS
 hS
 iO
 oi
-DC
+Fa
 DE
 tV
 qI
 Td
-YL
+Zw
 MR
 cl
 hS
@@ -47547,7 +47553,7 @@ tp
 KO
 Qw
 iO
-KV
+Mx
 ur
 vD
 cl
@@ -47802,9 +47808,9 @@ hS
 cl
 yH
 Yi
-Fa
+FL
 iO
-Mx
+QI
 yB
 GD
 cl
@@ -48061,9 +48067,9 @@ iO
 iO
 iO
 cl
-QI
+Tg
 OT
-Zw
+gy
 cl
 cl
 kM
@@ -48322,7 +48328,7 @@ pK
 mf
 Gt
 iO
-sT
+dq
 yI
 fw
 ob
@@ -48577,9 +48583,9 @@ Kt
 JC
 jv
 ur
-ia
+rP
 iO
-Zs
+Kq
 TK
 Ms
 ga
@@ -48834,12 +48840,12 @@ RZ
 qo
 IJ
 Td
-YL
+Zw
 iO
-dD
+kA
 vB
 TK
-UG
+Bc
 kM
 hS
 hS
@@ -49089,14 +49095,14 @@ cl
 cl
 cl
 cl
-Tg
+VY
 OT
-gq
+UU
 xy
 ks
 kQ
 TK
-oI
+qg
 cl
 hS
 hS
@@ -49346,11 +49352,11 @@ Df
 fL
 cb
 cl
-VY
+XQ
 Td
-Ij
+Lo
 iO
-jZ
+Dk
 tJ
 TK
 ga
@@ -49599,7 +49605,7 @@ VE
 VE
 VE
 cl
-Df
+DC
 Fb
 kR
 qy
@@ -49607,7 +49613,7 @@ tP
 cJ
 Xz
 iO
-Zs
+Kq
 TK
 Ms
 ga
@@ -49860,11 +49866,11 @@ cl
 cl
 cl
 cl
-XQ
+YL
 qS
 wA
 iO
-rl
+AI
 La
 fq
 dB

--- a/_maps/map_files/Snaxi/IcemoonUnderground_Above_Lumos.dmm
+++ b/_maps/map_files/Snaxi/IcemoonUnderground_Above_Lumos.dmm
@@ -46,15 +46,10 @@
 	},
 /area/icemoon/underground/unexplored/rivers)
 "au" = (
-/obj/structure/table,
-/obj/item/strangerock,
-/obj/machinery/light,
-/obj/structure/sign/poster/official/random{
-	pixel_x = 32
-	},
-/turf/open/floor/plasteel/median/whitetodark/fullcorner{
-	dir = 4
-	},
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/structure/fans/tiny,
+/turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "aw" = (
 /obj/machinery/door/firedoor/border_only{
@@ -107,15 +102,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/execution/education)
-"aI" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 5
-	},
-/turf/open/floor/plating/asteroid/snow/icemoon,
-/area/xenoarch/arch)
 "aJ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -206,8 +192,11 @@
 /turf/closed/wall/r_wall,
 /area/science/storage)
 "bm" = (
-/obj/effect/turf_decal/trimline/brown/filled/line,
-/obj/machinery/light,
+/obj/effect/turf_decal/trimline/purple/line{
+	dir = 1;
+	pixel_y = 6
+	},
+/obj/structure/closet/emcloset,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "bo" = (
@@ -264,10 +253,15 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/chapel/main)
 "cb" = (
+/obj/machinery/power/smes{
+	charge = 5e+006
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
 	},
-/obj/machinery/power/terminal,
 /turf/open/floor/plating,
 /area/xenoarch/arch)
 "cd" = (
@@ -323,14 +317,14 @@
 /turf/open/floor/plasteel,
 /area/science/circuit)
 "cv" = (
-/obj/machinery/suit_storage_unit/mining,
-/obj/effect/turf_decal/tile/neutral{
+/obj/structure/railing/corner{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/effect/turf_decal/trimline/purple/line{
+	dir = 1;
+	pixel_y = 6
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "cw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -383,18 +377,9 @@
 /turf/open/floor/plating,
 /area/science/test_area)
 "cJ" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
+/obj/effect/turf_decal/trimline/brown,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "cM" = (
@@ -501,12 +486,13 @@
 /turf/open/floor/plating,
 /area/security/execution/education)
 "dB" = (
-/obj/item/radio/intercom{
-	dir = 4;
-	name = "Station Intercom (General)";
-	pixel_x = 27
+/obj/structure/table,
+/obj/item/strangerock,
+/obj/machinery/light,
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
 	},
-/turf/open/floor/plasteel/median/whitetodark{
+/turf/open/floor/plasteel/median/whitetodark/fullcorner{
 	dir = 4
 	},
 /area/xenoarch/arch)
@@ -518,6 +504,14 @@
 	},
 /turf/open/floor/plating,
 /area/security/execution/education)
+"dD" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/median/whitetodark{
+	dir = 1
+	},
+/area/xenoarch/arch)
 "dF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 1
@@ -576,14 +570,14 @@
 /turf/open/floor/plasteel/white,
 /area/science/misc_lab)
 "dU" = (
-/obj/effect/turf_decal/trimline/brown/filled/line,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
+/obj/structure/stairs{
+	dir = 4;
+	icon_state = "stairs_t"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 9
+/obj/structure/railing{
+	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/space/basic,
 /area/xenoarch/arch)
 "dW" = (
 /turf/closed/wall,
@@ -598,14 +592,12 @@
 /turf/open/floor/plating,
 /area/hallway/primary/aft)
 "ea" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+/obj/effect/turf_decal/trimline/brown/filled/corner,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
@@ -1035,39 +1027,16 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "fq" = (
-/obj/structure/chair/office/dark{
-	dir = 1
-	},
-/obj/machinery/newscaster{
-	pixel_x = 32;
-	pixel_y = 1
+/obj/item/radio/intercom{
+	dir = 4;
+	name = "Station Intercom (General)";
+	pixel_x = 27
 	},
 /turf/open/floor/plasteel/median/whitetodark{
 	dir = 4
 	},
 /area/xenoarch/arch)
-"fv" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 1
-	},
-/obj/structure/railing/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "fw" = (
-/obj/structure/chair/office/dark{
-	dir = 1
-	},
 /turf/open/floor/plasteel/median/whitetodark{
 	dir = 8
 	},
@@ -1226,8 +1195,8 @@
 /turf/open/floor/plating,
 /area/icemoon/surface/outdoors)
 "ga" = (
-/obj/structure/chair/office/dark,
-/turf/open/floor/plating/asteroid/snow/icemoon,
+/obj/structure/table,
+/turf/open/floor/plasteel/median/whitetodark,
 /area/xenoarch/arch)
 "gb" = (
 /obj/structure/chair/comfy/black{
@@ -1282,6 +1251,16 @@
 	},
 /turf/open/floor/plating,
 /area/science/misc_lab)
+"gq" = (
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "gu" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -1464,18 +1443,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/production)
-"hA" = (
-/obj/effect/turf_decal/trimline/brown/filled/corner{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "hD" = (
 /obj/machinery/button/door{
 	id = "misclab";
@@ -1512,6 +1479,10 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/plasteel,
 /area/mine/eva)
+"ia" = (
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "id" = (
 /obj/structure/table/wood,
 /obj/structure/window/reinforced{
@@ -1697,10 +1668,14 @@
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
 "jv" = (
-/obj/machinery/door/firedoor/border_only{
-	name = "south facing firelock"
+/obj/effect/turf_decal/lumos/loading_area/white,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
 	},
-/turf/open/floor/plasteel/stairs/medium,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "jy" = (
 /turf/open/openspace,
@@ -1718,12 +1693,14 @@
 /turf/open/floor/plating,
 /area/hallway/primary/port)
 "jF" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
 	},
-/obj/machinery/quantumpad{
-	map_pad_id = "xenoarch";
-	map_pad_link_id = "miningbase"
+/obj/effect/turf_decal/lumos/loading_area/white{
+	dir = 1
+	},
+/obj/structure/railing/corner{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
@@ -1741,11 +1718,9 @@
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
 "jI" = (
-/obj/machinery/door/airlock/external,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
-/obj/structure/fans/tiny,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "jK" = (
@@ -1794,6 +1769,14 @@
 /obj/machinery/light/small,
 /turf/open/floor/plasteel,
 /area/mine/eva)
+"jZ" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/median/whitetodark{
+	dir = 1
+	},
+/area/xenoarch/arch)
 "kb" = (
 /obj/structure/ore_box,
 /turf/open/floor/plasteel,
@@ -1814,17 +1797,14 @@
 /turf/open/floor/plasteel/stairs/left,
 /area/chapel/main)
 "ks" = (
-/obj/machinery/door/airlock/research{
-	name = "Xenoarchaeology Lab";
-	req_access_txt = "47"
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1;
-	name = "north facing firelock"
+/turf/open/floor/plasteel/median/whitetodark{
+	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
 "ku" = (
 /obj/machinery/portable_atmospherics/canister,
@@ -1872,21 +1852,25 @@
 /turf/open/floor/plating,
 /area/xenoarch/arch)
 "kQ" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel/median/whitetodark{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
 	},
+/turf/open/floor/plating/asteroid/snow/icemoon,
 /area/xenoarch/arch)
 "kR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/power/terminal{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
 	},
-/obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/xenoarch/arch)
 "kS" = (
@@ -1935,15 +1919,7 @@
 /turf/open/floor/plasteel,
 /area/icemoon/surface/outdoors)
 "lf" = (
-/obj/structure/table,
-/obj/item/gps/mining{
-	gpstag = "XENOARCH";
-	pixel_x = -6
-	},
-/obj/item/gps/mining{
-	gpstag = "XENOARCH";
-	pixel_x = 6
-	},
+/obj/machinery/suit_storage_unit/mining,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
@@ -2017,12 +1993,16 @@
 /turf/open/floor/plating,
 /area/icemoon/surface/outdoors)
 "lM" = (
-/obj/effect/turf_decal/trimline/purple/filled/line,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -6;
-	pixel_y = -31
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
 "lN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -2051,9 +2031,10 @@
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "lU" = (
-/obj/machinery/door/airlock/external,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/structure/fans/tiny,
+/obj/effect/turf_decal/trimline/brown/line{
+	dir = 1;
+	pixel_y = 6
+	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "lV" = (
@@ -2083,17 +2064,7 @@
 /turf/open/floor/plating,
 /area/security/execution/education)
 "mf" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/lumos/loading_area/white,
-/obj/structure/railing/corner{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -2206,10 +2177,10 @@
 /turf/open/floor/plating,
 /area/science/misc_lab)
 "mR" = (
-/obj/effect/turf_decal/trimline/brown/filled/corner{
-	dir = 1
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/machinery/light{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -2344,11 +2315,8 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/chapel/main)
 "nN" = (
-/obj/effect/turf_decal/trimline/purple/line{
-	dir = 1;
-	pixel_y = 6
-	},
-/obj/structure/closet/emcloset,
+/obj/effect/turf_decal/trimline/brown/filled/corner,
+/obj/structure/ore_box,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "nP" = (
@@ -2382,8 +2350,13 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "ob" = (
-/turf/open/floor/plasteel/median/whitetodark{
-	dir = 8
+/obj/structure/table,
+/obj/machinery/light,
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel/median/whitetodark/fullcorner{
+	dir = 1
 	},
 /area/xenoarch/arch)
 "oc" = (
@@ -2397,12 +2370,14 @@
 /turf/open/floor/plasteel,
 /area/science/circuit)
 "oi" = (
-/obj/effect/turf_decal/trimline/brown/filled/corner,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
+/obj/structure/closet/wardrobe/xenoarch,
+/obj/item/clothing/shoes/winterboots/ice_boots,
+/obj/item/clothing/glasses/meson,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
@@ -2486,6 +2461,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"oI" = (
+/obj/machinery/button/electrochromatic{
+	id = "xenoarch";
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel/median/whitetodark,
+/area/xenoarch/arch)
 "oK" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/heater,
 /obj/machinery/light{
@@ -2556,10 +2538,12 @@
 /turf/open/floor/plasteel,
 /area/mine/production)
 "oZ" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 9
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
 	},
-/obj/item/kirbyplants/random,
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "pc" = (
@@ -2659,12 +2643,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
-"pH" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "pJ" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -2675,13 +2653,20 @@
 /turf/open/floor/plasteel,
 /area/mine/production)
 "pK" = (
-/obj/structure/railing{
-	dir = 8
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 1
 	},
-/obj/machinery/door/firedoor/border_only{
-	name = "south facing firelock"
+/obj/effect/turf_decal/lumos/loading_area/white,
+/obj/structure/railing/corner{
+	dir = 1
 	},
-/turf/open/floor/plasteel/stairs/left,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "pN" = (
 /obj/structure/table/glass,
@@ -2755,18 +2740,13 @@
 /turf/open/floor/plating,
 /area/chapel/main)
 "qo" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/structure/railing{
 	dir = 4
 	},
-/obj/effect/turf_decal/lumos/loading_area/white{
-	dir = 1
+/obj/machinery/door/firedoor/border_only{
+	name = "south facing firelock"
 	},
-/obj/structure/railing/corner,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/stairs/right,
 /area/xenoarch/arch)
 "qq" = (
 /obj/machinery/disposal/bin,
@@ -2784,10 +2764,13 @@
 /turf/open/floor/plasteel,
 /area/mine/production)
 "qy" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/structure/cable{
-	icon_state = "2-8"
+	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
 /area/xenoarch/arch)
@@ -2816,16 +2799,16 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "qI" = (
-/obj/machinery/door/airlock/research{
-	name = "Xenoarchaeology Equipment Room";
-	req_access_txt = "47"
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/door/firedoor/border_only{
-	name = "south facing firelock"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
 	},
-/turf/open/floor/plasteel/dark,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "qL" = (
 /obj/machinery/airalarm{
@@ -2865,15 +2848,14 @@
 /turf/open/floor/plating,
 /area/chapel/main)
 "qS" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 5
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
 	},
-/obj/structure/chair/sofa/corp/right{
+/obj/structure/chair/sofa/corp/left{
 	dir = 8
 	},
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
@@ -2961,10 +2943,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/circuit)
+"rl" = (
+/obj/structure/table,
+/obj/machinery/camera/autoname{
+	dir = 8
+	},
+/obj/machinery/status_display/evac{
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel/median/whitetodark/fullcorner{
+	dir = 8
+	},
+/area/xenoarch/arch)
 "rp" = (
-/obj/structure/closet/wardrobe/xenoarch,
-/obj/item/clothing/shoes/winterboots/ice_boots,
-/obj/item/clothing/glasses/meson,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
+	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
@@ -3043,12 +3037,15 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/security/execution/education)
 "rZ" = (
-/obj/machinery/suit_storage_unit/mining,
+/obj/structure/tank_dispenser/oxygen,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
@@ -3261,6 +3258,15 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/primary/aft)
+"sT" = (
+/obj/structure/table,
+/obj/item/strangerock,
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -23
+	},
+/turf/open/floor/plasteel/median/whitetodark/fullcorner,
+/area/xenoarch/arch)
 "sW" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/plasteel/dark,
@@ -3344,11 +3350,17 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/underground/unexplored/rivers)
 "tp" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 10
+/obj/machinery/rnd/production/protolathe/department/science,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
-/obj/item/kirbyplants/random,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
 "ts" = (
 /obj/machinery/light/small{
@@ -3394,12 +3406,10 @@
 /turf/open/floor/plating,
 /area/mine/living_quarters)
 "tJ" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner{
-	dir = 1
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
 	},
-/turf/open/floor/plasteel/median/whitetodark{
-	dir = 1
-	},
+/turf/open/floor/plating/asteroid/snow/icemoon,
 /area/xenoarch/arch)
 "tL" = (
 /obj/machinery/atmospherics/components/unary/tank/air{
@@ -3408,22 +3418,29 @@
 /turf/open/floor/plating,
 /area/mine/living_quarters)
 "tP" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "1-8"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "tV" = (
-/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/machinery/door/airlock/research{
+	name = "Xenoarchaeology Equipment Room";
+	req_access_txt = "47"
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/obj/machinery/door/firedoor/border_only{
+	name = "south facing firelock"
 	},
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
@@ -3496,13 +3513,7 @@
 /turf/open/floor/plasteel,
 /area/science/explab)
 "ur" = (
-/obj/effect/turf_decal/lumos/loading_area/white,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
+/obj/effect/turf_decal/trimline/brown,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "uv" = (
@@ -3658,22 +3669,6 @@
 /obj/structure/grille,
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors)
-"vu" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/lumos/loading_area/white,
-/obj/structure/railing/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "vw" = (
 /obj/effect/turf_decal/loading_area,
 /turf/open/floor/plasteel,
@@ -3690,15 +3685,17 @@
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/mine/production)
 "vB" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
-/turf/open/floor/plasteel/median/whitetodark{
-	dir = 1
-	},
+/turf/open/floor/plating/asteroid/snow/icemoon,
 /area/xenoarch/arch)
 "vD" = (
-/obj/effect/turf_decal/trimline/brown,
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "vG" = (
@@ -3837,15 +3834,14 @@
 /turf/open/floor/carpet,
 /area/chapel/main)
 "wA" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 4
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 6
 	},
-/obj/structure/chair/sofa/corp/left{
-	dir = 8
+/obj/structure/table,
+/obj/item/paper_bin{
+	pixel_y = 6
 	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/item/pen,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "wF" = (
@@ -4005,14 +4001,17 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "xy" = (
-/obj/effect/turf_decal/trimline/brown/filled/line,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
+/obj/machinery/door/airlock/research{
+	name = "Xenoarchaeology Lab";
+	req_access_txt = "47"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 6
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1;
+	name = "north facing firelock"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
 "xE" = (
 /obj/machinery/button/door{
@@ -4026,12 +4025,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
-"xF" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "xK" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel/dark,
@@ -4064,10 +4057,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/mine/living_quarters)
-"ye" = (
-/obj/effect/turf_decal/trimline/purple,
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "yf" = (
 /obj/structure/table,
 /obj/item/storage/firstaid/regular,
@@ -4078,11 +4067,12 @@
 /turf/open/floor/plasteel/white,
 /area/mine/living_quarters)
 "yg" = (
-/obj/effect/turf_decal/trimline/brown/filled/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
+	},
+/obj/machinery/quantumpad{
+	map_pad_id = "xenoarch";
+	map_pad_link_id = "miningbase"
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
@@ -4154,13 +4144,7 @@
 /turf/open/floor/engine,
 /area/science/misc_lab)
 "yB" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -4185,24 +4169,22 @@
 /turf/open/floor/plasteel,
 /area/mine/production)
 "yH" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 6
+/obj/machinery/computer/rdconsole/core,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
-/obj/structure/table,
-/obj/item/paper_bin{
-	pixel_y = 6
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
 	},
-/obj/item/pen,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
 "yI" = (
-/obj/structure/table,
-/obj/item/strangerock,
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -23
+/obj/structure/chair/office/dark{
+	dir = 1
 	},
-/turf/open/floor/plasteel/median/whitetodark/fullcorner,
+/turf/open/floor/plasteel/median/whitetodark{
+	dir = 8
+	},
 /area/xenoarch/arch)
 "yQ" = (
 /obj/effect/turf_decal/stripes/line{
@@ -4345,9 +4327,13 @@
 /turf/open/floor/engine,
 /area/science/storage)
 "zL" = (
-/obj/structure/table,
-/obj/item/relic,
-/turf/open/floor/plasteel/median/whitetodark,
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "zQ" = (
 /obj/machinery/mineral/unloading_machine{
@@ -4448,12 +4434,6 @@
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plating,
 /area/hallway/primary/port)
-"Av" = (
-/obj/structure/table,
-/turf/open/floor/plasteel/median/whitetodark{
-	dir = 1
-	},
-/area/xenoarch/arch)
 "Aw" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Mining Station Communications";
@@ -4821,22 +4801,19 @@
 /turf/open/floor/plating,
 /area/icemoon/surface/outdoors)
 "CC" = (
-/obj/structure/table,
-/obj/machinery/light,
-/obj/structure/sign/poster/official/random{
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel/median/whitetodark/fullcorner{
+/obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "CD" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 8
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 10
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/item/kirbyplants/random,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "CG" = (
@@ -4900,16 +4877,7 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "Df" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/machinery/airalarm{
-	pixel_y = 24
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plating,
 /area/xenoarch/arch)
 "Dh" = (
 /obj/effect/turf_decal/tile/brown{
@@ -4985,7 +4953,12 @@
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
 "DC" = (
-/obj/machinery/computer/rdconsole/core,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
+	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
@@ -5004,15 +4977,9 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/underground/unexplored/rivers)
 "DE" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 6
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
@@ -5254,8 +5221,22 @@
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
 "Fa" = (
-/obj/effect/turf_decal/trimline/brown/filled/line,
-/turf/open/floor/plasteel,
+/obj/structure/table,
+/obj/item/gps/mining{
+	gpstag = "XENOARCH";
+	pixel_x = -6
+	},
+/obj/item/gps/mining{
+	gpstag = "XENOARCH";
+	pixel_x = 6
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
 "Fb" = (
 /obj/machinery/atmospherics/pipe/simple/multiz{
@@ -5281,22 +5262,6 @@
 /obj/structure/chair/wood/normal,
 /turf/open/floor/plasteel/grimy,
 /area/chapel/main)
-"Fg" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/power/apc/auto_name/north,
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "Fo" = (
 /obj/structure/table/reinforced,
 /obj/item/stack/sheet/glass/fifty,
@@ -5362,13 +5327,11 @@
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/underground/unexplored/rivers)
 "FL" = (
-/obj/machinery/power/smes{
-	charge = 5e+006
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 9
 	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating,
+/obj/item/kirbyplants/random,
+/turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "FM" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -5488,10 +5451,7 @@
 /turf/closed/wall/r_wall,
 /area/science/circuit)
 "Gt" = (
-/obj/effect/turf_decal/trimline/brown/line{
-	dir = 1;
-	pixel_y = 6
-	},
+/obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "Gu" = (
@@ -5524,8 +5484,10 @@
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
 "GD" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1
+/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -6;
+	pixel_y = -31
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
@@ -5568,9 +5530,10 @@
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
 "GQ" = (
-/obj/effect/turf_decal/trimline/brown/filled/corner{
-	dir = 8
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 10
 	},
+/obj/machinery/vending/snack/random,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "GS" = (
@@ -5882,6 +5845,18 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"Ij" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "Ik" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plating,
@@ -6006,13 +5981,20 @@
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "IJ" = (
-/obj/structure/railing{
+/obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only{
-	name = "south facing firelock"
+/obj/effect/turf_decal/lumos/loading_area/white,
+/obj/structure/railing/corner{
+	dir = 4
 	},
-/turf/open/floor/plasteel/stairs/right,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "IK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -6083,14 +6065,11 @@
 /turf/open/floor/plasteel,
 /area/science/circuit)
 "IZ" = (
-/obj/structure/tank_dispenser/oxygen,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/machinery/suit_storage_unit/mining,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/machinery/light{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -6112,12 +6091,8 @@
 /turf/closed/wall,
 /area/icemoon/underground/unexplored/rivers)
 "Jl" = (
-/obj/structure/railing/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/purple/line{
-	dir = 1;
-	pixel_y = 6
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
@@ -6154,10 +6129,7 @@
 	dir = 4;
 	icon_state = "stairs_t"
 	},
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/open/space/basic,
+/turf/closed/wall,
 /area/xenoarch/arch)
 "Jy" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
@@ -6172,17 +6144,11 @@
 "Jz" = (
 /turf/open/floor/carpet,
 /area/chapel/main)
-"JB" = (
-/obj/effect/turf_decal/trimline/brown/filled/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "JC" = (
-/obj/effect/turf_decal/lumos/loading_area/white{
-	dir = 1
+/obj/machinery/door/firedoor/border_only{
+	name = "south facing firelock"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/stairs/medium,
 /area/xenoarch/arch)
 "JD" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
@@ -6196,8 +6162,9 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "JK" = (
-/obj/effect/turf_decal/trimline/brown/filled/corner,
-/obj/structure/ore_box,
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "JL" = (
@@ -6309,6 +6276,9 @@
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "Kt" = (
+/obj/effect/turf_decal/lumos/loading_area/white{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "KE" = (
@@ -6339,15 +6309,14 @@
 /turf/open/floor/plating,
 /area/hallway/primary/port)
 "KO" = (
-/obj/machinery/rnd/production/protolathe/department/science,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
-	},
-/obj/machinery/light{
-	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
@@ -6370,22 +6339,27 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/chapel/main)
 "KV" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 10
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 1
 	},
-/obj/machinery/vending/snack/random,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "La" = (
-/obj/structure/table,
-/obj/machinery/camera/autoname{
-	dir = 8
+/obj/structure/chair/office/dark{
+	dir = 1
 	},
-/obj/machinery/status_display/evac{
-	pixel_x = 32
+/obj/machinery/newscaster{
+	pixel_x = 32;
+	pixel_y = 1
 	},
-/turf/open/floor/plasteel/median/whitetodark/fullcorner{
-	dir = 8
+/turf/open/floor/plasteel/median/whitetodark{
+	dir = 4
 	},
 /area/xenoarch/arch)
 "Le" = (
@@ -6626,6 +6600,7 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "Ms" = (
+/obj/structure/chair/office/dark,
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/xenoarch/arch)
 "Mt" = (
@@ -6636,11 +6611,16 @@
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
 "Mx" = (
-/obj/structure/stairs{
-	dir = 4;
-	icon_state = "stairs_t"
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
 	},
-/turf/closed/wall,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "MG" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -6682,7 +6662,10 @@
 /turf/open/floor/engine,
 /area/science/mixing)
 "MR" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 6
+	},
+/obj/machinery/vending/cola/random,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "MT" = (
@@ -7005,22 +6988,13 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "OG" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/structure/railing{
 	dir = 8
 	},
-/obj/effect/turf_decal/lumos/loading_area/white{
-	dir = 1
+/obj/machinery/door/firedoor/border_only{
+	name = "south facing firelock"
 	},
-/obj/structure/railing/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
-"OJ" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8
-	},
-/turf/open/floor/plating/asteroid/snow/icemoon,
+/turf/open/floor/plasteel/stairs/left,
 /area/xenoarch/arch)
 "OO" = (
 /obj/machinery/sparker/toxmix{
@@ -7039,18 +7013,7 @@
 /turf/open/floor/plating,
 /area/hallway/primary/port)
 "OT" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 1
-	},
-/obj/structure/railing/corner{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
+/obj/effect/turf_decal/trimline/purple,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "OY" = (
@@ -7269,10 +7232,7 @@
 /turf/open/floor/carpet,
 /area/chapel/main)
 "Qw" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -7305,13 +7265,22 @@
 /turf/open/floor/plating,
 /area/icemoon/surface/outdoors)
 "QI" = (
-/obj/effect/turf_decal/trimline/brown/filled/corner{
-	dir = 8
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/structure/railing/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/status_display/evac{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "QJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -7369,7 +7338,11 @@
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
 "QY" = (
-/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/structure/fans/tiny,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "Rb" = (
@@ -7588,11 +7561,16 @@
 /turf/open/floor/plasteel,
 /area/science/test_area)
 "RZ" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 4
+/obj/effect/turf_decal/lumos/loading_area/white{
+	dir = 1
+	},
+/obj/structure/railing/corner,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 28
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
@@ -7739,22 +7717,20 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "Td" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 5
-	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "Tg" = (
-/obj/effect/turf_decal/trimline/brown/filled/line,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
@@ -7863,9 +7839,6 @@
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
 "TK" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4
-	},
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/xenoarch/arch)
 "TN" = (
@@ -8022,6 +7995,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
+"UG" = (
+/obj/structure/table,
+/obj/item/relic,
+/turf/open/floor/plasteel/median/whitetodark,
+/area/xenoarch/arch)
 "UH" = (
 /obj/structure/table,
 /obj/item/storage/box/donkpockets,
@@ -8313,8 +8291,8 @@
 /turf/open/floor/carpet,
 /area/mine/living_quarters)
 "VY" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner{
-	dir = 8
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
@@ -8322,6 +8300,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc/auto_name/north,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "Wd" = (
@@ -8580,9 +8562,13 @@
 /turf/open/floor/plasteel/freezer,
 /area/mine/living_quarters)
 "Xz" = (
-/obj/effect/turf_decal/trimline/brown,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
+	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "XA" = (
@@ -8633,11 +8619,17 @@
 /turf/open/floor/carpet,
 /area/hallway/primary/port)
 "XQ" = (
-/obj/machinery/button/electrochromatic{
-	id = "xenoarch";
-	pixel_y = -26
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 5
 	},
-/turf/open/floor/plasteel/median/whitetodark,
+/obj/structure/chair/sofa/corp/right{
+	dir = 8
+	},
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "XR" = (
 /turf/closed/wall/r_wall,
@@ -8818,8 +8810,8 @@
 /turf/open/floor/plasteel,
 /area/science/test_area)
 "YL" = (
-/obj/structure/table,
-/turf/open/floor/plasteel/median/whitetodark,
+/obj/effect/turf_decal/trimline/purple/filled/corner,
+/turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "YP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -8942,14 +8934,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/test_area)
+"Zs" = (
+/obj/structure/table,
+/turf/open/floor/plasteel/median/whitetodark{
+	dir = 1
+	},
+/area/xenoarch/arch)
 "Zu" = (
 /turf/closed/wall/r_wall,
 /area/security/execution/education)
 "Zw" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 6
-	},
-/obj/machinery/vending/cola/random,
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "Zy" = (
@@ -46003,7 +45999,7 @@ ah
 ah
 ah
 ah
-ah
+VE
 VE
 VE
 VE
@@ -46259,7 +46255,6 @@ ah
 ah
 ah
 ah
-ah
 VE
 VE
 cl
@@ -46267,6 +46262,7 @@ cl
 cl
 cl
 cl
+VE
 VE
 VE
 VE
@@ -46516,18 +46512,18 @@ VE
 VE
 VE
 VE
-ah
 VE
 hS
 cl
+lf
 rZ
 IZ
-cv
 cl
 cl
 cl
 cl
 cl
+VE
 VE
 VE
 ah
@@ -46771,21 +46767,21 @@ hS
 hS
 hS
 hS
-hS
 VE
 VE
 VE
 hS
 cl
-Df
+lM
 Yi
 Yi
 iO
+FL
 oZ
 CD
-tp
 cl
 cl
+VE
 VE
 ah
 ah
@@ -47026,7 +47022,6 @@ hS
 hS
 hS
 DN
-vI
 hS
 hS
 VE
@@ -47034,15 +47029,16 @@ VE
 hS
 hS
 iO
+oi
 rp
 ea
-oi
 iO
-JB
-ye
+JK
+OT
+Jl
 GQ
-KV
 cl
+VE
 VE
 VE
 VE
@@ -47289,19 +47285,19 @@ hS
 hS
 hS
 hS
-hS
 iO
-rp
+oi
+DC
 DE
 tV
 qI
 Td
-Kt
+YL
 MR
-Zw
 cl
 hS
 hS
+VE
 VE
 VE
 ah
@@ -47540,7 +47536,6 @@ vI
 hS
 hS
 VE
-VE
 vI
 vI
 hS
@@ -47548,18 +47543,19 @@ hS
 hS
 hS
 iO
+tp
 KO
 Qw
-QI
 iO
-hA
+KV
+ur
 vD
-Tg
 cl
 cl
 hS
 hS
 hS
+VE
 VE
 VE
 VE
@@ -47797,7 +47793,6 @@ hS
 hS
 VE
 VE
-VE
 hS
 DN
 hS
@@ -47805,13 +47800,13 @@ hS
 hS
 hS
 cl
-DC
+yH
 Yi
-lf
+Fa
 iO
+Mx
 yB
 GD
-lM
 cl
 hS
 hS
@@ -47819,6 +47814,7 @@ hS
 hS
 hS
 hS
+VE
 VE
 ah
 ah
@@ -48054,7 +48050,6 @@ hS
 VE
 VE
 VE
-VE
 hS
 hS
 vI
@@ -48066,9 +48061,9 @@ iO
 iO
 iO
 cl
-fv
-ye
-bm
+QI
+OT
+Zw
 cl
 cl
 kM
@@ -48076,6 +48071,7 @@ kM
 cl
 cl
 hS
+VE
 VE
 VE
 ah
@@ -48311,29 +48307,29 @@ hS
 VE
 VE
 VE
-VE
 hS
 hS
 vI
 iO
+bm
 nN
-JK
 iO
+zL
 yg
 jF
 OG
 pK
 mf
-pH
-QY
+Gt
 iO
+sT
 yI
 fw
 ob
-CC
 cl
 hS
 hS
+VE
 VE
 VE
 ah
@@ -48569,29 +48565,29 @@ VE
 VE
 VE
 VE
-VE
 hS
 hS
+au
 lU
 Gt
 QY
 jI
-xF
+Td
 Kt
 JC
 jv
 ur
-vD
-Fa
+ia
 iO
-Av
+Zs
+TK
 Ms
 ga
-YL
 kM
 hS
 hS
 hS
+VE
 VE
 ah
 ah
@@ -48826,29 +48822,29 @@ VE
 VE
 VE
 VE
-VE
 hS
 hS
 iO
+cv
 Jl
-GQ
 iO
+CC
 mR
 RZ
 qo
 IJ
-vu
-Kt
-MR
+Td
+YL
 iO
+dD
 vB
 TK
-Ms
-zL
+UG
 kM
 hS
 hS
 hS
+VE
 VE
 ah
 ah
@@ -49084,28 +49080,28 @@ VE
 VE
 VE
 VE
-VE
 hS
 cl
+dU
 Jv
-Mx
 cl
 cl
 cl
 cl
 cl
+Tg
 OT
-ye
+gq
 xy
 ks
 kQ
-aI
-Ms
-XQ
+TK
+oI
 cl
 hS
 hS
 hS
+VE
 VE
 ah
 ah
@@ -49340,28 +49336,28 @@ ah
 ah
 ah
 ah
-ah
 VE
 hS
 cl
 cl
 cl
 cl
+Df
 fL
 cb
-FL
 cl
-Fg
-Kt
 VY
+Td
+Ij
 iO
+jZ
 tJ
-OJ
-Ms
-YL
+TK
+ga
 kM
 hS
 hS
+VE
 VE
 VE
 ah
@@ -49597,28 +49593,28 @@ ah
 ah
 ah
 ah
-ah
 VE
 VE
 VE
 VE
 VE
 cl
+Df
 Fb
 kR
 qy
 tP
 cJ
 Xz
-dU
 iO
-Av
+Zs
+TK
 Ms
 ga
-YL
 kM
 hS
 hS
+VE
 VE
 ah
 ah
@@ -49858,24 +49854,24 @@ ah
 ah
 ah
 ah
-ah
 VE
 cl
 cl
 cl
 cl
 cl
+XQ
 qS
 wA
-yH
 iO
+rl
 La
 fq
 dB
-au
 cl
 hS
 hS
+VE
 VE
 VE
 ah
@@ -50115,7 +50111,6 @@ ah
 ah
 ah
 ah
-ah
 VE
 VE
 VE
@@ -50134,6 +50129,7 @@ cl
 hS
 hS
 hS
+VE
 VE
 ah
 ah
@@ -50388,9 +50384,9 @@ VE
 VE
 VE
 VE
+hS
+hS
 VE
-hS
-hS
 VE
 ah
 ah

--- a/_maps/map_files/Snaxi/IcemoonUnderground_Above_Lumos.dmm
+++ b/_maps/map_files/Snaxi/IcemoonUnderground_Above_Lumos.dmm
@@ -45,6 +45,15 @@
 	name = "hyper-reinforced wall"
 	},
 /area/icemoon/underground/unexplored/rivers)
+"au" = (
+/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/xenoarch/arch)
 "aw" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1;
@@ -128,6 +137,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"aU" = (
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "aW" = (
 /obj/structure/table_frame,
 /obj/item/storage/box/papersack,
@@ -172,6 +184,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
+"bi" = (
+/obj/machinery/computer/rdconsole/core,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/xenoarch/arch)
 "bj" = (
 /obj/machinery/door/airlock/glass_large,
 /turf/open/floor/plating,
@@ -212,6 +234,34 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
+"bz" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/lumos/loading_area/white,
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
+"bB" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
+/obj/structure/chair/sofa/corp/left{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "bG" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
@@ -227,6 +277,17 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/primary/port)
+"bV" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 6
+	},
+/obj/structure/table,
+/obj/item/paper_bin{
+	pixel_y = 6
+	},
+/obj/item/pen,
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "bZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
@@ -259,6 +320,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"ch" = (
+/obj/machinery/suit_storage_unit/mining,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/xenoarch/arch)
 "ci" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -270,19 +341,8 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/security/execution/education)
 "cl" = (
-/obj/machinery/suit_storage_unit/mining,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/mine/living_quarters)
+/turf/closed/wall,
+/area/xenoarch/arch)
 "cm" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -301,6 +361,24 @@
 /obj/structure/target_stake,
 /turf/open/floor/plasteel,
 /area/science/circuit)
+"cv" = (
+/obj/structure/table,
+/obj/item/gps/mining{
+	gpstag = "XENOARCH";
+	pixel_x = -6
+	},
+/obj/item/gps/mining{
+	gpstag = "XENOARCH";
+	pixel_x = 6
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/xenoarch/arch)
 "cw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -344,6 +422,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"cG" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/plasteel/median/whitetodark{
+	dir = 1
+	},
+/area/xenoarch/arch)
 "cH" = (
 /obj/machinery/mass_driver{
 	dir = 1;
@@ -448,6 +536,30 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/test_area)
+"ds" = (
+/obj/effect/spawner/structure/window/reinforced/tinted/electrochromatic{
+	electrochromatic_id = xenoarch
+	},
+/turf/open/floor/plating,
+/area/xenoarch/arch)
+"dw" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
+/obj/structure/railing/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/status_display/evac{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "dx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
@@ -542,6 +654,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/test_area)
+"eh" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner,
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "ei" = (
 /obj/structure/table,
 /obj/item/pickaxe,
@@ -595,6 +711,10 @@
 /obj/structure/grille/broken,
 /turf/open/floor/plating,
 /area/icemoon/surface/outdoors)
+"eo" = (
+/obj/structure/chair/office/dark,
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/xenoarch/arch)
 "eq" = (
 /turf/closed/wall,
 /area/mine/production)
@@ -651,6 +771,14 @@
 	},
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors)
+"ey" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/machinery/space_heater,
+/turf/open/floor/plating,
+/area/xenoarch/arch)
 "eB" = (
 /obj/machinery/firealarm{
 	pixel_y = 24
@@ -759,6 +887,17 @@
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel,
 /area/mine/eva)
+"eU" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/xenoarch/arch)
 "eV" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -1367,9 +1506,28 @@
 /obj/structure/barricade/wooden/crude/snow,
 /turf/open/floor/plating,
 /area/icemoon/surface/outdoors)
+"hQ" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 6
+	},
+/obj/machinery/vending/cola/random,
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "hS" = (
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors)
+"hV" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "hY" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plasteel,
@@ -1384,6 +1542,18 @@
 	},
 /turf/open/floor/carpet,
 /area/hallway/primary/port)
+"ie" = (
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "ig" = (
 /obj/structure/table,
 /obj/item/stack/sheet/mineral/plasma,
@@ -1464,21 +1634,18 @@
 /turf/open/floor/carpet,
 /area/chapel/main)
 "iO" = (
-/obj/structure/closet/wardrobe/xenoarch,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/xenoarch/arch)
+"iP" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/item/flashlight,
-/obj/item/clothing/glasses/meson,
-/turf/open/floor/plasteel,
-/area/mine/living_quarters)
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/xenoarch/arch)
 "iY" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio6";
@@ -1530,6 +1697,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"jm" = (
+/obj/effect/turf_decal/trimline/brown,
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "jn" = (
 /obj/machinery/light/small,
 /turf/open/floor/plasteel/dark,
@@ -1573,6 +1744,15 @@
 "jy" = (
 /turf/open/openspace,
 /area/mine/eva)
+"jz" = (
+/obj/machinery/power/smes{
+	charge = 5e+006
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/xenoarch/arch)
 "jA" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -1618,6 +1798,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/eva)
+"jM" = (
+/obj/structure/closet/wardrobe/xenoarch,
+/obj/item/clothing/shoes/winterboots/ice_boots,
+/obj/item/clothing/glasses/meson,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/xenoarch/arch)
 "jN" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -1774,6 +1966,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/storage)
+"ly" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "lB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/cafeteria,
@@ -1838,22 +2036,24 @@
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "lU" = (
-/obj/structure/tank_dispenser/oxygen,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/structure/fans/tiny,
 /turf/open/floor/plasteel,
-/area/mine/living_quarters)
+/area/xenoarch/arch)
 "lV" = (
 /turf/open/floor/plasteel/grimy,
 /area/chapel/main)
+"lY" = (
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "ma" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 5
@@ -2005,6 +2205,18 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"mW" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel/dark,
+/area/xenoarch/arch)
 "mY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -2114,12 +2326,13 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/chapel/main)
 "nN" = (
-/obj/machinery/door/airlock/research{
-	name = "Xenoarchaeology";
-	req_access_txt = "47"
+/obj/effect/turf_decal/trimline/purple/line{
+	dir = 1;
+	pixel_y = 6
 	},
+/obj/structure/closet/emcloset,
 /turf/open/floor/plasteel,
-/area/mine/living_quarters)
+/area/xenoarch/arch)
 "nP" = (
 /obj/structure/ladder,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
@@ -2240,6 +2453,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"oJ" = (
+/obj/machinery/suit_storage_unit/mining,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/xenoarch/arch)
 "oK" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/heater,
 /obj/machinery/light{
@@ -2260,6 +2483,18 @@
 	},
 /turf/open/floor/plating,
 /area/mine/living_quarters)
+"oM" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "oO" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/structure/cable{
@@ -2309,6 +2544,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/production)
+"oY" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "pc" = (
 /obj/structure/grille/broken,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -2373,6 +2620,16 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/plasteel,
 /area/science/test_area)
+"ps" = (
+/obj/item/radio/intercom{
+	dir = 4;
+	name = "Station Intercom (General)";
+	pixel_x = 27
+	},
+/turf/open/floor/plasteel/median/whitetodark{
+	dir = 4
+	},
+/area/xenoarch/arch)
 "pu" = (
 /obj/machinery/mineral/mint,
 /turf/open/floor/plasteel,
@@ -2415,6 +2672,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/production)
+"pM" = (
+/obj/structure/table,
+/obj/machinery/light,
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel/median/whitetodark/fullcorner{
+	dir = 1
+	},
+/area/xenoarch/arch)
 "pN" = (
 /obj/structure/table/glass,
 /obj/item/paper_bin{
@@ -2605,6 +2872,12 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"qY" = (
+/obj/machinery/door/firedoor/border_only{
+	name = "south facing firelock"
+	},
+/turf/open/floor/plasteel/stairs/medium,
+/area/xenoarch/arch)
 "rb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -2838,6 +3111,21 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel/white,
 /area/mine/living_quarters)
+"sB" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/xenoarch/arch)
 "sD" = (
 /obj/machinery/light/small,
 /turf/open/floor/plating,
@@ -2864,6 +3152,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/mine/living_quarters)
+"sI" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/obj/machinery/power/terminal,
+/turf/open/floor/plating,
+/area/xenoarch/arch)
 "sJ" = (
 /obj/item/transfer_valve{
 	pixel_x = -5
@@ -3049,6 +3344,13 @@
 	},
 /turf/open/floor/plating,
 /area/mine/living_quarters)
+"tK" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 10
+	},
+/obj/machinery/vending/snack/random,
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "tL" = (
 /obj/machinery/atmospherics/components/unary/tank/air{
 	dir = 8
@@ -3141,6 +3443,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"uy" = (
+/turf/open/floor/plasteel/median/whitetodark{
+	dir = 8
+	},
+/area/xenoarch/arch)
 "uD" = (
 /obj/machinery/door/airlock{
 	id_tag = "Cell2";
@@ -3163,6 +3470,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/production)
+"uH" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/xenoarch/arch)
 "uI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -3211,6 +3530,20 @@
 /obj/machinery/vending/wardrobe/science_wardrobe,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"uW" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/lumos/loading_area/white{
+	dir = 1
+	},
+/obj/structure/railing/corner,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 28
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "vb" = (
 /obj/machinery/mineral/equipment_vendor,
 /obj/effect/turf_decal/tile/purple,
@@ -3251,6 +3584,14 @@
 /obj/machinery/suit_storage_unit/rd,
 /turf/open/floor/engine,
 /area/science/test_area)
+"vp" = (
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "vq" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -3384,6 +3725,19 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/engine,
 /area/science/mixing)
+"wo" = (
+/obj/structure/tank_dispenser/oxygen,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/xenoarch/arch)
 "wp" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/food/snacks/sugarcookie/spookycoffin,
@@ -3594,6 +3948,12 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
+"xF" = (
+/obj/effect/turf_decal/lumos/loading_area/white{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "xK" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel/dark,
@@ -3721,6 +4081,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/production)
+"yL" = (
+/obj/machinery/atmospherics/pipe/simple/multiz{
+	piping_layer = 1
+	},
+/turf/open/floor/plating,
+/area/xenoarch/arch)
+"yM" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "yQ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -3750,6 +4122,9 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/mine/production)
+"yZ" = (
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/xenoarch/arch)
 "zd" = (
 /obj/machinery/airalarm/unlocked{
 	dir = 4;
@@ -3779,6 +4154,18 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel,
 /area/mine/production)
+"zm" = (
+/obj/structure/table,
+/obj/machinery/camera/autoname{
+	dir = 8
+	},
+/obj/machinery/status_display/evac{
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel/median/whitetodark/fullcorner{
+	dir = 8
+	},
+/area/xenoarch/arch)
 "zn" = (
 /obj/machinery/camera{
 	c_tag = "Processing Area Room";
@@ -3844,6 +4231,21 @@
 /obj/machinery/shieldwallgen/xenobiologyaccess,
 /turf/open/floor/plating,
 /area/science/misc_lab)
+"zC" = (
+/obj/machinery/button/electrochromatic{
+	id = "xenoarch";
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel/median/whitetodark,
+/area/xenoarch/arch)
+"zD" = (
+/obj/structure/chair/office/dark{
+	dir = 1
+	},
+/turf/open/floor/plasteel/median/whitetodark{
+	dir = 8
+	},
+/area/xenoarch/arch)
 "zE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -3853,6 +4255,18 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"zG" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/xenoarch/arch)
 "zH" = (
 /obj/machinery/power/apc/auto_name/south,
 /obj/machinery/light,
@@ -3996,6 +4410,11 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"AI" = (
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/machinery/light,
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "AN" = (
 /obj/structure/ladder,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
@@ -4015,6 +4434,13 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"AU" = (
+/obj/structure/stairs{
+	dir = 4;
+	icon_state = "stairs_t"
+	},
+/turf/closed/wall,
+/area/xenoarch/arch)
 "AV" = (
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_toxmix,
 /turf/open/floor/engine,
@@ -4200,6 +4626,15 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/grimy,
 /area/chapel/main)
+"BX" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "BY" = (
 /turf/closed/wall/r_wall,
 /area/hallway/primary/port)
@@ -4215,10 +4650,25 @@
 	},
 /turf/open/floor/circuit/telecomms,
 /area/science/xenobiology)
+"Ca" = (
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "Cb" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/plasteel,
 /area/science/test_area)
+"Cc" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 10
+	},
+/obj/item/kirbyplants/random,
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "Cd" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
@@ -4421,6 +4871,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
+"Dp" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	name = "south facing firelock"
+	},
+/turf/open/floor/plasteel/stairs/left,
+/area/xenoarch/arch)
 "Ds" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 4;
@@ -4459,6 +4918,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
+"DC" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/xenoarch/arch)
 "DD" = (
 /obj/structure/chair{
 	dir = 8
@@ -4703,6 +5171,19 @@
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
+"EW" = (
+/obj/structure/table,
+/obj/item/relic,
+/turf/open/floor/plasteel/median/whitetodark,
+/area/xenoarch/arch)
+"Fa" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating,
+/area/xenoarch/arch)
 "Fd" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -4793,6 +5274,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/icemoon/surface/outdoors)
+"FO" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "FQ" = (
 /obj/machinery/light{
 	dir = 4
@@ -4806,6 +5293,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/production)
+"FR" = (
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "FT" = (
 /obj/structure/punching_bag,
 /obj/machinery/light/small{
@@ -4903,12 +5396,12 @@
 /turf/closed/wall/r_wall,
 /area/science/circuit)
 "Gt" = (
-/obj/machinery/quantumpad{
-	map_pad_id = "xenoarch";
-	map_pad_link_id = "miningbase"
+/obj/effect/turf_decal/trimline/brown/line{
+	dir = 1;
+	pixel_y = 6
 	},
 /turf/open/floor/plasteel,
-/area/mine/living_quarters)
+/area/xenoarch/arch)
 "Gu" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible,
 /obj/machinery/meter,
@@ -4976,6 +5469,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
+"GQ" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/xenoarch/arch)
 "GS" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -5115,6 +5614,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/icemoon/surface/outdoors)
+"HC" = (
+/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -6;
+	pixel_y = -31
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "HD" = (
 /obj/machinery/door/window/southleft{
 	dir = 1;
@@ -5151,6 +5658,19 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
+"HK" = (
+/obj/machinery/door/airlock/research{
+	name = "Xenoarchaeology Lab";
+	req_access_txt = "47"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1;
+	name = "north facing firelock"
+	},
+/turf/open/floor/plasteel/dark,
+/area/xenoarch/arch)
 "HM" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
@@ -5492,23 +6012,22 @@
 "Ji" = (
 /turf/closed/wall,
 /area/icemoon/underground/unexplored/rivers)
-"Jl" = (
-/obj/machinery/computer/rdconsole/core,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
+"Jj" = (
+/obj/structure/table,
+/turf/open/floor/plasteel/median/whitetodark{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
+/area/xenoarch/arch)
+"Jl" = (
+/obj/structure/railing/corner{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 1
+/obj/effect/turf_decal/trimline/purple/line{
+	dir = 1;
+	pixel_y = 6
 	},
 /turf/open/floor/plasteel,
-/area/mine/living_quarters)
+/area/xenoarch/arch)
 "Jo" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
@@ -5538,18 +6057,15 @@
 /turf/open/floor/plasteel/grimy,
 /area/chapel/main)
 "Jv" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
+/obj/structure/stairs{
+	dir = 4;
+	icon_state = "stairs_t"
 	},
-/obj/effect/turf_decal/tile/purple{
+/obj/structure/railing{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/mine/living_quarters)
+/turf/open/space/basic,
+/area/xenoarch/arch)
 "Jy" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -5575,19 +6091,10 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "JK" = (
-/obj/machinery/rnd/production/protolathe/department/science,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
+/obj/effect/turf_decal/trimline/brown/filled/corner,
+/obj/structure/ore_box,
 /turf/open/floor/plasteel,
-/area/mine/living_quarters)
+/area/xenoarch/arch)
 "JL" = (
 /obj/structure/chair/stool,
 /turf/open/floor/plasteel/white,
@@ -5659,6 +6166,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/production)
+"Ki" = (
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/xenoarch/arch)
 "Kk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
@@ -5723,6 +6239,22 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/primary/port)
+"KL" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/lumos/loading_area/white,
+/obj/structure/railing/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "KP" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "47"
@@ -5741,6 +6273,15 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/chapel/main)
+"KZ" = (
+/obj/structure/table,
+/obj/item/strangerock,
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -23
+	},
+/turf/open/floor/plasteel/median/whitetodark/fullcorner,
+/area/xenoarch/arch)
 "Le" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -5907,6 +6448,18 @@
 /obj/machinery/atmospherics/pipe/simple/supply/visible,
 /turf/open/floor/plating,
 /area/hallway/primary/port)
+"LZ" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/lumos/loading_area/white{
+	dir = 1
+	},
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "Ma" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -5959,6 +6512,15 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/execution/education)
+"Mj" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	name = "south facing firelock"
+	},
+/turf/open/floor/plasteel/stairs/right,
+/area/xenoarch/arch)
 "Mm" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -6014,6 +6576,15 @@
 /obj/structure/closet/radiation,
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
+"MO" = (
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "MP" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -6066,6 +6637,31 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
+"Nk" = (
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
+"Nq" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "Nr" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
@@ -6140,6 +6736,12 @@
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel,
 /area/mine/production)
+"NL" = (
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "NO" = (
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
@@ -6359,6 +6961,27 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/primary/port)
+"OR" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 5
+	},
+/obj/structure/chair/sofa/corp/right{
+	dir = 8
+	},
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
+"OW" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/median/whitetodark{
+	dir = 1
+	},
+/area/xenoarch/arch)
 "OY" = (
 /obj/structure/sign/warning/vacuum/external{
 	pixel_y = 32
@@ -6436,6 +7059,10 @@
 /obj/structure/flora/rock/icy,
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors)
+"PC" = (
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "PD" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/monkeycubes,
@@ -6563,6 +7190,25 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"Qi" = (
+/obj/effect/turf_decal/trimline/brown/filled/corner,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/xenoarch/arch)
+"Qn" = (
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "Qp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
@@ -6583,6 +7229,31 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
+"QA" = (
+/obj/machinery/door/airlock/research{
+	name = "Xenoarchaeology Equipment Room";
+	req_access_txt = "47"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/door/firedoor/border_only{
+	name = "south facing firelock"
+	},
+/turf/open/floor/plasteel/dark,
+/area/xenoarch/arch)
+"QE" = (
+/obj/machinery/rnd/production/protolathe/department/science,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/xenoarch/arch)
 "QH" = (
 /obj/effect/decal/remains/human,
 /obj/item/pipe{
@@ -6654,22 +7325,17 @@
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
 "QY" = (
-/obj/structure/closet/wardrobe/xenoarch,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/trimline/purple/filled/line,
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
+"Ra" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 4
 	},
-/obj/item/flashlight,
-/obj/item/clothing/glasses/night,
-/obj/item/clothing/glasses/meson,
-/turf/open/floor/plasteel,
-/area/mine/living_quarters)
+/turf/open/floor/plasteel/median/whitetodark{
+	dir = 1
+	},
+/area/xenoarch/arch)
 "Rb" = (
 /obj/structure/table,
 /obj/machinery/microwave{
@@ -6979,6 +7645,15 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/science/xenobiology)
+"SN" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "SO" = (
 /obj/machinery/sparker{
 	id = "testigniter";
@@ -7027,6 +7702,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"Th" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "Ti" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
@@ -7236,6 +7926,10 @@
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/chapel/main)
+"Uo" = (
+/obj/structure/table,
+/turf/open/floor/plasteel/median/whitetodark,
+/area/xenoarch/arch)
 "Up" = (
 /turf/open/floor/plating,
 /area/security/execution/education)
@@ -7422,6 +8116,13 @@
 /obj/effect/spawner/structure/window/ice,
 /turf/open/floor/plating,
 /area/chapel/main)
+"Vk" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 9
+	},
+/obj/item/kirbyplants/random,
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "Vm" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -7506,6 +8207,18 @@
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/security/execution/education)
+"VG" = (
+/obj/structure/chair/office/dark{
+	dir = 1
+	},
+/obj/machinery/newscaster{
+	pixel_x = 32;
+	pixel_y = 1
+	},
+/turf/open/floor/plasteel/median/whitetodark{
+	dir = 4
+	},
+/area/xenoarch/arch)
 "VH" = (
 /obj/structure/stairs,
 /obj/structure/railing{
@@ -7575,6 +8288,38 @@
 	},
 /turf/open/floor/carpet,
 /area/mine/living_quarters)
+"VZ" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
+/obj/machinery/quantumpad{
+	map_pad_id = "xenoarch";
+	map_pad_link_id = "miningbase"
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
+"Wb" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
+	},
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/xenoarch/arch)
+"Wc" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc/auto_name/north,
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "Wd" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -5;
@@ -7623,6 +8368,12 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/hallway/primary/aft)
+"Wt" = (
+/obj/machinery/atmospherics/pipe/simple/multiz{
+	piping_layer = 3
+	},
+/turf/open/floor/plating,
+/area/xenoarch/arch)
 "Wz" = (
 /obj/structure/grille,
 /turf/closed/mineral/random/snow,
@@ -7780,6 +8531,10 @@
 	},
 /turf/open/floor/engine,
 /area/science/explab)
+"Xj" = (
+/obj/effect/turf_decal/trimline/purple,
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "Xl" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -7905,6 +8660,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"Yc" = (
+/obj/effect/turf_decal/trimline/brown,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "Yf" = (
 /obj/structure/table,
 /obj/item/strangerock,
@@ -8046,6 +8807,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/test_area)
+"YN" = (
+/obj/effect/turf_decal/lumos/loading_area/white,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "YP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -8180,6 +8951,17 @@
 /obj/structure/chair/stool,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
+"ZB" = (
+/obj/structure/table,
+/obj/item/strangerock,
+/obj/machinery/light,
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel/median/whitetodark/fullcorner{
+	dir = 4
+	},
+/area/xenoarch/arch)
 "ZF" = (
 /obj/machinery/atmospherics/pipe/simple/multiz,
 /obj/effect/turf_decal/stripes/box,
@@ -36966,9 +37748,9 @@ ah
 ah
 ah
 ah
-VE
-VE
-VE
+ah
+ah
+ah
 VE
 VE
 nd
@@ -37222,10 +38004,10 @@ ah
 ah
 ah
 ah
-VE
-VE
-VE
-VE
+ah
+ah
+ah
+ah
 VE
 VE
 nd
@@ -37478,13 +38260,13 @@ ah
 ah
 ah
 ah
+ah
+ah
+ah
+ah
+ah
 VE
 VE
-VE
-nd
-nd
-nd
-nd
 nd
 rj
 sa
@@ -37735,13 +38517,13 @@ ah
 ah
 ah
 ah
+ah
+ah
+ah
+ah
+ah
 VE
 VE
-nd
-nd
-iO
-iO
-QY
 nd
 ET
 aa
@@ -37992,13 +38774,13 @@ ah
 ah
 ah
 ah
+ah
+ah
+ah
+ah
+ah
 VE
 VE
-nd
-JK
-Jv
-Jv
-Jv
 nd
 ry
 vW
@@ -38249,16 +39031,16 @@ ah
 ah
 ah
 ah
+ah
+ah
+ah
+ah
+ah
 VE
 VE
 nd
-Jl
-Jv
-Jv
-Jv
-nN
 sa
-Gt
+sa
 sa
 sa
 GN
@@ -38506,13 +39288,13 @@ ah
 ah
 ah
 ah
+ah
+ah
+ah
+ah
+ah
 VE
 VE
-nd
-lU
-Jv
-Jv
-Jv
 nd
 sa
 sa
@@ -38763,13 +39545,13 @@ ah
 ah
 ah
 ah
+ah
+ah
+ah
+ah
+ah
 VE
 VE
-nd
-nd
-cl
-cl
-cl
 nV
 nV
 nV
@@ -39020,13 +39802,13 @@ ah
 ah
 ah
 ah
+ah
+ah
+ah
+ah
+ah
 VE
 VE
-VE
-nd
-nd
-nd
-nd
 nV
 sj
 sj
@@ -39278,10 +40060,10 @@ ah
 ah
 ah
 ah
-VE
-VE
-VE
-VE
+ah
+ah
+ah
+ah
 VE
 VE
 nV
@@ -39537,8 +40319,8 @@ ah
 ah
 ah
 ah
-VE
-VE
+ah
+ah
 VE
 VE
 nV
@@ -44956,7 +45738,7 @@ hS
 hS
 hS
 hS
-ah
+VE
 ah
 ah
 ah
@@ -45213,6 +45995,7 @@ hS
 hS
 hS
 hS
+VE
 ah
 ah
 ah
@@ -45221,14 +46004,13 @@ ah
 ah
 ah
 ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
+VE
+VE
+VE
+VE
+VE
+VE
+VE
 ah
 ah
 ah
@@ -45469,27 +46251,27 @@ hS
 hS
 hS
 hS
+hS
+VE
+VE
 ah
 ah
 ah
 ah
 ah
 ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
+VE
+VE
+cl
+cl
+cl
+cl
+cl
+VE
+VE
+VE
+VE
+VE
 ah
 ah
 ah
@@ -45725,29 +46507,29 @@ hS
 hS
 hS
 hS
+hS
+hS
+hS
+VE
+VE
+VE
+VE
+VE
+VE
 ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
+VE
+hS
+cl
+oJ
+wo
+ch
+cl
+cl
+cl
+cl
+cl
+VE
+VE
 ah
 ah
 ah
@@ -45982,29 +46764,29 @@ VE
 hS
 hS
 hS
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
+hS
+hS
+hS
+hS
+hS
+hS
+hS
+hS
+VE
+VE
+VE
+hS
+cl
+mW
+DC
+DC
+iO
+Vk
+SN
+Cc
+cl
+cl
+VE
 ah
 ah
 ah
@@ -46240,30 +47022,30 @@ Vw
 hS
 hS
 hS
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
+hS
+hS
+hS
+DN
+vI
+hS
+hS
+VE
+VE
+hS
+hS
+iO
+jM
+uH
+Qi
+iO
+NL
+Xj
+FR
+tK
+cl
+VE
+VE
+VE
 ah
 ah
 ah
@@ -46497,31 +47279,31 @@ Vw
 hS
 hS
 hS
+vI
 hS
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
+hS
+hS
+hS
+hS
+hS
+hS
+hS
+hS
+hS
+iO
+jM
+sB
+au
+QA
+oM
+aU
+eh
+hQ
+cl
+hS
+hS
+VE
+VE
 ah
 ah
 ah
@@ -46754,33 +47536,33 @@ Vw
 VE
 hS
 hS
+vI
 hS
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
+hS
+VE
+VE
+vI
+vI
+hS
+hS
+hS
+hS
+iO
+QE
+zG
+Ki
+iO
+ie
+jm
+vp
+cl
+cl
+hS
+hS
+hS
+VE
+VE
+VE
 ah
 ah
 ah
@@ -47010,34 +47792,34 @@ VE
 VE
 VE
 hS
+vI
 hS
 hS
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
+VE
+VE
+VE
+hS
+DN
+hS
+hS
+hS
+hS
+cl
+bi
+DC
+cv
+iO
+oY
+ly
+HC
+cl
+hS
+hS
+hS
+hS
+hS
+hS
+VE
 ah
 ah
 ah
@@ -47267,35 +48049,35 @@ WD
 VE
 hS
 hS
+DN
+hS
+VE
+VE
+VE
+VE
 hS
 hS
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
+vI
+cl
+cl
+cl
+cl
+iO
+iO
+iO
+cl
+dw
+Xj
+AI
+cl
+cl
+ds
+ds
+cl
+cl
+hS
+VE
+VE
 ah
 ah
 ah
@@ -47522,38 +48304,38 @@ Vg
 er
 hS
 hS
+vI
 hS
 hS
 hS
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
+VE
+VE
+VE
+VE
+hS
+hS
+vI
+iO
+nN
+JK
+iO
+MO
+VZ
+LZ
+Dp
+bz
+FO
+QY
+iO
+KZ
+zD
+uy
+pM
+cl
+hS
+hS
+VE
+VE
 ah
 ah
 ah
@@ -47778,39 +48560,39 @@ Tn
 NP
 VC
 hS
+vI
+vI
 hS
 hS
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
+hS
+VE
+VE
+VE
+VE
+VE
+hS
+hS
+lU
+Gt
+QY
+Ca
+yM
+aU
+xF
+qY
+YN
+jm
+PC
+iO
+Jj
+yZ
+eo
+Uo
+ds
+hS
+hS
+hS
+VE
 ah
 ah
 ah
@@ -48036,38 +48818,38 @@ UJ
 er
 hS
 hS
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
+hS
+hS
+VE
+VE
+VE
+VE
+VE
+VE
+VE
+hS
+hS
+iO
+Jl
+FR
+iO
+Qn
+BX
+uW
+Mj
+KL
+aU
+eh
+iO
+Ra
+Wb
+yZ
+EW
+ds
+hS
+hS
+hS
+VE
 ah
 ah
 ah
@@ -48293,38 +49075,38 @@ eq
 eq
 WD
 VE
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
+VE
+VE
+VE
+VE
+VE
+VE
+VE
+VE
+VE
+VE
+hS
+cl
+Jv
+AU
+cl
+cl
+cl
+cl
+cl
+Th
+Xj
+lY
+HK
+cG
+iP
+yZ
+zC
+cl
+hS
+hS
+hS
+VE
 ah
 ah
 ah
@@ -48559,29 +49341,29 @@ ah
 ah
 ah
 ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
+VE
+hS
+cl
+cl
+cl
+cl
+yL
+sI
+jz
+cl
+Wc
+aU
+hV
+iO
+OW
+GQ
+yZ
+Uo
+ds
+hS
+hS
+VE
+VE
 ah
 ah
 ah
@@ -48816,28 +49598,28 @@ ah
 ah
 ah
 ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
+VE
+VE
+VE
+VE
+VE
+cl
+Wt
+ey
+Fa
+eU
+Nq
+Yc
+Nk
+iO
+Jj
+yZ
+eo
+Uo
+ds
+hS
+hS
+VE
 ah
 ah
 ah
@@ -49077,25 +49859,25 @@ ah
 ah
 ah
 ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
+VE
+cl
+cl
+cl
+cl
+cl
+OR
+bB
+bV
+iO
+zm
+VG
+ps
+ZB
+cl
+hS
+hS
+VE
+VE
 ah
 ah
 ah
@@ -49334,25 +50116,25 @@ ah
 ah
 ah
 ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
+VE
+VE
+VE
+VE
+VE
+cl
+cl
+cl
+cl
+cl
+cl
+cl
+cl
+cl
+cl
+hS
+hS
+hS
+VE
 ah
 ah
 ah
@@ -49595,21 +50377,21 @@ ah
 ah
 ah
 ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
+VE
+VE
+VE
+VE
+VE
+VE
+VE
+VE
+VE
+VE
+VE
+VE
+hS
+hS
+VE
 ah
 ah
 ah
@@ -49863,10 +50645,10 @@ ah
 ah
 ah
 ah
-ah
-ah
-ah
-ah
+VE
+VE
+VE
+VE
 ah
 ah
 ah

--- a/_maps/map_files/Snaxi/Snaxi_Lumos.dmm
+++ b/_maps/map_files/Snaxi/Snaxi_Lumos.dmm
@@ -7564,6 +7564,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"ceh" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "cep" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -9225,6 +9237,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"cJM" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 8;
+	name = "west facing firelock"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "cKe" = (
 /obj/structure/cable,
 /obj/machinery/power/smes,
@@ -14333,17 +14352,6 @@
 	dir = 1
 	},
 /area/chapel/office)
-"ffl" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/stalkybush,
-/turf/open/floor/grass,
-/area/hallway/primary/central)
 "ffm" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -19846,6 +19854,15 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/carpet,
 /area/hallway/secondary/exit/departure_lounge)
+"hJM" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "hJW" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 10
@@ -23707,11 +23724,6 @@
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
-"jyK" = (
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "jyU" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -29440,6 +29452,11 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/virology)
+"mpR" = (
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "mqb" = (
 /obj/machinery/vending/wardrobe/jani_wardrobe,
 /obj/structure/sign/poster/official/random{
@@ -36109,6 +36126,12 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
+"ptn" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "ptv" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on/layer1,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -40757,6 +40780,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"rzr" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/stalkybush,
+/turf/open/floor/grass,
+/area/hallway/primary/central)
 "rAa" = (
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/disposal/bin,
@@ -42483,21 +42517,6 @@
 	dir = 8
 	},
 /area/chapel/office)
-"svl" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "svp" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/engine,
@@ -45896,12 +45915,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
-"uej" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "ueq" = (
 /obj/structure/bodycontainer/morgue{
 	dir = 2
@@ -46063,6 +46076,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"uiU" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "ujD" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -47083,6 +47111,18 @@
 	dir = 4
 	},
 /area/chapel/main)
+"uOG" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "uOT" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -48748,18 +48788,6 @@
 "vAs" = (
 /turf/open/floor/plating,
 /area/icemoon/surface/outdoors)
-"vAx" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 9
-	},
-/turf/open/floor/plasteel/dark,
-/area/bridge)
 "vAy" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -49764,6 +49792,15 @@
 	},
 /turf/open/floor/plating,
 /area/bridge)
+"vXe" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "vXs" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -49859,17 +49896,6 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
-"vZO" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/biolumi/mine/weaklight,
-/turf/open/floor/grass,
-/area/hallway/primary/central)
 "vZR" = (
 /obj/effect/landmark/start/bartender,
 /turf/open/floor/plasteel/grimy,
@@ -50069,6 +50095,17 @@
 	},
 /turf/open/floor/grass,
 /area/hallway/primary/aft)
+"wda" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/biolumi/mine/weaklight,
+/turf/open/floor/grass,
+/area/hallway/primary/central)
 "wdb" = (
 /turf/closed/wall/r_wall,
 /area/science/explab)
@@ -50878,15 +50915,6 @@
 	},
 /turf/closed/wall,
 /area/hallway/primary/aft)
-"wzq" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "wzv" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -51327,18 +51355,6 @@
 	dir = 4
 	},
 /area/chapel/main)
-"wLy" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/bridge)
 "wLG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/closed/wall/mineral/wood,
@@ -52177,15 +52193,6 @@
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"xhE" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "xhH" = (
 /turf/closed/wall/r_wall,
 /area/hallway/primary/central)
@@ -52582,13 +52589,6 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/grass,
 /area/maintenance/aft/secondary)
-"xtw" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 8;
-	name = "west facing firelock"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "xty" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-22"
@@ -86554,7 +86554,7 @@ wJb
 lhQ
 sAw
 lhQ
-vZO
+wda
 dMj
 riE
 hGy
@@ -86811,7 +86811,7 @@ wRX
 lhQ
 cZq
 lhQ
-ffl
+rzr
 dMj
 dMj
 dMj
@@ -87580,7 +87580,7 @@ tys
 tys
 tys
 tys
-jyK
+mpR
 bPd
 tys
 tys
@@ -87847,7 +87847,7 @@ bUL
 cgZ
 iIS
 cmU
-wLy
+uOG
 ckX
 clV
 cmV
@@ -88096,7 +88096,7 @@ srk
 srk
 cTO
 cdE
-xtw
+cJM
 chb
 chb
 yiZ
@@ -88104,7 +88104,7 @@ chb
 vqS
 iIS
 hYD
-wLy
+uOG
 cqo
 clV
 oBF
@@ -88361,7 +88361,7 @@ rnA
 hsP
 iIS
 kxf
-wLy
+uOG
 iIK
 iIS
 iAt
@@ -88608,7 +88608,7 @@ uJe
 njU
 agy
 xjF
-svl
+uiU
 mbh
 bwr
 chb
@@ -88618,7 +88618,7 @@ gSY
 uAs
 obL
 fJW
-vAx
+ceh
 rAj
 iIS
 cph
@@ -91178,7 +91178,7 @@ nHQ
 agy
 xjF
 lhQ
-wzq
+vXe
 kSP
 oBj
 tpn
@@ -92720,7 +92720,7 @@ iZs
 gKs
 srk
 cQU
-wzq
+vXe
 lDi
 cVc
 kpT
@@ -94262,7 +94262,7 @@ wGq
 wGq
 kAX
 lhQ
-xhE
+hJM
 tNf
 jcT
 avT
@@ -94519,7 +94519,7 @@ wTK
 wTK
 wTK
 bdm
-uej
+ptn
 tNf
 jcT
 avT
@@ -101468,9 +101468,9 @@ haK
 nNk
 jcO
 eNc
-bqN
-bqN
-bqN
+ydp
+ydp
+ydp
 ydp
 ydp
 ydp
@@ -101726,7 +101726,7 @@ ttS
 lff
 eNc
 eNc
-bqN
+ydp
 ydp
 ydp
 ydp
@@ -101983,10 +101983,10 @@ qAo
 lSs
 xty
 eNc
-bqN
 ydp
-ydp
-ydp
+qrR
+qrR
+qrR
 qrR
 qrR
 qrR
@@ -102240,10 +102240,10 @@ qAo
 xDu
 jNv
 eNc
-bqN
-bqN
 ydp
-ydp
+qrR
+qrR
+qrR
 qrR
 qrR
 qrR
@@ -102497,10 +102497,10 @@ xDu
 xDu
 aET
 wcK
-bqN
-bqN
 ydp
-ydp
+qrR
+qrR
+qrR
 qrR
 qrR
 qrR
@@ -102754,10 +102754,10 @@ qAo
 xDu
 jNv
 eNc
-bqN
-bqN
 ydp
-ydp
+qrR
+qrR
+qrR
 qrR
 qrR
 qrR
@@ -103011,10 +103011,10 @@ qAo
 mCK
 uNq
 eNc
-bqN
-bqN
 ydp
-ydp
+qrR
+qrR
+qrR
 qrR
 qrR
 qrR
@@ -103268,10 +103268,10 @@ rkw
 lff
 eNc
 eNc
-bqN
 ydp
-ydp
-ydp
+qrR
+qrR
+qrR
 qrR
 qrR
 qrR
@@ -103501,7 +103501,7 @@ yhx
 yhx
 yhx
 yhx
-nbC
+yhx
 nbC
 nbC
 lfs
@@ -103524,11 +103524,11 @@ dSb
 oJM
 fvn
 eNc
-bqN
-bqN
-bqN
 ydp
-bqN
+ydp
+ydp
+ydp
+ydp
 qrR
 qrR
 qrR
@@ -103758,9 +103758,9 @@ yhx
 yhx
 yhx
 yhx
+yhx
 nbC
-nbC
-nbC
+ydp
 lfs
 aji
 tjh
@@ -103781,13 +103781,13 @@ wcK
 eJa
 wcK
 wcK
-bqN
-bqN
-bqN
-bqN
-bqN
-bqN
-bqN
+ydp
+ydp
+ydp
+ydp
+ydp
+ydp
+ydp
 qrR
 qrR
 qrR
@@ -104015,9 +104015,9 @@ yhx
 yhx
 yhx
 yhx
-nbC
-nbC
-nbC
+yhx
+ydp
+ydp
 lfs
 thD
 iMc
@@ -104043,8 +104043,8 @@ eNc
 eNc
 eNc
 eNc
-bqN
-bqN
+ydp
+ydp
 qrR
 qrR
 qrR
@@ -104272,9 +104272,9 @@ yhx
 yhx
 yhx
 yhx
-nbC
-nbC
-bqN
+yhx
+ydp
+ydp
 lfs
 yfC
 iMc
@@ -104301,8 +104301,8 @@ nVs
 epT
 nVs
 eNc
-bqN
-bqN
+ydp
+ydp
 qrR
 qrR
 qrR
@@ -104529,9 +104529,9 @@ yhx
 yhx
 yhx
 yhx
-nbC
-nbC
-bqN
+yhx
+ydp
+ydp
 lfs
 eDs
 pVU
@@ -104558,9 +104558,9 @@ dzF
 pWT
 nVs
 eNc
-bqN
-bqN
-bqN
+ydp
+ydp
+ydp
 qrR
 qrR
 qrR
@@ -104786,9 +104786,9 @@ yhx
 yhx
 yhx
 yhx
-nbC
-nbC
-bqN
+yhx
+ydp
+ydp
 lfs
 kxk
 sOc
@@ -104816,8 +104816,8 @@ ggg
 nVs
 jJG
 eNc
-bqN
-bqN
+ydp
+ydp
 qrR
 qrR
 qrR
@@ -105043,9 +105043,9 @@ yhx
 yhx
 yhx
 yhx
-nbC
-bqN
-bqN
+yhx
+ydp
+ydp
 qdK
 yfC
 iMc
@@ -105073,8 +105073,8 @@ fPO
 nVs
 aSk
 eNc
-bqN
-bqN
+ydp
+ydp
 qrR
 qrR
 qrR
@@ -105300,9 +105300,9 @@ yhx
 yhx
 yhx
 yhx
-nbC
-bqN
-bqN
+yhx
+ydp
+ydp
 qdK
 hte
 lRZ
@@ -105330,7 +105330,7 @@ qjQ
 nVs
 xMo
 eNc
-bqN
+ydp
 qrR
 qrR
 qrR
@@ -105557,9 +105557,9 @@ yhx
 yhx
 yhx
 yhx
-nbC
-bqN
-bqN
+yhx
+ydp
+ydp
 lfs
 xfG
 kUq
@@ -105587,8 +105587,8 @@ ggg
 nVs
 tjC
 eNc
-bqN
-bqN
+ydp
+ydp
 qrR
 qrR
 qrR
@@ -105814,9 +105814,9 @@ yhx
 yhx
 yhx
 yhx
+yhx
 nbC
-nbC
-bqN
+ydp
 lfs
 tQq
 tQq
@@ -105843,8 +105843,8 @@ ggg
 wsK
 nVs
 eNc
-bqN
-bqN
+ydp
+ydp
 qrR
 qrR
 qrR
@@ -106071,7 +106071,7 @@ yhx
 yhx
 yhx
 yhx
-nbC
+yhx
 nbC
 nbC
 lfs
@@ -106100,9 +106100,9 @@ nVs
 wUb
 nVs
 eNc
-bqN
-bqN
-bqN
+ydp
+ydp
+ydp
 qrR
 qrR
 qrR
@@ -106328,7 +106328,7 @@ yhx
 yhx
 yhx
 yhx
-nbC
+yhx
 nbC
 nbC
 nbC
@@ -106356,9 +106356,9 @@ eNc
 eNc
 eNc
 eNc
-bqN
-bqN
-bqN
+ydp
+ydp
+ydp
 qrR
 qrR
 qrR
@@ -106585,7 +106585,7 @@ yhx
 yhx
 yhx
 yhx
-nbC
+yhx
 nbC
 nbC
 nbC
@@ -106608,13 +106608,13 @@ trD
 wcK
 wcK
 wcK
-bqN
-bqN
-bqN
-bqN
-bqN
-bqN
-bqN
+ydp
+ydp
+ydp
+ydp
+ydp
+ydp
+ydp
 qrR
 qrR
 qrR
@@ -106848,9 +106848,9 @@ yhx
 nbC
 nbC
 nbC
-bqN
-bqN
-bqN
+ydp
+ydp
+ydp
 lfs
 yfC
 ovr
@@ -106865,13 +106865,13 @@ wcK
 wcK
 bqN
 bqN
-bqN
-bqN
-bqN
 ydp
-bqN
+ydp
+ydp
 qrR
-bqN
+qrR
+qrR
+ydp
 qrR
 qrR
 qrR
@@ -107105,9 +107105,9 @@ yhx
 nbC
 nbC
 nbC
-nbC
-bqN
-bqN
+ydp
+ydp
+ydp
 lfs
 yfC
 ovr
@@ -107123,10 +107123,10 @@ bqN
 bqN
 bqN
 bqN
-bqN
 ydp
-ydp
-ydp
+qrR
+qrR
+qrR
 qrR
 qrR
 qrR
@@ -107361,10 +107361,10 @@ yhx
 yhx
 yhx
 yhx
+yhx
 nbC
 nbC
-nbC
-bqN
+ydp
 qdK
 yfC
 mSQ
@@ -107380,10 +107380,10 @@ bqN
 bqN
 bqN
 bqN
-bqN
 ydp
-ydp
-ydp
+qrR
+qrR
+qrR
 qrR
 qrR
 qrR
@@ -107618,10 +107618,10 @@ yhx
 yhx
 yhx
 yhx
+yhx
 nbC
-nbC
-bqN
-bqN
+ydp
+ydp
 qdK
 yfC
 mSQ
@@ -107638,9 +107638,9 @@ bqN
 bqN
 bqN
 ydp
-ydp
-ydp
-ydp
+qrR
+qrR
+qrR
 qrR
 qrR
 qrR
@@ -107875,10 +107875,10 @@ yhx
 yhx
 yhx
 yhx
+yhx
 nbC
-nbC
-bqN
-bqN
+ydp
+ydp
 qdK
 nZD
 jRW
@@ -107895,9 +107895,9 @@ bqN
 bqN
 bqN
 ydp
-ydp
-ydp
-ydp
+qrR
+qrR
+qrR
 qrR
 qrR
 qrR
@@ -108132,10 +108132,10 @@ yhx
 yhx
 yhx
 yhx
+yhx
 nbC
 nbC
-nbC
-bqN
+ydp
 lfs
 sqr
 iMc
@@ -108152,9 +108152,9 @@ bqN
 bqN
 bqN
 ydp
-ydp
-ydp
-ydp
+qrR
+qrR
+qrR
 qrR
 qrR
 qrR
@@ -108389,7 +108389,7 @@ yhx
 yhx
 yhx
 yhx
-nbC
+yhx
 nbC
 nbC
 nbC
@@ -108409,9 +108409,9 @@ bqN
 bqN
 bqN
 nbC
-nbC
-nbC
-nbC
+yhx
+yhx
+yhx
 yhx
 yhx
 yhx
@@ -108646,7 +108646,7 @@ yhx
 yhx
 yhx
 yhx
-nbC
+yhx
 nbC
 nbC
 nbC
@@ -108666,9 +108666,9 @@ bqN
 bqN
 bqN
 nbC
-nbC
-nbC
-nbC
+yhx
+yhx
+yhx
 yhx
 yhx
 yhx
@@ -108903,29 +108903,29 @@ yhx
 yhx
 yhx
 yhx
+yhx
 nbC
 nbC
 nbC
 nbC
+ydp
+ydp
+ydp
+ydp
+bqN
+bqN
+bqN
+bqN
+bqN
+bqN
+bqN
+bqN
+bqN
+bqN
 nbC
-bqN
-bqN
-bqN
-bqN
-bqN
-bqN
-bqN
-bqN
-bqN
-bqN
-bqN
-bqN
-bqN
-bqN
-nbC
-nbC
-nbC
-nbC
+yhx
+yhx
+yhx
 yhx
 yhx
 yhx
@@ -109160,29 +109160,29 @@ yhx
 yhx
 yhx
 yhx
+yhx
+yhx
 nbC
 nbC
 nbC
 nbC
 nbC
+ydp
+ydp
 nbC
 nbC
-bqN
-bqN
-nbC
-nbC
-bqN
-bqN
-bqN
 bqN
 bqN
 bqN
 bqN
 bqN
+bqN
+bqN
+bqN
 nbC
-nbC
-nbC
-nbC
+yhx
+yhx
+yhx
 yhx
 yhx
 yhx
@@ -109417,9 +109417,9 @@ yhx
 yhx
 yhx
 yhx
-nbC
-nbC
-nbC
+yhx
+yhx
+yhx
 nbC
 nbC
 nbC
@@ -109437,9 +109437,9 @@ bqN
 bqN
 bqN
 nbC
-nbC
-nbC
-nbC
+yhx
+yhx
+yhx
 yhx
 yhx
 yhx
@@ -109674,17 +109674,17 @@ yhx
 yhx
 yhx
 yhx
-nbC
-nbC
-nbC
-nbC
-nbC
-nbC
-nbC
-nbC
-nbC
-nbC
-nbC
+yhx
+yhx
+yhx
+yhx
+yhx
+yhx
+yhx
+yhx
+yhx
+yhx
+yhx
 nbC
 nbC
 nbC
@@ -109694,9 +109694,9 @@ bqN
 nbC
 nbC
 nbC
-nbC
-nbC
-nbC
+yhx
+yhx
+yhx
 yhx
 yhx
 yhx

--- a/_maps/map_files/Snaxi/Snaxi_Lumos.dmm
+++ b/_maps/map_files/Snaxi/Snaxi_Lumos.dmm
@@ -1040,7 +1040,7 @@
 	pixel_x = 6;
 	pixel_y = 4
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/wood,
 /area/library)
 "aoj" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -3360,10 +3360,14 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aPy" = (
-/obj/structure/chair/comfy/brown,
-/obj/effect/landmark/start/assistant,
-/turf/open/floor/wood,
-/area/library)
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "aPA" = (
 /turf/closed/wall/r_wall,
 /area/security/checkpoint/medical)
@@ -3561,8 +3565,8 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
 "aSE" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -3577,11 +3581,8 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "aSN" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -3885,11 +3886,10 @@
 /turf/open/floor/plating,
 /area/hallway/primary/port)
 "bcq" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
+/area/science/robotics/mechbay)
 "bcu" = (
 /obj/effect/turf_decal/vg_decals/atmos/plasma,
 /obj/machinery/light/small{
@@ -4004,10 +4004,14 @@
 /turf/open/floor/plating,
 /area/medical/virology)
 "bff" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel,
-/area/science/robotics/mechbay)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/hallway/primary/port)
 "bfg" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -4202,13 +4206,10 @@
 /area/chapel/office)
 "bkQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 9
+	dir = 6
 	},
 /turf/open/floor/plating,
-/area/hallway/primary/port)
+/area/hallway/secondary/entry)
 "blg" = (
 /obj/docking_port/stationary{
 	dir = 2;
@@ -4566,10 +4567,16 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bsL" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/corner{
+	dir = 8
+	},
 /area/hallway/secondary/entry)
 "bsU" = (
 /obj/effect/turf_decal/tile/purple{
@@ -4687,7 +4694,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
+	dir = 9
 	},
 /turf/open/floor/plasteel/white/corner{
 	dir = 8
@@ -5609,16 +5616,8 @@
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "bCQ" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
-/turf/open/floor/plasteel/white/corner{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "bCT" = (
 /obj/structure/cable{
@@ -5628,6 +5627,16 @@
 	dir = 1;
 	sortType = 17
 	},
+/obj/effect/turf_decal/lumos/loading_area/white{
+	dir = 1
+	},
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1;
+	name = "north facing firelock"
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bCW" = (
@@ -5636,6 +5645,14 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/lumos/loading_area/white{
+	dir = 1
+	},
+/obj/structure/railing/corner,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1;
+	name = "north facing firelock"
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bCY" = (
@@ -5725,16 +5742,18 @@
 /turf/open/floor/wood,
 /area/bridge/meeting_room)
 "bDI" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/flora/grass/jungle,
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/grass,
 /area/hallway/primary/central)
 "bDR" = (
 /obj/structure/table/wood,
@@ -5791,9 +5810,14 @@
 /turf/open/floor/plating,
 /area/hallway/primary/aft)
 "bEe" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/plating,
-/area/hallway/secondary/entry)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/science/robotics/mechbay)
 "bEi" = (
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
@@ -5942,7 +5966,7 @@
 	dir = 4
 	},
 /obj/structure/table/wood,
-/turf/open/floor/carpet,
+/turf/open/floor/wood,
 /area/library)
 "bFO" = (
 /obj/structure/disposalpipe/segment,
@@ -5951,7 +5975,7 @@
 	pixel_x = 1;
 	pixel_y = 5
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/wood,
 /area/library)
 "bFT" = (
 /obj/structure/table/wood,
@@ -6411,6 +6435,9 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -6896,14 +6923,10 @@
 /turf/open/floor/plating,
 /area/maintenance/central)
 "bQs" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/science/robotics/mechbay)
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors)
 "bQt" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -6952,11 +6975,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/wood,
+/obj/structure/railing/corner,
+/turf/open/floor/carpet,
 /area/library)
 "bRN" = (
+/obj/machinery/atmospherics/pipe/layer_manifold,
 /obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors)
 "bSb" = (
@@ -7056,9 +7080,13 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "bUm" = (
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/obj/structure/lattice/catwalk,
-/turf/open/floor/plating/asteroid/snow/icemoon,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
+	},
+/turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
 "bUB" = (
 /obj/structure/cable{
@@ -7123,7 +7151,10 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 5
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
@@ -7608,7 +7639,6 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain)
 "cfm" = (
-/obj/structure/table/wood,
 /obj/item/kirbyplants{
 	icon_state = "plant-21";
 	pixel_y = 3
@@ -8113,17 +8143,15 @@
 /turf/open/floor/carpet,
 /area/bridge)
 "cng" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
+/obj/structure/bed/roller,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/surface/outdoors)
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/zone2)
 "cni" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/effect/turf_decal/tile/green{
@@ -8517,12 +8545,11 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/bed/roller,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/zone2)
+/turf/open/floor/wood,
+/area/hallway/secondary/exit/departure_lounge)
 "cvH" = (
 /obj/machinery/power/apc{
 	areastring = "/area/crew_quarters/theatre";
@@ -8911,7 +8938,7 @@
 /obj/item/pen/blue{
 	pixel_x = -5
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/wood,
 /area/library)
 "cCv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -9055,13 +9082,10 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
 "cFO" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
-/turf/open/floor/wood,
+/turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
 "cFP" = (
 /obj/structure/cable{
@@ -9738,6 +9762,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_y = 32
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -10690,8 +10717,11 @@
 /turf/closed/indestructible/rock/glacierrock/blue,
 /area/engine/secure_construction)
 "drK" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
@@ -10754,7 +10784,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/table/wood,
-/turf/open/floor/carpet,
+/turf/open/floor/wood,
 /area/library)
 "dtm" = (
 /obj/machinery/door/firedoor/border_only{
@@ -11680,7 +11710,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 6
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
@@ -12437,6 +12467,9 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
 "enP" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Cryogenic Storage"
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
@@ -13287,16 +13320,13 @@
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
 "eGL" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Cryogenic Storage"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "eGO" = (
 /obj/structure/cable{
@@ -13636,7 +13666,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/wood,
 /area/hallway/secondary/exit/departure_lounge)
 "eNK" = (
 /obj/structure/cable{
@@ -13649,6 +13679,13 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "eOn" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/landmark/start/assistant,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
@@ -13977,12 +14014,11 @@
 /area/maintenance/department/bridge)
 "eVp" = (
 /obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/chair{
 	dir = 8
 	},
-/obj/effect/landmark/start/assistant,
+/obj/structure/chair{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
@@ -14003,19 +14039,14 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "eWp" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/chair{
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/wood,
+/turf/open/floor/carpet,
 /area/hallway/secondary/exit/departure_lounge)
 "eWw" = (
 /obj/machinery/door/airlock/external{
@@ -14241,18 +14272,14 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "fcu" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/hallway/secondary/exit/departure_lounge)
-"fcJ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/hallway/secondary/exit/departure_lounge)
+"fcJ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
@@ -14306,6 +14333,17 @@
 	dir = 1
 	},
 /area/chapel/office)
+"ffl" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/stalkybush,
+/turf/open/floor/grass,
+/area/hallway/primary/central)
 "ffm" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -15237,11 +15275,9 @@
 /turf/open/floor/plasteel/dark,
 /area/teleporter)
 "fBc" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 9
-	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel/dark,
-/area/hallway/secondary/exit/departure_lounge)
+/area/security/brig)
 "fBf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -16137,9 +16173,13 @@
 /turf/open/floor/carpet,
 /area/hallway/secondary/exit/departure_lounge)
 "fXa" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/wood,
+/area/security/courtroom)
 "fXd" = (
 /obj/structure/chair/comfy/brown,
 /obj/structure/cable{
@@ -16395,15 +16435,11 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "gdd" = (
-/obj/machinery/door/window/northright{
-	dir = 8;
-	name = "Library Desk Door";
-	req_access_txt = "37"
-	},
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/carpet,
+/obj/structure/table/wood,
+/turf/open/floor/wood,
 /area/library)
 "gdg" = (
 /obj/structure/cable{
@@ -16568,13 +16604,11 @@
 /turf/open/floor/carpet,
 /area/hallway/secondary/exit/departure_lounge)
 "ggt" = (
-/obj/structure/chair{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/wood,
-/area/security/courtroom)
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
 "ggD" = (
 /obj/structure/closet/crate/wooden/fish_learning,
 /turf/open/floor/plasteel/freezer,
@@ -16780,11 +16814,17 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
 "gmv" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 9
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "gmA" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 4
@@ -18391,22 +18431,20 @@
 /area/engine/atmospherics_engine)
 "hez" = (
 /obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
-"heM" = (
-/obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"heM" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -18500,13 +18538,10 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "hgO" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 8
-	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "hho" = (
@@ -18781,10 +18816,15 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "hoX" = (
-/obj/effect/turf_decal/tile/neutral{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "hpd" = (
@@ -19823,14 +19863,8 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "hKl" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -20295,7 +20329,9 @@
 /turf/open/floor/plating,
 /area/hallway/primary/fore)
 "hUc" = (
-/obj/structure/table/wood,
+/obj/structure/railing/corner{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/library)
 "hUo" = (
@@ -20802,7 +20838,7 @@
 /turf/open/floor/wood,
 /area/security/courtroom)
 "idS" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -21181,9 +21217,11 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "iog" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "iop" = (
@@ -21272,7 +21310,7 @@
 	name = "Library Desk Door";
 	req_access_txt = "37"
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/wood,
 /area/library)
 "iqT" = (
 /obj/structure/disposalpipe/segment{
@@ -21627,8 +21665,8 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "izd" = (
@@ -23111,11 +23149,19 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "jjA" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "jjB" = (
@@ -23382,18 +23428,12 @@
 	},
 /area/chapel/office)
 "jrf" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/structure/table/wood,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
-	},
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -23667,6 +23707,11 @@
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
+"jyK" = (
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "jyU" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -23969,15 +24014,27 @@
 /turf/open/floor/plating,
 /area/maintenance/bar)
 "jFT" = (
-/obj/structure/table/wood,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/obj/effect/turf_decal/tile/red,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "jFY" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -25040,24 +25097,14 @@
 /turf/open/floor/plating,
 /area/chapel/office)
 "kgr" = (
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/computer/arcade{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 10
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
@@ -27127,17 +27174,15 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
 "lhi" = (
-/obj/machinery/computer/arcade{
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 10
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/prison)
+/area/security/main)
 "lhr" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -27513,11 +27558,13 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
-/area/security/main)
+/area/security/prison)
 "lqW" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -27918,7 +27965,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/open/floor/wood,
+/turf/open/floor/carpet,
 /area/library)
 "lBF" = (
 /obj/structure/table,
@@ -28396,15 +28443,13 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
 "lQs" = (
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/computer/arcade{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "lQJ" = (
@@ -28980,15 +29025,9 @@
 /turf/closed/wall,
 /area/medical/medbay/central)
 "mdG" = (
-/obj/machinery/computer/arcade{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
+/obj/machinery/door/airlock/maintenance/abandoned,
+/turf/open/floor/plating,
+/area/library)
 "meG" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -29132,13 +29171,13 @@
 /turf/open/floor/engine,
 /area/engine/atmospherics_engine)
 "mhH" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/obj/structure/chair/comfy/brown{
+	dir = 1
+	},
+/turf/open/floor/carpet,
 /area/hallway/primary/central)
 "mia" = (
 /obj/structure/cable{
@@ -29462,8 +29501,10 @@
 /turf/open/floor/carpet,
 /area/bridge)
 "mqq" = (
-/obj/machinery/door/airlock/maintenance/abandoned,
-/turf/open/floor/plating,
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/carpet,
 /area/library)
 "mqC" = (
 /obj/effect/turf_decal/tile/blue,
@@ -29531,6 +29572,16 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel/dark,
 /area/engine/secure_construction)
+"msm" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/floor/plasteel/stairs/left,
+/area/hallway/primary/central)
 "msA" = (
 /obj/machinery/holopad,
 /turf/open/floor/wood,
@@ -30000,12 +30051,16 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "mGa" = (
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/structure/rack,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/area/maintenance/aft/secondary)
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/flora/grass/jungle,
+/obj/structure/flora/ausbushes/brflowers,
+/turf/open/floor/grass,
+/area/hallway/primary/central)
 "mGb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -30199,16 +30254,13 @@
 /turf/open/floor/plasteel/dark,
 /area/security/warden)
 "mKA" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
+/obj/structure/railing/corner{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 6
-	},
-/turf/open/floor/wood,
+/turf/open/floor/carpet,
 /area/library)
 "mKD" = (
 /obj/structure/chair/sofa/right,
@@ -31066,11 +31118,12 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "ndS" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/rack,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
 	},
-/turf/open/floor/wood,
-/area/library)
+/area/maintenance/aft/secondary)
 "ndX" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -31291,7 +31344,7 @@
 /area/engine/atmos)
 "njU" = (
 /obj/structure/table/wood,
-/turf/open/floor/carpet,
+/turf/open/floor/wood,
 /area/library)
 "nkP" = (
 /obj/structure/cable{
@@ -32037,15 +32090,13 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	name = "east facing firelock"
+/obj/machinery/light/small{
+	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/execution/education)
+/obj/structure/flora/grass/jungle,
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/grass,
+/area/hallway/primary/central)
 "nDa" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -32167,13 +32218,13 @@
 /turf/open/floor/carpet,
 /area/bridge)
 "nFc" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/wood,
-/area/library)
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/plasteel/stairs/right,
+/area/hallway/primary/central)
 "nFw" = (
 /obj/machinery/button/door{
 	id = "bridge blast";
@@ -32274,15 +32325,16 @@
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "nGx" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+/obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/wood,
-/area/library)
+/obj/structure/flora/grass/jungle,
+/obj/structure/flora/ausbushes/brflowers,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/grass,
+/area/hallway/primary/central)
 "nGR" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -32299,7 +32351,7 @@
 	pixel_x = 1;
 	pixel_y = 5
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/wood,
 /area/library)
 "nHI" = (
 /obj/machinery/computer/arcade{
@@ -34763,9 +34815,7 @@
 	},
 /area/hallway/secondary/exit/departure_lounge)
 "oME" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8
-	},
+/obj/structure/railing/corner,
 /turf/open/floor/wood,
 /area/library)
 "oMJ" = (
@@ -35548,11 +35598,11 @@
 	},
 /area/maintenance/aft/secondary)
 "phf" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
+/obj/structure/railing{
+	dir = 8
 	},
-/turf/open/floor/plating,
-/area/maintenance/central)
+/turf/open/floor/plasteel/stairs/left,
+/area/library)
 "phg" = (
 /obj/structure/railing/corner{
 	dir = 4
@@ -37356,11 +37406,14 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "pVz" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/railing{
 	dir = 4
 	},
-/turf/open/floor/wood,
-/area/security/vacantoffice/a)
+/turf/open/floor/plasteel/stairs/right,
+/area/library)
 "pVM" = (
 /obj/effect/decal/cleanable/cobweb{
 	icon_state = "cobweb2"
@@ -38650,11 +38703,11 @@
 	},
 /area/chapel/office)
 "qCa" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1
+/obj/structure/railing/corner{
+	dir = 8
 	},
 /turf/open/floor/wood,
-/area/security/vacantoffice/a)
+/area/library)
 "qCo" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -39439,14 +39492,14 @@
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "qUY" = (
-/obj/structure/disposalpipe/segment{
+/obj/structure/railing/corner{
 	dir = 4
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 8
+	dir = 4
 	},
-/obj/structure/flora/ausbushes/reedbush,
+/obj/structure/flora/rock/jungle,
 /turf/open/floor/grass,
 /area/hallway/primary/central)
 "qVf" = (
@@ -39672,11 +39725,15 @@
 /turf/open/floor/plasteel/checker,
 /area/crew_quarters/heads/hor)
 "raA" = (
+/obj/effect/turf_decal/caution/stand_clear,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/machinery/door/poddoor/shutters{
 	id = "jangarage";
 	name = "Custodial Closet Shutters"
 	},
-/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/janitor)
 "raM" = (
@@ -40275,7 +40332,7 @@
 "roF" = (
 /obj/structure/table/wood,
 /obj/item/folder,
-/turf/open/floor/carpet,
+/turf/open/floor/wood,
 /area/library)
 "roS" = (
 /obj/effect/turf_decal/tile/blue{
@@ -40606,16 +40663,15 @@
 /turf/open/floor/plasteel/grimy,
 /area/chapel/main)
 "rwR" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/lumos/loading_area/white,
+/obj/structure/railing/corner{
+	dir = 1
 	},
-/obj/structure/window/reinforced,
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/flora/tree/jungle/small,
-/turf/open/floor/grass,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "rwW" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
@@ -40646,7 +40702,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/wood,
+/obj/structure/railing{
+	dir = 6
+	},
+/turf/open/floor/carpet,
 /area/library)
 "rxI" = (
 /obj/structure/cable{
@@ -40690,11 +40749,14 @@
 /turf/open/floor/plasteel/dark,
 /area/blueshield)
 "ryE" = (
-/obj/structure/window/reinforced,
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/grass,
-/area/maintenance/aft/secondary)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/lumos/loading_area/white,
+/obj/structure/railing/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "rAa" = (
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/disposal/bin,
@@ -41897,13 +41959,13 @@
 /area/chapel/main)
 "sjk" = (
 /obj/structure/window/reinforced,
-/obj/structure/flora/tree/jungle/small{
-	pixel_x = -48;
-	pixel_y = 8
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/obj/structure/flora/ausbushes/grassybush,
+/obj/structure/flora/grass/jungle,
+/obj/structure/flora/rock/jungle,
 /turf/open/floor/grass,
-/area/maintenance/aft/secondary)
+/area/hallway/primary/central)
 "sjB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 9
@@ -42280,9 +42342,11 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
 "srJ" = (
-/obj/machinery/door/airlock/maintenance/abandoned,
-/turf/closed/wall,
-/area/maintenance/aft/secondary)
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/library)
 "srL" = (
 /obj/machinery/airalarm{
 	dir = 1;
@@ -42419,6 +42483,21 @@
 	dir = 8
 	},
 /area/chapel/office)
+"svl" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "svp" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/engine,
@@ -42507,25 +42586,32 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "sxN" = (
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"syd" = (
-/obj/effect/turf_decal/tile/neutral{
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
+	},
+/obj/structure/railing/corner{
 	dir = 4
 	},
+/turf/open/floor/wood,
+/area/library)
+"syd" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/structure/railing/corner{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/turf/open/floor/wood,
+/area/library)
 "syz" = (
 /obj/machinery/airalarm{
 	dir = 1;
@@ -42801,14 +42887,11 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "sFp" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 1
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/turf/open/floor/wood,
+/area/library)
 "sGC" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/effect/turf_decal/stripes/line,
@@ -43034,14 +43117,18 @@
 /turf/open/floor/plasteel/dark,
 /area/teleporter)
 "sLv" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+/obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8
+/obj/machinery/door/firedoor/border_only{
+	dir = 4;
+	name = "east facing firelock"
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "sLN" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel,
@@ -43152,13 +43239,11 @@
 /turf/open/floor/carpet,
 /area/security/vacantoffice/b)
 "sOv" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/obj/structure/chair/comfy/brown,
+/turf/open/floor/carpet,
 /area/hallway/primary/central)
 "sOz" = (
 /obj/structure/disposalpipe/junction/flip{
@@ -43237,8 +43322,8 @@
 	},
 /area/hallway/primary/port)
 "sRh" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -43393,16 +43478,11 @@
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "sUX" = (
-/obj/structure/window/reinforced{
+/obj/structure/chair/comfy/brown{
 	dir = 8
 	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/biolumi/mine/weaklight,
-/turf/open/floor/grass,
-/area/hallway/primary/central)
+/turf/open/floor/wood,
+/area/library)
 "sVh" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
@@ -44183,16 +44263,13 @@
 /turf/open/floor/engine,
 /area/engine/atmospherics_engine)
 "toP" = (
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/stalkybush,
-/turf/open/floor/grass,
-/area/hallway/primary/central)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/wood,
+/area/library)
 "tpf" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -45151,13 +45228,17 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/pool)
 "tOE" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/caution/stand_clear,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/machinery/door/poddoor/shutters{
 	id = "jangarage";
 	name = "Custodial Closet Shutters"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/janitor)
 "tOP" = (
@@ -45484,9 +45565,8 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/paramedic)
 "tWj" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 8;
-	name = "west facing firelock"
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -45644,17 +45724,14 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain)
 "uaA" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/bridge)
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "uaC" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -45819,6 +45896,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
+"uej" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "ueq" = (
 /obj/structure/bodycontainer/morgue{
 	dir = 2
@@ -46774,17 +46857,10 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "uJe" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 9
-	},
-/turf/open/floor/plasteel/dark,
-/area/bridge)
+/obj/structure/chair/comfy/brown,
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/wood,
+/area/library)
 "uJx" = (
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
@@ -48399,6 +48475,16 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
+"vun" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/wood,
+/area/library)
 "vuJ" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -26
@@ -48662,6 +48748,18 @@
 "vAs" = (
 /turf/open/floor/plating,
 /area/icemoon/surface/outdoors)
+"vAx" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "vAy" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -49254,6 +49352,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
+"vNY" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/library)
 "vOo" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -49755,6 +49859,17 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
+"vZO" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/biolumi/mine/weaklight,
+/turf/open/floor/grass,
+/area/hallway/primary/central)
 "vZR" = (
 /obj/effect/landmark/start/bartender,
 /turf/open/floor/plasteel/grimy,
@@ -50404,6 +50519,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/computer)
+"wpO" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/central)
 "wqd" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -50634,7 +50755,7 @@
 /area/maintenance/aft/secondary)
 "wvg" = (
 /obj/machinery/bookbinder,
-/turf/open/floor/wood,
+/turf/open/floor/carpet,
 /area/library)
 "wvj" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -50757,6 +50878,15 @@
 	},
 /turf/closed/wall,
 /area/hallway/primary/aft)
+"wzq" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "wzv" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -50981,6 +51111,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
+"wFU" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/security/vacantoffice/a)
 "wFY" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -51039,6 +51175,12 @@
 	},
 /turf/open/floor/wood,
 /area/maintenance/bar)
+"wHB" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/security/vacantoffice/a)
 "wHM" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -51089,6 +51231,15 @@
 	},
 /turf/open/floor/carpet/orange,
 /area/engine/secure_construction)
+"wJb" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/chair/comfy/brown{
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/hallway/primary/central)
 "wJf" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -51176,6 +51327,18 @@
 	dir = 4
 	},
 /area/chapel/main)
+"wLy" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "wLG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/closed/wall/mineral/wood,
@@ -51188,14 +51351,12 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "wLU" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/machinery/airalarm{
 	dir = 8;
 	pixel_x = 24
 	},
-/turf/open/floor/plasteel,
+/obj/structure/table/wood,
+/turf/open/floor/carpet,
 /area/hallway/primary/central)
 "wMp" = (
 /obj/machinery/door/airlock/maintenance,
@@ -51395,8 +51556,13 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "wRX" = (
-/turf/closed/wall/r_wall,
-/area/library)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/table/wood,
+/obj/item/taperecorder,
+/turf/open/floor/carpet,
+/area/hallway/primary/central)
 "wRY" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/solars/starboard/aft)
@@ -52011,6 +52177,15 @@
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"xhE" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "xhH" = (
 /turf/closed/wall/r_wall,
 /area/hallway/primary/central)
@@ -52402,8 +52577,18 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "xtq" = (
-/turf/closed/wall/r_wall,
+/obj/structure/window/reinforced,
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/grass,
 /area/maintenance/aft/secondary)
+"xtw" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 8;
+	name = "west facing firelock"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "xty" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-22"
@@ -52559,7 +52744,8 @@
 /obj/machinery/newscaster{
 	pixel_x = -30
 	},
-/turf/open/floor/wood,
+/obj/structure/railing,
+/turf/open/floor/carpet,
 /area/library)
 "xyT" = (
 /obj/structure/cable{
@@ -53598,6 +53784,15 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/dark,
 /area/storage/eva)
+"xZL" = (
+/obj/structure/window/reinforced,
+/obj/structure/flora/tree/jungle/small{
+	pixel_x = -48;
+	pixel_y = 8
+	},
+/obj/structure/flora/ausbushes/grassybush,
+/turf/open/floor/grass,
+/area/maintenance/aft/secondary)
 "xZX" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -53691,6 +53886,10 @@
 /obj/item/bedsheet/green,
 /obj/effect/decal/cleanable/flour,
 /turf/open/floor/plating,
+/area/maintenance/aft/secondary)
+"ydo" = (
+/obj/machinery/door/airlock/maintenance/abandoned,
+/turf/closed/wall,
 /area/maintenance/aft/secondary)
 "ydp" = (
 /turf/closed/mineral/random/snow/no_caves,
@@ -68821,8 +69020,8 @@ sUE
 aEJ
 vYc
 aIP
-bsL
-bEe
+bkQ
+bCQ
 vPV
 oIT
 kPV
@@ -69592,7 +69791,7 @@ aIP
 aAQ
 eZi
 aFU
-bvo
+bsL
 iqJ
 hLo
 aLD
@@ -69849,7 +70048,7 @@ bxk
 aDg
 hgJ
 aFY
-bvo
+bsL
 aIS
 aKn
 aLF
@@ -70106,7 +70305,7 @@ bxk
 ovq
 aFO
 aEC
-bvo
+bsL
 rJM
 aKm
 aLE
@@ -70362,8 +70561,8 @@ vsN
 bxk
 aDk
 aBw
-aSE
-bCQ
+aPy
+bvo
 hUo
 sMi
 oWw
@@ -70876,7 +71075,7 @@ aDd
 vfr
 wje
 aFO
-aSN
+aSE
 ldE
 aPA
 nlk
@@ -72428,7 +72627,7 @@ aOq
 aPD
 aQT
 omC
-bUP
+bUm
 avT
 ydp
 ydp
@@ -72675,7 +72874,7 @@ vMB
 uBG
 aDm
 hLZ
-bcq
+aSN
 aHD
 aPC
 cKK
@@ -73451,9 +73650,9 @@ aHE
 wUr
 aKs
 aOr
-bRN
-bRN
-bRN
+bQs
+bQs
+bQs
 aQX
 vcG
 lzB
@@ -73713,7 +73912,7 @@ xUL
 xUL
 xUL
 vcG
-cng
+bUP
 avT
 avT
 ydp
@@ -74474,11 +74673,11 @@ ogM
 kRz
 kRz
 plc
-bff
+bcq
 ikk
 gnv
-bff
-bQs
+bcq
+bEe
 qpE
 xUL
 xUL
@@ -77044,7 +77243,7 @@ eex
 eex
 qUr
 aBG
-bkQ
+bff
 gdQ
 sCC
 tmO
@@ -78628,7 +78827,7 @@ fAj
 oZR
 cyy
 qdZ
-lQs
+lqG
 spI
 dkO
 uAZ
@@ -79398,7 +79597,7 @@ rKZ
 vlv
 ahW
 pEK
-kgr
+jFT
 rOd
 jfq
 pEo
@@ -79655,8 +79854,8 @@ lFK
 jro
 fAj
 wJw
-lhi
-mdG
+kgr
+lQs
 tfY
 fAj
 pAS
@@ -80672,7 +80871,7 @@ foy
 ilb
 ilb
 ilb
-gmv
+ggt
 rlG
 wSb
 wav
@@ -80693,7 +80892,7 @@ fnc
 nxv
 pnu
 dvj
-nCU
+sLv
 gdE
 rcY
 duI
@@ -82470,7 +82669,7 @@ wql
 uUJ
 vOU
 bcc
-fXa
+fBc
 cuX
 oKD
 wql
@@ -82985,7 +83184,7 @@ khf
 vOU
 qEz
 vOU
-hez
+gmv
 xRL
 hNn
 xCC
@@ -83780,7 +83979,7 @@ air
 wuS
 wql
 cIH
-phf
+wpO
 sdN
 chA
 tod
@@ -84037,7 +84236,7 @@ wql
 wql
 wql
 sdN
-phf
+wpO
 dCh
 sdN
 sdN
@@ -84776,8 +84975,8 @@ wcB
 wcB
 bok
 wrh
-drK
-fcJ
+cFO
+fcu
 wvL
 bwt
 ewK
@@ -85020,7 +85219,7 @@ bHt
 nZE
 nZE
 nZE
-bUm
+bRN
 aUd
 avT
 avT
@@ -85033,8 +85232,8 @@ wcB
 wcB
 bok
 wrh
-dTo
-fBc
+drK
+fcJ
 wVg
 bwt
 aNw
@@ -85065,8 +85264,8 @@ dYl
 rYN
 qOb
 bSd
-pVz
-qCa
+wFU
+wHB
 kJE
 xXX
 sdN
@@ -85290,7 +85489,7 @@ wcB
 wcB
 bok
 wrh
-enP
+dTo
 tif
 nUk
 bwt
@@ -85547,14 +85746,14 @@ uFq
 uFq
 bok
 unA
-eGL
+enP
 bmA
 unA
 grV
 xTL
 lHn
 bsk
-ggt
+fXa
 ciO
 cTD
 bCz
@@ -85804,7 +86003,7 @@ wbE
 wbE
 fPp
 rqE
-eNG
+eGL
 rqE
 dGB
 cTD
@@ -85823,7 +86022,7 @@ cBD
 ndL
 dpZ
 dpZ
-lqG
+lhi
 smP
 wtt
 bMN
@@ -86061,7 +86260,7 @@ wbE
 wbE
 uBa
 uBa
-eOn
+eNG
 uBa
 dGB
 cTD
@@ -86318,7 +86517,7 @@ lRx
 wbE
 got
 got
-eVp
+eOn
 uBa
 dGB
 cTD
@@ -86351,11 +86550,11 @@ sdN
 sdN
 sdN
 jcT
-qUY
+wJb
 lhQ
 sAw
 lhQ
-sUX
+vZO
 dMj
 riE
 hGy
@@ -86575,7 +86774,7 @@ xYD
 wbE
 xZg
 xZg
-eWp
+eVp
 uBa
 eeh
 grV
@@ -86608,11 +86807,11 @@ tod
 tod
 tod
 jcT
-rwR
+wRX
 lhQ
 cZq
 lhQ
-toP
+ffl
 dMj
 dMj
 dMj
@@ -86824,7 +87023,7 @@ iQD
 riC
 qXN
 uBa
-cFO
+cvE
 uBa
 uBa
 uBa
@@ -86832,7 +87031,7 @@ xYD
 wbE
 uBa
 uBa
-eOn
+eNG
 uBa
 qHO
 lbp
@@ -86858,12 +87057,12 @@ qQt
 vPQ
 bJF
 bVX
-cGQ
-vPQ
-vPQ
-vPQ
-vPQ
-vPQ
+mGa
+nCU
+qUY
+sRh
+tWj
+uaA
 pjn
 tNf
 lhQ
@@ -87100,7 +87299,7 @@ bAk
 hxf
 hxf
 hxf
-heM
+hez
 bAj
 ezY
 wZl
@@ -87116,8 +87315,8 @@ wZl
 bPa
 fZV
 bCT
-wZl
-wZl
+msm
+rwR
 wZl
 wZl
 wZl
@@ -87346,7 +87545,7 @@ beq
 wdk
 wdk
 wdk
-fcu
+eWp
 wdk
 wdk
 bnE
@@ -87357,7 +87556,7 @@ udI
 fqE
 fqE
 fqE
-hgO
+heM
 nRt
 xmB
 tys
@@ -87373,15 +87572,15 @@ tys
 tXn
 mEo
 bCW
+nFc
+ryE
 tys
 tys
 tys
 tys
 tys
 tys
-tys
-tys
-sxN
+jyK
 bPd
 tys
 tys
@@ -87630,10 +87829,10 @@ wLU
 mhH
 ceA
 bDI
-ceA
-ceA
-ceA
-ceA
+nGx
+sjk
+lhQ
+lhQ
 ceA
 ceA
 fsF
@@ -87648,7 +87847,7 @@ bUL
 cgZ
 iIS
 cmU
-uaA
+wLy
 ckX
 clV
 cmV
@@ -87887,7 +88086,7 @@ srk
 srk
 srk
 bDU
-xjF
+srk
 xjF
 xjF
 xjF
@@ -87897,7 +88096,7 @@ srk
 srk
 cTO
 cdE
-tWj
+xtw
 chb
 chb
 yiZ
@@ -87905,7 +88104,7 @@ chb
 vqS
 iIS
 hYD
-uaA
+wLy
 cqo
 clV
 oBF
@@ -88144,12 +88343,12 @@ srk
 wvg
 lBE
 xyA
-gpN
+oME
 hUc
+njU
 agy
 gpN
-hUc
-agy
+njU
 cfm
 srk
 gtG
@@ -88162,7 +88361,7 @@ rnA
 hsP
 iIS
 kxf
-uaA
+wLy
 iIK
 iIS
 iAt
@@ -88362,7 +88561,7 @@ wxT
 moD
 aQd
 jUn
-cvE
+cng
 wxT
 pqe
 uBa
@@ -88399,17 +88598,17 @@ agy
 xTI
 vBV
 xTI
+xTI
+mKA
+phf
+srJ
+sUX
 agy
-sAD
-gpN
-hUc
-agy
-aPy
-hUc
-agy
+uJe
+njU
 agy
 xjF
-syd
+svl
 mbh
 bwr
 chb
@@ -88419,7 +88618,7 @@ gSY
 uAs
 obL
 fJW
-uJe
+vAx
 rAj
 iIS
 cph
@@ -88656,15 +88855,15 @@ agy
 xTI
 vBV
 xTI
-agy
+xTI
 bRH
-qoy
-mKA
-nFc
-nFc
-nGx
-nFc
-nFc
+pVz
+sxN
+toP
+toP
+vun
+toP
+toP
 eDu
 gpp
 bXU
@@ -88899,7 +89098,7 @@ bBL
 bBL
 bBL
 bBL
-hoX
+hgO
 mIz
 cSG
 bzS
@@ -88912,14 +89111,14 @@ ikt
 fNE
 tAM
 srk
-agy
-agy
+mqq
+mqq
 rxu
+qCa
+syd
 agy
-pyI
 agy
-agy
-oME
+vNY
 agy
 agy
 xjF
@@ -89933,7 +90132,7 @@ kis
 bzU
 bDW
 bME
-jrf
+jjA
 bFK
 srk
 xLN
@@ -90186,7 +90385,7 @@ bBL
 bBL
 bBL
 rle
-hKl
+hoX
 lhQ
 bvw
 lhQ
@@ -90444,10 +90643,10 @@ bxR
 mPM
 ohK
 tlc
-idS
+hKl
 bvw
 bFT
-jFT
+jrf
 biW
 wTK
 wTK
@@ -90458,7 +90657,7 @@ hzs
 xTI
 msg
 njU
-ndS
+sFp
 agy
 agy
 nHQ
@@ -90701,7 +90900,7 @@ cZq
 lbp
 cqd
 qlW
-iog
+idS
 bvw
 bFT
 czg
@@ -90958,11 +91157,11 @@ jLp
 bDT
 bAt
 mmO
-iza
+iog
 bzl
-jjA
+iza
 mmO
-jjA
+iza
 lJC
 cpB
 qEM
@@ -90979,7 +91178,7 @@ nHQ
 agy
 xjF
 lhQ
-sFp
+wzq
 kSP
 oBj
 tpn
@@ -91224,7 +91423,7 @@ wTK
 wTK
 wTK
 xbC
-mqq
+mdG
 agy
 agy
 agy
@@ -92521,7 +92720,7 @@ iZs
 gKs
 srk
 cQU
-sFp
+wzq
 lDi
 cVc
 kpT
@@ -92766,16 +92965,16 @@ wGq
 wTK
 wTK
 wTK
-xtq
-xtq
-wRX
-wRX
-mqq
-wRX
-wRX
-wRX
-wRX
-wRX
+wTK
+wTK
+srk
+srk
+srk
+srk
+srk
+srk
+srk
+srk
 srk
 jCF
 xPP
@@ -93290,7 +93489,7 @@ wTK
 wTK
 wGq
 wTK
-ryE
+xtq
 lhQ
 xPP
 tNf
@@ -93540,14 +93739,14 @@ wGq
 doP
 mzv
 wTK
-mGa
+ndS
 wGq
 wGq
 ofH
 wGq
 rHo
 wTK
-sjk
+xZL
 lhQ
 hSV
 hZa
@@ -93804,7 +94003,7 @@ wTK
 wTK
 wGq
 wTK
-srJ
+ydo
 lhQ
 xPP
 tNf
@@ -94063,7 +94262,7 @@ wGq
 wGq
 kAX
 lhQ
-sLv
+xhE
 tNf
 jcT
 avT
@@ -94320,7 +94519,7 @@ wTK
 wTK
 wTK
 bdm
-sRh
+uej
 tNf
 jcT
 avT

--- a/_maps/map_files/Snaxi/Snaxi_Lumos.dmm
+++ b/_maps/map_files/Snaxi/Snaxi_Lumos.dmm
@@ -7564,18 +7564,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"ceh" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 9
-	},
-/turf/open/floor/plasteel/dark,
-/area/bridge)
 "cep" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -7840,6 +7828,21 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/central)
+"ciA" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1;
+	name = "north facing firelock"
+	},
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -22
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "ciG" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/mix_input,
 /turf/open/floor/engine/airless,
@@ -9237,13 +9240,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"cJM" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 8;
-	name = "west facing firelock"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "cKe" = (
 /obj/structure/cable,
 /obj/machinery/power/smes,
@@ -9784,6 +9780,23 @@
 	},
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"cTQ" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1;
+	name = "north facing firelock"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -10593,12 +10606,14 @@
 /turf/closed/wall/r_wall,
 /area/security/prison)
 "dno" = (
-/obj/structure/chair/wood,
-/obj/structure/sign/poster/random{
-	pixel_y = 32
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/maintenance/aft/secondary)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/hallway/secondary/exit/departure_lounge)
 "dns" = (
 /obj/docking_port/stationary{
 	dwidth = 3;
@@ -10740,7 +10755,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 6
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
@@ -11725,6 +11740,9 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
 "dTo" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Cryogenic Storage"
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
@@ -12306,6 +12324,12 @@
 /obj/structure/bed,
 /turf/open/floor/wood,
 /area/mine/living_quarters)
+"ehp" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "ehL" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -12313,6 +12337,14 @@
 /obj/machinery/holopad,
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
+"ehW" = (
+/obj/structure/railing,
+/obj/effect/turf_decal/trimline/brown/line,
+/obj/machinery/door/firedoor/border_only{
+	name = "south facing firelock"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "ehX" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/closed/wall/r_wall,
@@ -12420,6 +12452,17 @@
 /obj/structure/chair/wood/normal,
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
+"ekJ" = (
+/obj/machinery/atmospherics/pipe/simple/multiz{
+	dir = 8;
+	piping_layer = 1
+	},
+/obj/effect/turf_decal/stripes/box,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft/secondary)
 "ekX" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
@@ -12486,16 +12529,13 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
 "enP" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Cryogenic Storage"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "eoT" = (
 /obj/machinery/camera{
@@ -13345,7 +13385,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/wood,
 /area/hallway/secondary/exit/departure_lounge)
 "eGO" = (
 /obj/structure/cable{
@@ -13679,6 +13719,13 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
 "eNG" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/landmark/start/assistant,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
@@ -13699,12 +13746,11 @@
 /area/hallway/primary/fore)
 "eOn" = (
 /obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/chair{
 	dir = 8
 	},
-/obj/effect/landmark/start/assistant,
+/obj/structure/chair{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
@@ -14032,19 +14078,14 @@
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/bridge)
 "eVp" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/chair{
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/wood,
+/turf/open/floor/carpet,
 /area/hallway/secondary/exit/departure_lounge)
 "eVW" = (
 /obj/vehicle/ridden/secway,
@@ -14058,14 +14099,10 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "eWp" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/carpet,
+/turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
 "eWw" = (
 /obj/machinery/door/airlock/external{
@@ -14291,17 +14328,15 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "fcu" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/hallway/secondary/exit/departure_lounge)
-"fcJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
+"fcJ" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "fcU" = (
 /obj/machinery/vending/kink,
 /turf/open/floor/plasteel,
@@ -15283,9 +15318,13 @@
 /turf/open/floor/plasteel/dark,
 /area/teleporter)
 "fBc" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/wood,
+/area/security/courtroom)
 "fBf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -16181,13 +16220,11 @@
 /turf/open/floor/carpet,
 /area/hallway/secondary/exit/departure_lounge)
 "fXa" = (
-/obj/structure/chair{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/wood,
-/area/security/courtroom)
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
 "fXd" = (
 /obj/structure/chair/comfy/brown,
 /obj/structure/cable{
@@ -16612,11 +16649,17 @@
 /turf/open/floor/carpet,
 /area/hallway/secondary/exit/departure_lounge)
 "ggt" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 9
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "ggD" = (
 /obj/structure/closet/crate/wooden/fish_learning,
 /turf/open/floor/plasteel/freezer,
@@ -16823,16 +16866,13 @@
 /area/icemoon/surface/outdoors)
 "gmv" = (
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "gmA" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 4
@@ -18438,15 +18478,6 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/atmospherics_engine)
 "hez" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"heM" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
@@ -18454,6 +18485,13 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"heM" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "heR" = (
@@ -18546,10 +18584,15 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "hgO" = (
-/obj/effect/turf_decal/tile/neutral{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "hho" = (
@@ -18824,14 +18867,8 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "hoX" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -19570,6 +19607,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
+"hDf" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "hDj" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/effect/turf_decal/tile/green{
@@ -19854,15 +19900,6 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/carpet,
 /area/hallway/secondary/exit/departure_lounge)
-"hJM" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "hJW" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 10
@@ -19880,7 +19917,7 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "hKl" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -20059,6 +20096,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/bridge)
+"hOa" = (
+/obj/machinery/door/airlock/maintenance,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/plating,
+/area/maintenance/aft/secondary)
 "hOc" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -20601,12 +20644,11 @@
 /turf/open/floor/plating,
 /area/hallway/primary/aft)
 "hZa" = (
-/obj/machinery/firealarm{
-	pixel_y = -24
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "hZy" = (
@@ -20645,6 +20687,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
+"hZO" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 8;
+	name = "west facing firelock"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "hZU" = (
 /obj/structure/table/wood,
 /obj/item/radio/intercom{
@@ -20855,9 +20904,11 @@
 /turf/open/floor/wood,
 /area/security/courtroom)
 "idS" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "iee" = (
@@ -21234,11 +21285,19 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "iog" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "iop" = (
@@ -21679,11 +21738,13 @@
 /turf/open/floor/wood,
 /area/medical/psych)
 "iza" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/table/wood,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "izd" = (
@@ -21970,6 +22031,24 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
+"iFj" = (
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/brown/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8;
+	name = "west facing firelock"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "iFl" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -23098,6 +23177,15 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating/airless,
 /area/maintenance/solars/port/aft)
+"jhU" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft/secondary)
 "jie" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -23166,21 +23254,27 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "jjA" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/tile/red,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "jjB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -23445,15 +23539,17 @@
 	},
 /area/chapel/office)
 "jrf" = (
-/obj/structure/table/wood,
+/obj/machinery/computer/arcade{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
+	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
+	dir = 10
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "jro" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -24029,24 +24125,12 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/red,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/prison)
+/area/security/main)
 "jFY" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -24150,6 +24234,17 @@
 /obj/machinery/door/airlock/glass_large,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
+"jIb" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/stalkybush,
+/turf/open/floor/grass,
+/area/hallway/primary/central)
 "jIc" = (
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible,
 /turf/open/floor/plasteel,
@@ -24809,6 +24904,17 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
+"jYf" = (
+/obj/docking_port/stationary{
+	dir = 2;
+	dwidth = 2;
+	height = 13;
+	id = "ferry_home";
+	name = "port bay 2";
+	width = 5
+	},
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors)
 "jYt" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
@@ -25075,6 +25181,14 @@
 /obj/item/reagent_containers/glass/beaker/waterbottle/wataur,
 /turf/open/floor/plasteel/grimy,
 /area/chapel/main)
+"kfl" = (
+/obj/machinery/atmospherics/pipe/simple/multiz{
+	dir = 8;
+	piping_layer = 3
+	},
+/obj/effect/turf_decal/stripes/box,
+/turf/open/floor/plating,
+/area/maintenance/aft/secondary)
 "kfv" = (
 /turf/closed/wall/r_wall,
 /area/security/prison)
@@ -25109,15 +25223,15 @@
 /turf/open/floor/plating,
 /area/chapel/office)
 "kgr" = (
-/obj/machinery/computer/arcade{
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
+/obj/effect/turf_decal/tile/red,
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "kgx" = (
@@ -27186,15 +27300,15 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
 "lhi" = (
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/computer/arcade{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
-/area/security/main)
+/area/security/prison)
 "lhr" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -27566,17 +27680,9 @@
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "lqG" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
+/obj/machinery/door/airlock/maintenance/abandoned,
+/turf/open/floor/plating,
+/area/library)
 "lqW" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -28369,6 +28475,14 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
+"lMC" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "lMF" = (
 /obj/machinery/camera{
 	c_tag = "Virology Module";
@@ -28440,6 +28554,24 @@
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmospherics_engine)
+"lPR" = (
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "lQc" = (
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
@@ -28455,15 +28587,14 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
 "lQs" = (
-/obj/machinery/computer/arcade{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+/obj/structure/chair/comfy/brown{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
+/turf/open/floor/carpet,
+/area/hallway/primary/central)
 "lQJ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
@@ -29037,8 +29168,10 @@
 /turf/closed/wall,
 /area/medical/medbay/central)
 "mdG" = (
-/obj/machinery/door/airlock/maintenance/abandoned,
-/turf/open/floor/plating,
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/carpet,
 /area/library)
 "meG" = (
 /obj/structure/cable{
@@ -29183,13 +29316,13 @@
 /turf/open/floor/engine,
 /area/engine/atmospherics_engine)
 "mhH" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
 	},
-/obj/structure/chair/comfy/brown{
-	dir = 1
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 4
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "mia" = (
 /obj/structure/cable{
@@ -29452,11 +29585,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/virology)
-"mpR" = (
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "mqb" = (
 /obj/machinery/vending/wardrobe/jani_wardrobe,
 /obj/structure/sign/poster/official/random{
@@ -29518,11 +29646,16 @@
 /turf/open/floor/carpet,
 /area/bridge)
 "mqq" = (
-/obj/structure/railing{
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
 	dir = 4
 	},
-/turf/open/floor/carpet,
-/area/library)
+/obj/structure/flora/grass/jungle,
+/obj/structure/flora/ausbushes/brflowers,
+/turf/open/floor/grass,
+/area/hallway/primary/central)
 "mqC" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -30014,14 +30147,14 @@
 /turf/open/floor/plasteel,
 /area/engine/atmospherics_engine)
 "mEo" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 4
+/obj/structure/railing/corner{
+	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/turf/open/floor/carpet,
+/area/library)
 "mEE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
@@ -30068,16 +30201,12 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "mGa" = (
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/rack,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
 	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/flora/grass/jungle,
-/obj/structure/flora/ausbushes/brflowers,
-/turf/open/floor/grass,
-/area/hallway/primary/central)
+/area/maintenance/aft/secondary)
 "mGb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -30271,14 +30400,16 @@
 /turf/open/floor/plasteel/dark,
 /area/security/warden)
 "mKA" = (
-/obj/structure/disposalpipe/segment{
+/obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/structure/railing/corner{
+/obj/machinery/light/small{
 	dir = 8
 	},
-/turf/open/floor/carpet,
-/area/library)
+/obj/structure/flora/grass/jungle,
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/grass,
+/area/hallway/primary/central)
 "mKD" = (
 /obj/structure/chair/sofa/right,
 /turf/open/floor/carpet,
@@ -31135,12 +31266,13 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "ndS" = (
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/structure/rack,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/railing{
+	dir = 4
 	},
-/area/maintenance/aft/secondary)
+/turf/open/floor/plasteel/stairs/right,
+/area/hallway/primary/central)
 "ndX" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -32105,13 +32237,13 @@
 /area/security/prison)
 "nCU" = (
 /obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/light/small{
 	dir = 8
 	},
 /obj/structure/flora/grass/jungle,
-/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/flora/ausbushes/brflowers,
+/obj/machinery/light/small{
+	dir = 4
+	},
 /turf/open/floor/grass,
 /area/hallway/primary/central)
 "nDa" = (
@@ -32235,13 +32367,9 @@
 /turf/open/floor/carpet,
 /area/bridge)
 "nFc" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/open/floor/plasteel/stairs/right,
-/area/hallway/primary/central)
+/obj/structure/railing/corner,
+/turf/open/floor/wood,
+/area/library)
 "nFw" = (
 /obj/machinery/button/door{
 	id = "bridge blast";
@@ -32342,16 +32470,11 @@
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "nGx" = (
-/obj/structure/window/reinforced{
+/obj/structure/railing{
 	dir = 8
 	},
-/obj/structure/flora/grass/jungle,
-/obj/structure/flora/ausbushes/brflowers,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/grass,
-/area/hallway/primary/central)
+/turf/open/floor/plasteel/stairs/left,
+/area/library)
 "nGR" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -33582,6 +33705,18 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
+"oiq" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "oiC" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -34158,6 +34293,12 @@
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plasteel/dark,
 /area/storage/eva)
+"oud" = (
+/obj/machinery/door/airlock/research/glass,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "oui" = (
 /turf/open/floor/plasteel/yellowsiding,
 /area/crew_quarters/fitness/pool)
@@ -34832,8 +34973,13 @@
 	},
 /area/hallway/secondary/exit/departure_lounge)
 "oME" = (
-/obj/structure/railing/corner,
-/turf/open/floor/wood,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/plasteel/stairs/right,
 /area/library)
 "oMJ" = (
 /obj/structure/cable{
@@ -35615,10 +35761,10 @@
 	},
 /area/maintenance/aft/secondary)
 "phf" = (
-/obj/structure/railing{
+/obj/structure/railing/corner{
 	dir = 8
 	},
-/turf/open/floor/plasteel/stairs/left,
+/turf/open/floor/wood,
 /area/library)
 "phg" = (
 /obj/structure/railing/corner{
@@ -36126,12 +36272,6 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
-"ptn" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "ptv" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on/layer1,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -36404,6 +36544,20 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
+"pxP" = (
+/obj/structure/railing,
+/obj/effect/turf_decal/trimline/purple/line,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
+	},
+/obj/machinery/door/firedoor/border_only{
+	name = "south facing firelock"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "pxS" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -37036,10 +37190,34 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"pLg" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 5
+	},
+/obj/machinery/newscaster{
+	pixel_y = 32
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "pLo" = (
 /obj/structure/fence/post,
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors)
+"pLx" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "pLP" = (
 /obj/machinery/turnstile{
 	dir = 8;
@@ -37429,14 +37607,16 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "pVz" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/railing{
+/obj/structure/railing/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel/stairs/right,
-/area/library)
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/flora/rock/jungle,
+/turf/open/floor/grass,
+/area/hallway/primary/central)
 "pVM" = (
 /obj/effect/decal/cleanable/cobweb{
 	icon_state = "cobweb2"
@@ -37572,6 +37752,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"pYH" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "pYM" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -38726,11 +38914,16 @@
 	},
 /area/chapel/office)
 "qCa" = (
-/obj/structure/railing/corner{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/open/floor/wood,
-/area/library)
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/lumos/loading_area/white,
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "qCo" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -39515,15 +39708,13 @@
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "qUY" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/lumos/loading_area/white,
 /obj/structure/railing/corner{
 	dir = 4
 	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/flora/rock/jungle,
-/turf/open/floor/grass,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "qVf" = (
 /obj/structure/cable{
@@ -40106,6 +40297,17 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/bar)
+"rka" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/biolumi/mine/weaklight,
+/turf/open/floor/grass,
+/area/hallway/primary/central)
 "rkd" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -40686,15 +40888,13 @@
 /turf/open/floor/plasteel/grimy,
 /area/chapel/main)
 "rwR" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/lumos/loading_area/white,
-/obj/structure/railing/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
+/obj/structure/flora/grass/jungle,
+/obj/structure/flora/rock/jungle,
+/turf/open/floor/grass,
 /area/hallway/primary/central)
 "rwW" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
@@ -40772,25 +40972,11 @@
 /turf/open/floor/plasteel/dark,
 /area/blueshield)
 "ryE" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/effect/turf_decal/lumos/loading_area/white,
 /obj/structure/railing/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"rzr" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/stalkybush,
-/turf/open/floor/grass,
-/area/hallway/primary/central)
+/turf/open/floor/wood,
+/area/library)
 "rAa" = (
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/disposal/bin,
@@ -41992,14 +42178,20 @@
 /turf/open/floor/plasteel/grimy,
 /area/chapel/main)
 "sjk" = (
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/structure/flora/grass/jungle,
-/obj/structure/flora/rock/jungle,
-/turf/open/floor/grass,
-/area/hallway/primary/central)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
+	},
+/obj/structure/railing/corner{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/library)
 "sjB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 9
@@ -42376,6 +42568,12 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
 "srJ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /obj/structure/railing/corner{
 	dir = 1
 	},
@@ -42605,32 +42803,24 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "sxN" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 6
-	},
-/obj/structure/railing/corner{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
 	},
 /turf/open/floor/wood,
 /area/library)
 "syd" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+/obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
+/obj/machinery/door/firedoor/border_only{
+	dir = 4;
+	name = "east facing firelock"
 	},
-/obj/structure/railing/corner{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
 	},
-/turf/open/floor/wood,
-/area/library)
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "syz" = (
 /obj/machinery/airalarm{
 	dir = 1;
@@ -42666,6 +42856,12 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"szC" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "szD" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -42906,11 +43102,11 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "sFp" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
 	},
-/turf/open/floor/wood,
-/area/library)
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "sGC" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/effect/turf_decal/stripes/line,
@@ -42951,6 +43147,20 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
+"sHj" = (
+/obj/structure/railing,
+/obj/effect/turf_decal/trimline/brown/line,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	name = "south facing firelock"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "sHl" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -43136,18 +43346,11 @@
 /turf/open/floor/plasteel/dark,
 /area/teleporter)
 "sLv" = (
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/structure/chair/comfy/brown{
+	dir = 8
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	name = "east facing firelock"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/execution/education)
+/turf/open/floor/wood,
+/area/library)
 "sLN" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel,
@@ -43341,11 +43544,13 @@
 	},
 /area/hallway/primary/port)
 "sRh" = (
-/obj/structure/sign/poster/official/random{
-	pixel_x = -32
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/wood,
+/area/library)
 "sRM" = (
 /obj/machinery/light{
 	dir = 1
@@ -43497,11 +43702,11 @@
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "sUX" = (
-/obj/structure/chair/comfy/brown{
-	dir = 8
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
 	},
-/turf/open/floor/wood,
-/area/library)
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "sVh" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
@@ -44165,6 +44370,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"tmx" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8;
+	name = "west facing firelock"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "tmy" = (
 /obj/machinery/sleeper{
 	dir = 8
@@ -44201,6 +44421,17 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
+"tnV" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1;
+	name = "north facing firelock"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "tnX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -44282,13 +44513,14 @@
 /turf/open/floor/engine,
 /area/engine/atmospherics_engine)
 "toP" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/wood,
-/area/library)
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "tpf" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -45026,16 +45258,8 @@
 /turf/open/floor/carpet,
 /area/hallway/secondary/exit/departure_lounge)
 "tJJ" = (
-/obj/docking_port/stationary{
-	dir = 2;
-	dwidth = 2;
-	height = 13;
-	id = "ferry_home";
-	name = "port bay 2";
-	width = 5
-	},
-/turf/open/floor/plating/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors)
+/turf/open/openspace,
+/area/hallway/primary/central)
 "tJL" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -45584,11 +45808,10 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/paramedic)
 "tWj" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/obj/structure/chair/comfy/brown,
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/wood,
+/area/library)
 "tWx" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
@@ -45743,14 +45966,15 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain)
 "uaA" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/structure/sign/poster/official/random{
-	pixel_x = -32
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/wood,
+/area/library)
 "uaC" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -46076,21 +46300,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"uiU" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "ujD" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -46696,6 +46905,15 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"uBW" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	pixel_y = -24
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "uCi" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plasteel/white,
@@ -46885,8 +47103,9 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "uJe" = (
-/obj/structure/chair/comfy/brown,
-/obj/effect/landmark/start/assistant,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8
+	},
 /turf/open/floor/wood,
 /area/library)
 "uJx" = (
@@ -47111,18 +47330,6 @@
 	dir = 4
 	},
 /area/chapel/main)
-"uOG" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/bridge)
 "uOT" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -48516,15 +48723,11 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
 "vun" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/wood,
-/area/library)
+/turf/open/floor/plating,
+/area/maintenance/central)
 "vuJ" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -26
@@ -49104,10 +49307,10 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "vHd" = (
-/obj/structure/table/wood,
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/structure/chair/wood,
 /turf/open/floor/plating,
 /area/maintenance/aft/secondary)
 "vHU" = (
@@ -49381,11 +49584,11 @@
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
 "vNY" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/wood,
-/area/library)
+/area/security/vacantoffice/a)
 "vOo" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -49792,15 +49995,6 @@
 	},
 /turf/open/floor/plating,
 /area/bridge)
-"vXe" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "vXs" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -50095,17 +50289,6 @@
 	},
 /turf/open/floor/grass,
 /area/hallway/primary/aft)
-"wda" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/biolumi/mine/weaklight,
-/turf/open/floor/grass,
-/area/hallway/primary/central)
 "wdb" = (
 /turf/closed/wall/r_wall,
 /area/science/explab)
@@ -50269,6 +50452,24 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"wiD" = (
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/purple/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "wje" = (
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
@@ -50356,6 +50557,15 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
+"wkv" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "wkS" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -50557,11 +50767,11 @@
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/computer)
 "wpO" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1
 	},
-/turf/open/floor/plating,
-/area/maintenance/central)
+/turf/open/floor/wood,
+/area/security/vacantoffice/a)
 "wqd" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -51140,11 +51350,14 @@
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
 "wFU" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/wood,
-/area/security/vacantoffice/a)
+/obj/structure/chair/comfy/brown{
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/hallway/primary/central)
 "wFY" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -51204,11 +51417,13 @@
 /turf/open/floor/wood,
 /area/maintenance/bar)
 "wHB" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/wood,
-/area/security/vacantoffice/a)
+/obj/structure/table/wood,
+/obj/item/taperecorder,
+/turf/open/floor/carpet,
+/area/hallway/primary/central)
 "wHM" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -51260,14 +51475,11 @@
 /turf/open/floor/carpet/orange,
 /area/engine/secure_construction)
 "wJb" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/chair/comfy/brown{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/hallway/primary/central)
+/obj/structure/window/reinforced,
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/grass,
+/area/maintenance/aft/secondary)
 "wJf" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -51528,6 +51740,7 @@
 	},
 /obj/structure/table,
 /obj/item/lightreplacer,
+/obj/item/rcl/pre_loaded,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "wRz" = (
@@ -51572,13 +51785,14 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "wRX" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/window/reinforced,
+/obj/structure/flora/tree/jungle/small{
+	pixel_x = -48;
+	pixel_y = 8
 	},
-/obj/structure/table/wood,
-/obj/item/taperecorder,
-/turf/open/floor/carpet,
-/area/hallway/primary/central)
+/obj/structure/flora/ausbushes/grassybush,
+/turf/open/floor/grass,
+/area/maintenance/aft/secondary)
 "wRY" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/solars/starboard/aft)
@@ -52584,11 +52798,10 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "xtq" = (
-/obj/structure/window/reinforced,
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/grass,
-/area/maintenance/aft/secondary)
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "xty" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-22"
@@ -53785,14 +53998,20 @@
 /turf/open/floor/plasteel/dark,
 /area/storage/eva)
 "xZL" = (
-/obj/structure/window/reinforced,
-/obj/structure/flora/tree/jungle/small{
-	pixel_x = -48;
-	pixel_y = 8
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
 	},
-/obj/structure/flora/ausbushes/grassybush,
-/turf/open/floor/grass,
-/area/maintenance/aft/secondary)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "xZX" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -53888,9 +54107,14 @@
 /turf/open/floor/plating,
 /area/maintenance/aft/secondary)
 "ydo" = (
-/obj/machinery/door/airlock/maintenance/abandoned,
-/turf/closed/wall,
-/area/maintenance/aft/secondary)
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "ydp" = (
 /turf/closed/mineral/random/snow/no_caves,
 /area/icemoon/surface/outdoors)
@@ -78827,7 +79051,7 @@ fAj
 oZR
 cyy
 qdZ
-lqG
+kgr
 spI
 dkO
 uAZ
@@ -79597,7 +79821,7 @@ rKZ
 vlv
 ahW
 pEK
-jFT
+jjA
 rOd
 jfq
 pEo
@@ -79854,8 +80078,8 @@ lFK
 jro
 fAj
 wJw
-kgr
-lQs
+jrf
+lhi
 tfY
 fAj
 pAS
@@ -80871,7 +81095,7 @@ foy
 ilb
 ilb
 ilb
-ggt
+fXa
 rlG
 wSb
 wav
@@ -80892,7 +81116,7 @@ fnc
 nxv
 pnu
 dvj
-sLv
+syd
 gdE
 rcY
 duI
@@ -82669,7 +82893,7 @@ wql
 uUJ
 vOU
 bcc
-fBc
+fcJ
 cuX
 oKD
 wql
@@ -83184,7 +83408,7 @@ khf
 vOU
 qEz
 vOU
-gmv
+ggt
 xRL
 hNn
 xCC
@@ -83979,7 +84203,7 @@ air
 wuS
 wql
 cIH
-wpO
+vun
 sdN
 chA
 tod
@@ -84236,7 +84460,7 @@ wql
 wql
 wql
 sdN
-wpO
+vun
 dCh
 sdN
 sdN
@@ -84976,7 +85200,7 @@ wcB
 bok
 wrh
 cFO
-fcu
+eWp
 wvL
 bwt
 ewK
@@ -85232,8 +85456,8 @@ wcB
 wcB
 bok
 wrh
-drK
-fcJ
+dno
+fcu
 wVg
 bwt
 aNw
@@ -85264,8 +85488,8 @@ dYl
 rYN
 qOb
 bSd
-wFU
-wHB
+vNY
+wpO
 kJE
 xXX
 sdN
@@ -85489,7 +85713,7 @@ wcB
 wcB
 bok
 wrh
-dTo
+drK
 tif
 nUk
 bwt
@@ -85746,14 +85970,14 @@ uFq
 uFq
 bok
 unA
-enP
+dTo
 bmA
 unA
 grV
 xTL
 lHn
 bsk
-fXa
+fBc
 ciO
 cTD
 bCz
@@ -86003,7 +86227,7 @@ wbE
 wbE
 fPp
 rqE
-eGL
+enP
 rqE
 dGB
 cTD
@@ -86022,7 +86246,7 @@ cBD
 ndL
 dpZ
 dpZ
-lhi
+jFT
 smP
 wtt
 bMN
@@ -86260,7 +86484,7 @@ wbE
 wbE
 uBa
 uBa
-eNG
+eGL
 uBa
 dGB
 cTD
@@ -86517,7 +86741,7 @@ lRx
 wbE
 got
 got
-eOn
+eNG
 uBa
 dGB
 cTD
@@ -86550,11 +86774,11 @@ sdN
 sdN
 sdN
 jcT
-wJb
+wFU
 lhQ
 sAw
 lhQ
-wda
+rka
 dMj
 riE
 hGy
@@ -86774,7 +86998,7 @@ xYD
 wbE
 xZg
 xZg
-eVp
+eOn
 uBa
 eeh
 grV
@@ -86807,11 +87031,11 @@ tod
 tod
 tod
 jcT
-wRX
+wHB
 lhQ
 cZq
 lhQ
-rzr
+jIb
 dMj
 dMj
 dMj
@@ -87031,7 +87255,7 @@ xYD
 wbE
 uBa
 uBa
-eNG
+eGL
 uBa
 qHO
 lbp
@@ -87057,12 +87281,12 @@ qQt
 vPQ
 bJF
 bVX
-mGa
-nCU
-qUY
-sRh
-tWj
-uaA
+mqq
+mKA
+pVz
+sFp
+sUX
+toP
 pjn
 tNf
 lhQ
@@ -87299,7 +87523,7 @@ bAk
 hxf
 hxf
 hxf
-hez
+gmv
 bAj
 ezY
 wZl
@@ -87316,7 +87540,7 @@ bPa
 fZV
 bCT
 msm
-rwR
+qCa
 wZl
 wZl
 wZl
@@ -87545,7 +87769,7 @@ beq
 wdk
 wdk
 wdk
-eWp
+eVp
 wdk
 wdk
 bnE
@@ -87556,7 +87780,7 @@ udI
 fqE
 fqE
 fqE
-heM
+hez
 nRt
 xmB
 tys
@@ -87570,17 +87794,17 @@ tys
 tys
 tys
 tXn
-mEo
+mhH
 bCW
-nFc
-ryE
+ndS
+qUY
 tys
 tys
 tys
 tys
 tys
 tys
-mpR
+xtq
 bPd
 tys
 tys
@@ -87826,11 +88050,11 @@ ceA
 ceA
 sOv
 wLU
-mhH
+lQs
 ceA
 bDI
-nGx
-sjk
+nCU
+rwR
 lhQ
 lhQ
 ceA
@@ -87847,7 +88071,7 @@ bUL
 cgZ
 iIS
 cmU
-uOG
+oiq
 ckX
 clV
 cmV
@@ -88096,7 +88320,7 @@ srk
 srk
 cTO
 cdE
-cJM
+hZO
 chb
 chb
 yiZ
@@ -88104,7 +88328,7 @@ chb
 vqS
 iIS
 hYD
-uOG
+oiq
 cqo
 clV
 oBF
@@ -88343,7 +88567,7 @@ srk
 wvg
 lBE
 xyA
-oME
+nFc
 hUc
 njU
 agy
@@ -88361,7 +88585,7 @@ rnA
 hsP
 iIS
 kxf
-uOG
+oiq
 iIK
 iIS
 iAt
@@ -88599,16 +88823,16 @@ xTI
 vBV
 xTI
 xTI
-mKA
-phf
-srJ
-sUX
+mEo
+nGx
+ryE
+sLv
 agy
-uJe
+tWj
 njU
 agy
 xjF
-uiU
+xZL
 mbh
 bwr
 chb
@@ -88618,7 +88842,7 @@ gSY
 uAs
 obL
 fJW
-ceh
+pLx
 rAj
 iIS
 cph
@@ -88857,13 +89081,13 @@ vBV
 xTI
 xTI
 bRH
-pVz
-sxN
-toP
-toP
-vun
-toP
-toP
+oME
+sjk
+sRh
+sRh
+uaA
+sRh
+sRh
 eDu
 gpp
 bXU
@@ -89098,7 +89322,7 @@ bBL
 bBL
 bBL
 bBL
-hgO
+heM
 mIz
 cSG
 bzS
@@ -89111,14 +89335,14 @@ ikt
 fNE
 tAM
 srk
-mqq
-mqq
+mdG
+mdG
 rxu
-qCa
-syd
+phf
+srJ
 agy
 agy
-vNY
+uJe
 agy
 agy
 xjF
@@ -90132,7 +90356,7 @@ kis
 bzU
 bDW
 bME
-jjA
+iog
 bFK
 srk
 xLN
@@ -90385,7 +90609,7 @@ bBL
 bBL
 bBL
 rle
-hoX
+hgO
 lhQ
 bvw
 lhQ
@@ -90643,10 +90867,10 @@ bxR
 mPM
 ohK
 tlc
-hKl
+hoX
 bvw
 bFT
-jrf
+iza
 biW
 wTK
 wTK
@@ -90657,7 +90881,7 @@ hzs
 xTI
 msg
 njU
-sFp
+sxN
 agy
 agy
 nHQ
@@ -90900,7 +91124,7 @@ cZq
 lbp
 cqd
 qlW
-idS
+hKl
 bvw
 bFT
 czg
@@ -91157,11 +91381,11 @@ jLp
 bDT
 bAt
 mmO
-iog
+hZa
 bzl
-iza
+idS
 mmO
-iza
+idS
 lJC
 cpB
 qEM
@@ -91178,7 +91402,7 @@ nHQ
 agy
 xjF
 lhQ
-vXe
+ydo
 kSP
 oBj
 tpn
@@ -91423,7 +91647,7 @@ wTK
 wTK
 wTK
 xbC
-mdG
+lqG
 agy
 agy
 agy
@@ -92720,7 +92944,7 @@ iZs
 gKs
 srk
 cQU
-vXe
+ydo
 lDi
 cVc
 kpT
@@ -93243,10 +93467,10 @@ jpS
 jpS
 sBN
 wTK
-dno
+epJ
 vHd
+hzL
 rRH
-wGq
 pSs
 hzL
 rRH
@@ -93489,21 +93713,21 @@ wTK
 wTK
 wGq
 wTK
-xtq
+wJb
 lhQ
 xPP
-tNf
+uBW
 sqH
 sqH
-sqH
-sqH
-sqH
+xTw
+xTw
+xTw
 sqH
 wTK
+tZf
 wTK
-wTK
-wTK
-wTK
+lYJ
+lYJ
 wTK
 wTK
 wTK
@@ -93739,26 +93963,26 @@ wGq
 doP
 mzv
 wTK
-ndS
+mGa
 wGq
 wGq
 ofH
 wGq
 rHo
 wTK
-xZL
+wRX
 lhQ
 hSV
-hZa
-jcT
-avT
-avT
+tNf
+lbp
+wkv
+ehW
 tJJ
-avT
-avT
-avT
-avT
-avT
+tJJ
+tnV
+wTK
+wGq
+wTK
 avT
 avT
 avT
@@ -94003,19 +94227,19 @@ wTK
 wTK
 wGq
 wTK
-ydo
+wTK
 lhQ
-xPP
-tNf
-jcT
-avT
-avT
-avT
-avT
-avT
-avT
-avT
-avT
+ydo
+pYH
+oud
+lMC
+pxP
+tJJ
+tJJ
+ciA
+wTK
+wGq
+wTK
 avT
 avT
 avT
@@ -94262,17 +94486,17 @@ wGq
 wGq
 kAX
 lhQ
-hJM
+hDf
 tNf
-jcT
-avT
-avT
-avT
-avT
-avT
-avT
-avT
-avT
+lbp
+szC
+sHj
+tJJ
+tJJ
+cTQ
+hOa
+jhU
+wTK
 avT
 avT
 avT
@@ -94519,17 +94743,17 @@ wTK
 wTK
 wTK
 bdm
-ptn
+ehp
 tNf
 jcT
-avT
-avT
-avT
-avT
-avT
-avT
-avT
-avT
+pLg
+wiD
+iFj
+tmx
+lPR
+wTK
+ekJ
+wTK
 avT
 avT
 avT
@@ -94779,14 +95003,14 @@ fmw
 fmw
 wEn
 jcT
-avT
-avT
-avT
-avT
-avT
-avT
-avT
-avT
+jcT
+lbp
+jcT
+lbp
+jcT
+wTK
+kfl
+wTK
 avT
 avT
 avT
@@ -95041,9 +95265,9 @@ avT
 avT
 avT
 avT
-avT
-avT
-avT
+wTK
+wTK
+wTK
 avT
 avT
 avT
@@ -96067,7 +96291,7 @@ avT
 avT
 avT
 avT
-avT
+jYf
 avT
 avT
 avT
@@ -96834,19 +97058,19 @@ avT
 xUL
 vBe
 avT
-ydp
-ydp
-ydp
-ydp
-ydp
-ydp
-ydp
-ydp
-ydp
 avT
-ydp
-ydp
-ydp
+avT
+avT
+avT
+avT
+avT
+avT
+avT
+avT
+avT
+avT
+avT
+avT
 avT
 avT
 avT

--- a/_maps/map_files/Snaxi/Snaxi_Lumos.dmm
+++ b/_maps/map_files/Snaxi/Snaxi_Lumos.dmm
@@ -2883,6 +2883,18 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/hallway/primary/aft)
+"aJd" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8;
+	name = "west facing firelock"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4;
+	name = "east facing firelock"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "aJe" = (
 /obj/machinery/light{
 	dir = 4
@@ -7905,8 +7917,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/closet/radiation,
-/obj/item/storage/firstaid/radbgone,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "cjN" = (
@@ -11456,8 +11466,6 @@
 /obj/machinery/airalarm{
 	pixel_y = 28
 	},
-/obj/structure/closet/radiation,
-/obj/item/storage/firstaid/radbgone,
 /obj/machinery/light{
 	dir = 1
 	},
@@ -15789,18 +15797,6 @@
 /obj/item/seeds/watermelon/holy,
 /turf/open/floor/grass,
 /area/chapel/main)
-"fQc" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	name = "east facing firelock"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8;
-	name = "west facing firelock"
-	},
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/turf/open/floor/plating,
-/area/engine/engineering)
 "fQe" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Auxiliary Tool Storage";
@@ -16517,6 +16513,13 @@
 "ghq" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/ai)
+"gis" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "Mix to Gas"
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "giv" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -17561,6 +17564,10 @@
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
+"gJr" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/turf/open/floor/engine,
+/area/engine/engineering)
 "gJx" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -17595,6 +17602,8 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
 	},
+/obj/structure/closet/radiation,
+/obj/item/storage/firstaid/radbgone,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "gKo" = (
@@ -19765,6 +19774,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/medical/medbay/central)
+"hLg" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Gas to Mix"
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "hLo" = (
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_x = -30
@@ -20753,6 +20769,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
+"ieF" = (
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "ieI" = (
 /obj/machinery/telecomms/server/presets/service,
 /obj/machinery/light{
@@ -24672,11 +24694,6 @@
 /obj/machinery/light/floor,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
-"jYN" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/light,
-/turf/open/floor/engine,
-/area/engine/engineering)
 "jYT" = (
 /obj/machinery/power/solar_control{
 	dir = 4;
@@ -26971,6 +26988,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 4
+	},
 /turf/open/floor/engine,
 /area/engine/engineering)
 "lff" = (
@@ -29032,6 +29052,14 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"mhC" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "mhF" = (
 /obj/structure/loot_pile,
 /turf/open/floor/plating,
@@ -29509,12 +29537,23 @@
 "mtP" = (
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
+"mtW" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "mtY" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/green/visible,
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
 /turf/open/floor/engine,
 /area/engine/engineering)
 "muN" = (
@@ -32409,12 +32448,6 @@
 	},
 /turf/open/floor/plasteel/stairs/left,
 /area/hallway/primary/aft)
-"nKb" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "nKf" = (
 /obj/structure/chair/sofa/left,
 /turf/open/floor/plasteel/grimy,
@@ -34624,8 +34657,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/obj/structure/closet/radiation,
-/obj/item/storage/firstaid/radbgone,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "oJp" = (
@@ -35798,6 +35829,21 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
+"pkj" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/green/visible{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "pko" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel/yellowsiding{
@@ -38999,14 +39045,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"qIn" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "qIx" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -39448,6 +39486,9 @@
 	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 6
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -40946,6 +40987,14 @@
 /obj/structure/rack,
 /turf/open/floor/plating,
 /area/hallway/primary/fore)
+"rDt" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/light,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "rDv" = (
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/disposal/bin,
@@ -43047,8 +43096,10 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/green/visible,
 /obj/effect/turf_decal/stripes/corner,
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
 /turf/open/floor/engine,
 /area/engine/engineering)
 "sIl" = (
@@ -46872,16 +46923,13 @@
 /turf/open/floor/wood,
 /area/security/vacantoffice/b)
 "uIU" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/door/firedoor/border_only{
-	dir = 8;
-	name = "west facing firelock"
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	name = "east facing firelock"
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 1
 	},
-/turf/open/floor/plating,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "uIZ" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
@@ -47066,7 +47114,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -47933,6 +47981,9 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/south,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
+	},
 /turf/open/floor/engine,
 /area/engine/engineering)
 "vgW" = (
@@ -50030,11 +50081,16 @@
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "wcy" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/machinery/door/firedoor/border_only{
+	dir = 4;
+	name = "east facing firelock"
 	},
-/turf/open/floor/engine,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8;
+	name = "west facing firelock"
+	},
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "wcB" = (
 /turf/open/floor/plating,
@@ -50196,11 +50252,13 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/machinery/light{
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/green/visible{
 	dir = 4
 	},
 /turf/open/floor/engine,
@@ -53402,6 +53460,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 6
+	},
 /turf/open/floor/engine,
 /area/engine/engineering)
 "xPP" = (
@@ -53725,6 +53786,13 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/dark,
 /area/storage/eva)
+"xZA" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "xZL" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -106699,12 +106767,12 @@ iiY
 oty
 ijZ
 bnU
-fQc
+wcy
 gWc
 npp
 pKN
-uIU
-uIU
+aJd
+aJd
 bnU
 mDW
 scH
@@ -106961,7 +107029,7 @@ ftM
 tcq
 ftM
 xPK
-nKb
+mtW
 bnU
 mDW
 scH
@@ -107217,8 +107285,8 @@ cjH
 cLO
 fVT
 cLO
-jOE
-svp
+uIU
+xZA
 wku
 mDW
 dbN
@@ -107474,8 +107542,8 @@ dLj
 cLO
 qQb
 cLO
-jOE
-jYN
+uIU
+rDt
 bnU
 eMi
 dkQ
@@ -107728,9 +107796,9 @@ ovI
 oAX
 tyF
 qSR
-cLO
-cLO
-cLO
+gJr
+gJr
+ieF
 lfd
 vgI
 bnU
@@ -107984,10 +108052,10 @@ cfs
 vUj
 cLO
 nqc
+gis
 cLO
 cLO
-cLO
-cLO
+hLg
 jOE
 nUN
 sza
@@ -108237,11 +108305,11 @@ bum
 kLn
 jPj
 ucC
-wcy
+cfs
 sIk
 aTc
 sax
-bdd
+pkj
 bdd
 bdd
 whW
@@ -108494,7 +108562,7 @@ bum
 hJW
 jls
 ucC
-wcy
+cfs
 mtY
 rco
 vQo
@@ -108762,7 +108830,7 @@ qha
 vQo
 bnU
 lWP
-qIn
+mhC
 bnU
 kPQ
 jzc
@@ -111073,7 +111141,7 @@ bnU
 dtm
 pvj
 bnU
-uIU
+aJd
 bnU
 bnU
 bnU

--- a/_maps/map_files/Snaxi/Snaxi_Lumos.dmm
+++ b/_maps/map_files/Snaxi/Snaxi_Lumos.dmm
@@ -8,7 +8,6 @@
 /turf/open/floor/plating,
 /area/medical/chemistry)
 "aaO" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -117,7 +116,7 @@
 /area/quartermaster/storage)
 "abZ" = (
 /obj/effect/landmark/start/medical_doctor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /turf/open/floor/plasteel/freezer,
@@ -211,7 +210,10 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -301,6 +303,12 @@
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 10
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -543,7 +551,6 @@
 /obj/structure/chair/office/dark{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -553,12 +560,15 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 8;
 	sortType = 13
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
@@ -587,10 +597,11 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "ahX" = (
@@ -659,12 +670,12 @@
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/maintenance/solars/port/fore)
 "ajq" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 5
 	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "ajA" = (
 /obj/machinery/light{
 	dir = 4
@@ -728,12 +739,17 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
 "akB" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/machinery/door/firedoor/border_only{
+	dir = 4;
+	name = "east facing firelock"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
+/obj/machinery/door/firedoor/border_only{
+	dir = 8;
+	name = "west facing firelock"
+	},
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/plating,
+/area/engine/engineering)
 "akQ" = (
 /obj/machinery/light{
 	dir = 4
@@ -751,11 +767,14 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -791,18 +810,18 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "alG" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/security/main)
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/surface/outdoors)
 "alR" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "Mix to Gas"
 	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
+/turf/open/floor/engine,
+/area/engine/engineering)
 "alS" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -833,11 +852,11 @@
 	},
 /area/chapel/main)
 "amm" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/machinery/atmospherics/components/binary/valve/layer1{
+	dir = 4
 	},
-/turf/open/floor/wood,
-/area/library)
+/turf/open/floor/plating,
+/area/icemoon/surface/outdoors)
 "amy" = (
 /obj/machinery/vending/wallmed{
 	pixel_y = -28
@@ -847,9 +866,20 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "amA" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/green/visible{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "amD" = (
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = "MedbayFoyer";
@@ -904,20 +934,9 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "ani" = (
-/obj/machinery/door/airlock/medical/glass{
-	id_tag = "MedbayFoyer";
-	name = "Medbay";
-	req_access_txt = "5"
-	},
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only{
-	name = "south facing firelock"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/turf/open/floor/engine,
+/area/engine/engineering)
 "anm" = (
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -972,16 +991,18 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "anJ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 10
 	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
+/turf/open/floor/plasteel/freezer,
+/area/medical/surgery)
 "anK" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/medical/chemistry)
 "anL" = (
@@ -993,9 +1014,6 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/chemist,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/medical/chemistry)
 "anO" = (
@@ -1029,27 +1047,22 @@
 /turf/open/floor/plating,
 /area/medical/medbay/central)
 "aok" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/plasteel/freezer,
+/area/medical/surgery)
 "aol" = (
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "aom" = (
-/obj/structure/chair{
-	dir = 1
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Gas to Mix"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
+/turf/open/floor/engine,
+/area/engine/engineering)
 "aon" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -1097,23 +1110,12 @@
 /obj/item/storage/box/medipens,
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
-"aoT" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/white,
-/area/medical/storage)
 "aoU" = (
 /obj/structure/chair{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"aoV" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/security/brig)
 "aoX" = (
 /turf/closed/wall/r_wall,
 /area/medical/chemistry)
@@ -1149,9 +1151,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -1167,11 +1166,15 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "aqd" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/wood,
-/area/library)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/surface/outdoors)
 "aqP" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 10
@@ -1203,9 +1206,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
 /obj/machinery/airalarm{
 	pixel_y = 32
 	},
@@ -1224,19 +1224,26 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "arN" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8;
+	name = "west facing firelock"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/plasteel,
-/area/hallway/primary/port)
+/obj/machinery/door/firedoor/border_only{
+	dir = 4;
+	name = "east facing firelock"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "arP" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -1262,9 +1269,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "asc" = (
@@ -1287,10 +1292,13 @@
 /turf/open/floor/plating,
 /area/maintenance/aft/secondary)
 "asr" = (
-/obj/machinery/atmospherics/pipe/simple/supply/visible{
+/obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 9
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
@@ -1318,15 +1326,20 @@
 /turf/open/floor/plasteel/dark,
 /area/teleporter)
 "asO" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "asQ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall/r_wall,
-/area/science/robotics/lab)
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "atb" = (
 /obj/machinery/light{
 	dir = 1
@@ -1376,16 +1389,15 @@
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/computer)
 "atJ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall/r_wall,
-/area/teleporter)
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "atM" = (
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
 	},
 /obj/structure/disposalpipe/sorting/mail/flip{
 	sortType = 14
@@ -1400,9 +1412,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -1425,9 +1434,6 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 6
-	},
 /obj/machinery/light/floor,
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -1438,9 +1444,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
@@ -1450,14 +1453,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/port)
-"aue" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
@@ -1471,14 +1471,17 @@
 /obj/machinery/porta_turret/ai{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "auP" = (
 /obj/structure/cable{
 	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
@@ -1496,18 +1499,14 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "auT" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
+	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
-"auV" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/hallway/primary/port)
 "auX" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -1515,11 +1514,14 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
@@ -1530,42 +1532,38 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 8;
 	sortType = 12
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/port)
-"ava" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "avp" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/light,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/port)
+/turf/open/floor/engine,
+/area/engine/engineering)
 "avP" = (
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
@@ -1580,9 +1578,6 @@
 	areastring = "/area/hallway/primary/port";
 	name = "Port Hall APC";
 	pixel_y = -26
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -1609,8 +1604,11 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
@@ -1633,9 +1631,6 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
 "awW" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_x = 29
@@ -1653,7 +1648,10 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -1694,40 +1692,35 @@
 /turf/open/floor/wood,
 /area/hallway/primary/port)
 "axk" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple,
-/turf/open/floor/plasteel,
-/area/hallway/primary/port)
+/turf/open/floor/engine,
+/area/engine/engineering)
 "axl" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
+"axn" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
-/area/hallway/primary/port)
-"axn" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "robotics2";
-	name = "robotics lab shutters"
-	},
-/turf/open/floor/plating,
-/area/science/robotics/lab)
+/turf/open/floor/plasteel/dark,
+/area/medical/medbay/central)
 "axo" = (
 /obj/machinery/mecha_part_fabricator,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
@@ -1776,26 +1769,31 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
 "ayk" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "ayl" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/closed/wall/r_wall,
-/area/ai_monitored/turret_protected/ai_upload)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/plasteel/dark,
+/area/medical/morgue)
 "aym" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/loading_area,
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -1864,7 +1862,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
@@ -1872,6 +1869,8 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "ayu" = (
@@ -1923,18 +1922,18 @@
 /obj/structure/bodycontainer/morgue,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
-"ayE" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/science/robotics/lab)
 "ayG" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/machinery/light,
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_y = -26
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
@@ -1954,14 +1953,11 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/maintenance/department/electrical)
+/area/icemoon/surface/outdoors)
 "azq" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -1987,6 +1983,8 @@
 	req_access_txt = "19"
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/service)
 "azA" = (
@@ -2002,11 +2000,14 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
 	},
 /turf/open/floor/plasteel/checker,
 /area/crew_quarters/heads/hor)
@@ -2018,13 +2019,16 @@
 	name = "Research Director";
 	req_access_txt = "30"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel/checker,
@@ -2033,24 +2037,18 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
-/area/science/lab)
-"azG" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/port)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/lab)
 "azH" = (
 /obj/machinery/autolathe,
 /turf/open/floor/plasteel/dark,
@@ -2060,9 +2058,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aAe" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
@@ -2070,16 +2070,10 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/visible,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
 "aAw" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
@@ -2113,8 +2107,8 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/service)
@@ -2123,6 +2117,12 @@
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/service)
 "aAG" = (
@@ -2156,9 +2156,6 @@
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "aAJ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
@@ -2176,11 +2173,17 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "aAL" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/port)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/binary/pump/on/layer3{
+	dir = 4
+	},
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/maintenance/department/electrical)
 "aAO" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -2202,36 +2205,22 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"aAS" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white/side,
-/area/hallway/primary/port)
 "aAT" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
 /turf/open/floor/plasteel/white/side,
 /area/hallway/primary/port)
-"aAU" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+"aAV" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white/side,
-/area/hallway/primary/port)
-"aAV" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/port)
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "aAY" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plasteel/white/side,
 /area/hallway/primary/port)
 "aBq" = (
@@ -2245,15 +2234,14 @@
 /turf/open/floor/plating,
 /area/hallway/primary/aft)
 "aBw" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "aBG" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
-/area/hallway/secondary/entry)
+/area/hallway/primary/port)
 "aBH" = (
 /obj/machinery/vending/wardrobe/science_wardrobe,
 /turf/open/floor/plasteel/white,
@@ -2262,12 +2250,14 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
@@ -2380,9 +2370,6 @@
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "aDg" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
 /obj/structure/closet/cabinet,
 /obj/item/clothing/shoes/winterboots,
 /obj/item/clothing/shoes/winterboots,
@@ -2399,30 +2386,22 @@
 /obj/item/pickaxe,
 /obj/item/pickaxe,
 /obj/item/pickaxe,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"aDh" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
-/area/hallway/primary/port)
 "aDk" = (
 /obj/machinery/space_heater,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
 /obj/machinery/status_display{
 	layer = 4;
 	pixel_y = 32
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "aDm" = (
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
 /obj/item/clothing/suit/hooded/wintercoat,
 /obj/item/clothing/suit/hooded/wintercoat,
 /obj/item/clothing/suit/hooded/wintercoat,
@@ -2439,6 +2418,7 @@
 /obj/item/pickaxe,
 /obj/item/pickaxe,
 /obj/item/pickaxe,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "aDn" = (
@@ -2481,12 +2461,14 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/atmospherics/components/binary/pump/on/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/maintenance/department/electrical)
@@ -2498,8 +2480,11 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "aDQ" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/visible,
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
@@ -2538,17 +2523,11 @@
 	},
 /area/chapel/office)
 "aEC" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	desc = "Privacy shutters for the Private Study. Stops people spying in on your game.";
-	id = "PrivateStudy1";
-	name = "Privacy Shutters"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/library)
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "aEE" = (
 /obj/machinery/rnd/destructive_analyzer,
 /turf/open/floor/circuit,
@@ -2622,8 +2601,11 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
@@ -2658,33 +2640,33 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "aFO" = (
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "aFQ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "aFR" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/supply,
 /obj/structure/disposalpipe/sorting{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "aFT" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
@@ -2695,21 +2677,15 @@
 	dir = 1
 	},
 /obj/effect/landmark/start/assistant,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "aFY" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "aFZ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
@@ -2744,8 +2720,8 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "aGF" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
@@ -2760,7 +2736,8 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/white/corner{
 	dir = 8
 	},
@@ -2774,10 +2751,7 @@
 /area/science/server)
 "aHA" = (
 /obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white/corner{
@@ -2788,9 +2762,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -2800,18 +2771,15 @@
 	},
 /area/hallway/secondary/entry)
 "aHE" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
@@ -2841,9 +2809,6 @@
 /obj/machinery/computer/aifixer{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -2867,6 +2832,8 @@
 	pixel_x = -28
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/entry)
 "aIP" = (
@@ -2883,18 +2850,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/hallway/primary/aft)
-"aJd" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/door/firedoor/border_only{
-	dir = 8;
-	name = "west facing firelock"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	name = "east facing firelock"
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
 "aJe" = (
 /obj/machinery/light{
 	dir = 4
@@ -2929,10 +2884,10 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/entry)
 "aKa" = (
@@ -2969,10 +2924,9 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
 "aKp" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/entry)
 "aKs" = (
@@ -3003,11 +2957,10 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/entry)
 "aLp" = (
@@ -3017,15 +2970,12 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "aLu" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
 	},
@@ -3223,9 +3173,6 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
 "aNk" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/computer/security{
 	dir = 8
 	},
@@ -3233,27 +3180,27 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
 "aNl" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+/obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
 	},
-/obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
 "aNm" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plating,
 /area/security/checkpoint/medical)
 "aNo" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/entry)
@@ -3370,7 +3317,7 @@
 /area/storage/atmos)
 "aOr" = (
 /obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors)
 "aOJ" = (
@@ -3436,7 +3383,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plating,
 /area/storage/atmos)
 "aPE" = (
@@ -3542,21 +3489,21 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 8
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
 "aQV" = (
 /obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors)
 "aQX" = (
 /obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 9
 	},
 /turf/open/floor/plating/asteroid/snow/icemoon,
@@ -3588,10 +3535,10 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
 "aRt" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
 	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
 "aSk" = (
@@ -3608,23 +3555,20 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
 "aSE" = (
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 9
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/surface/outdoors)
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "aSI" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -3633,15 +3577,14 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "aSN" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/chair{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/wood,
-/area/hallway/secondary/exit/departure_lounge)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "aTc" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -3693,9 +3636,10 @@
 /turf/open/floor/carpet,
 /area/security/vacantoffice/b)
 "aUd" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
+/obj/structure/lattice/catwalk,
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors)
 "aUg" = (
@@ -3862,17 +3806,19 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "aZB" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/airlock/security/glass{
 	id_tag = "innerbrig";
 	name = "Brig Infirmary";
 	req_access_txt = "2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -3883,20 +3829,20 @@
 /turf/open/floor/wood,
 /area/hallway/secondary/exit/departure_lounge)
 "aZZ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
 	},
 /turf/open/floor/wood,
 /area/hallway/secondary/exit/departure_lounge)
 "baa" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
 /obj/structure/window/reinforced{
 	dir = 4
 	},
 /obj/structure/chair{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/wood,
 /area/hallway/secondary/exit/departure_lounge)
@@ -3939,15 +3885,11 @@
 /turf/open/floor/plating,
 /area/hallway/primary/port)
 "bcq" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
 	},
-/obj/structure/chair{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/hallway/secondary/exit/departure_lounge)
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "bcu" = (
 /obj/effect/turf_decal/vg_decals/atmos/plasma,
 /obj/machinery/light/small{
@@ -4038,10 +3980,13 @@
 /turf/open/floor/carpet,
 /area/hallway/secondary/exit/departure_lounge)
 "beq" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
+	},
 /turf/open/floor/carpet,
 /area/hallway/secondary/exit/departure_lounge)
 "beC" = (
@@ -4059,14 +4004,10 @@
 /turf/open/floor/plating,
 /area/medical/virology)
 "bff" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/chair{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/security/courtroom)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/plasteel,
+/area/science/robotics/mechbay)
 "bfg" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -4099,9 +4040,6 @@
 /turf/open/floor/plating,
 /area/medical/storage)
 "bfT" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/machinery/door/firedoor/border_only{
 	name = "south facing firelock"
 	},
@@ -4151,7 +4089,8 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "bhZ" = (
@@ -4206,6 +4145,8 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "biW" = (
@@ -4223,7 +4164,9 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/education)
 "bjU" = (
@@ -4258,12 +4201,14 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "bkQ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
 	},
-/obj/effect/landmark/start/shaft_miner,
-/turf/open/floor/plasteel,
-/area/quartermaster/miningdock)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/hallway/primary/port)
 "blg" = (
 /obj/docking_port/stationary{
 	dir = 2;
@@ -4300,10 +4245,6 @@
 	},
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors)
-"bmS" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "bmW" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -4348,7 +4289,6 @@
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
 "bnE" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
 	},
@@ -4360,6 +4300,8 @@
 	name = "south facing firelock"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bnU" = (
@@ -4394,11 +4336,11 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "bpD" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
 /obj/item/radio/intercom{
 	pixel_x = -25
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
 	},
 /turf/open/floor/plasteel/cult,
 /area/lawoffice)
@@ -4418,7 +4360,7 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "bpM" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
 	},
 /turf/open/floor/plasteel/cult,
@@ -4434,11 +4376,14 @@
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
 "bpT" = (
-/obj/machinery/atmospherics/pipe/simple/supply/visible{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
@@ -4471,14 +4416,16 @@
 /turf/closed/indestructible/rock/snow/ice,
 /area/icemoon/surface/outdoors)
 "bqO" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/light_switch{
 	pixel_x = -27
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
 	},
 /turf/open/floor/plasteel/cult,
 /area/lawoffice)
 "bqW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = -24
@@ -4487,11 +4434,11 @@
 /area/quartermaster/miningdock)
 "bra" = (
 /obj/structure/window/reinforced,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
 /obj/machinery/door/firedoor/border_only{
 	name = "south facing firelock"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
@@ -4499,15 +4446,18 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/window/reinforced{
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 1;
 	name = "north facing firelock"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
@@ -4526,7 +4476,6 @@
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
 "brE" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/machinery/door/window/southleft{
 	dir = 1;
 	name = "Court Cell";
@@ -4541,6 +4490,8 @@
 /obj/structure/chair{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /turf/open/floor/wood,
 /area/security/courtroom)
 "brJ" = (
@@ -4553,9 +4504,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/door/airlock{
 	name = "Law Office";
 	req_access_txt = "38"
@@ -4567,24 +4515,30 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/lawoffice)
 "bsk" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
 	},
 /turf/open/floor/wood,
 /area/security/courtroom)
 "bsm" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
 /obj/effect/landmark/event_spawn,
-/turf/open/floor/wood,
-/area/security/courtroom)
-"bsn" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
 	},
 /turf/open/floor/wood,
 /area/security/courtroom)
@@ -4612,15 +4566,12 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bsL" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
 	},
-/turf/open/floor/plasteel,
-/area/quartermaster/miningdock)
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "bsU" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
@@ -4643,10 +4594,13 @@
 /turf/open/floor/plasteel/cult,
 /area/lawoffice)
 "btu" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/structure/table/wood,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/structure/table/wood,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/security/courtroom)
 "btZ" = (
@@ -4711,7 +4665,9 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "buX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
+	},
 /turf/open/floor/wood,
 /area/security/courtroom)
 "buZ" = (
@@ -4726,17 +4682,20 @@
 /turf/open/floor/plating,
 /area/lawoffice)
 "bvo" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/quartermaster/miningdock)
+/turf/open/floor/plasteel/white/corner{
+	dir = 8
+	},
+/area/hallway/secondary/entry)
 "bvq" = (
 /obj/structure/cable{
 	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
@@ -4762,7 +4721,6 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "bwa" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/effect/turf_decal/arrows/red{
 	dir = 4
 	},
@@ -4798,9 +4756,6 @@
 /obj/item/storage/firstaid/toxin{
 	pixel_x = 3;
 	pixel_y = 3
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -4840,9 +4795,6 @@
 /turf/closed/wall,
 /area/lawoffice)
 "bwG" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/closet/wardrobe/miner,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
@@ -4852,9 +4804,6 @@
 	},
 /obj/effect/turf_decal/plaque{
 	icon_state = "L9"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -4868,9 +4817,6 @@
 /obj/effect/turf_decal/plaque{
 	icon_state = "L7"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -4882,9 +4828,6 @@
 	},
 /obj/effect/turf_decal/plaque{
 	icon_state = "L13"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -4898,7 +4841,6 @@
 /obj/effect/turf_decal/plaque{
 	icon_state = "L11"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -4928,14 +4870,13 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "bxh" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4;
-	pixel_y = 5
-	},
 /obj/machinery/camera{
 	c_tag = "AI Chamber - Starboard";
 	dir = 8;
 	network = list("aicore")
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
 	},
 /turf/open/floor/circuit/off,
 /area/ai_monitored/turret_protected/ai)
@@ -4959,7 +4900,6 @@
 	id = "Secure Gate";
 	name = "brig shutters"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -4978,27 +4918,28 @@
 /area/science/lab)
 "bxN" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/crew_quarters/theatre)
 "bxR" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/light{
 	dir = 8
 	},
 /obj/effect/turf_decal/arrows/red{
 	dir = 8
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bxU" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
 /area/icemoon/surface/outdoors)
 "byt" = (
@@ -5019,29 +4960,7 @@
 /obj/machinery/vending/cola/random,
 /turf/open/floor/carpet/eighties,
 /area/crew_quarters/fitness)
-"byR" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "byW" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
 /obj/effect/turf_decal/arrows/red{
 	dir = 4
 	},
@@ -5051,40 +4970,53 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /turf/open/floor/wood,
 /area/hallway/primary/central)
 "byY" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/plaque{
 	icon_state = "L10"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "byZ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/plaque{
 	icon_state = "L8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bzb" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/plaque{
 	icon_state = "L12"
 	},
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -5099,8 +5031,11 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
@@ -5109,7 +5044,6 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/tile/brown,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -5134,7 +5068,6 @@
 	department = "Mining";
 	pixel_x = -30
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "bzk" = (
@@ -5151,7 +5084,8 @@
 	dir = 1;
 	name = "north facing firelock"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bzn" = (
@@ -5162,10 +5096,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bzS" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bzU" = (
@@ -5190,11 +5124,14 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -5205,9 +5142,6 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -5217,6 +5151,12 @@
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -5233,7 +5173,6 @@
 /obj/effect/turf_decal/plaque{
 	icon_state = "L1"
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -5246,14 +5185,12 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bAp" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -5263,9 +5200,6 @@
 "bAr" = (
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
 	},
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
@@ -5291,10 +5225,13 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -5309,8 +5246,11 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -5331,7 +5271,6 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "bAM" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -5385,20 +5324,6 @@
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
-"bBk" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "bBl" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
@@ -5436,9 +5361,6 @@
 /turf/open/floor/plating,
 /area/security/warden)
 "bBr" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/door/poddoor/preopen{
 	id = "Secure Brig Control";
 	name = "brig shutters"
@@ -5450,9 +5372,6 @@
 /turf/open/floor/plating,
 /area/security/warden)
 "bBs" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
 /obj/machinery/door/poddoor/preopen{
 	id = "Secure Brig Control";
 	name = "brig shutters"
@@ -5464,9 +5383,6 @@
 /turf/open/floor/plating,
 /area/security/warden)
 "bBt" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 8;
 	sortType = 8
@@ -5484,6 +5400,12 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "bBx" = (
@@ -5492,6 +5414,9 @@
 	},
 /obj/structure/table/reinforced,
 /obj/item/flashlight/lamp,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/mineral/titanium/white{
 	barefootstep = "carpetbarefoot";
 	desc = "Stops the mentally unfit from hurting themselves";
@@ -5499,20 +5424,7 @@
 	name = "Padded Floor"
 	},
 /area/security/execution/education)
-"bBy" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/carpet,
-/area/hallway/primary/central)
 "bBz" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/door/airlock/public/glass{
 	name = "Security Lobby"
 	},
@@ -5526,27 +5438,41 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/hallway/primary/central)
 "bBA" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/carpet,
 /area/hallway/primary/central)
 "bBB" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -5564,10 +5490,13 @@
 /obj/machinery/airalarm{
 	pixel_y = 28
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/machinery/light{
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -5579,7 +5508,10 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -5677,16 +5609,21 @@
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "bCQ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/turf/open/floor/plasteel/white/corner{
+	dir = 8
+	},
+/area/hallway/secondary/entry)
 "bCT" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/sorting/mail{
 	dir = 1;
 	sortType = 17
@@ -5694,10 +5631,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bCW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bCY" = (
@@ -5705,10 +5643,10 @@
 	dir = 1;
 	pixel_y = -22
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+/obj/machinery/light/small,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
 	},
-/obj/machinery/light/small,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "bDe" = (
@@ -5814,6 +5752,8 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bDU" = (
@@ -5851,38 +5791,13 @@
 /turf/open/floor/plating,
 /area/hallway/primary/aft)
 "bEe" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/closed/wall,
-/area/crew_quarters/theatre)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "bEi" = (
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
-"bEJ" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/port)
-"bES" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/light,
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "bEZ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -5899,9 +5814,6 @@
 /turf/open/floor/plasteel/white,
 /area/security/prison)
 "bFc" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
@@ -5925,36 +5837,24 @@
 /obj/item/clothing/suit/hooded/wintercoat/security,
 /turf/open/floor/plasteel/dark,
 /area/security/warden)
-"bFf" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "bFj" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/item/radio/intercom{
 	pixel_x = -30
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/plasteel/dark,
 /area/security/warden)
 "bFk" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/visible{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
@@ -6001,9 +5901,6 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
 "bFD" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/table/wood,
 /obj/item/book/manual/wiki/security_space_law,
 /obj/item/pen/red,
@@ -6016,6 +5913,12 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
+	},
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
 "bFK" = (
@@ -6025,6 +5928,9 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/obj/effect/turf_decal/trimline/green/filled/corner{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -6077,7 +5983,7 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
 "bGu" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
@@ -6100,16 +6006,12 @@
 	name = "Armoury Desk"
 	},
 /obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "bGB" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -6121,6 +6023,12 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "bGD" = (
@@ -6130,10 +6038,10 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "bGE" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+/obj/effect/landmark/start/security_officer,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
 	},
-/obj/effect/landmark/start/security_officer,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "bGN" = (
@@ -6156,6 +6064,9 @@
 /obj/machinery/camera{
 	c_tag = "Brig Control";
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/warden)
@@ -6219,9 +6130,10 @@
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/bridge)
 "bHt" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 6
 	},
+/obj/structure/lattice/catwalk,
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors)
 "bHE" = (
@@ -6327,7 +6239,6 @@
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors)
 "bJl" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -6338,7 +6249,10 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -6371,8 +6285,11 @@
 	dir = 1;
 	pixel_y = -24
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/warden)
@@ -6383,9 +6300,6 @@
 "bJs" = (
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -6400,14 +6314,17 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "bJt" = (
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -6419,10 +6336,15 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "bJu" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -6436,6 +6358,8 @@
 	dir = 4;
 	pixel_x = 24
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "bJv" = (
@@ -6482,11 +6406,11 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -6531,7 +6455,7 @@
 /turf/open/floor/wood,
 /area/security/courtroom)
 "bKs" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 10
 	},
 /turf/open/floor/plating,
@@ -6602,6 +6526,9 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/geneticist,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/medical/genetics)
 "bLO" = (
@@ -6621,7 +6548,8 @@
 	},
 /obj/machinery/door/airlock/vault,
 /obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
 "bLR" = (
@@ -6649,12 +6577,12 @@
 	dir = 8;
 	network = list("ss13","medbay")
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = 24
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
@@ -6662,10 +6590,15 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/machinery/holopad,
 /obj/structure/disposalpipe/segment{
 	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
 	},
 /turf/open/floor/plasteel/cult,
 /area/lawoffice)
@@ -6675,25 +6608,22 @@
 	},
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors)
-"bMs" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
-/turf/open/floor/plasteel/dark,
-/area/bridge)
 "bME" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/effect/turf_decal/trimline/green/filled/corner{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bMN" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/structure/chair/comfy/brown{
 	dir = 8
 	},
 /obj/effect/landmark/start/detective,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/carpet,
 /area/security/detectives_office)
 "bMP" = (
@@ -6798,7 +6728,8 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/carpet,
 /area/security/detectives_office)
 "bOb" = (
@@ -6849,19 +6780,15 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bPc" = (
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -6875,10 +6802,11 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bPk" = (
@@ -6959,25 +6887,29 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/central)
 "bQs" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/science/robotics/mechbay)
 "bQt" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
 "bQF" = (
@@ -7023,9 +6955,10 @@
 /turf/open/floor/wood,
 /area/library)
 "bRN" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/wood,
-/area/library)
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors)
 "bSb" = (
 /obj/item/radio/intercom{
 	frequency = 1485;
@@ -7039,7 +6972,8 @@
 /turf/open/floor/wood,
 /area/medical/psych)
 "bSd" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
 	},
 /turf/open/floor/wood,
@@ -7103,9 +7037,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
@@ -7116,14 +7047,19 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "bUm" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/library)
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/structure/lattice/catwalk,
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors)
 "bUB" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -7183,12 +7119,14 @@
 	},
 /area/crew_quarters/fitness/pool)
 "bUP" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/medical/medbay/zone2)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
+	},
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/surface/outdoors)
 "bVu" = (
 /obj/machinery/airalarm{
 	pixel_y = 26
@@ -7198,9 +7136,6 @@
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
@@ -7246,19 +7181,22 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bVZ" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
 /obj/structure/bookcase/random/reference,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
+	},
 /turf/open/floor/wood,
 /area/library)
 "bWk" = (
@@ -7284,23 +7222,19 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/machinery/door/window/brigdoor{
 	dir = 4;
 	name = "HoS Office";
 	req_access_txt = "58"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
 	},
 /turf/open/floor/carpet/black,
 /area/crew_quarters/heads/hos)
 "bXe" = (
 /obj/machinery/airalarm{
 	pixel_y = 24
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/education)
@@ -7353,9 +7287,6 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
@@ -7365,7 +7296,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bXW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/wood,
 /area/library)
 "bYe" = (
@@ -7386,9 +7317,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "bYM" = (
@@ -7426,7 +7354,7 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/engine/atmospherics_engine)
 "bZt" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain)
 "bZx" = (
@@ -7596,11 +7524,12 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8;
+	name = "west facing firelock"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -7608,10 +7537,13 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/wood,
@@ -7620,15 +7552,15 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/central)
 "ces" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
 /obj/machinery/light,
 /obj/item/radio/intercom{
 	pixel_y = -26
 	},
 /obj/structure/chair/comfy/brown{
 	color = "#596479";
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
 	},
 /turf/open/floor/wood,
@@ -7844,7 +7776,6 @@
 /turf/open/floor/plating,
 /area/crew_quarters/heads/captain)
 "civ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/airlock/command/glass{
 	name = "Bridge";
 	req_access_txt = "19"
@@ -7854,6 +7785,8 @@
 	dir = 1;
 	name = "north facing firelock"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "ciz" = (
@@ -7870,12 +7803,15 @@
 /turf/open/floor/engine/airless,
 /area/engine/atmos)
 "ciO" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
 /obj/machinery/light,
 /obj/structure/chair{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
 	},
 /turf/open/floor/wood,
 /area/security/courtroom)
@@ -7886,13 +7822,6 @@
 	icon_state = "wood-broken5"
 	},
 /area/hallway/primary/port)
-"cjA" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "cjE" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -7970,6 +7899,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
+	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "cjY" = (
@@ -7989,10 +7924,13 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -8039,17 +7977,20 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "ckX" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "ckY" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -8106,9 +8047,10 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "clR" = (
@@ -8143,12 +8085,6 @@
 	dir = 4
 	},
 /area/chapel/office)
-"cmr" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/library)
 "cmE" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -8177,11 +8113,17 @@
 /turf/open/floor/carpet,
 /area/bridge)
 "cng" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/surface/outdoors)
 "cni" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/effect/turf_decal/tile/green{
@@ -8259,9 +8201,6 @@
 /turf/closed/wall,
 /area/ai_monitored/turret_protected/ai)
 "cpf" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/machinery/bloodbankgen,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -8288,7 +8227,10 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
 /turf/open/floor/plating,
 /area/maintenance/aft/secondary)
 "cpC" = (
@@ -8296,10 +8238,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "cqa" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/structure/chair/comfy/brown{
 	dir = 1
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain)
 "cqd" = (
@@ -8309,7 +8251,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "cqo" = (
@@ -8342,27 +8283,29 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
+	},
 /turf/open/floor/circuit/off,
 /area/ai_monitored/turret_protected/ai)
 "cqr" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
 "cqt" = (
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
 	},
 /obj/structure/window/reinforced{
 	dir = 1
@@ -8373,6 +8316,12 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1;
 	name = "north facing firelock"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
@@ -8530,8 +8479,11 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -8562,11 +8514,15 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "cvE" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/open/floor/wood,
-/area/security/vacantoffice/a)
+/obj/structure/bed/roller,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/zone2)
 "cvH" = (
 /obj/machinery/power/apc{
 	areastring = "/area/crew_quarters/theatre";
@@ -8644,17 +8600,30 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "cxX" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/turf/closed/wall,
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "cya" = (
 /obj/machinery/light{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
@@ -8671,6 +8640,12 @@
 	name = "AI Chamber entrance shutters"
 	},
 /obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -8704,7 +8679,10 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 10
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "cyG" = (
@@ -8738,11 +8716,14 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/holopad,
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/wood,
@@ -8750,7 +8731,12 @@
 "czg" = (
 /obj/structure/table/wood,
 /obj/item/paicard,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "czu" = (
@@ -8795,11 +8781,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "cAe" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/table/wood/poker,
 /obj/item/toy/cards/deck,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/library)
 "cAo" = (
@@ -8858,11 +8844,14 @@
 /turf/closed/wall/r_wall,
 /area/security/main)
 "cBF" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -8937,13 +8926,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
-"cCH" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "cCT" = (
 /obj/structure/table/wood,
 /obj/machinery/requests_console{
@@ -9039,6 +9021,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "cEq" = (
@@ -9067,11 +9055,14 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
 "cFO" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/closed/wall,
-/area/library)
+/turf/open/floor/wood,
+/area/hallway/secondary/exit/departure_lounge)
 "cFP" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -9122,7 +9113,12 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
 "cIg" = (
@@ -9249,9 +9245,6 @@
 /turf/open/floor/plasteel,
 /area/storage/atmos)
 "cKQ" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/junction/yjunction{
 	dir = 4
 	},
@@ -9290,10 +9283,10 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "cLD" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/structure/bookcase/random/nonfiction,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/obj/structure/bookcase/random/nonfiction,
 /turf/open/floor/wood,
 /area/library)
 "cLO" = (
@@ -9314,11 +9307,18 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "cMc" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 10
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "cMW" = (
@@ -9362,12 +9362,14 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
 "cNE" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 5
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "cOb" = (
 /obj/structure/pool/Lboard,
 /turf/open/pool,
@@ -9431,9 +9433,6 @@
 /turf/open/floor/plating,
 /area/icemoon/surface/outdoors)
 "cPQ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -9441,6 +9440,12 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -9484,7 +9489,6 @@
 	name = "Telecomms Access";
 	req_access_txt = "61"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/computer)
 "cQu" = (
@@ -9664,12 +9668,13 @@
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
 "cSG" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "cSJ" = (
@@ -9721,10 +9726,17 @@
 /turf/open/floor/plasteel/cult,
 /area/lawoffice)
 "cTO" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/machinery/door/firedoor/border_only{
+	dir = 8;
+	name = "west facing firelock"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -9773,10 +9785,11 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
 "cVu" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
 /obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/plasteel,
@@ -9834,7 +9847,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/junction/flip,
 /obj/structure/railing/corner{
 	dir = 8
@@ -9855,7 +9867,12 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "cXI" = (
@@ -9899,9 +9916,6 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "cYb" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
 /obj/effect/landmark/event_spawn,
 /obj/machinery/button/door{
 	id = "rdofficesh";
@@ -9909,6 +9923,9 @@
 	pixel_x = 5;
 	pixel_y = -56;
 	req_access_txt = "47"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel/checker,
 /area/crew_quarters/heads/hor)
@@ -9965,26 +9982,30 @@
 	dir = 1;
 	pixel_y = -24
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "cZk" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "cZq" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "cZr" = (
@@ -10017,9 +10038,6 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
 "cZN" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -10029,6 +10047,12 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1;
 	name = "north facing firelock"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
@@ -10064,9 +10088,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
@@ -10100,24 +10121,6 @@
 /obj/structure/sign/nanotrasen,
 /turf/closed/wall/r_wall,
 /area/ai_monitored/security/armory)
-"dbK" = (
-/obj/effect/landmark/start/prisoner,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "dbN" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -10157,9 +10160,6 @@
 "dcg" = (
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -10220,7 +10220,6 @@
 /obj/machinery/airalarm{
 	pixel_y = 23
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
@@ -10241,7 +10240,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -10259,10 +10258,19 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "dfn" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/obj/machinery/door/airlock/medical/glass{
+	id_tag = "MedbayFoyer";
+	name = "Medbay";
+	req_access_txt = "5"
 	},
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	name = "south facing firelock"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "dfx" = (
@@ -10394,21 +10402,25 @@
 /obj/machinery/door/airlock/public{
 	name = "Permabrig Dorm 4"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1;
 	name = "north facing firelock"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "dkP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/chair/comfy/brown{
 	dir = 8
 	},
 /obj/effect/landmark/start/assistant,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/library)
 "dkQ" = (
@@ -10466,7 +10478,6 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "dmc" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
@@ -10498,10 +10509,13 @@
 	name = "Telecommunications";
 	req_access_txt = "61"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -10610,7 +10624,6 @@
 /turf/open/floor/plasteel,
 /area/maintenance/disposal)
 "dpS" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
@@ -10628,9 +10641,6 @@
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "dqE" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/machinery/door/firedoor/border_only{
 	name = "south facing firelock"
 	},
@@ -10658,7 +10668,10 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "dqL" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -10677,17 +10690,11 @@
 /turf/closed/indestructible/rock/glacierrock/blue,
 /area/engine/secure_construction)
 "drK" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
-/obj/structure/table/wood,
-/obj/item/book/manual/wiki/security_space_law,
-/obj/item/flashlight/lamp/green{
-	pixel_x = -7;
-	pixel_y = 1
-	},
-/turf/open/floor/wood,
-/area/security/courtroom)
+/turf/open/floor/plasteel/dark,
+/area/hallway/secondary/exit/departure_lounge)
 "dsi" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -10802,7 +10809,6 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -10831,10 +10837,11 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "duX" = (
@@ -10850,10 +10857,13 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "dvc" = (
-/obj/machinery/atmospherics/pipe/simple/supply/visible{
+/obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 6
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
@@ -10876,7 +10886,10 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -10894,20 +10907,22 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/dorms)
 "dvw" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/brown,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "dwF" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/machinery/light/floor,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
@@ -10965,6 +10980,12 @@
 /obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -11123,24 +11144,26 @@
 	},
 /area/maintenance/central)
 "dCs" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
 /obj/structure/window/reinforced{
 	dir = 8
 	},
 /obj/structure/chair{
 	dir = 4
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
 /turf/open/floor/wood,
 /area/hallway/secondary/exit/departure_lounge)
 "dCI" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/medical/genetics)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/medical/chemistry)
 "dCM" = (
 /obj/machinery/status_display/supply{
 	pixel_x = 32
@@ -11208,7 +11231,7 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/secure_construction)
 "dDK" = (
-/obj/machinery/atmospherics/pipe/simple/supply/visible{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
 	},
 /turf/open/floor/plating,
@@ -11249,7 +11272,6 @@
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/bar)
 "dFb" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
@@ -11258,6 +11280,8 @@
 	},
 /obj/structure/bed/roller,
 /obj/machinery/iv_drip,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "dFp" = (
@@ -11267,9 +11291,6 @@
 /turf/open/floor/plating,
 /area/maintenance/aft/secondary)
 "dFt" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -11299,7 +11320,8 @@
 /area/engine/secure_construction)
 "dFJ" = (
 /obj/effect/turf_decal/stripes/corner,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "dGb" = (
@@ -11351,7 +11373,7 @@
 /turf/open/floor/plating,
 /area/security/checkpoint/supply)
 "dHe" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -11410,7 +11432,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
@@ -11537,6 +11558,12 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "dPn" = (
@@ -11547,10 +11574,10 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "dPx" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
+	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/entry)
 "dPL" = (
@@ -11563,11 +11590,11 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "dPM" = (
-/obj/machinery/atmospherics/pipe/simple/supply/visible,
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 8;
 	sortType = 29
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/icemoon/surface/outdoors)
 "dQd" = (
@@ -11596,10 +11623,6 @@
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
-"dRI" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/closed/wall/r_wall,
-/area/ai_monitored/turret_protected/aisat/service)
 "dRM" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -11631,13 +11654,16 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/landmark/start/medical_doctor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "dSQ" = (
@@ -11650,11 +11676,14 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
 "dTo" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/wood,
-/area/security/vacantoffice/a)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/hallway/secondary/exit/departure_lounge)
 "dTy" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/solars/starboard/fore)
@@ -11669,7 +11698,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -11753,9 +11785,6 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -11776,9 +11805,6 @@
 "dVV" = (
 /obj/structure/cable{
 	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay West";
@@ -11834,21 +11860,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/education)
-"dXF" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white/side{
-	dir = 1
-	},
-/area/hallway/primary/port)
 "dXR" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -11885,11 +11896,12 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "dYl" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/maintenance,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
 /area/security/vacantoffice/a)
 "dYL" = (
@@ -11919,12 +11931,15 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "dZa" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 1;
 	sortType = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -11947,7 +11962,6 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/construction/storage)
 "ebq" = (
@@ -11961,14 +11975,10 @@
 /turf/open/floor/wood,
 /area/bridge/meeting_room)
 "ebF" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "cmoofficesh";
-	name = "cmo shutters"
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/heads/cmo)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "ebK" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -11985,10 +11995,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/storage/auxiliary)
-"ebX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/circuit,
-/area/science/robotics/mechbay)
 "ect" = (
 /obj/structure/table/wood,
 /turf/open/floor/wood,
@@ -11997,7 +12003,6 @@
 /obj/machinery/door/firedoor/border_only{
 	name = "south facing firelock"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
@@ -12080,6 +12085,12 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 10
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "eeh" = (
@@ -12107,6 +12118,8 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
 /area/hallway/primary/port)
 "eeE" = (
@@ -12132,11 +12145,12 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "eeM" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/firedoor/border_only{
 	dir = 4;
 	name = "east facing firelock"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "efk" = (
@@ -12200,12 +12214,14 @@
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors)
 "egj" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -12306,7 +12322,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "eiL" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -12324,10 +12343,12 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "ejC" = (
@@ -12368,12 +12389,17 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hop)
 "emh" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
@@ -12411,10 +12437,12 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
 "enP" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
 "eoT" = (
@@ -12429,9 +12457,8 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "epa" = (
@@ -12451,9 +12478,12 @@
 /turf/open/floor/plating,
 /area/maintenance/aft/secondary)
 "epK" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel/dark,
-/area/medical/medbay/central)
+/area/tcommsat/computer)
 "epT" = (
 /obj/machinery/light{
 	dir = 8
@@ -12461,13 +12491,16 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "epU" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
 /turf/open/floor/plasteel/white,
 /area/security/brig)
 "eqP" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+/obj/item/kirbyplants/random,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
 	},
-/obj/item/kirbyplants/random,
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
 "erb" = (
@@ -12526,10 +12559,6 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
 	},
@@ -12571,15 +12600,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"erO" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/science/lab)
 "esi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -12608,11 +12628,12 @@
 /turf/closed/wall,
 /area/maintenance/disposal/incinerator)
 "esE" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/port)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/turf/open/floor/plasteel/dark,
+/area/teleporter)
 "esY" = (
 /turf/open/openspace/icemoon,
 /area/engine/atmos)
@@ -12638,18 +12659,21 @@
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
 "etB" = (
-/obj/machinery/atmospherics/pipe/simple/supply/visible,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/icemoon/surface/outdoors)
 "etM" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
@@ -12783,12 +12807,15 @@
 	req_access_txt = "61"
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/computer)
 "evY" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/storage/auxiliary)
 "ewK" = (
@@ -12810,9 +12837,6 @@
 /turf/open/floor/plasteel,
 /area/maintenance/starboard)
 "exq" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/machinery/airalarm{
 	dir = 8;
 	pixel_x = 24
@@ -12887,18 +12911,20 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/plaque{
 	icon_state = "L2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
 /obj/structure/cable{
 	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -12945,11 +12971,14 @@
 /turf/open/floor/plasteel,
 /area/janitor)
 "eBf" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/computer)
@@ -13018,9 +13047,11 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
@@ -13054,6 +13085,8 @@
 	id_tag = "PrivateStudy";
 	name = "Library"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/wood,
 /area/library)
 "eDE" = (
@@ -13142,9 +13175,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
@@ -13154,13 +13184,22 @@
 /obj/structure/chair{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
+	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
 "eFG" = (
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/wood,
@@ -13220,7 +13259,6 @@
 /turf/open/floor/carpet,
 /area/library)
 "eGF" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/light/small,
 /obj/machinery/firealarm{
 	dir = 1;
@@ -13229,6 +13267,9 @@
 /obj/machinery/camera{
 	c_tag = "Captain's Quarters";
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain)
@@ -13246,15 +13287,17 @@
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
 "eGL" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	desc = "Privacy shutters for the Private Study. Stops people spying in on your game.";
-	id = "PrivateStudy1";
-	name = "Privacy Shutters"
+/obj/machinery/door/airlock/public/glass{
+	name = "Cryogenic Storage"
 	},
-/turf/open/floor/plating,
-/area/library)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/hallway/secondary/exit/departure_lounge)
 "eGO" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -13266,12 +13309,13 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "rnd";
 	name = "research lab shutters"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/science/lab)
 "eHa" = (
@@ -13285,8 +13329,9 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "eHF" = (
@@ -13294,7 +13339,7 @@
 	dir = 9
 	},
 /obj/effect/turf_decal/stripes/corner,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -13330,7 +13375,10 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/green,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -13339,22 +13387,6 @@
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
 /area/chapel/main)
-"eJh" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "eJp" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -13428,16 +13460,20 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
 /area/hallway/primary/port)
 "eKy" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
 	},
-/obj/effect/landmark/blobstart,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/construction/storage)
 "eKO" = (
@@ -13459,11 +13495,8 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "eKZ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/blue,
+/obj/machinery/holopad,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
 "eLf" = (
@@ -13597,12 +13630,14 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
 "eNG" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/secondary/exit/departure_lounge)
 "eNK" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -13614,19 +13649,14 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "eOn" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/structure/closet/secure_closet/security/sec,
-/obj/item/clothing/suit/hooded/wintercoat/security,
-/turf/open/floor/plasteel/dark,
-/area/security/main)
+/turf/open/floor/wood,
+/area/hallway/secondary/exit/departure_lounge)
 "eOr" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/landmark/event_spawn,
@@ -13647,9 +13677,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -13738,7 +13765,10 @@
 	id = "permacell1";
 	name = "genpop blast door"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -13754,7 +13784,10 @@
 /area/chapel/main)
 "eSq" = (
 /obj/machinery/hydroponics/constructable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -13817,7 +13850,6 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "eSK" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 4
@@ -13830,18 +13862,18 @@
 /turf/open/floor/grass,
 /area/security/brig)
 "eSP" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
 "eSQ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/medical/surgery)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/plasteel/grimy,
+/area/tcommsat/computer)
 "eTg" = (
 /obj/effect/landmark/start/roboticist,
 /obj/structure/disposalpipe/segment{
@@ -13849,9 +13881,6 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
@@ -13872,7 +13901,7 @@
 	pixel_y = -22
 	},
 /obj/machinery/ore_silo,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
@@ -13903,7 +13932,6 @@
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
 "eUB" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/landmark/event_spawn,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/red{
@@ -13916,6 +13944,8 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "eVi" = (
@@ -13946,9 +13976,21 @@
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/bridge)
 "eVp" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/landmark/start/assistant,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/hallway/secondary/exit/departure_lounge)
 "eVW" = (
 /obj/vehicle/ridden/secway,
 /obj/item/key/security,
@@ -13961,13 +14003,20 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "eWp" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/dark,
-/area/blueshield)
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/hallway/secondary/exit/departure_lounge)
 "eWw" = (
 /obj/machinery/door/airlock/external{
 	name = "Solar Maintenance";
@@ -14014,10 +14063,6 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/camera{
 	c_tag = "Brig Genpop Cells";
 	dir = 1
@@ -14044,16 +14089,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"eYx" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/medical/chemistry)
 "eZe" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
@@ -14075,10 +14111,12 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
 "eZn" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
 "eZA" = (
@@ -14203,20 +14241,21 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "fcu" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/hallway/secondary/exit/departure_lounge)
+"fcJ" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/brig)
-"fcJ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plating,
-/area/hallway/primary/central)
+/area/hallway/secondary/exit/departure_lounge)
 "fcU" = (
 /obj/machinery/vending/kink,
 /turf/open/floor/plasteel,
@@ -14283,6 +14322,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "ffA" = (
+/obj/effect/landmark/blobstart,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/construction/storage)
 "ffJ" = (
@@ -14309,6 +14352,9 @@
 /obj/structure/sign/poster/contraband/clown{
 	pixel_y = -32
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
 "fgj" = (
@@ -14326,9 +14372,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
@@ -14337,6 +14380,12 @@
 	},
 /obj/effect/turf_decal/tile/purple,
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -14353,6 +14402,12 @@
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
@@ -14431,23 +14486,26 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible,
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
 "fiw" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/wood,
@@ -14513,16 +14571,25 @@
 	dir = 8;
 	name = "west facing firelock"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "fkN" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/plaque{
 	icon_state = "L14"
 	},
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -14557,9 +14624,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/door/airlock/security/glass{
 	name = "Equipment Room";
 	req_access_txt = "1"
@@ -14567,6 +14631,12 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8;
 	name = "west facing firelock"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)
@@ -14655,7 +14725,6 @@
 /turf/open/floor/plating,
 /area/medical/virology)
 "fnT" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -14681,7 +14750,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "foy" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
 "foz" = (
@@ -14701,9 +14770,6 @@
 /turf/open/floor/plasteel/cult,
 /area/library)
 "fpa" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
 "fpt" = (
@@ -14720,7 +14786,10 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
 "fpS" = (
@@ -14758,8 +14827,9 @@
 /turf/open/floor/plasteel/stairs/right,
 /area/hallway/primary/aft)
 "fqE" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "fqM" = (
@@ -14783,13 +14853,13 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/carpet,
 /area/bridge)
 "frn" = (
 /obj/structure/chair/office/light,
 /obj/effect/landmark/start/chemist,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
@@ -14856,9 +14926,6 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
@@ -14877,10 +14944,8 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "fsQ" = (
@@ -14895,7 +14960,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/dark,
 /area/blueshield)
 "ftb" = (
@@ -15117,14 +15181,6 @@
 	dir = 1
 	},
 /area/medical/medbay/central)
-"fze" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
 "fzg" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -15181,9 +15237,11 @@
 /turf/open/floor/plasteel/dark,
 /area/teleporter)
 "fBc" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall/r_wall,
-/area/ai_monitored/nuke_storage)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/hallway/secondary/exit/departure_lounge)
 "fBf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -15398,7 +15456,7 @@
 /area/security/prison)
 "fHF" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -15500,16 +15558,11 @@
 	dir = 4;
 	sortType = 11
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "fJW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "fJZ" = (
@@ -15594,6 +15647,12 @@
 	name = "Security Office APC";
 	pixel_y = -26
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "fLB" = (
@@ -15623,9 +15682,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8;
 	name = "west facing firelock"
@@ -15634,11 +15690,17 @@
 	id_tag = null;
 	name = "Medbay"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/zone2)
 "fLL" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/medical/genetics)
@@ -15675,7 +15737,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/carpet,
 /area/bridge)
 "fNE" = (
@@ -15700,8 +15761,11 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/medical/genetics)
@@ -15734,12 +15798,15 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "fOC" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
 "fOF" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/mineral/titanium/white{
 	barefootstep = "carpetbarefoot";
@@ -15802,7 +15869,6 @@
 	name = "Auxiliary Tool Storage";
 	req_access_txt = "12"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/storage/auxiliary)
@@ -15822,11 +15888,13 @@
 /turf/open/floor/plating,
 /area/hallway/primary/fore)
 "fQx" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/plasteel/dark,
+/area/teleporter)
 "fQz" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -16032,9 +16100,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -16045,6 +16110,12 @@
 	id_tag = "psy1";
 	name = "Psychology Office";
 	req_access_txt = "71"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/wood,
 /area/medical/psych)
@@ -16066,11 +16137,9 @@
 /turf/open/floor/carpet,
 /area/hallway/secondary/exit/departure_lounge)
 "fXa" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "fXd" = (
 /obj/structure/chair/comfy/brown,
 /obj/structure/cable{
@@ -16092,17 +16161,12 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "fXH" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/medical/medbay/central)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/plasteel/grimy,
+/area/tcommsat/computer)
 "fXU" = (
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -16113,6 +16177,12 @@
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 2;
 	sortType = 29
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -16190,7 +16260,12 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "gaf" = (
@@ -16257,9 +16332,6 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
 "gbS" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/junction/yjunction{
 	dir = 4
 	},
@@ -16443,9 +16515,6 @@
 	},
 /area/maintenance/disposal)
 "gfN" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
@@ -16493,19 +16562,19 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/junction/flip{
 	dir = 1
 	},
 /turf/open/floor/carpet,
 /area/hallway/secondary/exit/departure_lounge)
 "ggt" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/structure/chair{
+	dir = 8
 	},
-/obj/structure/bookcase/random/fiction,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/wood,
-/area/library)
+/area/security/courtroom)
 "ggD" = (
 /obj/structure/closet/crate/wooden/fish_learning,
 /turf/open/floor/plasteel/freezer,
@@ -16513,13 +16582,6 @@
 "ghq" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/ai)
-"gis" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "Mix to Gas"
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "giv" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -16555,11 +16617,14 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
 /obj/structure/cable{
 	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
 	},
 /turf/open/floor/plating,
 /area/maintenance/central)
@@ -16643,7 +16708,6 @@
 /turf/open/floor/plating,
 /area/icemoon/surface/outdoors)
 "gkH" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -16665,7 +16729,10 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -16694,7 +16761,6 @@
 /turf/open/floor/carpet,
 /area/chapel/main)
 "gmf" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet,
 /area/hallway/primary/central)
@@ -16714,12 +16780,11 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
 "gmv" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
 "gmA" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 4
@@ -16753,9 +16818,6 @@
 /turf/open/floor/plating,
 /area/chapel/main)
 "gnf" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 8;
 	sortType = 7
@@ -16766,10 +16828,15 @@
 /obj/effect/turf_decal/arrows/red{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "gnm" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -16783,11 +16850,15 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "gnv" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/reagent_dispensers/fueltank,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/circuit,
 /area/science/robotics/mechbay)
 "gnS" = (
@@ -16803,9 +16874,6 @@
 /turf/open/floor/plating,
 /area/maintenance/aft/secondary)
 "gop" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/machinery/camera{
 	c_tag = "Brig Gen-Pop Access"
 	},
@@ -16859,9 +16927,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "goW" = (
@@ -16890,11 +16957,13 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -16906,7 +16975,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -16957,17 +17026,8 @@
 	},
 /turf/open/floor/wood,
 /area/bridge/meeting_room)
-"gsM" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/port)
 "gsQ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "gto" = (
@@ -16978,13 +17038,19 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "gtG" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/machinery/light{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -17006,10 +17072,6 @@
 /obj/effect/turf_decal/stripes/box,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/engine/atmospherics_engine)
-"gtS" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "gum" = (
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_y = 32
@@ -17034,7 +17096,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/airlock/command/glass{
 	name = "Bridge";
 	req_access_txt = "19"
@@ -17077,7 +17138,6 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "gvp" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -17086,10 +17146,15 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "gvA" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -17102,6 +17167,8 @@
 /obj/machinery/door/firedoor/border_only{
 	name = "south facing firelock"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "gvB" = (
@@ -17142,9 +17209,6 @@
 "gxi" = (
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -17316,9 +17380,6 @@
 /turf/open/floor/wood,
 /area/security/vacantoffice/b)
 "gEd" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
@@ -17361,6 +17422,8 @@
 	icon_state = "1-2"
 	},
 /obj/structure/grille/broken,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
 /area/hallway/primary/port)
 "gEZ" = (
@@ -17424,9 +17487,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /turf/open/floor/plasteel/white/corner{
 	dir = 8
 	},
@@ -17437,9 +17497,6 @@
 	icon_state = "control_stun";
 	name = "AI Upload turret control";
 	pixel_x = -26
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -17453,13 +17510,13 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/window/reinforced{
 	dir = 8
 	},
 /obj/structure/chair{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /turf/open/floor/wood,
@@ -17471,9 +17528,7 @@
 /turf/open/floor/plating,
 /area/maintenance/bar)
 "gHG" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/circuit/off,
 /area/ai_monitored/turret_protected/ai)
 "gHH" = (
@@ -17512,7 +17567,6 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/fitness)
 "gId" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -17522,6 +17576,8 @@
 	req_access_txt = "5; 68"
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics)
 "gIm" = (
@@ -17543,10 +17599,13 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -17564,10 +17623,6 @@
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
-"gJr" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible,
-/turf/open/floor/engine,
-/area/engine/engineering)
 "gJx" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -17629,7 +17684,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
@@ -17662,7 +17716,10 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -17677,7 +17734,6 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/carpet,
 /area/bridge/meeting_room)
 "gMR" = (
@@ -17827,11 +17883,14 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/computer)
@@ -17891,9 +17950,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "gRt" = (
@@ -17915,9 +17971,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8;
 	name = "west facing firelock"
@@ -17928,6 +17981,12 @@
 /obj/machinery/door/airlock/mining/glass{
 	name = "Mining Office";
 	req_access_txt = "48"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
@@ -17959,11 +18018,17 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/carpet,
 /area/hallway/secondary/exit/departure_lounge)
 "gSy" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/mineral/titanium/white{
 	barefootstep = "carpetbarefoot";
@@ -17977,10 +18042,11 @@
 /turf/open/floor/plating,
 /area/chapel/main)
 "gSY" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/structure/chair/comfy/black{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/wood,
 /area/bridge/meeting_room)
 "gTb" = (
@@ -18031,13 +18097,10 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/visible,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
 "gUw" = (
@@ -18093,8 +18156,8 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/surgery)
 "gWl" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/medical/chemistry)
@@ -18132,7 +18195,8 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/medical/genetics)
 "gXM" = (
@@ -18170,12 +18234,16 @@
 /turf/open/floor/carpet/eighties,
 /area/crew_quarters/fitness)
 "gZQ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/medical/medbay/central)
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
 "gZR" = (
 /obj/structure/table,
 /turf/open/floor/plating,
@@ -18200,7 +18268,10 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -18213,7 +18284,7 @@
 /obj/structure/chair{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
 	},
 /turf/open/floor/carpet,
@@ -18240,7 +18311,7 @@
 /turf/open/floor/plating,
 /area/crew_quarters/bar)
 "hbd" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -18319,23 +18390,26 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/atmospherics_engine)
 "hez" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
-/area/quartermaster/miningdock)
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "heM" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	desc = "Privacy shutters for the Private Study. Stops people spying in on your game.";
-	id = "PrivateStudy1";
-	name = "Privacy Shutters"
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/library)
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "heR" = (
 /obj/effect/landmark/start/psychologist,
 /obj/structure/cable{
@@ -18416,6 +18490,7 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/assistant,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "hgM" = (
@@ -18425,11 +18500,15 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "hgO" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
 	},
-/turf/open/floor/wood,
-/area/hallway/secondary/exit/departure_lounge)
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "hho" = (
 /obj/machinery/light{
 	dir = 8
@@ -18452,7 +18531,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -18516,7 +18595,6 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/light,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
@@ -18609,8 +18687,13 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "hnc" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/tile/purple,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "hnB" = (
@@ -18701,13 +18784,10 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "hpd" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
 /turf/open/floor/plasteel/white,
 /area/security/brig)
 "hpg" = (
@@ -18726,7 +18806,6 @@
 /turf/open/floor/plasteel/dark,
 /area/blueshield)
 "hpw" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/structure/table/wood,
 /obj/item/folder/blue,
 /obj/item/folder/blue,
@@ -18751,9 +18830,6 @@
 "hpC" = (
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
 	},
 /turf/open/floor/carpet/black,
 /area/crew_quarters/heads/hos)
@@ -18821,7 +18897,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
@@ -18843,13 +18919,13 @@
 /turf/open/floor/plating,
 /area/construction/storage)
 "hra" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
 "hrc" = (
@@ -18868,15 +18944,18 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8;
 	name = "west facing firelock"
 	},
 /obj/machinery/door/airlock/mining{
 	req_access_txt = "48"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
@@ -18915,7 +18994,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
@@ -19033,18 +19111,23 @@
 /area/chapel/main)
 "hva" = (
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/ai_upload)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
 "hvr" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/junction{
 	dir = 1
 	},
@@ -19104,7 +19187,10 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -19131,7 +19217,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "hxr" = (
@@ -19216,9 +19301,16 @@
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/bridge)
 "hyY" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/closed/wall/r_wall,
-/area/science/robotics/lab)
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
 "hzh" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -19367,18 +19459,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"hCz" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "hCD" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -19480,15 +19560,13 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "hEm" = (
@@ -19510,12 +19588,12 @@
 	},
 /area/chapel/main)
 "hEQ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/effect/landmark/blobstart,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
 	},
-/turf/open/floor/plating,
-/area/medical/medbay/central)
+/turf/open/floor/plasteel/grimy,
+/area/tcommsat/computer)
 "hFj" = (
 /obj/structure/chair/comfy/brown,
 /turf/open/floor/wood,
@@ -19547,20 +19625,20 @@
 /turf/open/floor/carpet,
 /area/chapel/main)
 "hGr" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -24
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "hGy" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
 "hGK" = (
@@ -19642,7 +19720,7 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hop)
 "hIe" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel/freezer,
@@ -19667,10 +19745,13 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
 "hIH" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -19681,12 +19762,15 @@
 	},
 /area/maintenance/port/fore)
 "hIP" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/effect/turf_decal/tile/purple,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
 	},
-/turf/open/floor/plating,
-/area/medical/storage)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
 "hIR" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -19735,16 +19819,21 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "hKl" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/wood,
-/area/library)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "hKm" = (
 /obj/machinery/computer/aifixer{
 	dir = 8
@@ -19770,17 +19859,9 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
 "hKt" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/medical/medbay/central)
-"hLg" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Gas to Mix"
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "hLo" = (
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_x = -30
@@ -19819,6 +19900,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/assistant,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "hMy" = (
@@ -19884,12 +19966,11 @@
 /obj/machinery/door/firedoor/border_only{
 	name = "south facing firelock"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "hNt" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
@@ -19927,16 +20008,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/bridge)
-"hOb" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "hOc" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -19948,10 +20019,13 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -20023,9 +20097,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "hQb" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
@@ -20053,8 +20124,8 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/blueshield)
@@ -20067,9 +20138,6 @@
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
 "hRe" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/chair/office/dark{
 	dir = 8
 	},
@@ -20082,7 +20150,6 @@
 /turf/open/floor/plating,
 /area/hallway/primary/central)
 "hRH" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -20101,9 +20168,6 @@
 /turf/open/floor/grass,
 /area/security/brig)
 "hSl" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/machinery/door/airlock/security/glass{
 	name = "Brig Control";
 	req_access_txt = "3"
@@ -20161,6 +20225,12 @@
 /area/chapel/office)
 "hSV" = (
 /obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "hSZ" = (
@@ -20172,11 +20242,9 @@
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
 "hTk" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/disposal/bin,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "hTy" = (
@@ -20247,13 +20315,14 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "hUx" = (
@@ -20425,8 +20494,8 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "hXB" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -20466,9 +20535,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /obj/structure/fireaxecabinet{
@@ -20581,7 +20647,10 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "iat" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -20590,7 +20659,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/airlock/command/glass{
 	name = "Bridge";
 	req_access_txt = "19"
@@ -20646,7 +20714,6 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
 "iaY" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/table/wood,
 /obj/item/paper_bin{
 	pixel_x = -3;
@@ -20663,8 +20730,11 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain)
 "icx" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
@@ -20720,20 +20790,23 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "idQ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/chair/office/dark{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/wood,
 /area/security/courtroom)
 "idS" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
 	},
-/turf/closed/wall/r_wall,
-/area/security/execution/education)
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "iee" = (
 /obj/machinery/igniter{
 	id = "Incinerator"
@@ -20769,12 +20842,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
-"ieF" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "ieI" = (
 /obj/machinery/telecomms/server/presets/service,
 /obj/machinery/light{
@@ -20830,13 +20897,16 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "igR" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/machinery/door/window{
 	name = "Captain's Desk";
 	req_access_txt = "20"
 	},
 /obj/machinery/door/firedoor/border_only{
 	name = "south facing firelock"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
@@ -20957,12 +21027,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "ikk" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "ikt" = (
@@ -20987,18 +21056,9 @@
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/computer)
 "ilb" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
-"ilo" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white/side,
-/area/hallway/primary/port)
 "ilF" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -21009,10 +21069,6 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/junction{
 	dir = 1
 	},
@@ -21046,7 +21102,6 @@
 /turf/closed/wall,
 /area/security/prison)
 "imM" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
@@ -21060,13 +21115,12 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
 "ina" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/holopad,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "inf" = (
@@ -21094,7 +21148,6 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/structure/disposalpipe/junction{
 	dir = 8
 	},
@@ -21107,12 +21160,6 @@
 "inA" = (
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/dorms)
-"inU" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/medical/chemistry)
 "iob" = (
 /obj/structure/window/plasma/reinforced{
 	dir = 1
@@ -21134,16 +21181,11 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "iog" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1
 	},
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/effect/landmark/start/assistant,
-/turf/open/floor/wood,
-/area/hallway/secondary/exit/departure_lounge)
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "iop" = (
 /obj/machinery/computer/med_data{
 	dir = 1
@@ -21158,9 +21200,6 @@
 /area/hallway/primary/fore)
 "ioG" = (
 /obj/machinery/light,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
@@ -21282,9 +21321,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
@@ -21348,8 +21384,11 @@
 	},
 /area/hallway/primary/port)
 "itn" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
@@ -21417,7 +21456,8 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
 /area/maintenance/central)
 "iux" = (
@@ -21548,9 +21588,6 @@
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "iyD" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
@@ -21576,25 +21613,24 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "iyP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
 "iyW" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
 /turf/open/floor/wood,
 /area/medical/psych)
 "iza" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/closed/wall,
-/area/hallway/secondary/entry)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "izd" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /obj/structure/railing/corner{
@@ -21645,7 +21681,6 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "iAv" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -21679,7 +21714,10 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -21704,16 +21742,15 @@
 /turf/open/floor/plasteel/dark,
 /area/storage/eva)
 "iBm" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/table/wood,
 /obj/machinery/recharger{
 	pixel_x = -5
 	},
 /obj/item/hand_tele,
 /obj/structure/window/reinforced,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "iBo" = (
@@ -21782,10 +21819,13 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -21826,6 +21866,12 @@
 	dir = 6
 	},
 /obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
+	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
 "iEQ" = (
@@ -21855,23 +21901,23 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
 "iFl" = (
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/neutral{
@@ -21889,10 +21935,13 @@
 	},
 /area/hallway/secondary/entry)
 "iFq" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
 "iFF" = (
@@ -21929,9 +21978,6 @@
 /turf/open/floor/plasteel,
 /area/maintenance/department/electrical)
 "iGd" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -21945,13 +21991,11 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "iGg" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
@@ -21962,6 +22006,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "iGB" = (
@@ -21975,7 +22020,6 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "iGJ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/hallway/primary/central)
@@ -21999,9 +22043,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/door/airlock/security/glass{
 	name = "Prison Wing";
 	req_access_txt = "2"
@@ -22020,6 +22061,12 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "iHk" = (
@@ -22077,12 +22124,11 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "iIC" = (
@@ -22095,9 +22141,6 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/education)
 "iIK" = (
@@ -22109,8 +22152,13 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "iIN" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/purple,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "iIS" = (
@@ -22270,7 +22318,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
@@ -22345,6 +22392,8 @@
 "iOW" = (
 /obj/effect/landmark/observer_start,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/carpet,
 /area/hallway/secondary/exit/departure_lounge)
 "iPk" = (
@@ -22370,11 +22419,12 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1;
 	name = "north facing firelock"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "iPX" = (
@@ -22400,14 +22450,14 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/machinery/door/airlock/atmos/abandoned{
 	name = "Atmospherics Maintenance";
 	req_access_txt = "12;24"
 	},
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -22422,7 +22472,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
 "iRE" = (
@@ -22442,8 +22491,8 @@
 /turf/open/floor/plating,
 /area/hallway/primary/aft)
 "iRO" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
 	},
 /turf/open/floor/plasteel/checker,
 /area/crew_quarters/heads/hor)
@@ -22455,7 +22504,7 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "iSg" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
 /area/icemoon/surface/outdoors)
 "iSo" = (
@@ -22512,8 +22561,13 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/junction/flip,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/hallway/primary/port)
 "iUp" = (
@@ -22530,7 +22584,8 @@
 /turf/open/floor/grass,
 /area/chapel/main)
 "iVY" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "iWd" = (
@@ -22570,9 +22625,6 @@
 /obj/structure/table/reinforced,
 /obj/item/clothing/suit/straight_jacket,
 /obj/item/restraints/handcuffs,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/education)
 "iWY" = (
@@ -22581,9 +22633,6 @@
 	},
 /obj/structure/cable{
 	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
 	},
 /obj/structure/disposalpipe/junction{
 	dir = 2
@@ -22713,10 +22762,11 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
 "jah" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/railing{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/stairs/right,
 /area/hallway/primary/port)
 "jan" = (
@@ -22726,10 +22776,6 @@
 /obj/structure/closet/secure_closet/personal,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
-"jap" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
-/area/medical/chemistry)
 "jar" = (
 /obj/structure/chair/office/light{
 	dir = 8
@@ -22745,11 +22791,14 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/central)
@@ -22788,9 +22837,6 @@
 	},
 /obj/structure/disposalpipe/sorting/mail/flip{
 	sortType = 23
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
 	},
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -22834,7 +22880,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "jcT" = (
@@ -22857,10 +22902,12 @@
 	},
 /area/security/execution/education)
 "jdw" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
 	},
-/obj/effect/landmark/blobstart,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
+	},
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
 "jdS" = (
@@ -22922,15 +22969,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"jex" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/port)
 "jeJ" = (
 /obj/machinery/door/poddoor{
 	id = "tegvent";
@@ -22958,18 +22996,13 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "jga" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
 "jgj" = (
 /obj/machinery/telecomms/server/presets/common,
 /turf/open/floor/plasteel/dark/telecomms,
@@ -22995,7 +23028,6 @@
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
 "jhe" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -23003,6 +23035,8 @@
 	codes_txt = "patrol;next_patrol=AIE";
 	location = "AftH"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "jhF" = (
@@ -23016,14 +23050,22 @@
 /turf/open/floor/plating,
 /area/maintenance/aft/secondary)
 "jih" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
-"jil" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/robotics/lab)
+"jil" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "jin" = (
@@ -23035,12 +23077,12 @@
 /area/maintenance/solars/port/fore)
 "jix" = (
 /obj/item/kirbyplants/random,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "jiV" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
 "jiY" = (
@@ -23069,9 +23111,13 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "jjA" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/closed/wall,
-/area/security/prison)
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "jjB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -23117,11 +23163,14 @@
 /area/crew_quarters/bar)
 "jkL" = (
 /obj/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/machinery/door/firedoor/border_only{
 	name = "south facing firelock"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
@@ -23134,14 +23183,6 @@
 /obj/machinery/meter,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"jll" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/ai_upload_foyer)
 "jls" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 5
@@ -23164,9 +23205,6 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "jmd" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -23211,13 +23249,6 @@
 /obj/structure/chair/comfy/black,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"joq" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/carpet,
-/area/hallway/secondary/exit/departure_lounge)
 "jos" = (
 /obj/structure/closet/secure_closet/genpop,
 /obj/item/radio/headset{
@@ -23259,9 +23290,6 @@
 	},
 /obj/structure/chair{
 	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/surgery)
@@ -23354,11 +23382,21 @@
 	},
 /area/chapel/office)
 "jrf" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/closed/wall,
-/area/hallway/secondary/entry)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "jro" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -23374,7 +23412,6 @@
 	dir = 1;
 	pixel_y = -22
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "jrq" = (
@@ -23547,13 +23584,9 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/carpet,
 /area/bridge)
 "jwo" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
@@ -23585,9 +23618,6 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "jxw" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
@@ -23611,10 +23641,10 @@
 /turf/open/floor/wood,
 /area/icemoon/surface/outdoors)
 "jxS" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
 /area/icemoon/surface/outdoors)
 "jyA" = (
@@ -23628,6 +23658,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "jyH" = (
@@ -23671,14 +23702,14 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "jAb" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 10
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -23707,7 +23738,6 @@
 /turf/open/floor/wood,
 /area/maintenance/bar)
 "jAx" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/airlock/command{
 	name = "Head of Security's Office";
 	req_access_txt = "58"
@@ -23727,6 +23757,8 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "jAy" = (
@@ -23767,6 +23799,12 @@
 "jBr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -23832,13 +23870,16 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/machinery/door/firedoor/border_only{
 	name = "south facing firelock"
 	},
 /obj/effect/turf_decal/stripes/red/line,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/education)
 "jDD" = (
@@ -23928,12 +23969,15 @@
 /turf/open/floor/plating,
 /area/maintenance/bar)
 "jFT" = (
-/obj/structure/sign/poster/official/random,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/structure/table/wood,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/closed/wall,
-/area/security/prison)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "jFY" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -23951,9 +23995,6 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "jFZ" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
 /mob/living/simple_animal/bot/medbot,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/zone2)
@@ -23968,7 +24009,10 @@
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/bar)
 "jGi" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel/grimy,
@@ -23986,8 +24030,11 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
@@ -24124,6 +24171,12 @@
 /obj/effect/turf_decal/arrows/red{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "jLF" = (
@@ -24227,9 +24280,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -24285,12 +24335,13 @@
 /turf/open/floor/plating,
 /area/engine/atmospherics_engine)
 "jPh" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
 "jPj" = (
@@ -24453,10 +24504,11 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
 "jSV" = (
@@ -24476,11 +24528,14 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
 	},
 /turf/open/floor/wood,
 /area/medical/psych)
@@ -24501,8 +24556,8 @@
 /turf/closed/indestructible/rock/glacierrock/blue,
 /area/chapel/office)
 "jTE" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
@@ -24631,7 +24686,6 @@
 /turf/open/floor/plasteel,
 /area/medical/chemistry)
 "jWy" = (
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
@@ -24669,6 +24723,8 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/white/side{
 	dir = 1
 	},
@@ -24727,19 +24783,6 @@
 	},
 /turf/open/floor/carpet,
 /area/hallway/primary/aft)
-"jZS" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "jZW" = (
 /turf/open/floor/plasteel,
 /area/engine/atmospherics_engine)
@@ -24860,7 +24903,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "kdD" = (
@@ -24917,7 +24961,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
 "keu" = (
@@ -24941,9 +24985,6 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "keI" = (
@@ -24955,7 +24996,7 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "keN" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -24999,11 +25040,27 @@
 /turf/open/floor/plating,
 /area/chapel/office)
 "kgr" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 10
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
-/turf/open/floor/wood,
-/area/security/vacantoffice/a)
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "kgx" = (
 /obj/structure/chair/office/dark,
 /obj/structure/cable{
@@ -25062,21 +25119,28 @@
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "kij" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/robotics/lab)
 "kin" = (
 /obj/structure/table,
 /obj/item/toy/cards/deck,
 /turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
 "kis" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -25086,6 +25150,12 @@
 	icon_state = "4-8"
 	},
 /obj/structure/bed/roller,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/zone2)
 "kjh" = (
@@ -25108,10 +25178,13 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
 /obj/structure/disposalpipe/junction/yjunction,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "kkt" = (
@@ -25138,8 +25211,9 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "kkG" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
@@ -25151,6 +25225,9 @@
 /area/security/prison)
 "kkX" = (
 /obj/machinery/vending/cola/random,
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/open/floor/carpet/purple,
 /area/library)
 "kkY" = (
@@ -25203,17 +25280,20 @@
 /area/hallway/primary/fore)
 "klQ" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plating,
 /area/security/courtroom)
 "kmj" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4
 	},
 /turf/open/floor/wood,
 /area/medical/psych)
@@ -25280,7 +25360,6 @@
 	id = "Secure Gate";
 	name = "brig shutters"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/security/brig)
 "knI" = (
@@ -25365,11 +25444,12 @@
 /obj/machinery/door/airlock/public{
 	name = "Permabrig Dorm 3"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1;
 	name = "north facing firelock"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "kpO" = (
@@ -25389,6 +25469,8 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
 "kpX" = (
@@ -25442,6 +25524,8 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
 "kro" = (
@@ -25456,12 +25540,6 @@
 	},
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/hallway/secondary/exit/departure_lounge)
-"krs" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "krB" = (
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall,
@@ -25546,9 +25624,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -25568,6 +25643,12 @@
 	},
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel/airless/white/side{
 	dir = 8
@@ -25638,21 +25719,11 @@
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
 "kuy" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
+/turf/open/floor/plasteel/dark,
+/area/science/robotics/lab)
 "kuK" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment{
@@ -25684,11 +25755,11 @@
 	name = "Sergeant-at-Armsky";
 	weaponscheck = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
@@ -25743,9 +25814,6 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/machinery/light{
 	dir = 1
 	},
@@ -25771,7 +25839,7 @@
 /turf/open/floor/wood,
 /area/security/vacantoffice/b)
 "kxI" = (
-/obj/machinery/atmospherics/pipe/simple/supply/visible{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
 	},
 /turf/open/floor/plating,
@@ -25793,28 +25861,27 @@
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "kyf" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "kyo" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
+	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain)
-"kzf" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white/side,
-/area/hallway/primary/port)
 "kzG" = (
 /obj/machinery/atmospherics/pipe/simple/dark/visible{
 	dir = 6
@@ -25825,7 +25892,10 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
 "kzR" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/wood,
@@ -25898,9 +25968,8 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "kCE" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "kCI" = (
@@ -26010,16 +26079,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"kGS" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/dark,
-/area/medical/surgery)
 "kGX" = (
 /obj/structure/transit_tube/curved{
 	dir = 4
@@ -26038,18 +26097,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/paramedic)
-"kHl" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "kHm" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
@@ -26083,11 +26130,11 @@
 /area/engine/atmos)
 "kHX" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
 	},
 /turf/open/floor/wood,
 /area/medical/psych)
@@ -26137,12 +26184,11 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "kJz" = (
@@ -26233,10 +26279,10 @@
 	dir = 4;
 	network = list("vault")
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/item/radio/intercom{
 	pixel_x = -25
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
 "kMb" = (
@@ -26295,7 +26341,6 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/item/radio/intercom{
 	frequency = 1485;
 	name = "Station Intercom (Medbay)";
@@ -26395,19 +26440,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/atmospherics_engine)
-"kPj" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "kPn" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
@@ -26513,7 +26545,8 @@
 	},
 /area/crew_quarters/fitness/pool)
 "kRz" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
 "kRI" = (
@@ -26555,12 +26588,11 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "kSQ" = (
@@ -26587,9 +26619,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "kTY" = (
@@ -26609,16 +26639,15 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "kUo" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
 	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "psyshu";
-	name = "psy shutters"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
 	},
-/turf/open/floor/plating,
-/area/medical/psych)
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
 "kUq" = (
 /obj/structure/closet/crate/coffin,
 /obj/machinery/door/window/eastleft{
@@ -26641,12 +26670,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
-"kUC" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/execution/education)
 "kVo" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 5
@@ -26792,19 +26815,6 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
-"lam" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/landmark/start/scientist,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/science/lab)
 "lap" = (
 /obj/machinery/light{
 	dir = 4
@@ -26831,7 +26841,8 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/teleporter)
 "laC" = (
@@ -26899,8 +26910,9 @@
 	name = "Teleport and Gateway Access";
 	req_access_txt = "17"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/firedoor/border_only,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/teleporter)
 "ldE" = (
@@ -26908,9 +26920,6 @@
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
 	},
 /turf/open/floor/plasteel/white/corner{
 	dir = 8
@@ -26977,8 +26986,9 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/computer)
 "lfd" = (
@@ -27074,9 +27084,20 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "lgq" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall,
-/area/medical/medbay/central)
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
 "lgw" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -27106,11 +27127,17 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
 "lhi" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
+/obj/machinery/computer/arcade{
+	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "lhr" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -27176,7 +27203,7 @@
 /turf/open/floor/circuit/off,
 /area/ai_monitored/turret_protected/ai)
 "ljL" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/wood,
@@ -27241,9 +27268,15 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
 "lmu" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment{
 	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
@@ -27358,7 +27391,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
 "loe" = (
@@ -27370,6 +27403,9 @@
 /area/teleporter)
 "loD" = (
 /obj/machinery/nanite_chamber,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/circuit,
 /area/science/explab)
 "loM" = (
@@ -27446,6 +27482,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/medical/chemistry)
 "lqt" = (
@@ -27471,14 +27509,16 @@
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "lqG" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/hallway/secondary/entry)
-"lqW" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/main)
+"lqW" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -27516,7 +27556,6 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
@@ -27569,8 +27608,8 @@
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
 "ltw" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
@@ -27614,6 +27653,8 @@
 	name = "south facing firelock"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
 "luf" = (
@@ -27630,9 +27671,6 @@
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /obj/effect/turf_decal/arrows/red{
@@ -27726,7 +27764,6 @@
 	},
 /area/crew_quarters/fitness/pool)
 "lyu" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
@@ -27736,6 +27773,9 @@
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = -24
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
@@ -27790,10 +27830,13 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "lzB" = (
-/obj/machinery/atmospherics/pipe/simple/supply/visible{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
@@ -27913,11 +27956,11 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/junction/flip{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
@@ -27933,7 +27976,9 @@
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/structure/chair/comfy/black,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "lDi" = (
@@ -27943,6 +27988,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "lDj" = (
@@ -27959,9 +28006,6 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "lDD" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/table/wood/poker,
 /obj/effect/spawner/lootdrop{
 	loot = list(/obj/item/gun/ballistic/revolver/russian = 5, /obj/item/storage/box/syndie_kit/throwing_weapons, /obj/item/toy/cards/deck/syndicate = 2);
@@ -28030,9 +28074,6 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
 /obj/effect/landmark/start/prisoner/prilate,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
@@ -28071,10 +28112,6 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "lFN" = (
@@ -28090,10 +28127,10 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/wood,
 /area/hallway/primary/central)
 "lGy" = (
@@ -28174,7 +28211,10 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -28217,7 +28257,8 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/aft/secondary)
 "lKf" = (
@@ -28267,7 +28308,6 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "lMF" = (
@@ -28316,9 +28356,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "lOF" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -28334,6 +28371,9 @@
 	},
 /obj/machinery/light/small{
 	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
@@ -28356,9 +28396,17 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
 "lQs" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/wood,
-/area/hallway/secondary/exit/departure_lounge)
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "lQJ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
@@ -28378,7 +28426,7 @@
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "lRx" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
 /turf/open/floor/carpet,
@@ -28461,9 +28509,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/door/airlock/command{
 	name = "Captain's Office";
 	req_access_txt = "20"
@@ -28475,6 +28520,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "lUb" = (
@@ -28482,6 +28533,12 @@
 	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -28497,6 +28554,8 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
 "lUu" = (
@@ -28548,11 +28607,18 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "lWb" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall/r_wall,
-/area/science/lab)
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
 "lWf" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/aisat/service)
 "lWi" = (
@@ -28642,14 +28708,20 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
 "lYq" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
@@ -28734,11 +28806,8 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
 "lZs" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/port)
+/turf/open/floor/plasteel/checker,
+/area/crew_quarters/heads/hor)
 "lZL" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -28755,10 +28824,12 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "mai" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/machinery/camera{
 	c_tag = "Escape Arm Central";
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/wood,
 /area/hallway/secondary/exit/departure_lounge)
@@ -28833,9 +28904,6 @@
 "mbh" = (
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -28912,14 +28980,15 @@
 /turf/closed/wall,
 /area/medical/medbay/central)
 "mdG" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/machinery/computer/arcade{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "meG" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -28937,9 +29006,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -28970,10 +29036,11 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "mfC" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "mfD" = (
@@ -29043,7 +29110,6 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "mhv" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/window/reinforced{
 	dir = 8
 	},
@@ -29052,14 +29118,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"mhC" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "mhF" = (
 /obj/structure/loot_pile,
 /turf/open/floor/plating,
@@ -29074,12 +29132,14 @@
 /turf/open/floor/engine,
 /area/engine/atmospherics_engine)
 "mhH" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/security/courtroom)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "mia" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -29252,13 +29312,15 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
 "mmO" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "mmQ" = (
@@ -29370,9 +29432,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "mql" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/machinery/light{
 	dir = 1
 	},
@@ -29382,14 +29441,23 @@
 /obj/item/radio/intercom{
 	pixel_y = 25
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/green/filled/corner{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "mqm" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
 /turf/open/floor/carpet,
 /area/bridge)
@@ -29463,16 +29531,6 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel/dark,
 /area/engine/secure_construction)
-"msm" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "msA" = (
 /obj/machinery/holopad,
 /turf/open/floor/wood,
@@ -29525,7 +29583,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "mtE" = (
@@ -29537,15 +29597,6 @@
 "mtP" = (
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
-"mtW" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "mtY" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -29582,16 +29633,6 @@
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
-"mvJ" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "mvQ" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
@@ -29622,9 +29663,6 @@
 /obj/machinery/vending/medical{
 	pixel_x = -2
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
@@ -29632,9 +29670,6 @@
 /area/medical/medbay/central)
 "mwW" = (
 /obj/effect/landmark/start/security_officer,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "mxo" = (
@@ -29818,9 +29853,7 @@
 /turf/open/openspace/icemoon,
 /area/hallway/primary/aft)
 "mBK" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/wood,
 /area/security/courtroom)
 "mCK" = (
@@ -29855,9 +29888,6 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
-	dir = 1
-	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
 "mDJ" = (
@@ -29868,8 +29898,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
@@ -29913,12 +29946,19 @@
 /turf/open/floor/plasteel,
 /area/engine/atmospherics_engine)
 "mEo" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plating,
-/area/hydroponics/garden)
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "mEE" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -29960,19 +30000,20 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "mGa" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/rack,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/port)
+/area/maintenance/aft/secondary)
 "mGb" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -30011,30 +30052,13 @@
 /turf/open/floor/plasteel/checker,
 /area/crew_quarters/heads/hor)
 "mGT" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/space_heater,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
 /area/icemoon/surface/outdoors)
-"mHw" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "mHG" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/table/wood,
@@ -30095,10 +30119,6 @@
 /turf/open/floor/plating,
 /area/engine/atmos)
 "mIu" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
@@ -30108,23 +30128,23 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "mIz" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "mIO" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
@@ -30142,11 +30162,9 @@
 /turf/open/floor/wood,
 /area/maintenance/bar)
 "mJq" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "mJr" = (
@@ -30181,10 +30199,17 @@
 /turf/open/floor/plasteel/dark,
 /area/security/warden)
 "mKA" = (
-/obj/structure/table/wood,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
+	},
+/turf/open/floor/wood,
+/area/library)
 "mKD" = (
 /obj/structure/chair/sofa/right,
 /turf/open/floor/carpet,
@@ -30308,7 +30333,6 @@
 /turf/closed/wall/r_wall,
 /area/engine/break_room)
 "mMP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/airlock/command/glass{
 	name = "Bridge";
 	req_access_txt = "19"
@@ -30327,13 +30351,14 @@
 	dir = 1;
 	name = "north facing firelock"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "mNo" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "mNq" = (
@@ -30413,7 +30438,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/hallway/primary/central)
 "mPR" = (
@@ -30470,10 +30494,13 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -30572,6 +30599,12 @@
 	name = "Electrical Maintenance";
 	req_access_txt = "11"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/construction/storage)
 "mSU" = (
@@ -30580,9 +30613,6 @@
 "mTl" = (
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
 	},
 /obj/effect/landmark/event_spawn,
 /obj/structure/disposalpipe/segment{
@@ -30617,7 +30647,8 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "mVe" = (
@@ -30702,12 +30733,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"mVN" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/medical/medbay/central)
 "mWc" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -30782,7 +30807,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -30918,8 +30943,8 @@
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "nby" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
@@ -30927,15 +30952,11 @@
 /turf/closed/mineral/random/snow/more_caves,
 /area/icemoon/surface/outdoors)
 "nbU" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -30959,12 +30980,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -30975,6 +30990,8 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "ndm" = (
@@ -31049,22 +31066,14 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "ndS" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plating,
-/area/security/brig)
+/turf/open/floor/wood,
+/area/library)
 "ndX" = (
 /obj/structure/cable{
 	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -31093,7 +31102,6 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
 "nez" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/window/eastright{
 	name = "Robotics Surgery";
 	req_access_txt = "29"
@@ -31101,7 +31109,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -31159,16 +31170,14 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/medical/chemistry)
-"ngB" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/carpet,
-/area/hallway/secondary/exit/departure_lounge)
 "nhb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table_frame,
@@ -31184,10 +31193,6 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -31227,9 +31232,6 @@
 "nhv" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
@@ -31295,15 +31297,18 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/landmark/event_spawn,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
@@ -31312,7 +31317,7 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -31321,16 +31326,13 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "nmc" = (
 /obj/machinery/rnd/production/techfab/department/cargo,
 /obj/machinery/airalarm{
 	pixel_y = 26
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
@@ -31356,13 +31358,12 @@
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/bridge)
 "nmN" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /turf/open/floor/carpet,
 /area/bridge)
 "nmR" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/airlock/research/glass{
 	name = "Genetics Research";
 	req_access_txt = "5; 9; 68"
@@ -31381,9 +31382,6 @@
 	},
 /area/medical/genetics)
 "nmY" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
@@ -31538,7 +31536,6 @@
 /area/hallway/primary/port)
 "nre" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/poddoor/preopen{
 	id = "hos"
 	},
@@ -31603,18 +31600,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"nsi" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
 "nsv" = (
 /obj/machinery/requests_console{
 	department = "Kitchen";
@@ -31672,12 +31657,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"ntd" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
-/turf/open/floor/plasteel/dark,
-/area/medical/medbay/central)
 "ntO" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -31712,18 +31691,18 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
+	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "nuS" = (
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/neutral{
@@ -31753,6 +31732,7 @@
 	pixel_y = 24;
 	prison_radio = 1
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "nwe" = (
@@ -31761,13 +31741,14 @@
 	},
 /area/maintenance/aft/secondary)
 "nwq" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "nwz" = (
@@ -31809,10 +31790,11 @@
 	name = "Nanites Lab";
 	req_one_access_txt = "7;29"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/science/explab)
 "nxv" = (
@@ -31852,10 +31834,6 @@
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/port/fore)
-"nyT" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall/r_wall,
-/area/tcommsat/computer)
 "nyZ" = (
 /obj/structure/rack,
 /obj/item/gun/energy/laser{
@@ -31878,15 +31856,13 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
 "nzH" = (
@@ -31967,13 +31943,6 @@
 	},
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors)
-"nBx" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/medical/storage)
 "nBI" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -31999,8 +31968,8 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
 "nCc" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
 	},
 /turf/open/floor/wood,
 /area/library)
@@ -32065,17 +32034,18 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
 "nCU" = (
-/obj/effect/turf_decal/tile/blue{
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4;
+	name = "east facing firelock"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /turf/open/floor/plasteel/dark,
-/area/bridge)
+/area/security/execution/education)
 "nDa" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -32093,21 +32063,20 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/visible,
 /obj/machinery/light/floor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
 "nDl" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "nDu" = (
@@ -32174,10 +32143,10 @@
 	},
 /area/hallway/primary/port)
 "nEy" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/library)
 "nEI" = (
@@ -32188,16 +32157,23 @@
 /turf/open/floor/carpet,
 /area/hallway/primary/aft)
 "nEJ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 5
 	},
-/obj/machinery/holopad,
 /turf/open/floor/carpet,
 /area/bridge)
 "nFc" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
-/area/hydroponics/garden)
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/wood,
+/area/library)
 "nFw" = (
 /obj/machinery/button/door{
 	id = "bridge blast";
@@ -32301,10 +32277,12 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/surface/outdoors)
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/wood,
+/area/library)
 "nGR" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -32333,8 +32311,8 @@
 /turf/open/floor/carpet/eighties,
 /area/crew_quarters/fitness)
 "nHQ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/wood,
 /area/library)
@@ -32374,9 +32352,8 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "nIU" = (
@@ -32466,6 +32443,12 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -32579,7 +32562,7 @@
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "nOj" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
 /turf/open/floor/plasteel/freezer,
@@ -32631,9 +32614,6 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/service)
 "nOK" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
@@ -32672,9 +32652,11 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
@@ -32745,9 +32727,6 @@
 	location = "Medbay"
 	},
 /obj/structure/plasticflaps/opaque,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -32792,22 +32771,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
-"nRe" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "nRn" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Evidence Storage";
@@ -32832,16 +32795,14 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/plaque{
 	icon_state = "L3"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
 	},
 /obj/structure/disposalpipe/junction/yjunction{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "nRA" = (
@@ -32930,7 +32891,10 @@
 /turf/open/floor/plasteel/dark,
 /area/teleporter)
 "nTR" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -32986,8 +32950,11 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/storage/auxiliary)
@@ -33048,9 +33015,6 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "nWM" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
@@ -33080,10 +33044,6 @@
 /turf/open/floor/grass,
 /area/medical/genetics)
 "nXy" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
@@ -33124,7 +33084,6 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
 /area/construction/storage)
@@ -33151,7 +33110,8 @@
 /turf/open/floor/plasteel/median/darktogrime,
 /area/chapel/office)
 "nZE" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/lattice/catwalk,
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors)
 "nZL" = (
@@ -33181,21 +33141,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/white,
 /area/science/lab)
-"nZU" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/port)
 "oai" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
@@ -33214,7 +33163,7 @@
 	},
 /area/hallway/primary/fore)
 "oaG" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+/obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -33246,17 +33195,18 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "obL" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/airlock/command{
 	name = "Conference Room";
 	req_access_txt = "19"
@@ -33265,6 +33215,8 @@
 	dir = 1;
 	name = "north facing firelock"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/wood,
 /area/bridge)
 "obR" = (
@@ -33324,7 +33276,6 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
 "odD" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/button/door{
 	id = "robotics";
 	name = "Shutters Control Button";
@@ -33334,6 +33285,12 @@
 /obj/machinery/camera{
 	c_tag = "Robotics Lab  - East";
 	network = list("ss13","rd")
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
@@ -33357,10 +33314,10 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/entry)
 "oeh" = (
@@ -33369,6 +33326,8 @@
 	name = "Robotics Lab";
 	req_access_txt = "29"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
 "oez" = (
@@ -33410,23 +33369,9 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"ofy" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "rdofficesh";
-	name = "research director shutters"
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/heads/hor)
 "ofF" = (
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -33446,15 +33391,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"oge" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/medical/medbay/central)
 "ogM" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
 	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
@@ -33483,7 +33426,7 @@
 /area/teleporter)
 "ohi" = (
 /obj/structure/bookcase/random,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /turf/open/floor/wood,
@@ -33496,19 +33439,19 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
 /obj/structure/window/reinforced{
 	dir = 4
 	},
 /obj/structure/chair{
 	dir = 8
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/hallway/secondary/exit/departure_lounge)
 "oho" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
 	},
 /turf/open/floor/wood,
@@ -33552,10 +33495,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "ohS" = (
@@ -33575,7 +33514,6 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "oiC" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
@@ -33631,9 +33569,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -33647,6 +33582,12 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "ojs" = (
@@ -33674,11 +33615,13 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -33748,12 +33691,14 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/junction/yjunction{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
@@ -33814,12 +33759,10 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 5
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
 "omL" = (
@@ -33878,6 +33821,9 @@
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
@@ -33963,7 +33909,6 @@
 /turf/open/floor/circuit,
 /area/science/server)
 "opC" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/table,
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
@@ -33987,6 +33932,12 @@
 /obj/effect/turf_decal/tile/blue,
 /obj/structure/cable{
 	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
 /area/blueshield)
@@ -34037,9 +33988,6 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
@@ -34049,18 +33997,24 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "oqL" = (
 /obj/structure/closet/secure_closet/security/science,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -34069,8 +34023,11 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
@@ -34080,12 +34037,11 @@
 /turf/open/floor/plating,
 /area/maintenance/central)
 "osc" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "osC" = (
@@ -34094,9 +34050,7 @@
 	},
 /area/maintenance/disposal)
 "osD" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "oto" = (
@@ -34149,9 +34103,6 @@
 /obj/machinery/light_switch{
 	pixel_y = -28
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -34173,10 +34124,13 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -34188,14 +34142,14 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "ouX" = (
 /obj/structure/table/wood,
 /obj/machinery/photocopier/faxmachine/longrange,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
 /turf/open/floor/plasteel/cult,
 /area/lawoffice)
 "ovb" = (
@@ -34275,7 +34229,6 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "owV" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "oxh" = (
@@ -34285,10 +34238,11 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/structure/disposalpipe/junction{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "oxs" = (
@@ -34328,24 +34282,20 @@
 /turf/open/floor/pod/dark,
 /area/maintenance/starboard)
 "oym" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 6
 	},
 /turf/open/floor/wood,
 /area/security/courtroom)
-"oyz" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/circuit,
-/area/science/robotics/mechbay)
 "oyC" = (
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
@@ -34383,6 +34333,8 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/blueshield)
 "oBl" = (
@@ -34460,21 +34412,11 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
 /obj/structure/railing{
 	dir = 8
 	},
 /turf/open/floor/plasteel/stairs/left,
-/area/hallway/primary/port)
-"oDm" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "oDn" = (
 /obj/structure/cable{
@@ -34501,9 +34443,6 @@
 /turf/open/floor/plating,
 /area/maintenance/aft/secondary)
 "oDw" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
@@ -34562,12 +34501,12 @@
 /turf/open/floor/plating,
 /area/chapel/office)
 "oEz" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = -24
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/service)
@@ -34685,10 +34624,6 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/fitness)
 "oJF" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -34700,6 +34635,8 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "oJM" = (
@@ -34753,6 +34690,9 @@
 	c_tag = "Brig Cell Blocks";
 	dir = 1
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "oKG" = (
@@ -34794,10 +34734,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
 "oLK" = (
@@ -34824,21 +34763,17 @@
 	},
 /area/hallway/secondary/exit/departure_lounge)
 "oME" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
-/obj/machinery/light/floor,
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/surface/outdoors)
+/turf/open/floor/wood,
+/area/library)
 "oMJ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/medical/chemistry)
@@ -34856,20 +34791,21 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "oNR" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "oNT" = (
@@ -34890,7 +34826,6 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/holopad,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
@@ -34920,7 +34855,6 @@
 /area/blueshield)
 "oPP" = (
 /obj/structure/table/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/window/eastright{
 	base_state = "left";
 	dir = 1;
@@ -35017,13 +34951,6 @@
 "oTb" = (
 /turf/open/floor/plating,
 /area/hallway/primary/fore)
-"oTu" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
-/area/hallway/primary/port)
 "oTv" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -35043,7 +34970,8 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/medical/genetics)
 "oTT" = (
@@ -35119,6 +35047,9 @@
 	name = "Prison Intercom (General)";
 	pixel_y = -30;
 	prison_radio = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
@@ -35198,9 +35129,6 @@
 /turf/open/floor/wood,
 /area/library)
 "oYn" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -35218,10 +35146,6 @@
 /obj/machinery/holopad,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"oZq" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall,
-/area/medical/surgery)
 "oZC" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger{
@@ -35269,6 +35193,7 @@
 /obj/structure/sign/poster/official/random{
 	pixel_x = 32
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "oZV" = (
@@ -35301,10 +35226,13 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "paY" = (
-/obj/machinery/atmospherics/pipe/simple/supply/visible{
+/obj/structure/disposalpipe/junction{
 	dir = 4
 	},
-/obj/structure/disposalpipe/junction{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
@@ -35342,13 +35270,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"pbk" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
 "pbs" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -35362,7 +35283,6 @@
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
 "pbP" = (
@@ -35382,7 +35302,7 @@
 /turf/open/floor/engine,
 /area/engine/atmospherics_engine)
 "pbV" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/carpet,
@@ -35430,12 +35350,13 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "pdc" = (
@@ -35462,11 +35383,13 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -35560,8 +35483,8 @@
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/structure/chair/office/dark,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/blueshield)
@@ -35625,11 +35548,11 @@
 	},
 /area/maintenance/aft/secondary)
 "phf" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/zone2)
+/turf/open/floor/plating,
+/area/maintenance/central)
 "phg" = (
 /obj/structure/railing/corner{
 	dir = 4
@@ -35696,12 +35619,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
-"pig" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
 "piu" = (
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating,
@@ -35726,8 +35643,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -35805,9 +35725,6 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
 "pjX" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/machinery/door/airlock/maintenance,
 /turf/open/floor/wood,
 /area/security/vacantoffice/a)
@@ -35829,21 +35746,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
-"pkj" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/green/visible{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "pko" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel/yellowsiding{
@@ -35861,6 +35763,8 @@
 	name = "Robotics Lab";
 	req_access_txt = "29"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "pln" = (
@@ -35876,14 +35780,13 @@
 	},
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/security/warden)
 "plP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/structure/bookcase/random/religion,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/obj/structure/bookcase/random/religion,
 /turf/open/floor/wood,
 /area/library)
 "pmE" = (
@@ -35897,9 +35800,6 @@
 /turf/open/floor/wood,
 /area/security/courtroom)
 "pmK" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -35920,9 +35820,6 @@
 "pnu" = (
 /obj/machinery/light{
 	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/education)
@@ -35973,19 +35870,19 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
 "poR" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "poT" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/freezer,
 /area/medical/surgery)
 "poU" = (
@@ -36038,10 +35935,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "pqs" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/visible,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
 "pqL" = (
@@ -36065,10 +35962,10 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "pqX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
 "prf" = (
@@ -36091,15 +35988,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"prP" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
 "pss" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -36276,9 +36164,6 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "puY" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/arrows/red{
 	dir = 4
 	},
@@ -36287,6 +36172,12 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -36314,19 +36205,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"pvl" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "pvr" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/landmark/start/cargo_technician,
@@ -36370,7 +36248,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "pwo" = (
@@ -36442,9 +36320,14 @@
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/miningdock)
 "pxE" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
@@ -36485,22 +36368,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"pxZ" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
 "pyw" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -36521,8 +36388,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "pyI" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/wood,
 /area/library)
@@ -36657,7 +36527,6 @@
 /obj/effect/turf_decal/plaque{
 	icon_state = "L5"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -36824,7 +36693,7 @@
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "pED" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel/freezer,
@@ -36839,9 +36708,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "pEK" = (
@@ -36855,10 +36721,11 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "pFf" = (
@@ -36961,11 +36828,12 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "pIf" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
 "pIm" = (
@@ -36981,16 +36849,13 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "pIz" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
 /obj/structure/table/wood,
 /obj/item/storage/fancy/donut_box,
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/carpet,
 /area/bridge/meeting_room)
 "pIE" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -36998,9 +36863,6 @@
 "pIH" = (
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
@@ -37053,7 +36915,6 @@
 	plane = -4;
 	req_access_txt = "5"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/window/reinforced{
 	dir = 8
 	},
@@ -37064,8 +36925,11 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "pKF" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
@@ -37104,9 +36968,6 @@
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors)
 "pLP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/turnstile{
 	dir = 8;
 	name = "Genpop Exit Turnstile";
@@ -37121,6 +36982,12 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -37166,9 +37033,6 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "pMU" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
 /obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -37186,6 +37050,7 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel/dark,
 /area/security/warden)
 "pNh" = (
@@ -37239,9 +37104,11 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
 "pNU" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -37250,9 +37117,6 @@
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "pOg" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/table/wood,
 /obj/item/paper_bin,
 /obj/item/pen{
@@ -37284,11 +37148,14 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/medical/medbay/central)
@@ -37348,7 +37215,10 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -37486,14 +37356,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "pVz" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/door/poddoor/preopen{
-	id = "lawyer_blast";
-	name = "privacy door"
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/lawoffice)
+/turf/open/floor/wood,
+/area/security/vacantoffice/a)
 "pVM" = (
 /obj/effect/decal/cleanable/cobweb{
 	icon_state = "cobweb2"
@@ -37546,9 +37413,6 @@
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -37623,9 +37487,6 @@
 /turf/open/floor/carpet,
 /area/bridge/meeting_room)
 "pYh" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
@@ -37639,7 +37500,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
 /turf/open/floor/plasteel/checker,
@@ -37674,19 +37535,6 @@
 "pZD" = (
 /turf/closed/wall/r_wall,
 /area/medical/virology)
-"pZJ" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/white,
-/area/medical/genetics)
 "qal" = (
 /obj/structure/chair,
 /obj/structure/extinguisher_cabinet{
@@ -37740,9 +37588,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "qbr" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/machinery/computer/security{
 	dir = 8
 	},
@@ -37802,9 +37647,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -37818,10 +37660,11 @@
 /obj/machinery/door/airlock/public{
 	name = "Permabrig Dorm 2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/firedoor/border_only{
 	name = "south facing firelock"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "qel" = (
@@ -37907,6 +37750,8 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "qfB" = (
@@ -37990,9 +37835,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
@@ -38001,6 +37843,12 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
@@ -38020,7 +37868,8 @@
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/medical/virology)
 "qiF" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "qiZ" = (
@@ -38127,7 +37976,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -38289,15 +38141,18 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "qpF" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/arrows/red{
 	dir = 4
 	},
 /obj/machinery/airalarm{
 	dir = 1;
 	pixel_y = -22
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -38384,7 +38239,6 @@
 	name = "Teleporter APC";
 	pixel_y = -24
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
 /area/teleporter)
 "qrA" = (
@@ -38499,22 +38353,11 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/paramedic)
-"quj" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/structure/sign/departments/medbay{
-	pixel_x = 32
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/port)
 "qur" = (
 /turf/open/floor/plating,
 /area/quartermaster/storage)
 "quE" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -38616,9 +38459,6 @@
 	dir = 8;
 	name = "west facing firelock"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -38629,6 +38469,12 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "qxT" = (
@@ -38668,10 +38514,10 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/carpet,
 /area/hallway/secondary/exit/departure_lounge)
 "qzz" = (
@@ -38705,9 +38551,10 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "qAi" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
+/obj/structure/lattice/catwalk,
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors)
 "qAo" = (
@@ -38738,10 +38585,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/junction/flip{
 	dir = 4
 	},
@@ -38754,9 +38597,6 @@
 "qBb" = (
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
 	},
 /obj/effect/landmark/start/security_officer,
 /obj/structure/disposalpipe/segment{
@@ -38810,9 +38650,11 @@
 	},
 /area/chapel/office)
 "qCa" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall,
-/area/hallway/secondary/entry)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/security/vacantoffice/a)
 "qCo" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -38877,16 +38719,6 @@
 	},
 /turf/closed/wall,
 /area/maintenance/disposal)
-"qDO" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/ai_upload_foyer)
 "qDY" = (
 /obj/structure/fence/post,
 /obj/structure/cable{
@@ -38931,7 +38763,7 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
@@ -38970,16 +38802,21 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
 /area/hallway/primary/port)
 "qGn" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
 "qGL" = (
@@ -39002,6 +38839,12 @@
 	},
 /obj/structure/cable{
 	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
@@ -39119,12 +38962,12 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
 "qJM" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
 /obj/machinery/iv_drip,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/medical/medbay/central)
 "qJU" = (
@@ -39201,9 +39044,6 @@
 	},
 /area/chapel/office)
 "qLm" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/door/poddoor/shutters{
 	id = "Skynet_launch2";
 	name = "mech bay"
@@ -39267,7 +39107,6 @@
 /turf/open/floor/carpet,
 /area/library)
 "qNz" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -39286,7 +39125,8 @@
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hos)
 "qOb" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/wood,
 /area/security/vacantoffice/a)
 "qOr" = (
@@ -39308,7 +39148,6 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/machinery/power/apc{
 	areastring = "/area/medical/genetics";
 	dir = 8;
@@ -39319,6 +39158,8 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "qOJ" = (
@@ -39347,9 +39188,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 4;
 	name = "east facing firelock"
@@ -39367,9 +39205,6 @@
 "qQt" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -39462,13 +39297,14 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "qSP" = (
@@ -39501,6 +39337,7 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "qTb" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
 "qTo" = (
@@ -39516,9 +39353,6 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -39544,11 +39378,14 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/pool)
 "qTO" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -39570,9 +39407,6 @@
 	name = "Chemistry Desk";
 	req_access_txt = "5; 33"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "chemshu";
 	name = "chem shutters"
@@ -39586,6 +39420,8 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
 /area/hallway/primary/port)
 "qUF" = (
@@ -39603,16 +39439,16 @@
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "qUY" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
+/obj/structure/flora/ausbushes/reedbush,
+/turf/open/floor/grass,
+/area/hallway/primary/central)
 "qVf" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -39630,8 +39466,11 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/medical/chemistry)
@@ -39763,13 +39602,16 @@
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "qZs" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
 /obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -39871,10 +39713,13 @@
 /turf/open/floor/circuit/telecomms/server,
 /area/science/server)
 "rbo" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -39975,7 +39820,6 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/blueshield)
 "rem" = (
@@ -39995,9 +39839,6 @@
 /turf/open/floor/plating,
 /area/crew_quarters/heads/chief)
 "reS" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/plaque{
 	icon_state = "L6"
 	},
@@ -40007,6 +39848,12 @@
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=CHE";
 	location = "AIE"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -40052,7 +39899,7 @@
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors)
 "rgh" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
 	},
 /turf/open/floor/wood,
@@ -40075,11 +39922,11 @@
 /turf/open/floor/plasteel/grimy,
 /area/chapel/main)
 "rgH" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/components/binary/pump/on/layer3{
 	dir = 4;
 	name = "External to Filter"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/visible,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/maintenance/department/electrical)
 "rhg" = (
@@ -40118,9 +39965,6 @@
 	name = "Morgue Maintenance";
 	req_access_txt = "6;5"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /turf/open/floor/plating,
 /area/medical/morgue)
 "riC" = (
@@ -40157,7 +40001,12 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "rjO" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/medical/genetics)
 "rjP" = (
@@ -40197,11 +40046,11 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 5
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 5
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/hallway/primary/port)
@@ -40233,9 +40082,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/machinery/camera{
 	c_tag = "Southeastern Hall 2"
 	},
@@ -40266,7 +40112,6 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/zone3)
 "rlG" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/sign/nanotrasen,
 /turf/closed/wall,
 /area/security/prison)
@@ -40328,7 +40173,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
 	},
@@ -40493,9 +40337,6 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
@@ -40574,9 +40415,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "rrd" = (
@@ -40593,22 +40431,17 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
 "rsp" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"rsy" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/medical/medbay/central)
 "rsD" = (
 /obj/structure/table/wood,
 /obj/structure/bedsheetbin/towel,
@@ -40637,20 +40470,6 @@
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
 /area/maintenance/aft/secondary)
-"rti" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "rtm" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -40787,9 +40606,17 @@
 /turf/open/floor/plasteel/grimy,
 /area/chapel/main)
 "rwR" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/hydroponics/garden)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/tree/jungle/small,
+/turf/open/floor/grass,
+/area/hallway/primary/central)
 "rwW" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 5
@@ -40863,17 +40690,12 @@
 /turf/open/floor/plasteel/dark,
 /area/blueshield)
 "ryE" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
+/obj/structure/window/reinforced,
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/grass,
+/area/maintenance/aft/secondary)
 "rAa" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/disposal/bin,
 /turf/open/floor/plasteel/white,
@@ -40904,15 +40726,15 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "rAw" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/security/brig)
 "rAW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
@@ -40926,8 +40748,11 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
 "rBc" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
@@ -40945,9 +40770,6 @@
 "rBG" = (
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -40987,14 +40809,6 @@
 /obj/structure/rack,
 /turf/open/floor/plating,
 /area/hallway/primary/fore)
-"rDt" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/light,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "rDv" = (
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/disposal/bin,
@@ -41025,13 +40839,14 @@
 /area/maintenance/bar)
 "rEx" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
 "rFk" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/freezer,
 /area/medical/surgery)
 "rFn" = (
@@ -41095,9 +40910,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "rGP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/turnstile{
 	dir = 8;
 	name = "Genpop Exit Turnstile";
@@ -41112,6 +40924,12 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -41166,9 +40984,6 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "rIB" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
 /obj/effect/landmark/event_spawn,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -41180,14 +40995,17 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/machinery/light{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
@@ -41214,18 +41032,6 @@
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
-"rJw" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/port)
 "rJM" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -41246,9 +41052,6 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/hallway/secondary/exit/departure_lounge)
 "rJQ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
 /obj/machinery/button/door{
 	id = "rnd3";
 	name = "Lab Shutters Button";
@@ -41292,9 +41095,8 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "rLb" = (
@@ -41308,7 +41110,8 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "rLk" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/carpet,
 /area/bridge)
 "rLU" = (
@@ -41335,21 +41138,24 @@
 /turf/open/floor/plasteel/dark,
 /area/teleporter)
 "rMS" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "rNM" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "rNP" = (
@@ -41387,10 +41193,13 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
 	},
-/obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "rOD" = (
@@ -41408,7 +41217,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/camera{
 	c_tag = "Northwestern Hall 8";
 	dir = 4
@@ -41436,15 +41244,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
-"rQz" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
 "rQG" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/spawner/lootdrop/organ_spawner,
@@ -41478,9 +41277,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
@@ -41491,7 +41287,10 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "rRk" = (
@@ -41519,14 +41318,10 @@
 /turf/open/floor/plating,
 /area/hallway/primary/port)
 "rRV" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
 "rSn" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
@@ -41563,13 +41358,9 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "rTt" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/computer/operating{
 	dir = 8
 	},
@@ -41603,7 +41394,9 @@
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/effect/decal/cleanable/cobweb,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
 /turf/open/floor/plating,
 /area/maintenance/aft/secondary)
 "rTW" = (
@@ -41646,6 +41439,12 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
+	},
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
 "rVg" = (
@@ -41658,13 +41457,13 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "rVA" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
 "rVB" = (
@@ -41718,7 +41517,6 @@
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
 "rYD" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -41730,10 +41528,11 @@
 	},
 /area/chapel/main)
 "rYN" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/wood,
 /area/security/vacantoffice/a)
 "rYQ" = (
@@ -41957,9 +41756,6 @@
 /turf/open/floor/carpet/purple,
 /area/library)
 "seZ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -42087,8 +41883,11 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
@@ -42097,11 +41896,14 @@
 /turf/open/floor/plasteel/grimy,
 /area/chapel/main)
 "sjk" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
+/obj/structure/window/reinforced,
+/obj/structure/flora/tree/jungle/small{
+	pixel_x = -48;
+	pixel_y = 8
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/obj/structure/flora/ausbushes/grassybush,
+/turf/open/floor/grass,
+/area/maintenance/aft/secondary)
 "sjB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 9
@@ -42128,9 +41930,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "sjW" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
@@ -42157,9 +41956,8 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
 "skB" = (
@@ -42264,9 +42062,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/machinery/door/airlock/research{
 	name = "Mech Bay";
 	req_access_txt = "29"
@@ -42344,7 +42139,6 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "snb" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/computer/card,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
@@ -42364,9 +42158,6 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "soN" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
@@ -42405,7 +42196,8 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/supply,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "spV" = (
@@ -42479,7 +42271,6 @@
 	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "srB" = (
@@ -42489,11 +42280,9 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
 "srJ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/hallway/secondary/exit/departure_lounge)
+/obj/machinery/door/airlock/maintenance/abandoned,
+/turf/closed/wall,
+/area/maintenance/aft/secondary)
 "srL" = (
 /obj/machinery/airalarm{
 	dir = 1;
@@ -42601,9 +42390,6 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "sve" = (
@@ -42673,6 +42459,8 @@
 	name = "Medbay RC";
 	pixel_x = 30
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "sxb" = (
@@ -42719,14 +42507,25 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "sxN" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
-/area/hallway/primary/port)
+/area/hallway/primary/central)
 "syd" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/turf/open/floor/wood,
-/area/security/vacantoffice/a)
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "syz" = (
 /obj/machinery/airalarm{
 	dir = 1;
@@ -42738,7 +42537,6 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "syN" = (
@@ -42829,7 +42627,7 @@
 /turf/open/floor/plasteel/dark,
 /area/hydroponics)
 "sAw" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -42859,8 +42657,11 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
@@ -42975,7 +42776,10 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -42984,9 +42788,6 @@
 /turf/closed/wall,
 /area/medical/medbay/zone3)
 "sFh" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -43000,11 +42801,14 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "sFp" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
 	},
-/turf/closed/wall/r_wall,
-/area/crew_quarters/heads/captain)
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "sGC" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/effect/turf_decal/stripes/line,
@@ -43155,6 +42959,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "sKh" = (
@@ -43224,10 +43034,14 @@
 /turf/open/floor/plasteel/dark,
 /area/teleporter)
 "sLv" = (
-/obj/machinery/atmospherics/pipe/simple/supply/visible,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/surface/outdoors)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "sLN" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel,
@@ -43236,13 +43050,13 @@
 /turf/open/floor/engine,
 /area/engine/atmospherics_engine)
 "sMi" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -43267,7 +43081,8 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/teleporter)
 "sNb" = (
@@ -43319,9 +43134,6 @@
 	name = "south facing firelock"
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /obj/structure/cable{
@@ -43425,8 +43237,8 @@
 	},
 /area/hallway/primary/port)
 "sRh" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -43492,20 +43304,13 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -24
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "sTe" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/airlock/medical{
 	name = "Operating Theatre";
 	req_access_txt = "45"
@@ -43517,6 +43322,8 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/freezer,
 /area/medical/medbay/central)
 "sTq" = (
@@ -43561,7 +43368,10 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -43583,10 +43393,16 @@
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "sUX" = (
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/structure/rack,
-/turf/open/floor/plating,
-/area/maintenance/aft/secondary)
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/biolumi/mine/weaklight,
+/turf/open/floor/grass,
+/area/hallway/primary/central)
 "sVh" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
@@ -43638,9 +43454,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/machinery/door/airlock/security{
 	name = "Brig";
 	req_access_txt = "63; 42"
@@ -43648,6 +43461,12 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4;
 	name = "east facing firelock"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/wood,
 /area/security/brig)
@@ -43828,9 +43647,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "tcq" = (
@@ -43899,13 +43715,15 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "tcW" = (
@@ -43952,10 +43770,10 @@
 /turf/open/floor/plasteel/checker,
 /area/security/prison)
 "tey" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/closed/wall/mineral/wood,
 /area/icemoon/surface/outdoors)
 "teB" = (
@@ -43965,9 +43783,6 @@
 /turf/open/floor/wood,
 /area/chapel/main)
 "teC" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
 	},
@@ -43980,6 +43795,12 @@
 	name = "east facing firelock"
 	},
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -44047,13 +43868,13 @@
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "tfY" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
 /obj/structure/table,
 /obj/structure/bedsheetbin/towel,
 /obj/structure/sign/poster/official/random{
 	pixel_x = 32
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
@@ -44077,12 +43898,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"thy" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/hallway/secondary/exit/departure_lounge)
 "thD" = (
 /obj/machinery/light{
 	dir = 1
@@ -44093,9 +43908,6 @@
 /turf/closed/wall,
 /area/security/brig)
 "thV" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/mineral/ore_redemption{
 	input_dir = 4;
 	output_dir = 8
@@ -44153,20 +43965,7 @@
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
-"tkr" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/port)
 "tkG" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/airlock/command{
 	name = "Captain's Quarters";
 	req_access_txt = "20"
@@ -44174,6 +43973,8 @@
 /obj/machinery/door/firedoor/border_only{
 	name = "south facing firelock"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain)
 "tkH" = (
@@ -44183,7 +43984,6 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/machinery/light{
 	dir = 1
 	},
@@ -44193,7 +43993,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "tlg" = (
@@ -44217,10 +44022,13 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -44258,10 +44066,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"tmx" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/white,
-/area/science/lab)
 "tmy" = (
 /obj/machinery/sleeper{
 	dir = 8
@@ -44277,14 +44081,6 @@
 "tmO" = (
 /turf/closed/wall,
 /area/hallway/primary/port)
-"tmU" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "tnd" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/closed/wall,
@@ -44387,15 +44183,16 @@
 /turf/open/floor/engine,
 /area/engine/atmospherics_engine)
 "toP" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	desc = "Privacy shutters for the Private Study. Stops people spying in on your game.";
-	id = "PrivateStudy1";
-	name = "Privacy Shutters"
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/library)
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/stalkybush,
+/turf/open/floor/grass,
+/area/hallway/primary/central)
 "tpf" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -44423,6 +44220,8 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/blueshield)
 "tpD" = (
@@ -44446,11 +44245,14 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/landmark/event_spawn,
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -44459,16 +44261,12 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 6
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
 "tqp" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
@@ -44529,14 +44327,17 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "trO" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -44568,7 +44369,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/item/paper_bin,
 /obj/item/pen,
 /turf/open/floor/plasteel/white,
@@ -44688,7 +44488,10 @@
 /turf/open/floor/wood,
 /area/maintenance/bar)
 "twZ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
@@ -44703,6 +44506,7 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "txt" = (
@@ -44743,9 +44547,8 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "tys" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "tyF" = (
@@ -44842,9 +44645,6 @@
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
 	},
 /obj/machinery/newscaster/security_unit{
 	pixel_y = 32
@@ -44947,7 +44747,6 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/blueshield)
 "tDC" = (
@@ -45001,9 +44800,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
 /obj/machinery/light/floor,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -45030,7 +44826,6 @@
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "tGc" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -45094,15 +44889,17 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -45123,8 +44920,13 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/carpet,
 /area/hallway/secondary/exit/departure_lounge)
 "tJJ" = (
@@ -45179,12 +44981,15 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
 "tLA" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/button/flasher{
 	id = "PCell 1";
 	pixel_y = -24
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -45242,7 +45047,6 @@
 /turf/open/floor/plasteel/dark,
 /area/security/warden)
 "tLV" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -45252,6 +45056,8 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "tMk" = (
@@ -45390,7 +45196,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "tPP" = (
@@ -45556,7 +45362,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/airlock/security{
 	name = "Detective's Office";
 	req_access_txt = "4"
@@ -45564,6 +45369,8 @@
 /obj/machinery/door/firedoor/border_only{
 	name = "south facing firelock"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
 /area/security/detectives_office)
 "tUi" = (
@@ -45635,7 +45442,6 @@
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
 "tVV" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/sorting/mail/flip{
 	sortType = 27
 	},
@@ -45645,6 +45451,12 @@
 /obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable{
 	icon_state = "0-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -45672,14 +45484,17 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/paramedic)
 "tWj" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
+/obj/machinery/door/firedoor/border_only{
+	dir = 8;
+	name = "west facing firelock"
 	},
 /turf/open/floor/plasteel,
-/area/science/robotics/mechbay)
+/area/hallway/primary/central)
 "tWx" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "tXj" = (
@@ -45690,8 +45505,11 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "tXn" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -45787,9 +45605,6 @@
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "uah" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -45829,13 +45644,17 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain)
 "uaA" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 1;
-	name = "north facing firelock"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "uaC" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -45876,12 +45695,10 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
 "uba" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
 /obj/machinery/iv_drip,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel,
 /area/medical/medbay/central)
 "ubd" = (
@@ -45930,13 +45747,14 @@
 /obj/item/reagent_containers/food/drinks/bottle/vodka/badminka,
 /obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
 /obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
-/obj/item/clothing/head/bearpelt,
 /obj/machinery/power/apc{
 	areastring = "/area/ai_monitored/nuke_storage";
 	name = "Vault APC";
 	pixel_y = -25
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
 "udd" = (
@@ -45970,7 +45788,10 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -45979,14 +45800,16 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "udO" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
@@ -46081,8 +45904,8 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
@@ -46111,12 +45934,15 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 4;
 	name = "east facing firelock"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
@@ -46126,6 +45952,7 @@
 	},
 /obj/vehicle/ridden/atv/snowmobile,
 /obj/item/key,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "uhN" = (
@@ -46179,7 +46006,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
 "ukv" = (
@@ -46324,10 +46151,16 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "uoc" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/wood,
@@ -46404,11 +46237,11 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "urV" = (
-/obj/machinery/atmospherics/pipe/simple/supply/visible,
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 8;
 	sortType = 24
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/icemoon/surface/outdoors)
 "usn" = (
@@ -46447,8 +46280,11 @@
 /turf/open/floor/plating,
 /area/hallway/primary/fore)
 "utj" = (
-/obj/machinery/atmospherics/pipe/manifold4w/supply/visible,
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
@@ -46470,14 +46306,17 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "uup" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plating,
 /area/storage/atmos)
 "uuu" = (
@@ -46486,10 +46325,12 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "uuD" = (
@@ -46501,10 +46342,9 @@
 	},
 /obj/structure/bed/roller,
 /obj/machinery/iv_drip,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "uvB" = (
@@ -46520,9 +46360,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -46536,7 +46373,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "uwn" = (
@@ -46646,11 +46488,14 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
@@ -46665,16 +46510,20 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "uAs" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/wood,
 /area/bridge/meeting_room)
 "uAu" = (
@@ -46695,8 +46544,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
@@ -46716,7 +46566,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/department/electrical)
 "uBi" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -46725,7 +46575,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -46734,7 +46583,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "uCi" = (
@@ -46742,11 +46590,12 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "uCo" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/effect/turf_decal/lumos/loading_area/white,
 /obj/structure/railing/corner{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "uCr" = (
@@ -46754,9 +46603,6 @@
 /turf/open/floor/plating,
 /area/maintenance/bar)
 "uCE" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
@@ -46768,12 +46614,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/teleporter)
-"uDO" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
 "uEd" = (
 /obj/effect/turf_decal/tile/red,
 /obj/machinery/space_heater,
@@ -46839,7 +46679,6 @@
 /turf/open/floor/wood,
 /area/chapel/main)
 "uGl" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/closet/secure_closet/engineering_personal,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -46886,9 +46725,6 @@
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
 "uIs" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/wood,
 /area/hallway/secondary/exit/departure_lounge)
@@ -46938,9 +46774,17 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "uJe" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/turf/open/floor/wood,
-/area/security/vacantoffice/a)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "uJx" = (
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
@@ -47077,6 +46921,7 @@
 /obj/structure/chair/comfy/black{
 	dir = 4
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/wood,
 /area/bridge/meeting_room)
 "uLk" = (
@@ -47163,7 +47008,6 @@
 	},
 /area/chapel/main)
 "uOT" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -47176,6 +47020,8 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "uPa" = (
@@ -47207,7 +47053,6 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
@@ -47245,8 +47090,11 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/zone2)
@@ -47460,10 +47308,13 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
 "uWS" = (
-/obj/machinery/atmospherics/pipe/simple/supply/visible{
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
 	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
@@ -47491,16 +47342,25 @@
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "uXi" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel/checker,
@@ -47538,6 +47398,12 @@
 /area/ai_monitored/turret_protected/ai)
 "uXB" = (
 /obj/structure/disposalpipe/junction{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -47588,7 +47454,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
@@ -47641,9 +47506,6 @@
 "uZd" = (
 /obj/structure/cable{
 	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -47719,7 +47581,6 @@
 /obj/structure/chair/office/light{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "vaB" = (
@@ -47803,9 +47664,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -47831,17 +47689,17 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "vdw" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/circuit,
 /area/science/robotics/mechbay)
 "vdQ" = (
 /obj/machinery/door/airlock/public{
 	name = "Permabrig Dorm 1"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/firedoor/border_only{
 	name = "south facing firelock"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "vdW" = (
@@ -47959,6 +47817,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/security/courtroom)
 "vgm" = (
@@ -48024,12 +47885,17 @@
 /turf/open/floor/plating,
 /area/security/checkpoint/supply)
 "vhO" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -48050,7 +47916,7 @@
 /turf/open/floor/plating,
 /area/icemoon/surface/outdoors)
 "viF" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -48145,9 +48011,6 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "vkW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/chair/comfy/brown{
 	dir = 4
 	},
@@ -48176,10 +48039,11 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "vlz" = (
@@ -48283,15 +48147,15 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "vor" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/construction/storage)
 "voD" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/item/radio/intercom{
 	pixel_x = 25
 	},
@@ -48319,7 +48183,6 @@
 	},
 /area/chapel/office)
 "vpz" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/airlock/public/glass{
 	name = "Security Lobby"
 	},
@@ -48338,7 +48201,10 @@
 	id = "PCell 1";
 	pixel_y = -25
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -48370,18 +48236,11 @@
 	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "vqP" = (
 /obj/structure/cable{
 	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/lumos/loading_area/white,
@@ -48520,14 +48379,10 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/entry)
 "vsM" = (
-/obj/machinery/atmospherics/pipe/simple/supply/visible,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
 "vsN" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -48544,15 +48399,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
-"vun" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "vuJ" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -26
@@ -48570,9 +48416,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "vvH" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
 /obj/effect/landmark/start/medical_doctor,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
@@ -48594,7 +48437,7 @@
 	},
 /area/maintenance/disposal)
 "vwq" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
 	},
 /turf/open/floor/carpet,
@@ -48621,9 +48464,6 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "vwW" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/table/wood,
 /obj/item/folder/blue,
 /obj/item/folder/blue,
@@ -48663,6 +48503,12 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4;
 	name = "east facing firelock"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/wood,
 /area/library)
@@ -48714,6 +48560,9 @@
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
+	},
+/obj/item/kirbyplants{
+	icon_state = "applebush"
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
@@ -48775,9 +48624,6 @@
 /area/library)
 "vzn" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "vzR" = (
@@ -48795,7 +48641,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/chair{
 	dir = 8
 	},
@@ -48880,7 +48725,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/airlock/command{
 	name = "Conference Room";
 	req_access_txt = "19"
@@ -49013,6 +48857,9 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "vEm" = (
@@ -49038,13 +48885,15 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "vEA" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -49057,6 +48906,8 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "vEG" = (
@@ -49093,8 +48944,9 @@
 /area/medical/paramedic)
 "vFe" = (
 /obj/item/beacon,
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/computer)
 "vFM" = (
@@ -49134,10 +48986,11 @@
 /area/maintenance/aft/secondary)
 "vHU" = (
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "vIf" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
 	},
 /turf/open/floor/plasteel/cafeteria,
@@ -49150,9 +49003,6 @@
 /turf/open/floor/wood,
 /area/hallway/primary/central)
 "vIA" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
@@ -49162,8 +49012,11 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
@@ -49180,6 +49033,12 @@
 /area/hallway/primary/aft)
 "vJG" = (
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -49255,9 +49114,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -49271,13 +49127,18 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
 "vLr" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light{
 	dir = 8
@@ -49331,10 +49192,6 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -49348,11 +49205,14 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
@@ -49365,9 +49225,6 @@
 "vMB" = (
 /obj/structure/cable{
 	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
 	},
 /turf/open/floor/plasteel/white/side,
 /area/hallway/primary/port)
@@ -49397,12 +49254,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
-"vNY" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "vOo" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -49415,6 +49266,8 @@
 	name = "Theatre Backstage";
 	req_access_txt = "46"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
 "vOB" = (
@@ -49466,7 +49319,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "vQd" = (
@@ -49499,7 +49352,6 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
 "vRa" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = "GeneticsDoor";
 	name = "Genetics";
@@ -49515,6 +49367,8 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/white/side,
 /area/medical/genetics)
 "vRc" = (
@@ -49534,9 +49388,6 @@
 /turf/open/floor/plasteel/cult,
 /area/library)
 "vRZ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/education)
 "vSb" = (
@@ -49571,8 +49422,11 @@
 	},
 /obj/machinery/holopad,
 /obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -49606,7 +49460,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "vSX" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/wood,
 /area/hallway/primary/central)
 "vTh" = (
@@ -49760,9 +49614,6 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
 "vWf" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -49827,6 +49678,12 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white/side{
 	dir = 4
 	},
@@ -49848,7 +49705,10 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -49943,7 +49803,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -49982,10 +49841,13 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "wbe" = (
@@ -50053,7 +49915,6 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "wbO" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -50061,12 +49922,11 @@
 	dir = 1
 	},
 /obj/structure/railing/corner,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "wck" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
 /obj/structure/table/wood,
 /obj/item/camera,
 /obj/item/storage/photo_album{
@@ -50080,18 +49940,6 @@
 /obj/item/restraints/handcuffs,
 /turf/open/floor/plasteel/dark,
 /area/security/main)
-"wcy" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	name = "east facing firelock"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8;
-	name = "west facing firelock"
-	},
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/turf/open/floor/plating,
-/area/engine/engineering)
 "wcB" = (
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
@@ -50111,14 +49959,13 @@
 /area/science/explab)
 "wdk" = (
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/carpet,
 /area/hallway/secondary/exit/departure_lounge)
 "wdt" = (
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -50130,6 +49977,10 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "wdu" = (
@@ -50203,11 +50054,14 @@
 /turf/open/floor/plating,
 /area/hallway/primary/central)
 "wgu" = (
-/obj/machinery/atmospherics/pipe/simple/supply/visible{
-	dir = 4
-	},
 /obj/machinery/light/floor,
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
@@ -50263,12 +50117,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"wix" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/science/robotics/lab)
 "wje" = (
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
@@ -50283,9 +50131,6 @@
 "wjn" = (
 /obj/machinery/firealarm{
 	pixel_y = 24
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/education)
@@ -50359,10 +50204,6 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
-"wkM" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
 "wkS" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -50411,9 +50252,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -50441,10 +50279,6 @@
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
-"wmf" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/turf/open/floor/plasteel/dark,
-/area/teleporter)
 "wmr" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -50485,8 +50319,8 @@
 /turf/closed/indestructible/rock/glacierrock/blue,
 /area/engine/atmos)
 "wmG" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
@@ -50494,15 +50328,18 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/door/airlock/public/glass{
 	name = "Auxiliary Tool Storage";
 	req_access_txt = "12"
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/storage/auxiliary)
@@ -50514,12 +50351,12 @@
 /turf/open/floor/plasteel/dark,
 /area/teleporter)
 "wnO" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "wnX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/visible,
 /obj/structure/mineral_door/woodrustic,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/icemoon/surface/outdoors)
 "won" = (
@@ -50543,7 +50380,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
@@ -50551,22 +50387,23 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
 "wph" = (
 /obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/computer)
-"wpO" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall,
-/area/security/prison)
 "wqd" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -50665,9 +50502,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -50715,9 +50549,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
 "wut" = (
@@ -50849,7 +50680,7 @@
 /turf/open/floor/plating,
 /area/hallway/primary/fore)
 "wwx" = (
-/obj/machinery/atmospherics/pipe/simple/supply/visible,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/closed/wall/mineral/wood,
 /area/icemoon/surface/outdoors)
 "wwC" = (
@@ -50867,11 +50698,11 @@
 /turf/open/floor/wood,
 /area/maintenance/bar)
 "wxf" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 6
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
 	},
 /turf/open/floor/plating,
 /area/icemoon/surface/outdoors)
@@ -50942,9 +50773,6 @@
 "wzH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
@@ -51028,9 +50856,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/door/airlock/atmos/abandoned{
 	name = "Atmospherics Maintenance";
 	req_access_txt = "12;24"
@@ -51038,6 +50863,9 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8;
 	name = "west facing firelock"
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/storage/atmos)
@@ -51118,9 +50946,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "wFB" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -51137,6 +50962,8 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "wFD" = (
@@ -51148,22 +50975,12 @@
 /turf/open/floor/plating,
 /area/engine/storage)
 "wFR" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/blue,
-/turf/open/floor/plasteel/white,
-/area/medical/storage)
-"wFU" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 9
 	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/carpet,
-/area/hallway/secondary/exit/departure_lounge)
+/turf/open/floor/plasteel/white,
+/area/medical/storage)
 "wFY" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -51208,10 +51025,11 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "wGD" = (
@@ -51221,16 +51039,6 @@
 	},
 /turf/open/floor/wood,
 /area/maintenance/bar)
-"wHB" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "wHM" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -51248,7 +51056,7 @@
 /turf/open/floor/grass,
 /area/hallway/primary/aft)
 "wHX" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/wood,
@@ -51281,11 +51089,6 @@
 	},
 /turf/open/floor/carpet/orange,
 /area/engine/secure_construction)
-"wJb" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plating,
-/area/hydroponics/garden)
 "wJf" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -51304,18 +51107,8 @@
 /obj/machinery/computer/arcade{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
-"wJH" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "robotics";
-	name = "robotics lab shutters"
-	},
-/turf/open/floor/plating,
-/area/science/robotics/lab)
 "wJN" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -51383,13 +51176,8 @@
 	dir = 4
 	},
 /area/chapel/main)
-"wLs" = (
-/obj/structure/sign/departments/medbay/alt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/closed/wall,
-/area/medical/medbay/central)
 "wLG" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/closed/wall/mineral/wood,
 /area/icemoon/surface/outdoors)
 "wLI" = (
@@ -51411,8 +51199,8 @@
 /area/hallway/primary/central)
 "wMp" = (
 /obj/machinery/door/airlock/maintenance,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
@@ -51475,8 +51263,11 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 10
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
@@ -51487,7 +51278,6 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -51567,11 +51357,14 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
@@ -51611,7 +51404,6 @@
 /obj/effect/turf_decal/arrows/red{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "wSc" = (
@@ -51637,7 +51429,6 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "wSA" = (
@@ -51732,8 +51523,8 @@
 /turf/closed/wall/r_wall,
 /area/engine/engineering)
 "wVP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/displaycase/trophy,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/wood,
 /area/library)
 "wWd" = (
@@ -51749,7 +51540,6 @@
 	pixel_x = -2;
 	pixel_y = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "wWl" = (
@@ -51808,9 +51598,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "wXk" = (
@@ -51837,10 +51624,6 @@
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
-"wYe" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/dark,
-/area/science/robotics/lab)
 "wYk" = (
 /obj/machinery/vending/snack/random,
 /turf/open/floor/plasteel,
@@ -51850,9 +51633,6 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "wZl" = (
@@ -51860,7 +51640,6 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "wZm" = (
@@ -52033,22 +51812,22 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "xdr" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
 /obj/structure/table/wood,
 /obj/item/paper_bin{
 	pixel_x = -3;
 	pixel_y = 7
 	},
 /obj/item/pen/fountain,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
+	},
 /turf/open/floor/carpet/black,
 /area/crew_quarters/heads/hos)
 "xdD" = (
@@ -52228,6 +52007,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "xhH" = (
@@ -52313,10 +52094,6 @@
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/hallway/primary/aft)
-"xkf" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/closed/wall/r_wall,
-/area/science/explab)
 "xkR" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/effect/turf_decal/tile/green{
@@ -52329,10 +52106,11 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "xkT" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
 /area/maintenance/central)
 "xkW" = (
@@ -52397,10 +52175,11 @@
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
 "xmB" = (
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /obj/effect/turf_decal/plaque{
 	icon_state = "L4"
 	},
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "xmP" = (
@@ -52427,10 +52206,13 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
 "xnq" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
 	},
-/obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "xnD" = (
@@ -52444,9 +52226,6 @@
 /turf/open/floor/plating,
 /area/quartermaster/miningdock)
 "xok" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/railing/corner{
 	dir = 1
 	},
@@ -52576,11 +52355,14 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
@@ -52638,9 +52420,6 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 9
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
@@ -52670,6 +52449,8 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/white/side{
 	dir = 1
 	},
@@ -52680,7 +52461,7 @@
 /area/medical/medbay/zone3)
 "xuN" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/visible,
+/obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
 "xve" = (
@@ -52796,6 +52577,12 @@
 	codes_txt = "patrol;next_patrol=HOP";
 	location = "CHE"
 	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
+	},
 /turf/open/floor/carpet,
 /area/hallway/secondary/exit/departure_lounge)
 "xzL" = (
@@ -52815,9 +52602,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "xAa" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -52834,10 +52618,22 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "xAi" = (
 /obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "xAm" = (
@@ -52856,9 +52652,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "xBi" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -52871,6 +52664,12 @@
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 10
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -52939,7 +52738,10 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -52951,9 +52753,6 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
@@ -52961,6 +52760,8 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "xCU" = (
@@ -52988,9 +52789,6 @@
 /area/maintenance/solars/port/aft)
 "xDS" = (
 /obj/machinery/status_display,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/ai_upload)
 "xEf" = (
@@ -53004,9 +52802,6 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "xEt" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -53025,6 +52820,10 @@
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -53064,10 +52863,13 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/structure/disposalpipe/junction/flip{
 	dir = 4
 	},
-/obj/structure/disposalpipe/junction/flip{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -53138,7 +52940,8 @@
 /obj/machinery/door/firedoor/border_only{
 	name = "south facing firelock"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "xGP" = (
@@ -53166,9 +52969,6 @@
 "xHE" = (
 /obj/structure/cable{
 	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -53291,9 +53091,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/machinery/camera{
 	c_tag = "Medbay South";
 	network = list("ss13","medbay")
@@ -53380,10 +53177,10 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
 "xNs" = (
-/obj/machinery/atmospherics/pipe/simple/supply/visible,
 /obj/structure/disposalpipe/junction/flip{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/icemoon/surface/outdoors)
 "xNX" = (
@@ -53466,8 +53263,11 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "xPP" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -53510,6 +53310,8 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "xQU" = (
@@ -53536,6 +53338,8 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "xRZ" = (
@@ -53555,7 +53359,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -53716,6 +53523,12 @@
 	c_tag = "Northwestern Hall 6";
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "xXS" = (
@@ -53734,20 +53547,19 @@
 /obj/structure/disposalpipe/junction/flip{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "xXX" = (
 /turf/closed/wall,
 /area/security/vacantoffice/a)
 "xYD" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/carpet,
 /area/hallway/secondary/exit/departure_lounge)
 "xYE" = (
-/obj/machinery/atmospherics/components/binary/valve{
+/obj/machinery/atmospherics/components/binary/valve/layer3{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -53786,33 +53598,20 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/dark,
 /area/storage/eva)
-"xZA" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"xZL" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/surface/outdoors)
 "xZX" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/bed/roller,
 /obj/machinery/iv_drip,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "yae" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "yaE" = (
@@ -53846,17 +53645,14 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/effect/landmark/start/prisoner/prilate,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "ybT" = (
-/obj/machinery/atmospherics/pipe/simple/supply/visible,
 /obj/machinery/light/floor,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
 "ycl" = (
@@ -53896,17 +53692,10 @@
 /obj/effect/decal/cleanable/flour,
 /turf/open/floor/plating,
 /area/maintenance/aft/secondary)
-"ydo" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/closed/wall/r_wall,
-/area/crew_quarters/heads/captain)
 "ydp" = (
 /turf/closed/mineral/random/snow/no_caves,
 /area/icemoon/surface/outdoors)
 "yds" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
 /turf/open/floor/plasteel,
 /area/medical/chemistry)
 "ydQ" = (
@@ -54048,7 +53837,7 @@
 /area/crew_quarters/heads/hos)
 "yhv" = (
 /obj/machinery/door/airlock/maintenance,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -54088,7 +53877,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
@@ -54165,6 +53953,7 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plating,
 /area/maintenance/aft/secondary)
 "yjJ" = (
@@ -54200,12 +53989,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
-"ykr" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/ai_monitored/turret_protected/ai_upload_foyer)
 "ykt" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -54232,6 +54015,12 @@
 	dir = 4;
 	sortType = 9
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "yld" = (
@@ -54248,12 +54037,14 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
@@ -63361,16 +63152,16 @@ kcw
 apN
 apJ
 qTb
-qTb
+eSQ
 jdw
-qTb
-qTb
+fXH
+hEQ
 cIh
 uVD
 wJO
 avP
 iEJ
-hva
+vZH
 vZH
 lac
 iMX
@@ -63883,7 +63674,7 @@ cIh
 cIh
 cIh
 awZ
-ayl
+cIh
 cIh
 cIh
 cIh
@@ -64655,7 +64446,7 @@ vJs
 eKZ
 iAv
 aIK
-dRI
+lWf
 aAE
 uKG
 vEm
@@ -64906,10 +64697,10 @@ pNo
 gzH
 pdv
 cQr
-nyT
+ayq
 uQc
-qDO
-jll
+vJs
+lOF
 clB
 clB
 clB
@@ -65159,7 +64950,7 @@ pvx
 apJ
 apJ
 apJ
-nIu
+epK
 vFe
 gQj
 leZ
@@ -65680,7 +65471,7 @@ lTJ
 ayq
 dAV
 tlk
-ykr
+dAV
 clB
 hKm
 pYM
@@ -65937,7 +65728,7 @@ arE
 ayq
 gYC
 auc
-avp
+gYC
 clB
 ayp
 azB
@@ -66193,12 +65984,12 @@ ayq
 ayq
 ayq
 ikh
-tkr
+xSH
 aLu
 clB
 ayo
 uXi
-iRO
+lZs
 uJL
 aHu
 isu
@@ -66450,12 +66241,12 @@ cTE
 axc
 gLH
 atb
-tkr
+xSH
 jwo
 clB
 dKQ
 azC
-ofy
+dKQ
 dKQ
 aHu
 wxw
@@ -66701,8 +66492,8 @@ nTQ
 fAz
 xVe
 wnM
-nTQ
-nTQ
+esE
+fQx
 sMX
 lat
 ldt
@@ -66960,12 +66751,12 @@ qQH
 qQH
 qQH
 qQH
-wmf
+qQH
 qrq
-atJ
+gLH
 oiC
-aBI
-bEJ
+xSH
+jwo
 aFI
 ayr
 azD
@@ -67221,7 +67012,7 @@ vjQ
 xCf
 gLH
 aCX
-tkr
+xSH
 pYh
 aFI
 iek
@@ -67478,12 +67269,12 @@ gLH
 gLH
 gLH
 aCX
-tkr
+xSH
 cYU
 aFI
 cwH
-lam
-erO
+mDJ
+jcS
 aBK
 aDf
 aEG
@@ -67736,8 +67527,8 @@ efn
 asc
 qmO
 nkP
-aue
-lWb
+jwo
+aFI
 dfa
 obB
 aAe
@@ -67985,9 +67776,9 @@ dJc
 wje
 aDd
 wje
-gsQ
-auV
-kkG
+wje
+wje
+wje
 wje
 wje
 igQ
@@ -68255,10 +68046,10 @@ aFI
 uJF
 mDJ
 jcS
-tmx
+aBK
 aDc
 aEH
-xkf
+wdb
 rJQ
 hoe
 erx
@@ -68742,7 +68533,7 @@ fDi
 fDi
 fGi
 fWo
-kUo
+fGi
 fDi
 sXJ
 tyI
@@ -68999,7 +68790,7 @@ ash
 adZ
 jxr
 xAa
-kuy
+jxr
 hQb
 gIm
 pNO
@@ -69014,7 +68805,7 @@ hKt
 hso
 dpS
 rRV
-aoT
+rRV
 pWz
 ash
 xCr
@@ -69029,9 +68820,9 @@ iBF
 sUE
 aEJ
 vYc
-iza
-oIT
-oIT
+aIP
+bsL
+bEe
 vPV
 oIT
 kPV
@@ -69263,7 +69054,7 @@ vTh
 lTB
 kMT
 rAW
-ebF
+gIm
 uba
 pPx
 qJM
@@ -69286,9 +69077,9 @@ bxM
 aFI
 aEJ
 aIP
-jrf
+aIP
 wMp
-qCa
+aIP
 mav
 gIS
 vPD
@@ -69511,7 +69302,7 @@ oto
 ash
 ash
 mAk
-pxZ
+jxr
 ojp
 jxr
 exq
@@ -69521,9 +69312,9 @@ rVA
 eFC
 ooa
 sXJ
-hEQ
+aoj
 vXs
-gZQ
+aoj
 ash
 lmF
 lSN
@@ -69768,10 +69559,10 @@ uAe
 ash
 ash
 ash
-hEQ
+aoj
 fkF
 aoj
-cxX
+ash
 sXJ
 pSY
 pNO
@@ -69789,10 +69580,10 @@ wFR
 vqd
 lmF
 arH
-auV
-auV
-azG
-aAL
+wje
+wje
+rbo
+wje
 wje
 wje
 wje
@@ -69801,7 +69592,7 @@ aIP
 aAQ
 eZi
 aFU
-aHA
+bvo
 iqJ
 hLo
 aLD
@@ -70025,7 +69816,7 @@ tOs
 ash
 kMc
 gdi
-nsi
+eLX
 cEf
 eLX
 cpf
@@ -70037,7 +69828,7 @@ gIm
 gIm
 rAa
 ykN
-alR
+anm
 vVs
 bfR
 olz
@@ -70047,18 +69838,18 @@ lmF
 lmF
 waP
 kCE
-aDh
+kCE
 lmu
 mNo
-xJr
-xJr
-xJr
+mNo
+mNo
+kUo
 aAT
-aBw
+bxk
 aDg
 hgJ
 aFY
-aHA
+bvo
 aIS
 aKn
 aLF
@@ -70282,40 +70073,40 @@ fgp
 ash
 adw
 anm
-anJ
+anm
 lUb
 anH
-prP
+anH
 lLv
 dVV
 czF
 oqF
 okm
 ajV
-aok
+anH
 sJD
-alR
+anm
 amy
 lmF
 lmF
-hIP
-nBx
+bfR
+bfR
 oUC
 tUF
 jGF
-jex
+uBi
 iKM
 bNb
 bNb
 dsk
 gsQ
 kkG
-ilo
+vsN
 bxk
 ovq
 aFO
-aFY
-aHA
+aEC
+bvo
 rJM
 aKm
 aLE
@@ -70539,28 +70330,28 @@ xgq
 xHU
 hui
 anm
-anJ
+anm
 uXB
-pbk
-jga
-kij
+vkY
+vkY
+vkY
 cKQ
-kij
+vkY
 dZa
-ajq
-kij
-cMc
+vkY
+vkY
+vkY
 alh
-uDO
-amA
-ani
+anm
+anm
+amD
 anI
-aol
-akB
+anm
+anm
 ecD
-esE
-nDl
-lZs
+wje
+pIm
+wje
 avU
 avX
 avX
@@ -70568,11 +70359,11 @@ pdo
 wje
 rBc
 vsN
-aBG
+bxk
 aDk
-aFO
-aFY
-aHA
+aBw
+aSE
+bCQ
 hUo
 sMi
 oWw
@@ -70789,31 +70580,31 @@ puS
 iIg
 pZD
 eDm
-pED
-xgq
+anJ
+aok
 poT
 rFk
 sTe
 vhO
-jih
-wkM
+anm
+anm
+axl
+anm
+anm
+anm
 uUk
-alR
 anm
-anm
-uUk
-anm
-anm
+aAV
 hXB
 pIE
-anJ
+anm
 xCn
 alS
 anH
 anh
 anH
-rQz
-aok
+anH
+anH
 loO
 aFJ
 arK
@@ -70824,7 +70615,7 @@ avX
 pdo
 wnO
 jil
-kzf
+vsN
 otz
 bxk
 bxk
@@ -71046,7 +70837,7 @@ sXV
 laE
 pZD
 aaS
-eSQ
+aba
 aba
 aba
 aba
@@ -71059,33 +70850,33 @@ egj
 eoW
 xZX
 dFb
-fze
+poR
 tVV
-fze
+cxX
 pcT
 poR
 mIu
 pKr
 mhv
-oge
-dfn
-pig
-aom
-wLs
-dXF
-arN
+aoj
+hui
+anm
+aoU
+apP
+oDw
+pIm
 wje
 axi
 axi
 axi
 kTI
 wje
-ava
-mGa
+rBc
+aDd
 vfr
 wje
 aFO
-aFY
+aSN
 ldE
 aPA
 nlk
@@ -71304,14 +71095,14 @@ aqP
 cGu
 aaS
 joT
-kGS
+vAh
 vAh
 rSn
-oZq
+oto
 kMy
 nbU
-lgq
-rsy
+ash
+aoj
 pxE
 jmd
 aoj
@@ -71326,11 +71117,11 @@ anm
 alU
 alF
 pJr
-anJ
+anm
 aoU
 aoj
 oDw
-oDm
+pIm
 wje
 axi
 ltF
@@ -71339,8 +71130,8 @@ kTI
 wje
 etM
 oNR
-sxN
-sxN
+mNo
+mNo
 aFQ
 mJq
 aHe
@@ -71570,7 +71361,7 @@ dJZ
 ash
 hWn
 eSP
-mVN
+sMA
 sMA
 nOR
 ykb
@@ -71583,7 +71374,7 @@ lDj
 gzk
 eiR
 pJr
-anJ
+anm
 aoU
 aoj
 oDw
@@ -71825,12 +71616,12 @@ pZD
 ady
 ofF
 iRy
-fXH
-eSP
-ntd
-epK
+sMA
+axn
+sMA
+sMA
 pbw
-epK
+sMA
 wzH
 sMA
 xGP
@@ -71840,19 +71631,19 @@ wen
 vyM
 aoj
 pZu
-fQx
+anm
 nya
 apP
 rqw
-tkr
+xSH
 wje
 kTI
 axi
 axi
 axi
 wje
-tkr
-aAL
+xSH
+wje
 nRA
 wje
 aFO
@@ -72100,7 +71891,7 @@ anm
 anm
 anm
 fyV
-aAV
+wje
 aBI
 asO
 uGY
@@ -72108,7 +71899,7 @@ avX
 avX
 axj
 wnO
-aBI
+lgq
 aAY
 sxt
 bxk
@@ -72349,25 +72140,25 @@ wKC
 rJl
 uan
 vMf
-iEa
-anm
+cMc
+cNE
 sxa
-amD
+dfn
 biV
-anm
+ebF
 cwW
 jXh
-aAL
-tkr
+kCE
+gZQ
 wje
 uGY
 avX
 avX
 axj
 wje
-gIG
-aAU
-lqG
+lWb
+aAY
+bxk
 hTk
 vHU
 qTO
@@ -72623,11 +72414,11 @@ was
 kRK
 gsQ
 eDr
-aAS
+aAY
 bxk
 srU
 aFO
-aFY
+aEC
 aHD
 aPC
 hxx
@@ -72637,7 +72428,7 @@ aOq
 aPD
 aQT
 omC
-bzc
+bUP
 avT
 ydp
 ydp
@@ -72864,7 +72655,7 @@ uUl
 ujD
 nYZ
 xKu
-anm
+aAV
 vmO
 hik
 mAx
@@ -72873,18 +72664,18 @@ rQN
 aaH
 soN
 ojv
-oTu
-oTu
-oTu
+qmO
+qmO
+qmO
 rTj
-oTu
-oTu
+qmO
+qmO
 nhe
 vMB
 uBG
 aDm
 hLZ
-aFY
+bcq
 aHD
 aPC
 cKK
@@ -73112,7 +72903,7 @@ jFY
 vIA
 rYD
 lYq
-rYD
+ayl
 nwq
 gId
 oTF
@@ -73125,17 +72916,17 @@ jBr
 mYT
 amF
 yds
-jap
+yds
 frn
 oPP
 tqp
 kkn
-iIN
-iIN
-iIN
+xJr
+xJr
+xJr
 atM
-axl
-iIN
+xJr
+xJr
 uCE
 sco
 aIP
@@ -73385,13 +73176,13 @@ qVD
 pyD
 guR
 aaH
-rJw
+tqp
 tqa
 wje
 wWL
 ayy
 atO
-axk
+xSZ
 xSZ
 xSZ
 aAO
@@ -73635,20 +73426,20 @@ fLL
 jNp
 wbg
 adM
-anm
+aAV
 aoX
 vAy
 ngp
 anK
 gTb
 aoX
-rJw
+tqp
 xSH
 fYQ
 tXN
 tXN
 rBG
-axn
+pjg
 pjg
 pjg
 tXN
@@ -73660,9 +73451,9 @@ aHE
 wUr
 aKs
 aOr
-aOr
-aOr
-aOr
+bRN
+bRN
+bRN
 aQX
 vcG
 lzB
@@ -73892,16 +73683,16 @@ seZ
 pXl
 nYZ
 uUk
-anm
+aAV
 aoX
 tcP
 oMJ
-inU
+yds
 iWu
 vmO
-rJw
-tkr
-fYQ
+tqp
+hva
+hIP
 tXN
 iOR
 eTg
@@ -73922,7 +73713,7 @@ xUL
 xUL
 xUL
 vcG
-lzB
+cng
 avT
 avT
 ydp
@@ -74145,22 +73936,22 @@ vAp
 ouB
 nYZ
 nYZ
-dCI
+nnj
 nnj
 nYZ
 uUk
-anm
+aAV
 aoX
 ali
-cQm
+dCI
 gWl
 aon
 aoX
-rJw
-tkr
-fYQ
+tqp
+gxi
+iIN
 oeh
-oaS
+kRz
 awb
 gRh
 xeI
@@ -74402,23 +74193,23 @@ jyA
 goK
 qfd
 qOA
-pZJ
+qfd
 utS
 nnj
 uUk
-anm
+aAV
 aoX
 mLD
 cQm
-eYx
+yds
 gev
 aaH
-gsM
-tkr
+soN
+gxi
 ayG
 tXN
 fwn
-awb
+jih
 rqW
 ayC
 rPU
@@ -74426,10 +74217,10 @@ fne
 ayC
 rPU
 myh
-tWj
-oyz
-ebX
-ebX
+uJx
+oYn
+vdw
+vdw
 ltw
 bDe
 xUL
@@ -74667,12 +74458,12 @@ xAi
 aoX
 nVv
 beC
-eYx
+yds
 qWL
 aoX
-gsM
-tkr
-wje
+soN
+gxi
+rBc
 pjg
 fpS
 wPD
@@ -74680,14 +74471,14 @@ skw
 iFq
 pIf
 ogM
-wix
-oaS
+kRz
+kRz
 plc
-uJx
+bff
 ikk
 gnv
-uJx
-uJx
+bff
+bQs
 qpE
 xUL
 xUL
@@ -74920,21 +74711,21 @@ vyJ
 fgM
 nnj
 uUk
-anm
+aAV
 aoX
 jWx
 nBI
 anL
 aoo
 aaH
-gsM
-tkr
-wje
+soN
+gxi
+rBc
 wEP
 inq
 oaS
 rMb
-oaS
+kuy
 azH
 oyC
 oaS
@@ -75185,8 +74976,8 @@ qUi
 aaH
 aoX
 iyD
-tkr
-wje
+gxi
+rBc
 xOY
 uUi
 oaS
@@ -75692,15 +75483,15 @@ pQd
 jrH
 rke
 vJG
-quj
-aDh
-aDh
+jrH
+kCE
+kCE
 nDl
 wbO
 jah
 uCo
-tkr
-wje
+hyY
+jga
 sqg
 uUi
 oaS
@@ -75956,8 +75747,8 @@ wmH
 ohr
 xWq
 xok
-tkr
-wje
+gxi
+rBc
 qeG
 inq
 oaS
@@ -76212,17 +76003,17 @@ nrJ
 iAR
 rik
 xWq
-aAL
+wje
 gxi
-auV
-wJH
+rBc
+sqg
 opC
-wYe
+oaS
 iat
 pEF
 nez
 rTt
-hyY
+tXN
 uGl
 nYt
 eKy
@@ -76469,17 +76260,17 @@ anO
 nVp
 kds
 xWq
-aAV
-nZU
+wje
+jFG
 hnc
-asQ
+tXN
 odD
 kRz
+kij
 kRz
-ayE
 pKF
-kRz
-asQ
+oaS
+tXN
 qNz
 eaX
 vor
@@ -76726,7 +76517,7 @@ vxX
 evY
 tGc
 fQe
-lZs
+wje
 jFG
 fhi
 oeh
@@ -76739,7 +76530,7 @@ jgD
 tXN
 tcD
 aGb
-aGb
+vor
 jAc
 opF
 dhg
@@ -77252,8 +77043,8 @@ eex
 eex
 eex
 qUr
-gdQ
-gdQ
+aBG
+bkQ
 gdQ
 sCC
 tmO
@@ -77808,10 +77599,10 @@ cux
 pKK
 mET
 mtv
-wpO
+fAj
 meL
 hjZ
-wpO
+fAj
 ugj
 qJU
 fAj
@@ -78067,7 +77858,7 @@ nvW
 cyy
 vdQ
 ylx
-kHl
+spI
 kpv
 uAZ
 oVW
@@ -78315,7 +78106,7 @@ tpN
 fAj
 fAj
 lfw
-eiL
+rhg
 eSq
 ipL
 jbq
@@ -78572,17 +78363,17 @@ tZe
 xoY
 fAj
 eIJ
-eiL
+rhg
 eSq
 ipL
 jPD
 fAj
 nUo
 mtv
-wpO
-rti
+fAj
+sBk
 eXZ
-wpO
+fAj
 ugj
 vbn
 pKK
@@ -78829,7 +78620,7 @@ upH
 rtq
 fAj
 tRw
-wHB
+svY
 eIT
 svY
 gmA
@@ -78837,7 +78628,7 @@ fAj
 oZR
 cyy
 qdZ
-ylx
+lQs
 spI
 dkO
 uAZ
@@ -79086,7 +78877,7 @@ fAj
 fAj
 fAj
 fAj
-jFT
+imv
 qxM
 imv
 fAj
@@ -79095,7 +78886,7 @@ fAj
 fAj
 fAj
 rIK
-bES
+hjZ
 fAj
 fAj
 fAj
@@ -79602,12 +79393,12 @@ tGY
 lFt
 nPd
 gKY
-dbK
+rKZ
 rKZ
 vlv
 ahW
 pEK
-pEK
+kgr
 rOd
 jfq
 pEo
@@ -79859,20 +79650,20 @@ rsW
 ybQ
 cXr
 oOe
-bBk
+lFK
 lFK
 jro
-jjA
+fAj
 wJw
-wJw
-wJw
+lhi
+mdG
 tfY
 fAj
 pAS
 vwE
 kfv
 hzH
-kUC
+vRZ
 bjk
 keN
 daH
@@ -80881,7 +80672,7 @@ foy
 ilb
 ilb
 ilb
-ilb
+gmv
 rlG
 wSb
 wav
@@ -80902,7 +80693,7 @@ fnc
 nxv
 pnu
 dvj
-gdE
+nCU
 gdE
 rcY
 duI
@@ -81398,7 +81189,7 @@ kfv
 kfv
 kfv
 bxG
-byR
+dFt
 qpF
 kfv
 kfv
@@ -81671,7 +81462,7 @@ toz
 cCd
 pDF
 nxv
-idS
+duI
 sEe
 duI
 dzh
@@ -81917,7 +81708,7 @@ eiW
 hRH
 eSK
 bAM
-eJh
+pmK
 nxv
 nxv
 vYL
@@ -82175,18 +81966,18 @@ hgg
 dGq
 bAL
 sFh
-ryE
-ryE
+dGq
+dGq
 bJl
-ryE
+dGq
 gkH
 aaO
-ryE
+dGq
 fnT
-ryE
-ryE
-qUY
-mHw
+dGq
+dGq
+dGq
+sTX
 vSF
 tgj
 tgj
@@ -82429,8 +82220,8 @@ xow
 lul
 bAg
 iPC
-pvl
-pvl
+tLV
+tLV
 hUs
 tLV
 vEA
@@ -82442,7 +82233,7 @@ tLV
 bJu
 vEA
 uOT
-nRe
+uOT
 wFB
 bUD
 jcH
@@ -82679,7 +82470,7 @@ wql
 uUJ
 vOU
 bcc
-vOU
+fXa
 cuX
 oKD
 wql
@@ -82699,7 +82490,7 @@ thQ
 thQ
 thQ
 oLy
-ndS
+oLy
 aZB
 oLy
 wql
@@ -82956,7 +82747,7 @@ xal
 xhZ
 thQ
 uqV
-aoV
+hpd
 dqL
 cMZ
 wql
@@ -83194,7 +82985,7 @@ khf
 vOU
 qEz
 vOU
-cuX
+hez
 xRL
 hNn
 xCC
@@ -83454,7 +83245,7 @@ rTA
 oNz
 wSy
 bxK
-fcu
+rTA
 bAh
 bBs
 sfn
@@ -83971,9 +83762,9 @@ wql
 txk
 xEt
 nXy
-pNU
-pNU
-pNU
+rTA
+rTA
+rTA
 pNU
 wPT
 dPL
@@ -83989,7 +83780,7 @@ air
 wuS
 wql
 cIH
-oaG
+phf
 sdN
 chA
 tod
@@ -84228,9 +84019,9 @@ tjA
 pzk
 xBi
 bBt
-bFf
+oJF
 eUB
-bFf
+oJF
 bGB
 oJF
 piv
@@ -84246,7 +84037,7 @@ wql
 wql
 wql
 sdN
-oaG
+phf
 dCh
 sdN
 sdN
@@ -84447,17 +84238,17 @@ avT
 avT
 avT
 tqg
-nGx
-nGx
-nGx
-nGx
-nGx
-nGx
-nGx
-nGx
-nGx
-nGx
-nGx
+qLM
+qLM
+qLM
+qLM
+qLM
+qLM
+qLM
+qLM
+qLM
+qLM
+qLM
 xtV
 lzB
 avT
@@ -84705,17 +84496,17 @@ avT
 avT
 tFr
 dvc
-sLv
-sLv
-sLv
-sLv
-sLv
+qRy
+qRy
+qRy
+qRy
+qRy
 ybT
-sLv
-sLv
-sLv
-sLv
-sLv
+qRy
+qRy
+qRy
+qRy
+qRy
 asr
 avT
 avT
@@ -84733,7 +84524,7 @@ unA
 unA
 bwt
 sPF
-bsk
+buZ
 dWF
 rgh
 uoc
@@ -84985,12 +84776,12 @@ wcB
 wcB
 bok
 wrh
-tif
-tif
+drK
+fcJ
 wvL
 bwt
 ewK
-drK
+fPN
 msA
 fPN
 btu
@@ -85003,7 +84794,7 @@ iad
 cBD
 bDr
 bDr
-alG
+bDr
 fmt
 fKC
 cbz
@@ -85218,7 +85009,7 @@ jxS
 mGT
 tey
 fhM
-lzB
+aqd
 avT
 avT
 avT
@@ -85229,7 +85020,7 @@ bHt
 nZE
 nZE
 nZE
-nZE
+bUm
 aUd
 avT
 avT
@@ -85242,8 +85033,8 @@ wcB
 wcB
 bok
 wrh
-tif
-tif
+dTo
+fBc
 wVg
 bwt
 aNw
@@ -85260,7 +85051,7 @@ vOU
 cBD
 cAL
 bFs
-eOn
+bFs
 bJt
 fKC
 uaC
@@ -85274,16 +85065,16 @@ dYl
 rYN
 qOb
 bSd
-wHX
+pVz
+qCa
 kJE
-cvE
 xXX
 sdN
 clR
 rTz
 bZt
 eGF
-ydo
+clR
 snb
 owV
 iBm
@@ -85475,7 +85266,7 @@ gky
 vmM
 jOo
 azc
-lzB
+aAL
 avT
 avT
 avT
@@ -85499,12 +85290,12 @@ wcB
 wcB
 bok
 wrh
-tif
+enP
 tif
 nUk
 bwt
 cTD
-mhH
+cTD
 iQv
 cTD
 klQ
@@ -85531,9 +85322,9 @@ xXX
 bUJ
 fzQ
 fzQ
-kgr
-uJe
-syd
+kJE
+kJE
+kJE
 xXX
 whB
 clR
@@ -85732,7 +85523,7 @@ bxU
 iSg
 wLG
 ker
-lzB
+aqd
 avT
 avT
 avT
@@ -85756,14 +85547,14 @@ uFq
 uFq
 bok
 unA
-bmA
+eGL
 bmA
 unA
 grV
 xTL
-bff
-bsk
 lHn
+bsk
+ggt
 ciO
 cTD
 bCz
@@ -85790,7 +85581,7 @@ bwh
 uPJ
 ndn
 vcY
-dTo
+kJE
 xXX
 sdN
 cer
@@ -86013,13 +85804,13 @@ wbE
 wbE
 fPp
 rqE
-rqE
+eNG
 rqE
 dGB
 cTD
 lHn
-bff
-bsn
+lHn
+uoc
 lHn
 lHn
 cTD
@@ -86032,7 +85823,7 @@ cBD
 ndL
 dpZ
 dpZ
-bJw
+lqG
 smP
 wtt
 bMN
@@ -86057,7 +85848,7 @@ kLQ
 eTv
 dMj
 dMj
-sFp
+clR
 lTT
 clR
 iIS
@@ -86241,7 +86032,7 @@ ydp
 ydp
 ydp
 ktw
-xYE
+amm
 aVC
 cgH
 lXk
@@ -86270,7 +86061,7 @@ wbE
 wbE
 uBa
 uBa
-uBa
+eOn
 uBa
 dGB
 cTD
@@ -86283,7 +86074,7 @@ vpz
 iGJ
 gmf
 qAI
-bBy
+bBA
 ewY
 cBD
 bFl
@@ -86304,8 +86095,8 @@ bPq
 nzn
 jcT
 cii
-sjk
-fXa
+lhQ
+lhQ
 lhQ
 bsy
 dMj
@@ -86527,7 +86318,7 @@ lRx
 wbE
 got
 got
-xui
+eVp
 uBa
 dGB
 cTD
@@ -86560,17 +86351,17 @@ sdN
 sdN
 sdN
 jcT
-tNf
+qUY
 lhQ
 sAw
 lhQ
-lhQ
+sUX
 dMj
 riE
 hGy
 ucZ
-fBc
-fBc
+dMj
+dMj
 tkH
 ckb
 cLX
@@ -86759,7 +86550,7 @@ ktw
 rbg
 cgH
 ktw
-xZL
+bBh
 lzB
 avT
 avT
@@ -86777,14 +86568,14 @@ aVv
 aXh
 uIs
 gGQ
-iog
-aSN
-lQs
+rkP
+xZg
+uBa
 xYD
 wbE
 xZg
 xZg
-xZg
+eWp
 uBa
 eeh
 grV
@@ -86817,11 +86608,11 @@ tod
 tod
 tod
 jcT
-tNf
-sRh
-sAw
-vNY
+rwR
 lhQ
+cZq
+lhQ
+toP
 dMj
 dMj
 dMj
@@ -87016,7 +86807,7 @@ gky
 ptY
 cgH
 ktw
-xZL
+bBh
 lzB
 avT
 avT
@@ -87032,16 +86823,16 @@ aVv
 iQD
 riC
 qXN
-srJ
-aZY
+uBa
+cFO
 uBa
 uBa
 uBa
-thy
+xYD
 wbE
 uBa
 uBa
-uBa
+eOn
 uBa
 qHO
 lbp
@@ -87053,7 +86844,7 @@ vPQ
 bwu
 lhQ
 yae
-kPj
+mbh
 bBB
 lhQ
 lhQ
@@ -87068,16 +86859,16 @@ vPQ
 bJF
 bVX
 cGQ
-hhz
+vPQ
 vPQ
 vPQ
 vPQ
 vPQ
 pjn
 tNf
-sAw
+lhQ
 haj
-mdG
+vPQ
 vPQ
 iwd
 ykt
@@ -87273,7 +87064,7 @@ cPI
 gmn
 xSd
 lXk
-xZL
+bBh
 paY
 mxF
 irt
@@ -87285,62 +87076,62 @@ mxF
 btZ
 uyK
 pqX
-enP
+uyK
 lCQ
 lEy
 ggl
-wFU
+beo
 gSh
 beo
 beo
 beo
 qyK
+beo
+beo
+beo
 tJA
-tJA
-tJA
-tJA
-tJA
-tJA
+beo
+beo
 rmQ
-tmU
+wZl
 xdc
 iNV
 bAk
 hxf
 hxf
 hxf
-hxf
+heM
 bAj
 ezY
-tmU
-tmU
-tmU
-tmU
-tmU
-mvJ
-tmU
-tmU
-uZd
-tmU
-bPa
-tmU
-bCT
-msm
-tmU
-tmU
-tmU
 wZl
-tmU
+wZl
+wZl
+wZl
+wZl
+wZl
+wZl
+wZl
+uZd
+wZl
+bPa
+fZV
+bCT
+wZl
+wZl
+wZl
+wZl
+wZl
+wZl
 xXV
-xdc
+wZl
 fZV
 ilF
-tmU
-tmU
-tmU
+wZl
+wZl
+wZl
 hvr
-tmU
-tmU
+wZl
+wZl
 iau
 hKc
 olx
@@ -87545,19 +87336,19 @@ aRt
 iyP
 qGn
 lud
-ngB
-joq
+wdk
+wdk
 xzn
 wdk
 iOW
 wdk
 beq
-ngB
-ngB
-ngB
-ngB
-ngB
-ngB
+wdk
+wdk
+wdk
+fcu
+wdk
+wdk
 bnE
 fqE
 cBF
@@ -87566,38 +87357,38 @@ udI
 fqE
 fqE
 fqE
-fqE
+hgO
 nRt
 xmB
-bmS
-bmS
-bmS
 tys
-bmS
-cCH
-bmS
-bmS
-bmS
-bmS
+tys
+tys
+tys
+tys
+tys
+tys
+tys
+tys
+tys
 tXn
-tys
+mEo
 bCW
-bmS
-bmS
-bmS
-bmS
-bmS
-bmS
-cCH
-bmS
-cCH
+tys
+tys
+tys
+tys
+tys
+tys
+tys
+tys
+sxN
 bPd
-bmS
-bmS
-bmS
+tys
+tys
+tys
 jhe
-bmS
-bmS
+tys
+tys
 civ
 fJW
 ina
@@ -87787,7 +87578,7 @@ cPI
 kxP
 vAs
 ktw
-xZL
+bBh
 lzB
 avT
 avT
@@ -87799,12 +87590,12 @@ nTz
 sLj
 rmN
 wxT
-bUP
+wxT
 fLK
 rmN
 oLT
-ljL
 uBa
+ljL
 uBa
 uBa
 uBa
@@ -87829,15 +87620,15 @@ reS
 lhQ
 czY
 ceA
-vun
 ceA
-gkX
+ceA
+ceA
 ceA
 ceA
 sOv
 wLU
+mhH
 ceA
-bQs
 bDI
 ceA
 ceA
@@ -87856,8 +87647,8 @@ tNf
 bUL
 cgZ
 iIS
-nCU
-oeS
+cmU
+uaA
 ckX
 clV
 cmV
@@ -88044,7 +87835,7 @@ cPI
 hPe
 vAs
 ktw
-xZL
+bBh
 lzB
 avT
 avT
@@ -88056,15 +87847,15 @@ hmM
 sLj
 aPZ
 kAO
-phf
+vcN
 uRi
 wxT
 pqe
-hgO
+uBa
 baa
-bcq
-bcq
-bcq
+got
+got
+got
 mai
 pcd
 piX
@@ -88086,9 +87877,9 @@ byZ
 caJ
 srk
 srk
-aEC
 xjF
-heM
+xjF
+xjF
 xjF
 xjF
 srk
@@ -88102,11 +87893,11 @@ xjF
 xjF
 xjF
 xjF
-cFO
+srk
 srk
 cTO
 cdE
-lhQ
+tWj
 chb
 chb
 yiZ
@@ -88114,7 +87905,7 @@ chb
 vqS
 iIS
 hYD
-oeS
+uaA
 cqo
 clV
 oBF
@@ -88301,7 +88092,7 @@ spa
 vir
 fkr
 ktw
-oME
+bGt
 lzB
 avT
 avT
@@ -88345,7 +88136,7 @@ srk
 dzf
 vkW
 agy
-aqd
+agy
 agy
 fNE
 tAM
@@ -88362,7 +88153,7 @@ agy
 cfm
 srk
 gtG
-cdE
+mbh
 lhQ
 chb
 vam
@@ -88371,7 +88162,7 @@ rnA
 hsP
 iIS
 kxf
-oeS
+uaA
 iIK
 iIS
 iAt
@@ -88558,7 +88349,7 @@ ktw
 hSD
 ktw
 ktw
-xZL
+bBh
 lzB
 avT
 avT
@@ -88571,7 +88362,7 @@ wxT
 moD
 aQd
 jUn
-kiB
+cvE
 wxT
 pqe
 uBa
@@ -88593,8 +88384,8 @@ ouX
 bFD
 hpw
 iaY
-pVz
-hoX
+bvl
+ceA
 bxc
 bzb
 bCD
@@ -88602,7 +88393,7 @@ xjF
 gpN
 lDD
 oXZ
-hKl
+agy
 agy
 agy
 xTI
@@ -88618,8 +88409,8 @@ hUc
 agy
 agy
 xjF
-cTO
-cdE
+syd
+mbh
 bwr
 chb
 eZA
@@ -88627,8 +88418,8 @@ uLd
 gSY
 uAs
 obL
-bMs
-oeS
+fJW
+uJe
 rAj
 iIS
 cph
@@ -88803,19 +88594,19 @@ ydp
 avT
 avT
 atX
-nGx
-nGx
-nGx
-nGx
-nGx
-nGx
+qLM
+qLM
+qLM
+qLM
+qLM
+qLM
 dwF
-nGx
-nGx
+qLM
+qLM
 uYf
-ujF
-ujF
-aSE
+sXy
+sXy
+jAq
 lzB
 avT
 avT
@@ -88868,16 +88659,16 @@ xTI
 agy
 bRH
 qoy
-qoy
-qoy
-qoy
-qoy
-qoy
-qoy
+mKA
+nFc
+nFc
+nGx
+nFc
+nFc
 eDu
 gpp
 bXU
-cjA
+hxf
 vBo
 gMD
 pIz
@@ -89061,18 +88852,18 @@ avT
 avT
 vcG
 dvc
-sLv
-sLv
-sLv
-sLv
-sLv
-sLv
-sLv
-sLv
-sLv
-sLv
-sLv
-sLv
+qRy
+qRy
+qRy
+qRy
+qRy
+qRy
+qRy
+qRy
+qRy
+qRy
+qRy
+qRy
 asr
 avT
 avT
@@ -89104,11 +88895,11 @@ bBL
 bBL
 bBL
 bBL
-bEe
 bBL
 bBL
 bBL
-ceA
+bBL
+hoX
 mIz
 cSG
 bzS
@@ -89125,15 +88916,15 @@ agy
 agy
 rxu
 agy
+pyI
 agy
 agy
+oME
 agy
-kzR
 agy
-agy
-eGL
+xjF
 cZk
-hOb
+mbh
 fad
 chb
 pXW
@@ -89371,7 +89162,7 @@ osc
 bCD
 xjF
 agy
-cmr
+pyI
 agy
 srk
 srk
@@ -89382,15 +89173,15 @@ gdd
 njU
 bFL
 nHB
+pyI
 agy
 agy
 agy
-aqd
 agy
 cfm
 srk
 mql
-cdE
+mbh
 lhQ
 chb
 qbv
@@ -89639,15 +89430,15 @@ xTI
 xTI
 msg
 njU
+pyI
 agy
 agy
 agy
-aqd
 jTc
 srk
 srk
 qZs
-cdE
+mbh
 lhQ
 cdD
 eyS
@@ -89899,12 +89690,12 @@ aoi
 kzR
 agy
 iJX
-ggt
+iJX
 iJX
 srk
-lhi
-cCH
-hOb
+lhQ
+xPP
+mbh
 lhQ
 cdD
 uQR
@@ -90142,7 +89933,7 @@ kis
 bzU
 bDW
 bME
-bME
+jrf
 bFK
 srk
 xLN
@@ -90154,14 +89945,14 @@ qMT
 sGT
 cCk
 nHQ
-bRN
-bRN
-bUm
-bRN
-toP
-eNG
-gtS
-cdE
+agy
+agy
+agy
+agy
+xjF
+lhQ
+xPP
+mbh
 lhQ
 cdD
 ebq
@@ -90395,11 +90186,11 @@ bBL
 bBL
 bBL
 rle
-cSG
-bCQ
+hKl
+lhQ
 bvw
 lhQ
-lhQ
+xPP
 bzn
 srk
 cRj
@@ -90415,10 +90206,10 @@ bXW
 wVP
 bVZ
 vKc
-eGL
-eVp
-sAw
-cdE
+xjF
+lhQ
+xPP
+mbh
 xRq
 chb
 chb
@@ -90653,10 +90444,10 @@ bxR
 mPM
 ohK
 tlc
-lhQ
+idS
 bvw
 bFT
-bFT
+jFT
 biW
 wTK
 wTK
@@ -90667,15 +90458,15 @@ hzs
 xTI
 msg
 njU
-pyI
+ndS
 agy
 agy
-cmr
+nHQ
 agy
 xjF
-cng
-sAw
-cdE
+lhQ
+xPP
+mbh
 xRq
 djx
 gEi
@@ -90684,7 +90475,7 @@ kuU
 djw
 xRq
 wGq
-rLU
+wGq
 wGq
 wGq
 wGq
@@ -90907,15 +90698,15 @@ vAs
 xhH
 xou
 cZq
-fcJ
+lbp
 cqd
 qlW
-bmS
-uaA
-mKA
+iog
+bvw
+bFT
 czg
-bmS
-aIf
+lhQ
+wTK
 rTQ
 yjq
 amc
@@ -90930,9 +90721,9 @@ xfW
 plP
 gVL
 xjF
-cng
-sAw
-hCz
+lhQ
+xPP
+mbh
 rdu
 fsT
 pfk
@@ -91167,11 +90958,11 @@ jLp
 bDT
 bAt
 mmO
-hxf
+iza
 bzl
-hxf
-hxf
-hxf
+jjA
+mmO
+jjA
 lJC
 cpB
 qEM
@@ -91184,11 +90975,11 @@ agy
 agy
 sAD
 agy
-cmr
+nHQ
 agy
 xjF
-cng
-sAw
+lhQ
+sFp
 kSP
 oBj
 tpn
@@ -91432,9 +91223,9 @@ fad
 wTK
 wTK
 wTK
-oDt
-srk
-amm
+xbC
+mqq
+agy
 agy
 agy
 agy
@@ -91444,11 +91235,11 @@ chp
 cLD
 chp
 srk
-cng
-krs
-jZS
+lhQ
+xPP
+mbh
 tDn
-eWp
+gEi
 hQl
 gEi
 gEi
@@ -91702,8 +91493,8 @@ nEy
 sMR
 srk
 hNt
-sAw
-cdE
+xPP
+mbh
 xRq
 ryA
 mqC
@@ -91938,7 +91729,7 @@ bqW
 bzi
 tcU
 jWy
-bsL
+bEi
 qJV
 bLT
 cbQ
@@ -91959,7 +91750,7 @@ vwq
 pSX
 srk
 dNo
-sAw
+xPP
 qdi
 xRq
 xRq
@@ -92216,8 +92007,8 @@ qoT
 sdM
 srk
 lhQ
-sAw
-cdE
+xPP
+mbh
 xTw
 jSV
 ilM
@@ -92447,12 +92238,12 @@ avT
 bLT
 bEi
 suL
-hez
+bEi
 jkL
 xRH
 xRH
 cZN
-bvo
+bEi
 afp
 bLT
 wTK
@@ -92473,11 +92264,11 @@ xTI
 pSX
 srk
 hIC
-sAw
+xPP
 mbh
-wJb
-rwR
-rwR
+xTw
+uid
+uid
 nby
 uid
 bWP
@@ -92703,13 +92494,13 @@ avT
 avT
 bLT
 bIm
-bkQ
+bIm
 bIm
 bra
 xRH
 xRH
 bri
-bvo
+bEi
 aDM
 bLT
 dFp
@@ -92730,7 +92521,7 @@ iZs
 gKs
 srk
 cQU
-sAw
+sFp
 lDi
 cVc
 kpT
@@ -92987,11 +92778,11 @@ wRX
 wRX
 srk
 jCF
-krs
-gmv
-mEo
-nFc
-nFc
+xPP
+tNf
+xTw
+uid
+uid
 jTE
 uid
 azs
@@ -93241,7 +93032,7 @@ wGq
 giD
 wGq
 wGq
-sUX
+wTK
 wTK
 lhQ
 xPP
@@ -93497,11 +93288,11 @@ blR
 wTK
 wTK
 wTK
-lJe
+wGq
 wTK
-wTK
+ryE
 lhQ
-lhQ
+xPP
 tNf
 sqH
 sqH
@@ -93749,14 +93540,14 @@ wGq
 doP
 mzv
 wTK
-fRK
+mGa
 wGq
 wGq
 ofH
 wGq
 rHo
-wGq
 wTK
+sjk
 lhQ
 hSV
 hZa
@@ -94012,10 +93803,10 @@ lJe
 wTK
 wTK
 wGq
-wGq
-kAX
+wTK
+srJ
 lhQ
-lhQ
+xPP
 tNf
 jcT
 avT
@@ -94268,11 +94059,11 @@ rHo
 wGq
 cbQ
 wTK
-cbQ
-uSH
-wTK
+wGq
+wGq
+kAX
 lhQ
-lhQ
+sLv
 tNf
 jcT
 avT
@@ -94529,7 +94320,7 @@ wTK
 wTK
 wTK
 bdm
-lhQ
+sRh
 tNf
 jcT
 avT
@@ -100366,7 +100157,7 @@ cuY
 qLM
 qLM
 qLM
-nGx
+qLM
 xtV
 lzB
 avT
@@ -100622,8 +100413,8 @@ ust
 sHJ
 qRy
 qRy
-irt
-sLv
+alG
+qRy
 ybT
 asr
 avT
@@ -105723,7 +105514,7 @@ iYF
 uIZ
 chd
 mOE
-cNE
+ajq
 sdr
 wGe
 sdr
@@ -106767,12 +106558,12 @@ iiY
 oty
 ijZ
 bnU
-wcy
+akB
 gWc
 npp
 pKN
-aJd
-aJd
+arN
+arN
 bnU
 mDW
 scH
@@ -107029,7 +106820,7 @@ ftM
 tcq
 ftM
 xPK
-mtW
+asQ
 bnU
 mDW
 scH
@@ -107286,7 +107077,7 @@ cLO
 fVT
 cLO
 uIU
-xZA
+atJ
 wku
 mDW
 dbN
@@ -107543,7 +107334,7 @@ cLO
 qQb
 cLO
 uIU
-rDt
+avp
 bnU
 eMi
 dkQ
@@ -107796,9 +107587,9 @@ ovI
 oAX
 tyF
 qSR
-gJr
-gJr
-ieF
+ani
+ani
+aol
 lfd
 vgI
 bnU
@@ -108052,10 +107843,10 @@ cfs
 vUj
 cLO
 nqc
-gis
+alR
 cLO
 cLO
-hLg
+aom
 jOE
 nUN
 sza
@@ -108309,7 +108100,7 @@ cfs
 sIk
 aTc
 sax
-pkj
+amA
 bdd
 bdd
 whW
@@ -108830,7 +108621,7 @@ qha
 vQo
 bnU
 lWP
-mhC
+axk
 bnU
 kPQ
 jzc
@@ -111141,7 +110932,7 @@ bnU
 dtm
 pvj
 bnU
-aJd
+arN
 bnU
 bnU
 bnU

--- a/_maps/map_files/Snaxi/Snaxi_Lumos.dmm
+++ b/_maps/map_files/Snaxi/Snaxi_Lumos.dmm
@@ -2637,6 +2637,10 @@
 	pixel_y = -32
 	},
 /obj/structure/reagent_dispensers/watertank,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/janitor)
 "aFB" = (
@@ -7898,12 +7902,11 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/structure/closet/radiation,
+/obj/item/storage/firstaid/radbgone,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "cjN" = (
@@ -9349,16 +9352,12 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
 "cNE" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 5
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/closet/radiation,
-/obj/item/storage/firstaid/radbgone,
-/turf/open/floor/engine,
-/area/engine/engineering)
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "cOb" = (
 /obj/structure/pool/Lboard,
 /turf/open/pool,
@@ -9695,9 +9694,6 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "cTp" = (
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/effect/landmark/xeno_spawn,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
@@ -10915,6 +10911,10 @@
 	dir = 9
 	},
 /obj/machinery/portable_atmospherics/canister/water_vapor,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/janitor)
 "dwT" = (
@@ -11455,6 +11455,11 @@
 	},
 /obj/machinery/airalarm{
 	pixel_y = 28
+	},
+/obj/structure/closet/radiation,
+/obj/item/storage/firstaid/radbgone,
+/obj/machinery/light{
+	dir = 1
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -12170,6 +12175,10 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel,
 /area/janitor)
 "efT" = (
@@ -12917,6 +12926,12 @@
 /obj/item/restraints/legcuffs/beartrap,
 /obj/item/restraints/legcuffs/beartrap,
 /obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -15775,12 +15790,16 @@
 /turf/open/floor/grass,
 /area/chapel/main)
 "fQc" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/door/firedoor/border_only{
+	dir = 4;
+	name = "east facing firelock"
 	},
-/obj/machinery/light,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/engine,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8;
+	name = "west facing firelock"
+	},
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "fQe" = (
 /obj/machinery/door/airlock/public/glass{
@@ -18873,6 +18892,10 @@
 	dir = 4
 	},
 /obj/effect/landmark/xeno_spawn,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/janitor)
 "hso" = (
@@ -21382,7 +21405,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/turf/open/floor/carpet/purple,
+/turf/open/floor/plasteel,
 /area/janitor)
 "iuy" = (
 /obj/machinery/light{
@@ -24649,6 +24672,11 @@
 /obj/machinery/light/floor,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
+"jYN" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/light,
+/turf/open/floor/engine,
+/area/engine/engineering)
 "jYT" = (
 /obj/machinery/power/solar_control{
 	dir = 4;
@@ -26943,9 +26971,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
 /turf/open/floor/engine,
 /area/engine/engineering)
 "lff" = (
@@ -27008,6 +27033,15 @@
 	},
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/janitor)
@@ -28344,6 +28378,13 @@
 	dir = 4
 	},
 /obj/machinery/light/small,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/janitor)
 "lSN" = (
@@ -28446,7 +28487,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/turf/open/floor/carpet/purple,
+/turf/open/floor/plasteel,
 /area/janitor)
 "lUz" = (
 /obj/machinery/light/small{
@@ -29275,6 +29316,13 @@
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
 	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/janitor)
 "mqc" = (
@@ -29424,6 +29472,10 @@
 	department = "Janitorial";
 	departmentType = 1;
 	pixel_y = -29
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/janitor)
@@ -30787,7 +30839,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/carpet/purple,
+/turf/open/floor/plasteel,
 /area/janitor)
 "mZp" = (
 /turf/closed/wall/r_wall,
@@ -32357,6 +32409,12 @@
 	},
 /turf/open/floor/plasteel/stairs/left,
 /area/hallway/primary/aft)
+"nKb" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "nKf" = (
 /obj/structure/chair/sofa/left,
 /turf/open/floor/plasteel/grimy,
@@ -34178,6 +34236,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
+	},
 /turf/open/floor/engine,
 /area/engine/engineering)
 "owV" = (
@@ -34454,6 +34515,13 @@
 /obj/structure/closet/jcloset,
 /obj/item/reagent_containers/glass/bucket,
 /obj/item/mop,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel,
 /area/janitor)
 "oEi" = (
@@ -36421,7 +36489,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/carpet/purple,
+/turf/open/floor/plasteel,
 /area/janitor)
 "pyY" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -38931,6 +38999,14 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"qIn" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "qIx" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -41764,7 +41840,13 @@
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "sdq" = (
-/turf/open/floor/carpet/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
 /area/janitor)
 "sdr" = (
 /turf/open/floor/plasteel,
@@ -42096,7 +42178,13 @@
 	pixel_x = -8;
 	pixel_y = 28
 	},
-/turf/open/floor/carpet/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
 /area/janitor)
 "slc" = (
 /obj/structure/cable{
@@ -43546,6 +43634,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 6
+	},
+/obj/machinery/light{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmospherics_engine)
@@ -46781,11 +46872,16 @@
 /turf/open/floor/wood,
 /area/security/vacantoffice/b)
 "uIU" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8;
+	name = "west facing firelock"
 	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/engine,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4;
+	name = "east facing firelock"
+	},
+/turf/open/floor/plating,
 /area/engine/engineering)
 "uIZ" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
@@ -47327,7 +47423,13 @@
 "uWW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/carpet/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
 /area/janitor)
 "uWY" = (
 /obj/machinery/door/airlock/medical/glass{
@@ -47828,12 +47930,9 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/south,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "vgW" = (
@@ -53296,27 +53395,13 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/structure/cable,
-/obj/machinery/power/apc/highcap/fifteen_k{
-	areastring = "/area/engine/engineering";
-	dir = 8;
-	name = "Engineering APC";
-	pixel_x = -27;
-	pixel_y = -1
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/structure/closet/radiation,
 /obj/machinery/camera{
 	c_tag = "Supermatter West";
 	dir = 4
 	},
-/obj/item/storage/firstaid/radbgone,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/engine,
 /area/engine/engineering)
 "xPP" = (
@@ -105570,7 +105655,7 @@ iYF
 uIZ
 chd
 mOE
-jlf
+cNE
 sdr
 wGe
 sdr
@@ -106614,12 +106699,12 @@ iiY
 oty
 ijZ
 bnU
-gWc
+fQc
 gWc
 npp
 pKN
-bnU
-bnU
+uIU
+uIU
 bnU
 mDW
 scH
@@ -106872,11 +106957,11 @@ ijZ
 ijZ
 bnU
 oJa
-cNE
+ftM
 tcq
 ftM
 xPK
-bnU
+nKb
 bnU
 mDW
 scH
@@ -107132,9 +107217,9 @@ cjH
 cLO
 fVT
 cLO
-fQc
-bnU
-bnU
+jOE
+svp
+wku
 mDW
 dbN
 qWs
@@ -107389,8 +107474,8 @@ dLj
 cLO
 qQb
 cLO
-uIU
-bnU
+jOE
+jYN
 bnU
 eMi
 dkQ
@@ -108164,7 +108249,7 @@ ebK
 gel
 rXn
 sGC
-bnU
+wku
 ojs
 jOI
 bnU
@@ -108677,7 +108762,7 @@ qha
 vQo
 bnU
 lWP
-svp
+qIn
 bnU
 kPQ
 jzc
@@ -110220,7 +110305,7 @@ qYN
 sbS
 iyL
 svp
-bnU
+wku
 pGs
 jzc
 bnU
@@ -110988,7 +111073,7 @@ bnU
 dtm
 pvj
 bnU
-bnU
+uIU
 bnU
 bnU
 bnU

--- a/_maps/map_files/Snaxi/Snaxi_Lumos.dmm
+++ b/_maps/map_files/Snaxi/Snaxi_Lumos.dmm
@@ -21,7 +21,6 @@
 /area/security/brig)
 "aaP" = (
 /obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
@@ -89,11 +88,10 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/plasteel,
 /area/engine/atmospherics_engine)
 "abQ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/table/wood/fancy,
 /obj/item/flashlight/lamp,
 /turf/open/floor/carpet,
@@ -105,7 +103,6 @@
 /obj/machinery/airalarm{
 	pixel_y = 28
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -126,14 +123,11 @@
 /turf/open/floor/plasteel/freezer,
 /area/medical/surgery)
 "ace" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
 	},
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/surface/outdoors)
+/turf/closed/wall,
+/area/maintenance/disposal/incinerator)
 "acq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -154,13 +148,15 @@
 /obj/effect/turf_decal/tile/brown,
 /obj/structure/chair/office/dark,
 /obj/effect/landmark/start/quartermaster,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "acx" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/button/door{
 	id = "qm_warehouse";
 	name = "Warehouse Door Control";
@@ -174,9 +170,6 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "acy" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
@@ -185,6 +178,12 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
@@ -218,16 +217,16 @@
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "ads" = (
-/obj/machinery/airalarm{
-	pixel_y = 28
-	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
-/obj/structure/closet/crate/trashcart,
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = 28
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "adt" = (
@@ -335,11 +334,14 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
@@ -350,22 +352,13 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/quartermaster/sorting)
-"adV" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -377,7 +370,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
@@ -387,14 +379,17 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "adX" = (
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 4;
@@ -405,6 +400,12 @@
 	req_access_txt = "31"
 	},
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -453,9 +454,6 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/pool)
 "aeG" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
@@ -486,7 +484,6 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "afq" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/power/apc{
 	areastring = "/area/maintenance/port/fore";
 	dir = 4;
@@ -569,7 +566,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/dorms)
 "ahW" = (
@@ -608,7 +604,8 @@
 /turf/open/floor/plasteel/white,
 /area/security/brig)
 "aiH" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/dorms)
 "aiS" = (
@@ -627,10 +624,9 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
 "aiU" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/effect/landmark/xeno_spawn,
-/turf/open/floor/plating,
-/area/engine/engineering)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "ajg" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/northleft{
@@ -723,7 +719,10 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/visible{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 9
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
@@ -879,7 +878,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -1668,13 +1670,16 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -31
 	},
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -2302,9 +2307,6 @@
 /turf/open/floor/wood,
 /area/icemoon/surface/outdoors)
 "aCV" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/conveyor{
 	dir = 1;
 	id = "packageSort2"
@@ -2630,10 +2632,11 @@
 /turf/closed/wall,
 /area/chapel/main)
 "aFA" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -32
 	},
-/obj/structure/janitorialcart,
+/obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plasteel,
 /area/janitor)
 "aFB" = (
@@ -2762,13 +2765,6 @@
 /obj/structure/barricade/wooden/snowed,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
-"aHt" = (
-/obj/machinery/atmospherics/components/binary/valve/digital{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/engine,
-/area/engine/engineering)
 "aHu" = (
 /turf/closed/wall/r_wall,
 /area/science/server)
@@ -2980,10 +2976,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
 "aKP" = (
@@ -3194,12 +3186,12 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "aNf" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
-/area/hallway/primary/port)
+/area/hallway/primary/aft)
 "aNg" = (
 /obj/machinery/light,
 /turf/open/floor/plating/asteroid/snow/icemoon,
@@ -3394,16 +3386,14 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aPy" = (
@@ -3501,6 +3491,12 @@
 "aQs" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
@@ -3671,14 +3667,15 @@
 /obj/machinery/camera{
 	c_tag = "Secure Tech Storage"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/pod,
 /area/storage/tech)
 "aUb" = (
-/obj/machinery/atmospherics/pipe/simple/supply/visible{
-	dir = 9
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/surface/outdoors)
+/turf/open/floor/carpet,
+/area/security/vacantoffice/b)
 "aUd" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 5
@@ -3735,9 +3732,11 @@
 /turf/open/floor/plating,
 /area/icemoon/surface/outdoors)
 "aWr" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall/r_wall,
-/area/engine/storage)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/closed/wall,
+/area/maintenance/disposal/incinerator)
 "aWK" = (
 /obj/machinery/door_timer{
 	id = "Cell 1";
@@ -3796,20 +3795,26 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aYf" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
@@ -3938,11 +3943,14 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "0-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
@@ -3954,11 +3962,10 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "bcA" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/crew_quarters/fitness)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "bcK" = (
 /obj/structure/transit_tube/curved{
 	dir = 4
@@ -3995,6 +4002,8 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "bei" = (
@@ -4322,14 +4331,6 @@
 /obj/effect/landmark/start/chaplain,
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
-"bnA" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "bnE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/airlock/public/glass{
@@ -4441,6 +4442,12 @@
 "bqE" = (
 /obj/machinery/camera{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
@@ -4885,9 +4892,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
 	},
@@ -4898,6 +4902,12 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8;
 	name = "west facing firelock"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
@@ -5720,6 +5730,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "bDo" = (
@@ -6040,9 +6056,6 @@
 "bGt" = (
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
 	},
 /obj/machinery/light/floor,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
@@ -6482,10 +6495,13 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "bKo" = (
@@ -6537,10 +6553,13 @@
 /obj/machinery/camera{
 	c_tag = "Engineering East"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -7026,12 +7045,6 @@
 /turf/open/floor/wood,
 /area/icemoon/surface/outdoors)
 "bSO" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
 /obj/structure/disposalpipe/sorting/mail{
 	dir = 4;
 	sortType = 3
@@ -7042,12 +7055,15 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=QM";
 	location = "CHW"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
@@ -7059,7 +7075,10 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -7142,7 +7161,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/yellowsiding{
 	dir = 8
 	},
@@ -7154,15 +7173,6 @@
 	},
 /turf/open/floor/plating,
 /area/medical/medbay/zone2)
-"bVj" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 9
-	},
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/surface/outdoors)
 "bVu" = (
 /obj/machinery/airalarm{
 	pixel_y = 26
@@ -7189,11 +7199,14 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/zone3)
 "bVI" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -7285,6 +7298,12 @@
 /obj/effect/turf_decal/lumos/loading_area/white,
 /obj/structure/railing/corner{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -7628,6 +7647,9 @@
 /area/maintenance/disposal)
 "ceZ" = (
 /mob/living/simple_animal/bot/medbot,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/zone3)
 "cfh" = (
@@ -7879,7 +7901,6 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -7906,11 +7927,14 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/light,
 /obj/structure/disposalpipe/junction/flip{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -8113,10 +8137,10 @@
 /turf/open/floor/wood,
 /area/library)
 "cmE" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -8339,12 +8363,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
-"cqx" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/yellowsiding{
-	dir = 8
-	},
-/area/crew_quarters/fitness/pool)
 "cqG" = (
 /obj/structure/disposalpipe/sorting/mail{
 	dir = 8;
@@ -8370,17 +8388,13 @@
 /turf/open/floor/plating,
 /area/hallway/primary/aft)
 "crg" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/supply)
+/area/hallway/primary/aft)
 "crr" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/structure/cable{
@@ -8490,19 +8504,15 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/lumos/loading_area/white{
 	dir = 1
 	},
 /obj/structure/railing/corner,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"cuO" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "cuX" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -8516,7 +8526,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/airlock/public/glass{
 	name = "Snow Airlock"
 	},
@@ -8531,9 +8540,6 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/fore)
 "cvB" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
@@ -8745,7 +8751,12 @@
 	pixel_x = 32;
 	pixel_y = -40
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "czF" = (
@@ -8801,6 +8812,8 @@
 	name = "EVA Storage";
 	req_access_txt = "18"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/storage/eva)
 "cAL" = (
@@ -8819,22 +8832,6 @@
 /obj/machinery/rnd/production/techfab/department/security,
 /turf/open/floor/plasteel/dark,
 /area/security/main)
-"cBa" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	name = "south facing firelock"
-	},
-/obj/machinery/door/airlock/public/glass{
-	name = "Primary Tool Storage"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/storage/primary)
 "cBe" = (
 /obj/structure/railing{
 	dir = 8
@@ -8864,7 +8861,7 @@
 /turf/open/floor/engine/air,
 /area/engine/atmos)
 "cBZ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel/yellowsiding,
@@ -9052,6 +9049,8 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
 "cFO" = (
@@ -9064,10 +9063,11 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "cGu" = (
@@ -9161,9 +9161,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8;
 	name = "west facing firelock"
@@ -9171,6 +9168,12 @@
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = null;
 	name = "Medbay"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/zone3)
@@ -9184,7 +9187,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmospherics_engine)
 "cJL" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -9208,7 +9211,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "cKD" = (
@@ -9330,8 +9338,14 @@
 /turf/open/floor/wood,
 /area/library)
 "cNm" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/effect/landmark/start/assistant,
+/obj/machinery/button/door{
+	id = "custodialwagon";
+	name = "Custodial Bay Toggle";
+	pixel_x = 8;
+	pixel_y = -24;
+	req_one_access_txt = "26"
+	},
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
 "cNE" = (
@@ -9356,26 +9370,19 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"cOn" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "qm_warehouse2";
-	name = "warehouse shutters"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "cOR" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -9391,7 +9398,10 @@
 	c_tag = "Auxiliary Bridge Hallway";
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -9486,12 +9496,18 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/starboard)
@@ -9502,13 +9518,12 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "cRa" = (
-/obj/structure/reagent_dispensers/watertank/high,
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = 28
+/obj/machinery/door/airlock/maintenance{
+	name = "Custodial Maintenance";
+	req_access_txt = "26"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/janitor)
@@ -9592,7 +9607,7 @@
 	dir = 1
 	},
 /obj/effect/landmark/blobstart,
-/turf/open/floor/plating,
+/turf/open/floor/pod,
 /area/storage/tech)
 "cSi" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
@@ -9634,6 +9649,9 @@
 /area/hallway/primary/fore)
 "cSC" = (
 /obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
 "cSG" = (
@@ -9656,7 +9674,10 @@
 	dir = 4
 	},
 /obj/machinery/portable_atmospherics/canister/toxins,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -9677,10 +9698,8 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
 /obj/effect/landmark/xeno_spawn,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/engine/atmospherics_engine)
 "cTD" = (
@@ -9705,14 +9724,14 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "cUd" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmospherics_engine)
+/area/hallway/primary/aft)
 "cUm" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Starboard Quarter Solar Access";
@@ -9735,11 +9754,12 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
 "cUV" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
 	},
-/turf/open/floor/pod/dark,
-/area/maintenance/starboard)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "cVc" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Garden"
@@ -9759,7 +9779,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "cVL" = (
@@ -9767,7 +9787,6 @@
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/maintenance/solars/starboard/fore)
 "cWG" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
@@ -9801,9 +9820,6 @@
 /turf/open/floor/wood,
 /area/maintenance/bar)
 "cWW" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/table,
 /obj/item/reagent_containers/glass/beaker/waterbottle/wataur,
 /turf/open/floor/plasteel,
@@ -9894,7 +9910,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/airlock{
 	name = "Kitchen cold room";
 	req_access_txt = "28"
@@ -9904,6 +9919,8 @@
 	name = "north facing firelock"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
 "cYq" = (
@@ -9986,9 +10003,13 @@
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
 "cZI" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/machinery/meter,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/surface/outdoors)
 "cZN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -10061,18 +10082,14 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 10
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/zone3)
-"dbl" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "dbB" = (
 /obj/structure/sign/nanotrasen,
 /turf/closed/wall/r_wall,
@@ -10102,10 +10119,13 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -10160,18 +10180,6 @@
 /obj/structure/fans/tiny,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
-"ddh" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "ddi" = (
 /obj/machinery/light{
 	dir = 1
@@ -10233,10 +10241,13 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "dfd" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 5
 	},
 /turf/open/floor/plasteel/freezer,
@@ -10299,11 +10310,11 @@
 /turf/closed/wall,
 /area/construction/storage)
 "dhX" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 6
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
@@ -10314,7 +10325,7 @@
 /turf/open/floor/carpet,
 /area/bridge)
 "diD" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -10361,11 +10372,9 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/fore)
 "dkD" = (
@@ -10412,7 +10421,6 @@
 	c_tag = "Engineering South";
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "dlg" = (
@@ -10542,9 +10550,6 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "dot" = (
@@ -10554,9 +10559,6 @@
 	pixel_y = -24
 	},
 /obj/machinery/light,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
 /obj/machinery/vending/kink,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/pool)
@@ -10702,9 +10704,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/door/airlock/atmos{
 	name = "Atmospherics";
 	req_access_txt = "24"
@@ -10712,6 +10711,12 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8;
 	name = "west facing firelock"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/secure_construction)
@@ -10724,7 +10729,6 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
 "dsX" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/structure/closet/crate,
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plasteel,
@@ -10803,7 +10807,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
@@ -10829,7 +10832,6 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "duX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_x = -28
@@ -10837,6 +10839,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "dvc" = (
@@ -10903,9 +10907,16 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
 "dwS" = (
-/obj/structure/closet/crate/freezer,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -6;
+	pixel_y = -31
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/machinery/portable_atmospherics/canister/water_vapor,
+/turf/open/floor/plasteel,
+/area/janitor)
 "dwT" = (
 /obj/structure/railing{
 	dir = 1
@@ -10913,9 +10924,6 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
 "dxF" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/door/airlock/atmos{
 	name = "Atmospherics";
 	req_access_txt = "24"
@@ -10923,6 +10931,9 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8;
 	name = "west facing firelock"
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -10952,10 +10963,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "dxZ" = (
@@ -10965,9 +10972,6 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -10976,6 +10980,12 @@
 	},
 /obj/structure/disposalpipe/sorting/mail/flip{
 	sortType = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
@@ -11012,7 +11022,7 @@
 /area/security/brig)
 "dzn" = (
 /obj/structure/closet/firecloset,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -11048,7 +11058,8 @@
 /obj/structure/sign/warning/pods{
 	pixel_x = -32
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
 "dAM" = (
@@ -11089,11 +11100,13 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/secure_construction)
 "dBR" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
-/turf/closed/wall,
-/area/quartermaster/sorting)
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/turf/open/floor/plating,
+/area/engine/atmos)
 "dCh" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg2"
@@ -11135,24 +11148,12 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/aft/secondary)
-"dDf" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "dDs" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/railing{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel/stairs/right,
 /area/hallway/primary/aft)
 "dDv" = (
@@ -11213,7 +11214,6 @@
 	name = "Station Intercom (General)";
 	pixel_x = 30
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -11221,9 +11221,6 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
 "dED" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/machinery/computer/card{
 	dir = 4
 	},
@@ -11236,9 +11233,6 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
 "dFa" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
 /obj/structure/sink/kitchen{
 	pixel_y = 28
 	},
@@ -11282,9 +11276,17 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "dFF" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/closed/wall,
-/area/quartermaster/qm)
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/carpet/orange,
+/area/engine/secure_construction)
 "dFJ" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -11304,8 +11306,11 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "dGc" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
@@ -11343,7 +11348,8 @@
 /area/bridge)
 "dHf" = (
 /obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "dHP" = (
@@ -11351,7 +11357,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
@@ -11405,8 +11410,14 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
+	},
+/obj/structure/disposalpipe/junction/flip{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
@@ -11451,10 +11462,9 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "dMj" = (
@@ -11474,9 +11484,6 @@
 /area/medical/surgery)
 "dMR" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
@@ -11498,13 +11505,16 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -11676,7 +11686,8 @@
 	name = "TEG Engine Room";
 	req_access_txt = "10"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/engine/atmospherics_engine)
 "dTV" = (
@@ -11764,11 +11775,11 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "dWt" = (
-/obj/machinery/airalarm{
-	pixel_y = 28
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
-/obj/vehicle/ridden/janicart,
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/janitor)
 "dWF" = (
 /obj/effect/landmark/event_spawn,
@@ -11778,9 +11789,11 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
+/turf/open/floor/carpet/orange,
+/area/engine/secure_construction)
 "dXa" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/hazardvest,
@@ -11871,9 +11884,6 @@
 /turf/open/pool,
 /area/crew_quarters/fitness/pool)
 "dYS" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
@@ -11989,7 +11999,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
@@ -11999,18 +12008,23 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "ecN" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/machinery/holopad,
 /obj/structure/disposalpipe/segment{
 	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
@@ -12019,9 +12033,6 @@
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -12069,7 +12080,7 @@
 /area/hallway/secondary/exit/departure_lounge)
 "eei" = (
 /obj/machinery/pool/controller,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 5
 	},
 /turf/open/floor/plasteel/yellowsiding,
@@ -12092,15 +12103,18 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
@@ -12150,10 +12164,12 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "efF" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/effect/landmark/blobstart,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/janitor)
 "efT" = (
@@ -12180,7 +12196,7 @@
 /turf/closed/wall,
 /area/engine/atmos)
 "ego" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plating,
 /area/hallway/primary/aft)
 "egJ" = (
@@ -12198,13 +12214,9 @@
 /turf/open/floor/plasteel/dark,
 /area/storage/eva)
 "eha" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "ehh" = (
@@ -12224,11 +12236,14 @@
 /turf/closed/wall/r_wall,
 /area/engine/atmospherics_engine)
 "ehZ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/landmark/event_spawn,
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -12264,9 +12279,6 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "eiz" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_y = -26
@@ -12328,7 +12340,6 @@
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "emd" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/landmark/event_spawn,
 /obj/structure/bed/dogbed/ian,
 /mob/living/simple_animal/pet/dog/corgi/Ian{
@@ -12377,6 +12388,9 @@
 	icon_state = "4-8"
 	},
 /obj/structure/chair/sofa/left,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
 "enP" = (
@@ -12440,18 +12454,27 @@
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
 "erb" = (
-/obj/structure/bed,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = -29
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/crew_quarters/fitness/pool)
+/area/hallway/primary/aft)
 "erc" = (
 /obj/structure/cable{
 	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
 	},
 /obj/machinery/door/window/northleft{
 	name = "Engineering Production";
@@ -12507,15 +12530,24 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
 "erG" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/closet/secure_closet/engineering_personal,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
-/area/engine/break_room)
+/area/hallway/primary/aft)
 "erL" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light/small{
 	dir = 4
@@ -12553,7 +12585,7 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "esq" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 6
 	},
 /turf/closed/wall,
@@ -12610,18 +12642,26 @@
 /turf/open/floor/plating,
 /area/maintenance/aft/secondary)
 "etV" = (
-/obj/machinery/atmospherics/pipe/simple/supply/visible,
-/turf/open/floor/plating/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors)
-"eua" = (
-/obj/effect/landmark/event_spawn,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
-/area/janitor)
-"eue" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/structure/plasticflaps/opaque,
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=2";
+	freq = 1400;
+	location = "Hydroponics"
 	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/hydroponics)
+"eua" = (
+/obj/structure/plasticflaps/opaque,
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=2";
+	freq = 1400;
+	location = "Kitchen"
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/freezer,
+/area/crew_quarters/kitchen)
+"eue" = (
 /obj/machinery/atm{
 	pixel_y = 28
 	},
@@ -12667,6 +12707,12 @@
 /obj/effect/turf_decal/tile/blue,
 /obj/structure/disposalpipe/segment{
 	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white/corner{
 	dir = 8
@@ -12820,12 +12866,6 @@
 	},
 /turf/open/floor/plating,
 /area/engine/atmos)
-"ezO" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hydroponics)
 "ezY" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -12849,9 +12889,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/yellowsiding{
 	dir = 8
 	},
@@ -12870,9 +12908,19 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "eAR" = (
-/obj/structure/closet/crate,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/table,
+/obj/item/storage/box/mousetraps,
+/obj/item/storage/box/mousetraps,
+/obj/item/restraints/legcuffs/beartrap,
+/obj/item/restraints/legcuffs/beartrap,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/janitor)
 "eBf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -13111,7 +13159,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
@@ -13163,11 +13210,12 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain)
 "eGH" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/railing/corner,
 /obj/effect/turf_decal/lumos/loading_area/white{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "eGJ" = (
@@ -13230,7 +13278,7 @@
 /area/ai_monitored/security/armory)
 "eHK" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+/obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -13254,15 +13302,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
-"eIN" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/storage/eva)
 "eIT" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 4
@@ -13304,20 +13343,26 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "eJC" = (
 /obj/structure/pool/Rboard,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
+	},
 /turf/open/floor/plasteel/yellowsiding{
 	dir = 8
 	},
 /area/crew_quarters/fitness/pool)
 "eJY" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
@@ -13326,9 +13371,6 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "eKe" = (
@@ -13420,9 +13462,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 4
 	},
@@ -13430,6 +13469,12 @@
 	id_tag = "MedbayFoyer";
 	name = "Paramedic Bay";
 	req_access_txt = "5"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
@@ -13449,9 +13494,6 @@
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
 	},
 /obj/effect/turf_decal/lumos/loading_area/white,
 /obj/structure/railing/corner{
@@ -13495,9 +13537,6 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
@@ -13511,8 +13550,8 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "eMQ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmospherics_engine)
@@ -13572,9 +13611,6 @@
 	c_tag = "Supermatter South";
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /turf/open/floor/engine,
 /area/engine/engineering)
 "eOt" = (
@@ -13633,6 +13669,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "eRu" = (
@@ -13660,6 +13699,9 @@
 /obj/structure/table,
 /obj/machinery/computer/security/telescreen/engine{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
@@ -13813,15 +13855,15 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
 "eTJ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -24
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 9
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
@@ -13872,7 +13914,10 @@
 	id = "aux_bridge";
 	name = "aux bridge blast door"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -13889,9 +13934,6 @@
 "eWg" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -13919,11 +13961,13 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
 "eWW" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/light/small{
 	dir = 8
 	},
 /obj/structure/closet/crate,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "eXd" = (
@@ -13962,15 +14006,18 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "eYq" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/pool)
 "eYu" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
@@ -14074,16 +14121,20 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
 "fbq" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/bar)
 "fch" = (
@@ -14404,9 +14455,11 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "fjw" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/obj/machinery/chem_master/condimaster{
+	name = "CondiMaster Neo"
+	},
+/turf/open/floor/plasteel/freezer,
+/area/crew_quarters/kitchen)
 "fjS" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
@@ -14495,9 +14548,6 @@
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "fmv" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/window/reinforced{
 	dir = 4
@@ -14605,7 +14655,6 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "foy" = (
@@ -14635,9 +14684,6 @@
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
 "fpt" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/bar)
@@ -14681,10 +14727,13 @@
 /turf/open/floor/pod/dark,
 /area/maintenance/starboard)
 "fqj" = (
-/obj/machinery/field/generator,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plating,
-/area/engine/storage)
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/plasteel/stairs/right,
+/area/hallway/primary/aft)
 "fqE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
@@ -14844,11 +14893,30 @@
 /turf/open/floor/plating,
 /area/hallway/primary/aft)
 "fuj" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
+/obj/structure/closet/crate/hydroponics,
+/obj/item/wirecutters,
+/obj/item/shovel/spade,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/wrench,
+/obj/item/paper/guides/jobs/hydroponics{
+	pixel_x = -5;
+	pixel_y = 3
 	},
-/turf/closed/wall,
-/area/storage/eva)
+/obj/item/book/manual/hydroponics_pod_people{
+	pixel_x = -4;
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/spray/plantbgone{
+	pixel_x = 13;
+	pixel_y = 5
+	},
+/obj/item/watertank,
+/obj/item/reagent_containers/spray/plantbgone{
+	pixel_x = 13;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "fur" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8;
@@ -14869,9 +14937,9 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "fuB" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/hop)
+/obj/effect/turf_decal/loading_area,
+/turf/open/floor/plasteel/freezer,
+/area/crew_quarters/kitchen)
 "fuX" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /obj/structure/chair/sofa{
@@ -14919,11 +14987,13 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -14998,24 +15068,14 @@
 /turf/open/floor/engine/plasma,
 /area/engine/atmos)
 "fyr" = (
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/structure/table,
-/obj/item/key/janitor,
-/obj/machinery/power/apc{
-	areastring = "/area/janitor";
-	dir = 4;
-	name = "Custodial Closet APC";
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
 /area/janitor)
 "fyz" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -15049,9 +15109,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "fzG" = (
@@ -15063,11 +15120,14 @@
 /turf/open/floor/wood,
 /area/security/vacantoffice/a)
 "fzT" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
@@ -15290,16 +15350,14 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /obj/structure/chair/office/dark{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "fGS" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/structure/closet/crate,
 /turf/open/floor/plating,
@@ -15323,11 +15381,11 @@
 /turf/open/floor/plating,
 /area/storage/atmos)
 "fHG" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
 	},
-/turf/open/floor/carpet/eighties,
-/area/crew_quarters/fitness)
+/turf/open/floor/plasteel/freezer,
+/area/crew_quarters/kitchen)
 "fHK" = (
 /obj/machinery/vending/boozeomat,
 /turf/closed/wall,
@@ -15342,6 +15400,12 @@
 "fIu" = (
 /obj/structure/cable{
 	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
@@ -15388,12 +15452,15 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
 /obj/structure/disposalpipe/sorting/mail{
 	dir = 4;
 	sortType = 21
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -15453,21 +15520,15 @@
 	name = "Station Intercom (General)";
 	pixel_y = -35
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /turf/open/floor/engine,
 /area/engine/engineering)
 "fKC" = (
 /turf/closed/wall/r_wall,
 /area/crew_quarters/heads/hos)
 "fKE" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
+/obj/effect/landmark/xeno_spawn,
+/turf/open/floor/plasteel/freezer,
+/area/crew_quarters/kitchen)
 "fKM" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -15529,7 +15590,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/camera{
 	c_tag = "Aft Primary Hallway - Middle";
 	dir = 4
@@ -15720,9 +15780,6 @@
 	},
 /obj/machinery/light,
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
 /turf/open/floor/engine,
 /area/engine/engineering)
 "fQe" = (
@@ -15739,8 +15796,8 @@
 /turf/closed/wall/r_wall,
 /area/security/prison)
 "fQs" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
@@ -15765,23 +15822,19 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "fQM" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "fQU" = (
@@ -15795,9 +15848,6 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /obj/machinery/door/airlock/public/glass{
@@ -15841,7 +15891,10 @@
 	name = "Vacant Office B";
 	req_access_txt = "32"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -15889,12 +15942,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
 /area/hallway/primary/aft)
 "fTy" = (
@@ -15947,7 +15998,12 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
 "fVT" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8
+	},
 /turf/open/floor/engine,
 /area/engine/engineering)
 "fWc" = (
@@ -15981,8 +16037,9 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "fWC" = (
@@ -16011,7 +16068,10 @@
 /turf/open/floor/circuit,
 /area/science/explab)
 "fXv" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -16070,8 +16130,11 @@
 	},
 /area/hallway/primary/port)
 "fYH" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
@@ -16119,7 +16182,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1;
 	name = "north facing firelock"
@@ -16128,6 +16190,8 @@
 	name = "Cargo Bay";
 	req_access_txt = "31"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "gag" = (
@@ -16151,10 +16215,10 @@
 /turf/open/floor/plasteel/dark,
 /area/storage/eva)
 "gaz" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
 /area/hallway/primary/aft)
 "gbg" = (
@@ -16230,7 +16294,6 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "gcY" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/airlock{
 	name = "Bar";
 	req_access_txt = "25"
@@ -16240,6 +16303,8 @@
 	name = "north facing firelock"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "gdd" = (
@@ -16257,13 +16322,13 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/structure/closet/secure_closet/freezer/fridge,
 /obj/machinery/power/apc{
 	areastring = "/area/crew_quarters/kitchen";
 	dir = 1;
 	name = "Kitchen APC";
 	pixel_y = 24
 	},
+/obj/structure/closet/secure_closet/freezer/kitchen,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "gdi" = (
@@ -16296,7 +16361,10 @@
 /turf/open/floor/plasteel/dark,
 /area/security/execution/education)
 "gdL" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -16326,6 +16394,10 @@
 	dir = 8;
 	pixel_x = 24
 	},
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/maintenance/starboard)
 "gfe" = (
@@ -16341,9 +16413,6 @@
 "gfC" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -16396,9 +16465,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "gga" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
+/obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/bridge)
 "ggg" = (
@@ -16422,14 +16492,9 @@
 /turf/open/floor/wood,
 /area/library)
 "ggD" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/obj/structure/closet/crate/wooden/fish_learning,
+/turf/open/floor/plasteel/freezer,
+/area/crew_quarters/kitchen)
 "ghq" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/ai)
@@ -16437,7 +16502,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_x = 28
@@ -16451,6 +16515,12 @@
 /obj/effect/turf_decal/lumos/loading_area/white,
 /obj/structure/railing/corner{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -16475,13 +16545,10 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "gjA" = (
@@ -16491,10 +16558,13 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -16516,10 +16586,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "gkt" = (
@@ -16618,11 +16684,6 @@
 	},
 /turf/open/floor/plating,
 /area/icemoon/surface/outdoors)
-"gmr" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "gmu" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /obj/structure/railing/corner{
@@ -16658,9 +16719,6 @@
 /turf/open/floor/carpet,
 /area/hallway/primary/aft)
 "gmU" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/chair/stool,
 /turf/open/floor/plating,
 /area/hallway/primary/aft)
@@ -16841,9 +16899,10 @@
 /turf/open/floor/plasteel,
 /area/storage/auxiliary)
 "grM" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/carpet/orange,
-/area/engine/secure_construction)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/obj/machinery/meter,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/surface/outdoors)
 "grV" = (
 /turf/closed/wall,
 /area/security/courtroom)
@@ -17027,7 +17086,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = -24
@@ -17047,7 +17105,7 @@
 /turf/open/floor/plasteel/cult,
 /area/library)
 "gvP" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -17110,14 +17168,14 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "gzt" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 1
 	},
-/obj/structure/chair/comfy/black{
-	dir = 8
-	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/crew_quarters/fitness)
 "gzH" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -17169,14 +17227,9 @@
 /turf/open/floor/plating,
 /area/maintenance/bar)
 "gBk" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/structure/chair/comfy/black{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/obj/machinery/holopad,
+/turf/open/floor/carpet,
+/area/crew_quarters/heads/hop)
 "gBo" = (
 /obj/effect/spawner/lootdrop/wall/fifty_percent_falsewall,
 /turf/open/floor/plating,
@@ -17219,9 +17272,6 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "gCT" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
@@ -17229,6 +17279,9 @@
 	areastring = /area/maintenance/disposal/incinerator;
 	auto_name = 0;
 	name = "Incinerator APC"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
 	},
 /turf/open/floor/plating,
 /area/hallway/primary/aft)
@@ -17275,8 +17328,8 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
@@ -17323,7 +17376,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/light{
 	dir = 8
 	},
@@ -17331,8 +17383,11 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/fore)
 "gFP" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
@@ -17408,19 +17463,16 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
 "gHQ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
 /obj/structure/disposalpipe/sorting/mail{
 	dir = 1;
 	sortType = 2
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "gHW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8;
 	name = "west facing firelock"
@@ -17428,6 +17480,12 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4;
 	name = "east facing firelock"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/fitness)
@@ -17501,10 +17559,6 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
@@ -17519,6 +17573,9 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "gKo" = (
@@ -17633,9 +17690,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "gNI" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "gNM" = (
@@ -17643,13 +17698,13 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
 "gOd" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hop)
 "gOi" = (
@@ -17659,18 +17714,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"gOp" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "gOr" = (
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
@@ -17822,7 +17869,10 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "gRt" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 10
 	},
 /turf/open/floor/carpet,
@@ -17946,9 +17996,6 @@
 /turf/open/floor/plating,
 /area/hallway/primary/central)
 "gUa" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
 /obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
@@ -18086,10 +18133,13 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/zone3)
 "gZo" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/carpet/eighties,
 /area/crew_quarters/fitness)
 "gZQ" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -18099,9 +18149,6 @@
 /turf/open/floor/plating,
 /area/medical/medbay/central)
 "gZR" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/table,
 /turf/open/floor/plating,
 /area/hallway/primary/aft)
@@ -18152,18 +18199,14 @@
 	},
 /area/chapel/main)
 "haU" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
-"haX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/turf/open/floor/carpet/eighties,
+/area/crew_quarters/fitness)
 "hbb" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -18175,7 +18218,6 @@
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "hcc" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
@@ -18189,8 +18231,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
@@ -18240,7 +18282,10 @@
 	name = "Station Intercom (General)";
 	pixel_y = -35
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -18364,9 +18409,6 @@
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/hallway/secondary/exit/departure_lounge)
 "hhx" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -18421,15 +18463,11 @@
 /turf/open/floor/plasteel,
 /area/medical/chemistry)
 "hiO" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hydroponics)
 "hjv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
@@ -18486,17 +18524,15 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "hlh" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
+/obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
 	},
 /turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
+/area/hydroponics)
 "hlT" = (
 /mob/living/simple_animal/bot/medbot{
 	name = "\improper Quick-Fix"
@@ -18751,9 +18787,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /turf/open/floor/plating,
 /area/hallway/primary/aft)
 "hqD" = (
@@ -18792,14 +18825,11 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
 "hrc" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hydroponics)
 "hru" = (
 /obj/machinery/light{
 	dir = 8
@@ -18839,8 +18869,12 @@
 /turf/open/floor/circuit/off,
 /area/ai_monitored/turret_protected/ai)
 "hsl" = (
-/turf/open/floor/plating,
-/area/maintenance/starboard)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/xeno_spawn,
+/turf/open/floor/plasteel,
+/area/janitor)
 "hso" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Medbay Storage";
@@ -18854,8 +18888,8 @@
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
 "hsu" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
@@ -18920,7 +18954,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -18993,11 +19026,12 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "hwd" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/lumos/loading_area/white,
 /obj/structure/railing/corner{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "hwg" = (
@@ -19055,9 +19089,6 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/fitness)
 "hwV" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
 /obj/machinery/computer/apc_control,
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -19123,12 +19154,14 @@
 /turf/open/floor/plating,
 /area/maintenance/aft/secondary)
 "hyl" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/obj/machinery/atmospherics/components/binary/valve{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/open/floor/plating/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors)
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "hyz" = (
 /obj/machinery/vending/autodrobe,
 /turf/open/floor/plasteel,
@@ -19164,12 +19197,8 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
-/obj/machinery/button/door{
-	id = "qm_warehouse2";
-	name = "Warehouse Door Control";
-	pixel_x = -1;
-	pixel_y = 24;
-	req_access_txt = "31"
+/obj/structure/sign/departments/custodian{
+	pixel_y = 32
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/starboard)
@@ -19238,14 +19267,12 @@
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
 "hAw" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
 	},
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
 "hAx" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/airlock/public/glass{
 	name = "Snow Airlock"
 	},
@@ -19254,6 +19281,8 @@
 	dir = 1;
 	name = "north facing firelock"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/dorms)
 "hAT" = (
@@ -19298,9 +19327,6 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "hBQ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
@@ -19376,6 +19402,12 @@
 /obj/machinery/keycard_auth{
 	pixel_y = 40
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "hDj" = (
@@ -19391,12 +19423,14 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "hDk" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
 "hDy" = (
 /obj/machinery/computer/holodeck{
 	dir = 4
@@ -19464,9 +19498,6 @@
 /turf/open/floor/plasteel,
 /area/storage/atmos)
 "hFG" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -19552,9 +19583,15 @@
 /turf/open/floor/plasteel,
 /area/engine/atmospherics_engine)
 "hHW" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall/r_wall,
-/area/crew_quarters/heads/hop)
+/obj/structure/chair/stool/bar,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "hHZ" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -19593,11 +19630,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "hIG" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/closed/wall,
-/area/hallway/primary/aft)
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/turf/open/floor/carpet,
+/area/crew_quarters/dorms)
 "hIH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -19623,8 +19659,11 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 5
+/obj/machinery/atmospherics/components/binary/valve/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
@@ -19687,8 +19726,14 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
+	},
+/obj/structure/sign/departments/custodian{
+	pixel_y = -32
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
@@ -19744,7 +19789,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/airlock/atmos{
 	name = "Atmospherics";
 	req_access_txt = "24"
@@ -19753,6 +19797,7 @@
 	dir = 1;
 	name = "north facing firelock"
 	},
+/obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "hMM" = (
@@ -19829,14 +19874,17 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
 "hNZ" = (
 /obj/machinery/firealarm{
 	pixel_y = 29
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/bridge)
@@ -19857,29 +19905,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/storage/atmos)
-"hOw" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/structure/closet/cabinet,
-/obj/item/clothing/suit/hooded/wintercoat,
-/obj/item/clothing/suit/hooded/wintercoat,
-/obj/item/clothing/suit/hooded/wintercoat,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/shoes/winterboots,
-/obj/item/clothing/shoes/winterboots,
-/obj/item/clothing/shoes/winterboots,
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/item/pickaxe,
-/obj/item/pickaxe,
-/obj/item/pickaxe,
-/turf/open/floor/plasteel/dark,
-/area/storage/eva)
 "hOA" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -19914,14 +19939,13 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_x = -28
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "hPA" = (
@@ -20197,9 +20221,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -20224,7 +20245,10 @@
 	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -20232,9 +20256,6 @@
 "hVk" = (
 /obj/machinery/door/firedoor/border_only{
 	name = "south facing firelock"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
 	},
 /obj/machinery/door/airlock/public/glass{
 	name = "Primary Tool Storage"
@@ -20258,9 +20279,14 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "hVt" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/engine,
-/area/engine/engineering)
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/turf/open/floor/carpet,
+/area/crew_quarters/dorms)
 "hVG" = (
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
@@ -20270,9 +20296,6 @@
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "hVN" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 4;
 	name = "east facing firelock"
@@ -20415,8 +20438,9 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "hYN" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/closed/wall,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/hallway/primary/aft)
 "hZa" = (
 /obj/machinery/firealarm{
@@ -20454,6 +20478,12 @@
 /obj/machinery/door/airlock/mining/glass{
 	name = "Quartermaster";
 	req_access_txt = "41"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
@@ -20548,11 +20578,14 @@
 /turf/open/floor/plating,
 /area/hallway/primary/port)
 "iaL" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness/pool)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/crew_quarters/dorms)
 "iaM" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
@@ -20606,11 +20639,14 @@
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "32"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/security/vacantoffice/b)
@@ -20702,9 +20738,6 @@
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
 "ifQ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8;
 	name = "west facing firelock"
@@ -20731,10 +20764,9 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "igi" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/obj/machinery/space_heater,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/hallway/primary/fore)
 "igK" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -20790,9 +20822,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 4;
 	name = "east facing firelock"
@@ -20803,6 +20832,12 @@
 	},
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
@@ -20844,12 +20879,12 @@
 	},
 /area/maintenance/aft/secondary)
 "ijz" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/starboard)
@@ -21025,9 +21060,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "inA" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/dorms)
 "inU" = (
@@ -21046,9 +21078,6 @@
 /turf/open/floor/plating,
 /area/engine/atmospherics_engine)
 "iod" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/northleft{
 	dir = 4;
@@ -21098,9 +21127,6 @@
 /turf/open/floor/plating,
 /area/engine/atmospherics_engine)
 "iph" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/closet/firecloset/full,
 /turf/open/floor/plating,
 /area/hallway/primary/aft)
@@ -21165,11 +21191,14 @@
 /turf/open/floor/carpet,
 /area/library)
 "iqT" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
 	},
-/turf/closed/wall,
-/area/hydroponics)
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "iqZ" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -21298,12 +21327,20 @@
 /turf/open/floor/plating,
 /area/storage/atmos)
 "itw" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/chair/comfy/brown{
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/carpet,
-/area/hallway/primary/aft)
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "itN" = (
 /obj/machinery/vending/coffee,
 /obj/item/radio/intercom{
@@ -21339,15 +21376,13 @@
 /turf/open/floor/plating,
 /area/maintenance/central)
 "iux" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
-/obj/effect/landmark/xeno_spawn,
-/turf/open/floor/plasteel,
+/turf/open/floor/carpet/purple,
 /area/janitor)
 "iuy" = (
 /obj/machinery/light{
@@ -21436,16 +21471,11 @@
 /area/quartermaster/storage)
 "ixd" = (
 /obj/structure/filingcabinet/chestdrawer,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
+	},
 /turf/open/floor/wood,
 /area/security/vacantoffice/b)
-"ixf" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "ixu" = (
 /obj/structure/table,
 /obj/item/hand_tele,
@@ -21458,9 +21488,6 @@
 "iyq" = (
 /obj/structure/cable{
 	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
 	},
 /obj/structure/table,
 /obj/item/storage/firstaid/regular,
@@ -21620,13 +21647,15 @@
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
 "iBl" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/effect/landmark/blobstart,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/storage/eva)
 "iBm" = (
@@ -21734,12 +21763,13 @@
 	icon_state = "1-4"
 	},
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/engine/atmospherics_engine)
 "iEJ" = (
@@ -21824,7 +21854,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/lumos/loading_area/white{
 	dir = 1
@@ -21906,8 +21935,11 @@
 /turf/open/floor/wood,
 /area/hallway/primary/central)
 "iGS" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
@@ -22052,9 +22084,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
 "iJK" = (
@@ -22072,11 +22101,20 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "iJS" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/closed/wall,
-/area/storage/eva)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "iJX" = (
 /obj/structure/bookcase/random/fiction,
 /turf/open/floor/wood,
@@ -22095,11 +22133,17 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "iLi" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/quartermaster/storage)
+/area/hallway/primary/fore)
 "iLw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
@@ -22166,14 +22210,14 @@
 /area/engine/engineering)
 "iNK" = (
 /obj/effect/landmark/start/assistant,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
@@ -22564,10 +22608,13 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "iZc" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/obj/structure/disposalpipe/junction{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/carpet,
@@ -22612,8 +22659,8 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
@@ -22817,9 +22864,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "jeo" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
 	},
@@ -22893,13 +22937,8 @@
 	name = "Station Intercom (General)";
 	pixel_x = -28
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"jgz" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "jgD" = (
 /obj/structure/table,
 /obj/item/storage/box/bodybags,
@@ -22971,7 +23010,7 @@
 /area/quartermaster/storage)
 "jji" = (
 /obj/machinery/door/airlock/maintenance,
-/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
 /area/hallway/primary/aft)
 "jjn" = (
@@ -22989,10 +23028,13 @@
 /turf/closed/wall,
 /area/security/prison)
 "jjB" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
 "jjC" = (
@@ -23015,7 +23057,6 @@
 /turf/open/floor/plating,
 /area/maintenance/aft/secondary)
 "jkw" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/delivery,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -23108,6 +23149,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/brown,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "jnh" = (
@@ -23224,20 +23268,24 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/bridge)
 "jpr" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "jpS" = (
@@ -23302,6 +23350,8 @@
 /obj/structure/sign/departments/medbay{
 	pixel_x = 32
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "jrR" = (
@@ -23315,10 +23365,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/fore)
@@ -23387,11 +23433,17 @@
 /turf/open/floor/plasteel/median/darktogrime,
 /area/chapel/main)
 "juI" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/quartermaster/storage)
+/area/hallway/primary/fore)
 "jvb" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -23470,7 +23522,8 @@
 /obj/structure/sign/poster/random{
 	pixel_x = 32
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "jxr" = (
@@ -23519,19 +23572,6 @@
 	},
 /turf/open/floor/plating,
 /area/icemoon/surface/outdoors)
-"jxZ" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "jyA" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/disposalpipe/segment{
@@ -23573,15 +23613,18 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "jzx" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/carpet,
-/area/hallway/primary/aft)
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "jAb" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -23643,7 +23686,7 @@
 /area/crew_quarters/heads/hos)
 "jAy" = (
 /obj/effect/landmark/blobstart,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -23713,9 +23756,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "jCL" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
@@ -23798,8 +23838,11 @@
 /turf/open/floor/carpet,
 /area/medical/psych)
 "jEb" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
@@ -23815,13 +23858,11 @@
 /turf/open/floor/plating,
 /area/maintenance/bar)
 "jFl" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "jFv" = (
@@ -23979,7 +24020,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 10
 	},
 /turf/open/floor/plasteel/yellowsiding/corner{
@@ -24005,7 +24046,7 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "jKb" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -24120,9 +24161,6 @@
 	},
 /area/chapel/main)
 "jNw" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
@@ -24138,11 +24176,7 @@
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "jNK" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/effect/landmark/start/janitor,
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/janitor)
 "jOj" = (
 /obj/structure/cable{
@@ -24185,9 +24219,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -24231,7 +24262,10 @@
 	dir = 8
 	},
 /obj/machinery/portable_atmospherics/canister/toxins,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -24292,6 +24326,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "jQB" = (
@@ -24326,11 +24361,14 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "jRD" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
@@ -24556,7 +24594,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/airlock/public/glass{
 	name = "Snow Airlock"
 	},
@@ -24566,6 +24603,8 @@
 	name = "north facing firelock"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/fore)
 "jXh" = (
@@ -24596,14 +24635,8 @@
 /turf/open/floor/wood,
 /area/icemoon/surface/outdoors)
 "jXL" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
 "jYt" = (
@@ -24683,13 +24716,11 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "kbr" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
 "kbR" = (
@@ -24707,7 +24738,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/lumos/loading_area/white,
 /obj/structure/railing/corner{
@@ -24762,7 +24792,10 @@
 /obj/machinery/camera{
 	c_tag = "Cargo Delivery Office"
 	},
-/obj/structure/closet/crate/trashcart,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/disposal/bin,
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "kds" = (
@@ -24869,9 +24902,6 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "keI" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
 /obj/structure/table,
 /obj/item/storage/box/donkpockets{
 	pixel_x = 3;
@@ -24894,23 +24924,28 @@
 /turf/closed/wall/r_wall,
 /area/security/prison)
 "kfI" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/carpet,
 /area/security/vacantoffice/b)
 "kfM" = (
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "kge" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
+/area/hallway/primary/fore)
 "kgo" = (
 /obj/machinery/door/poddoor{
 	id = "chapelgun";
@@ -24952,17 +24987,28 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "khw" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
 /obj/effect/turf_decal/delivery,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "khy" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/turf/closed/wall,
-/area/quartermaster/sorting)
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "kii" = (
 /obj/machinery/cryopod,
 /obj/machinery/light/small{
@@ -24998,11 +25044,18 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/zone2)
 "kjh" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
@@ -25089,17 +25142,20 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "klo" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/structure/table,
-/obj/item/storage/box/mousetraps,
-/obj/item/storage/box/mousetraps,
-/obj/item/restraints/legcuffs/beartrap,
-/obj/item/restraints/legcuffs/beartrap,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
-/area/janitor)
+/area/hallway/primary/fore)
 "klQ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -25186,11 +25242,14 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
@@ -25234,8 +25293,10 @@
 /turf/open/floor/carpet,
 /area/hallway/secondary/exit/departure_lounge)
 "kox" = (
-/obj/structure/table,
-/obj/machinery/reagentgrinder,
+/obj/effect/turf_decal/loading_area,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "koE" = (
@@ -25273,6 +25334,9 @@
 /obj/structure/table,
 /obj/machinery/recharger{
 	pixel_y = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
@@ -25354,9 +25418,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "krB" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall,
 /area/quartermaster/sorting)
@@ -25376,12 +25437,12 @@
 /turf/open/floor/plating,
 /area/icemoon/surface/outdoors)
 "krV" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
 /obj/effect/landmark/start/chief_engineer,
 /obj/structure/chair/office/light{
 	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
@@ -25659,7 +25720,6 @@
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "kxD" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -25678,17 +25738,12 @@
 	},
 /turf/open/floor/plating,
 /area/icemoon/surface/outdoors)
-"kxU" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/landmark/blobstart,
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "kyc" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
@@ -25741,7 +25796,10 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -25783,11 +25841,14 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -25798,9 +25859,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "kCI" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/table/reinforced,
 /obj/item/book/manual/wiki/barman_recipes,
 /obj/item/reagent_containers/food/drinks/shaker,
@@ -25824,9 +25882,17 @@
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/bar)
 "kDy" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/hop)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "kDE" = (
 /obj/structure/closet/cardboard,
 /turf/open/floor/plating,
@@ -25955,8 +26021,11 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "kHI" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
@@ -25992,11 +26061,14 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -26029,11 +26101,11 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "kJz" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/bridge)
@@ -26074,10 +26146,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel,
 /area/engine/atmospherics_engine)
 "kLh" = (
@@ -26090,8 +26159,11 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
@@ -26166,7 +26238,10 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -26289,9 +26364,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "kPn" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
-/area/quartermaster/storage)
+/area/hallway/primary/fore)
 "kPu" = (
 /obj/structure/window/plasma/reinforced{
 	dir = 4
@@ -26327,10 +26404,13 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -26353,15 +26433,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
-"kQr" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/visible{
-	dir = 6
-	},
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/surface/outdoors)
 "kQC" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -26415,9 +26486,6 @@
 /turf/open/floor/wood,
 /area/hallway/primary/port)
 "kRX" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/closet/secure_closet/hydroponics,
 /turf/open/floor/plasteel,
 /area/hydroponics)
@@ -26483,12 +26551,15 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 4;
 	sortType = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -26544,14 +26615,17 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/secure_construction)
@@ -26598,23 +26672,26 @@
 /turf/open/floor/wood,
 /area/icemoon/surface/outdoors)
 "kXY" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hop)
 "kYg" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/tile/red,
 /obj/structure/disposalpipe/segment{
 	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white/corner{
 	dir = 8
@@ -26687,9 +26764,6 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
@@ -26748,9 +26822,6 @@
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/bar)
 "lba" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
@@ -26875,9 +26946,6 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
 /turf/open/floor/engine,
 /area/engine/engineering)
 "lff" = (
@@ -26906,7 +26974,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/airlock/public/glass{
 	name = "Hydroponics";
 	req_access_txt = "35"
@@ -26916,6 +26983,8 @@
 	name = "north facing firelock"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "lfD" = (
@@ -26932,9 +27001,16 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "lfV" = (
-/obj/structure/closet/cardboard,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
+/obj/structure/closet/l3closet/janitor,
+/obj/machinery/power/apc/auto_name/north,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel,
+/area/janitor)
 "lgn" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -27022,7 +27098,12 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "liL" = (
@@ -27085,9 +27166,7 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "llu" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/hallway/primary/aft)
 "llz" = (
@@ -27095,9 +27174,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
@@ -27118,7 +27194,8 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "lmy" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "lmA" = (
@@ -27161,18 +27238,20 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/blue,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/white/corner{
 	dir = 8
 	},
 /area/hallway/primary/fore)
 "lnH" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
 /area/engine/storage)
 "lnI" = (
@@ -27209,10 +27288,13 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -27280,9 +27362,6 @@
 /turf/open/floor/wood,
 /area/security/courtroom)
 "lpl" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/junction/flip{
 	dir = 8
 	},
@@ -27362,10 +27441,13 @@
 /turf/open/floor/plating,
 /area/engine/atmospherics_engine)
 "lrV" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -27395,14 +27477,13 @@
 /turf/open/floor/plasteel,
 /area/medical/medbay/central)
 "lsK" = (
-/obj/machinery/vr_sleeper{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/turf/open/floor/plasteel/yellowsiding{
+	dir = 1
 	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/crew_quarters/fitness)
+/area/crew_quarters/fitness/pool)
 "ltk" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -27419,6 +27500,7 @@
 	name = "EVA Storage APC";
 	pixel_y = 24
 	},
+/obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plasteel/dark,
 /area/storage/eva)
 "ltn" = (
@@ -27462,6 +27544,8 @@
 	name = "south facing firelock"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "lud" = (
@@ -27580,9 +27664,13 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "lxL" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/closed/wall/r_wall,
-/area/engine/engineering)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel/yellowsiding{
+	dir = 1
+	},
+/area/crew_quarters/fitness/pool)
 "lyu" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/effect/turf_decal/tile/blue{
@@ -27600,9 +27688,6 @@
 "lyv" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -27672,11 +27757,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/closet/crate/hydroponics,
-/obj/item/wirecutters,
-/obj/item/shovel/spade,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/wrench,
+/obj/machinery/chem_master/condimaster,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "lAp" = (
@@ -27703,12 +27784,10 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark/corner{
 	dir = 1
 	},
@@ -27756,17 +27835,15 @@
 	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "lBT" = (
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "lCi" = (
@@ -27868,11 +27945,13 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
 "lEU" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/machinery/door/airlock/maintenance,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/closed/wall/r_wall,
-/area/engine/atmos)
+/turf/open/floor/plating,
+/area/janitor)
 "lFc" = (
 /obj/structure/transit_tube/horizontal{
 	dir = 1
@@ -27915,13 +27994,15 @@
 	name = "TEG Engine Room";
 	req_access_txt = "10"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/engine/atmospherics_engine)
 "lFv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
 	},
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/bar)
@@ -28094,9 +28175,6 @@
 /area/engine/atmos)
 "lKT" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
@@ -28115,7 +28193,10 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "lLD" = (
-/obj/structure/closet/crate/wooden/fish_learning,
+/obj/structure/closet/secure_closet/freezer/meat,
+/obj/machinery/camera{
+	c_tag = "Kitchen Cold Room"
+	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "lMx" = (
@@ -28158,26 +28239,26 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "lNN" = (
 /obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/plasteel/yellowsiding{
 	dir = 1
 	},
 /area/crew_quarters/fitness/pool)
-"lNU" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/carpet/orange,
-/area/engine/secure_construction)
 "lOs" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "lOF" = (
@@ -28225,9 +28306,11 @@
 /turf/open/floor/wood,
 /area/hallway/secondary/exit/departure_lounge)
 "lQJ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/crew_quarters/fitness/pool)
 "lRe" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/reagent_dispensers/fueltank,
@@ -28257,7 +28340,10 @@
 	},
 /area/chapel/main)
 "lSt" = (
-/obj/effect/landmark/start/janitor,
+/obj/structure/janitorialcart{
+	dir = 4
+	},
+/obj/machinery/light/small,
 /turf/open/floor/plasteel,
 /area/janitor)
 "lSN" = (
@@ -28353,11 +28439,15 @@
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
 "lUu" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/effect/landmark/start/janitor,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/turf/closed/wall,
-/area/storage/primary)
+/turf/open/floor/carpet/purple,
+/area/janitor)
 "lUz" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -28365,10 +28455,14 @@
 /turf/open/floor/plating,
 /area/security/brig)
 "lVd" = (
-/obj/structure/closet/secure_closet/freezer/meat,
-/obj/machinery/camera{
-	c_tag = "Kitchen Cold Room"
+/obj/structure/window/reinforced{
+	dir = 4
 	},
+/obj/machinery/door/window/southleft{
+	name = "Kitchen Delivery";
+	req_access_txt = "28"
+	},
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "lVi" = (
@@ -28384,7 +28478,10 @@
 /turf/open/floor/engine,
 /area/engine/supermatter)
 "lVS" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -28472,7 +28569,10 @@
 	dir = 8
 	},
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -28568,7 +28668,8 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/visible,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
 "lZs" = (
@@ -28639,10 +28740,13 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "maG" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -28681,11 +28785,12 @@
 /turf/closed/wall,
 /area/maintenance/port/fore)
 "mbt" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/delivery,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "mbE" = (
@@ -28720,8 +28825,9 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "mcU" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
@@ -28757,7 +28863,10 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -28788,12 +28897,14 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -28826,7 +28937,6 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
 "mgo" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1;
 	name = "north facing firelock"
@@ -28836,6 +28946,8 @@
 	req_access_txt = "31"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "mgC" = (
@@ -28849,7 +28961,7 @@
 /turf/open/floor/plasteel/cult,
 /area/library)
 "mgM" = (
-/turf/open/floor/plating,
+/turf/open/floor/pod,
 /area/storage/tech)
 "mgV" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -28925,21 +29037,22 @@
 /turf/open/floor/plating,
 /area/security/prison)
 "miu" = (
-/obj/machinery/chem_master/condimaster{
-	name = "CondiMaster Neo"
-	},
+/obj/machinery/gibber,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "mjH" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_y = 28
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
@@ -28953,10 +29066,13 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -28968,14 +29084,17 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/power/apc{
 	areastring = "/area/hallway/primary/fore";
 	dir = 1;
 	name = "Fore Primary Hallway APC";
 	pixel_y = 24
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
@@ -29000,11 +29119,11 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/sorting/mail{
 	sortType = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
@@ -29029,7 +29148,6 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/gibber,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "mmA" = (
@@ -29080,7 +29198,6 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "mmY" = (
@@ -29140,16 +29257,13 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = -29
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "mpj" = (
@@ -29157,20 +29271,24 @@
 /turf/open/floor/plating,
 /area/medical/virology)
 "mqb" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
+/obj/machinery/vending/wardrobe/jani_wardrobe,
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/janitor)
 "mqc" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/light,
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -29233,8 +29351,6 @@
 /turf/closed/wall/r_wall,
 /area/security/prison)
 "mrW" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/grass,
@@ -29296,11 +29412,21 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "msN" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
+/obj/structure/table,
+/obj/item/grenade/chem_grenade/cleaner,
+/obj/item/grenade/chem_grenade/cleaner,
+/obj/item/grenade/chem_grenade/cleaner,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/item/storage/box/lights/mixed,
+/obj/item/storage/box/lights/mixed,
+/obj/item/key/janitor,
+/obj/machinery/requests_console{
+	department = "Janitorial";
+	departmentType = 1;
+	pixel_y = -29
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/janitor)
 "msR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/grille/broken,
@@ -29354,9 +29480,17 @@
 	},
 /area/crew_quarters/fitness/pool)
 "mvA" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall,
-/area/quartermaster/storage)
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/components/binary/valve/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/surface/outdoors)
 "mvJ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -29372,9 +29506,6 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "mwQ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
@@ -29457,11 +29588,17 @@
 /turf/open/floor/plating,
 /area/science/robotics/lab)
 "myq" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
-/turf/open/floor/plasteel/grimy,
-/area/crew_quarters/bar)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/surface/outdoors)
 "myZ" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -29475,9 +29612,6 @@
 "mzj" = (
 /obj/structure/cable{
 	icon_state = "0-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -29507,9 +29641,6 @@
 	},
 /obj/item/toy/cards/deck{
 	pixel_x = -6
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
 	},
 /turf/open/floor/carpet/eighties,
 /area/crew_quarters/fitness)
@@ -29547,7 +29678,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "mAn" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -29673,9 +29804,6 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -29776,9 +29904,14 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "mGp" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall,
-/area/hydroponics)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
+	},
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/surface/outdoors)
 "mGL" = (
 /obj/structure/closet/secure_closet/RD,
 /obj/machinery/light_switch{
@@ -29829,12 +29962,12 @@
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
 "mHU" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/structure/closet/crate,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plating,
-/area/hallway/primary/aft)
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "mIc" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
@@ -29845,9 +29978,14 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/structure/disposalpipe/segment{
 	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
@@ -29960,15 +30098,6 @@
 /obj/structure/chair/sofa/right,
 /turf/open/floor/carpet,
 /area/hallway/primary/aft)
-"mKL" = (
-/obj/machinery/airalarm{
-	pixel_y = 26
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
-/turf/open/floor/plasteel/dark,
-/area/maintenance/department/bridge)
 "mKO" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -30052,9 +30181,6 @@
 /turf/open/floor/plasteel,
 /area/medical/chemistry)
 "mLK" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/table,
 /obj/structure/bedsheetbin/color,
 /obj/item/radio/intercom{
@@ -30064,19 +30190,20 @@
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/dorms)
 "mLO" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/effect/spawner/lootdrop/grille_or_trash,
-/turf/open/floor/plating,
-/area/hallway/primary/aft)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "mLP" = (
 /obj/structure/cable{
 	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
 	},
 /turf/closed/wall,
 /area/storage/eva)
@@ -30119,16 +30246,17 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "mNq" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
-/obj/machinery/portable_atmospherics/canister/water_vapor,
 /turf/open/floor/plasteel,
-/area/janitor)
+/area/quartermaster/storage)
 "mNL" = (
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
@@ -30170,10 +30298,8 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
 "mOx" = (
@@ -30293,11 +30419,9 @@
 	},
 /area/chapel/office)
 "mRx" = (
-/obj/machinery/atmospherics/pipe/simple/supply/visible{
-	dir = 6
-	},
-/turf/open/floor/plating/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors)
+/obj/effect/landmark/blobstart,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "mRz" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/plasteel/dark,
@@ -30306,7 +30430,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -30317,6 +30440,8 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "mSs" = (
@@ -30462,12 +30587,18 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "mVo" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
 	},
-/obj/machinery/holopad,
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/hop)
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 7;
+	pixel_y = 33
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/starboard)
 "mVr" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -30493,11 +30624,14 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -30524,15 +30658,15 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "mWD" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
 	},
-/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/brown,
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/maintenance/starboard)
 "mWJ" = (
 /turf/open/floor/plasteel,
 /area/storage/primary)
@@ -30601,11 +30735,16 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "mYE" = (
@@ -30644,9 +30783,12 @@
 /turf/open/floor/carpet/eighties,
 /area/crew_quarters/fitness)
 "mZk" = (
-/obj/effect/landmark/blobstart,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
+/obj/effect/landmark/start/janitor,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/carpet/purple,
+/area/janitor)
 "mZp" = (
 /turf/closed/wall/r_wall,
 /area/engine/storage)
@@ -30844,10 +30986,10 @@
 	},
 /area/maintenance/bar)
 "nek" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+/obj/item/kirbyplants/random,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
 	},
-/obj/item/kirbyplants/random,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "net" = (
@@ -30904,23 +31046,23 @@
 /obj/machinery/airalarm{
 	pixel_y = 25
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "ngj" = (
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/janitor)
 "ngp" = (
 /obj/structure/cable{
@@ -30974,6 +31116,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
 "nht" = (
@@ -31021,30 +31166,10 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/zone3)
 "nij" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/structure/table,
-/obj/item/watertank,
-/obj/item/reagent_containers/spray/plantbgone{
-	pixel_x = 13;
-	pixel_y = 5
-	},
-/obj/item/reagent_containers/spray/plantbgone{
-	pixel_x = 13;
-	pixel_y = 5
-	},
-/obj/item/reagent_containers/spray/plantbgone{
-	pixel_x = 13;
-	pixel_y = 5
-	},
-/obj/item/book/manual/hydroponics_pod_people{
-	pixel_x = -4;
-	pixel_y = 5
-	},
-/obj/item/paper/guides/jobs/hydroponics{
-	pixel_x = -5;
-	pixel_y = 3
+/obj/machinery/reagentgrinder,
+/obj/machinery/camera{
+	c_tag = "Hydroponics Storage"
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
@@ -31128,9 +31253,6 @@
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
 "nmL" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/chair{
 	dir = 4
 	},
@@ -31139,9 +31261,6 @@
 "nmM" = (
 /obj/machinery/airalarm{
 	pixel_y = 26
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/bridge)
@@ -31206,11 +31325,21 @@
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/bridge)
 "now" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+/obj/structure/closet/crate/trashcart,
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
-/area/hydroponics)
+/area/janitor)
 "noB" = (
 /obj/effect/turf_decal/bot,
 /mob/living/simple_animal/sloth/paperwork,
@@ -31233,23 +31362,23 @@
 /turf/open/openspace,
 /area/hallway/secondary/entry)
 "npl" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "npp" = (
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8;
@@ -31262,6 +31391,12 @@
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Supermatter Engine Room";
 	req_access_txt = "10"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -31280,6 +31415,8 @@
 	dir = 1;
 	name = "north facing firelock"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "npD" = (
@@ -31321,11 +31458,13 @@
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hos)
 "nrg" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/maintenance{
+	name = "Cargo Bay Maintenance";
+	req_access_txt = "31"
 	},
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
+/turf/open/floor/plating,
+/area/janitor)
 "nrJ" = (
 /obj/structure/table,
 /obj/item/stack/sheet/metal/fifty,
@@ -31352,7 +31491,6 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/paramedic)
 "nrY" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -31361,6 +31499,8 @@
 	name = "south facing firelock"
 	},
 /obj/structure/fans/tiny,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/dorms)
 "nsf" = (
@@ -31540,9 +31680,6 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "nwz" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
@@ -31563,15 +31700,18 @@
 /turf/open/floor/plating,
 /area/storage/primary)
 "nwR" = (
-/obj/machinery/door/airlock{
-	name = "Custodial Closet";
-	req_access_txt = "26"
+/obj/structure/closet/crate/trashcart,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only{
-	name = "south facing firelock"
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
 	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
+/obj/structure/sign/poster/official/random{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel,
 /area/janitor)
 "nxt" = (
 /obj/machinery/door/airlock/research{
@@ -31608,7 +31748,7 @@
 "nyp" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/techstorage/AI,
-/turf/open/floor/plating,
+/turf/open/floor/pod,
 /area/storage/tech)
 "nyq" = (
 /obj/structure/cable{
@@ -31675,7 +31815,6 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "nzK" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
@@ -31683,6 +31822,10 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -31702,10 +31845,13 @@
 /turf/open/floor/plating,
 /area/tcommsat/server)
 "nAS" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
 "nBd" = (
@@ -31812,11 +31958,14 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/door/airlock/public/glass{
 	name = "Arcade"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/carpet/eighties,
 /area/crew_quarters/fitness)
@@ -31839,9 +31988,6 @@
 "nDa" = (
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
 	},
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/turf_decal/tile/yellow{
@@ -31903,10 +32049,9 @@
 /turf/open/floor/plating,
 /area/science/lab)
 "nEl" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/fore)
 "nEs" = (
@@ -32007,9 +32152,6 @@
 /area/maintenance/disposal)
 "nGa" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/light{
 	dir = 4
 	},
@@ -32048,11 +32190,11 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "nGh" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
 	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "nGi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/reagent_dispensers/fueltank,
@@ -32075,9 +32217,6 @@
 "nGR" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
 	},
 /turf/open/floor/carpet/eighties,
 /area/crew_quarters/fitness)
@@ -32213,7 +32352,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/railing{
 	dir = 8
 	},
@@ -32302,11 +32440,11 @@
 /turf/open/floor/plating,
 /area/maintenance/aft/secondary)
 "nMJ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1
 	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "nNf" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
@@ -32370,7 +32508,6 @@
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
 "nOu" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/lumos/loading_area/white{
 	dir = 1
 	},
@@ -32378,6 +32515,8 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "nOE" = (
@@ -32422,7 +32561,6 @@
 	c_tag = "Dorms West";
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -32487,11 +32625,14 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -32636,7 +32777,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "nRR" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/wood,
@@ -32644,6 +32788,12 @@
 "nRS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -32732,9 +32882,6 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
 /turf/open/floor/engine,
 /area/engine/engineering)
 "nUT" = (
@@ -32797,7 +32944,6 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "nVY" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
@@ -32822,20 +32968,19 @@
 	},
 /area/hallway/primary/port)
 "nWO" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/quartermaster/storage)
 "nWP" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "packageSort2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/quartermaster/sorting)
 "nXs" = (
 /mob/living/carbon/monkey,
 /obj/structure/window/reinforced,
@@ -32866,9 +33011,6 @@
 /obj/effect/turf_decal/tile/blue,
 /obj/structure/disposalpipe/segment{
 	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
@@ -32936,11 +33078,12 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
 /obj/structure/railing{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/stairs/right,
 /area/hallway/primary/aft)
 "nZR" = (
@@ -33037,14 +33180,17 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/bar,
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -33135,9 +33281,6 @@
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
 "oez" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -33225,11 +33368,11 @@
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
 "ogX" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
 	},
-/turf/closed/wall,
-/area/quartermaster/sorting)
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "ogY" = (
 /obj/machinery/light{
 	dir = 4
@@ -33255,9 +33398,6 @@
 /turf/open/floor/wood,
 /area/medical/psych)
 "ohk" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
@@ -33306,7 +33446,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "ohF" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 5
 	},
 /turf/open/floor/plating,
@@ -33325,11 +33468,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "ohS" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/carpet/eighties,
-/area/crew_quarters/fitness)
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "oib" = (
 /obj/machinery/door/airlock/external{
 	name = "Engineering External Access";
@@ -33374,9 +33517,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/door/airlock/public/glass{
 	name = "Dormitory"
 	},
@@ -33387,6 +33527,12 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4;
 	name = "east facing firelock"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
@@ -33413,11 +33559,23 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "ojs" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/turf/closed/wall/r_wall,
-/area/crew_quarters/heads/hop)
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "ojv" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -33472,9 +33630,6 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "okq" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=Dorm";
 	location = "HOP2"
@@ -33491,9 +33646,8 @@
 /turf/open/floor/wood,
 /area/security/courtroom)
 "oln" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "olx" = (
@@ -33601,10 +33755,13 @@
 /turf/open/floor/pod/dark,
 /area/maintenance/starboard)
 "ond" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/effect/landmark/start/assistant,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/effect/landmark/start/assistant,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "ont" = (
@@ -33640,12 +33797,13 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "ooy" = (
@@ -33752,12 +33910,17 @@
 /turf/open/floor/carpet,
 /area/hallway/secondary/exit/departure_lounge)
 "oqr" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/structure/table,
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/storage/eva)
 "oqw" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -33904,11 +34067,17 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "ouE" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/turf/closed/wall,
-/area/crew_quarters/bar)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/storage/eva)
 "ouH" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -34008,9 +34177,6 @@
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -34143,7 +34309,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -34182,9 +34351,14 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
 "oBS" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/structure/cable{
 	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
 	},
 /turf/open/floor/plating,
 /area/hallway/primary/aft)
@@ -34270,17 +34444,16 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "oEf" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/machinery/vending/wardrobe/jani_wardrobe,
 /obj/machinery/camera{
 	c_tag = "Custodial Closet"
 	},
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = 28
+	},
+/obj/structure/closet/jcloset,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/mop,
 /turf/open/floor/plasteel,
 /area/janitor)
 "oEi" = (
@@ -34348,14 +34521,12 @@
 /turf/closed/wall/r_wall,
 /area/engine/supermatter)
 "oIb" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 1;
 	sortType = 22
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "oIq" = (
@@ -34395,7 +34566,6 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "oJA" = (
@@ -34496,7 +34666,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1;
 	name = "north facing firelock"
@@ -34508,6 +34677,8 @@
 	name = "Central Access"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "oLy" = (
@@ -34603,7 +34774,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "oNT" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -34676,22 +34847,25 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "oQg" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/landmark/start/station_engineer,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "oQj" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
 /obj/structure/cable{
 	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/wood,
 /area/security/vacantoffice/b)
@@ -34752,11 +34926,14 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "oTv" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
 	},
-/turf/closed/wall,
-/area/crew_quarters/kitchen)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/storage/eva)
 "oTF" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -34774,15 +34951,18 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
 /obj/machinery/holopad,
 /obj/structure/disposalpipe/segment{
 	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
@@ -34806,13 +34986,11 @@
 	id = "Secure Storage";
 	name = "secure storage"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
 /area/engine/storage)
 "oUV" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
@@ -34855,12 +35033,15 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 4;
 	sortType = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -34881,14 +35062,18 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "oXi" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/effect/turf_decal/tile/brown,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
 	},
 /turf/open/floor/plasteel,
-/area/engine/engineering)
+/area/quartermaster/qm)
 "oXl" = (
 /obj/machinery/camera{
 	c_tag = "Hydroponics South";
@@ -34998,17 +35183,19 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "par" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/medical/medbay/zone3)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/plasteel/dark,
+/area/storage/eva)
 "pax" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
+/obj/machinery/door/airlock{
+	name = "Custodial Closet";
+	req_access_txt = "26"
 	},
-/turf/closed/wall,
+/turf/open/floor/plasteel,
 /area/janitor)
 "paF" = (
 /obj/structure/disposalpipe/segment,
@@ -35034,6 +35221,12 @@
 /obj/effect/landmark/start/assistant,
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
@@ -35116,7 +35309,6 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
 "pcs" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
@@ -35181,9 +35373,6 @@
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/computer)
 "pdD" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -35227,6 +35416,10 @@
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
@@ -35294,15 +35487,11 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "pfZ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/dorms)
+/turf/open/floor/plating,
+/area/engine/storage)
 "pgk" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
@@ -35350,9 +35539,17 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
 "phq" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
-/area/janitor)
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/corner{
+	dir = 8
+	},
+/area/hallway/primary/fore)
 "phs" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -35360,9 +35557,6 @@
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors)
 "phu" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8;
 	name = "west facing firelock"
@@ -35374,6 +35568,12 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -35531,9 +35731,7 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "pko" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel/yellowsiding{
 	dir = 8
 	},
@@ -35792,7 +35990,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
 	},
@@ -35836,6 +36033,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/holopad,
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "psY" = (
@@ -35850,6 +36048,12 @@
 "ptl" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 10
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
@@ -35891,9 +36095,6 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "puf" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
-	dir = 1
-	},
 /obj/machinery/pipedispenser/disposal,
 /obj/structure/fireaxecabinet{
 	pixel_y = 32
@@ -35919,12 +36120,14 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "puA" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/effect/landmark/xeno_spawn,
 /obj/structure/disposalpipe/segment{
 	dir = 10
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
@@ -36016,17 +36219,17 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "pvs" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
+/obj/effect/turf_decal/tile/blue,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
+/turf/open/floor/plasteel/white/corner{
+	dir = 8
+	},
+/area/hallway/primary/fore)
 "pvw" = (
 /obj/machinery/telecomms/processor/preset_three,
 /turf/open/floor/plasteel/dark/telecomms,
@@ -36068,8 +36271,11 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/fitness)
 "pwC" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
 	},
 /turf/open/floor/plating,
 /area/engine/storage)
@@ -36132,7 +36338,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1;
 	name = "north facing firelock"
@@ -36141,6 +36346,8 @@
 	name = "Engineering";
 	req_access_txt = "10"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "pxX" = (
@@ -36153,10 +36360,13 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -36181,9 +36391,6 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "pyD" = (
@@ -36197,9 +36404,6 @@
 /obj/structure/sign/poster/random{
 	pixel_x = -32
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "pyI" = (
@@ -36209,9 +36413,16 @@
 /turf/open/floor/wood,
 /area/library)
 "pyW" = (
-/obj/structure/closet/crate/medical,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
+/obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/carpet/purple,
+/area/janitor)
 "pyY" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -36258,9 +36469,6 @@
 	},
 /obj/structure/disposalpipe/junction{
 	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -36317,14 +36525,17 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/dorms)
 "pBx" = (
-/obj/machinery/vr_sleeper{
-	dir = 4
+/obj/effect/turf_decal/tile/blue,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
 	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/crew_quarters/fitness)
+/turf/open/floor/plasteel/white/corner{
+	dir = 8
+	},
+/area/hallway/primary/fore)
 "pBU" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -36398,7 +36609,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
 /obj/structure/railing{
 	dir = 8
@@ -36422,14 +36632,17 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
 /obj/structure/disposalpipe/sorting/mail/flip{
 	sortType = 5
 	},
 /obj/machinery/atm{
 	pixel_x = -28
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -36535,9 +36748,6 @@
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "pFf" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
 /obj/machinery/pipedispenser/disposal/transit_tube,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -36548,19 +36758,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"pFu" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "pFI" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -36605,10 +36802,13 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -36640,10 +36840,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/machinery/atmospherics/components/unary/portables_connector/layer3{
 	dir = 8
 	},
-/obj/machinery/portable_atmospherics/scrubber,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "pIf" = (
@@ -36655,12 +36855,17 @@
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
 "pIm" = (
-/obj/effect/landmark/start/assistant,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/carpet/eighties,
-/area/crew_quarters/fitness)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
 "pIz" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -36687,10 +36892,6 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
 "pIP" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -36814,11 +37015,8 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -36826,7 +37024,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -36843,13 +37041,14 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "pMU" = (
@@ -36906,12 +37105,12 @@
 "pNB" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/techstorage/RnD_secure,
-/turf/open/floor/plating,
+/turf/open/floor/pod,
 /area/storage/tech)
 "pNL" = (
 /obj/structure/table,
 /obj/machinery/recharger,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -36965,9 +37164,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "pPx" = (
@@ -37001,7 +37197,6 @@
 	pixel_y = 6;
 	req_access_txt = "57"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/machinery/button/door{
 	id = "hop1";
 	name = "Privacy Shutters Control";
@@ -37012,14 +37207,14 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hop)
 "pQd" = (
-/obj/structure/cable{
-	icon_state = "2-8"
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 4
 	},
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/surface/outdoors)
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
 "pQg" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 6
@@ -37092,14 +37287,11 @@
 /turf/open/floor/plating,
 /area/hallway/primary/fore)
 "pSO" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/zone3)
 "pST" = (
 /obj/machinery/firealarm{
 	pixel_y = 29
@@ -37207,7 +37399,6 @@
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
 "pVW" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/airlock/public/glass{
 	name = "Snow Airlock"
 	},
@@ -37229,9 +37420,11 @@
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/bar)
 "pWa" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/zone3)
 "pWc" = (
 /turf/open/floor/plating,
 /area/maintenance/disposal)
@@ -37260,10 +37453,6 @@
 /turf/open/floor/grass,
 /area/chapel/main)
 "pXb" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -37349,10 +37538,13 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/structure/fans/tiny,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/structure/fans/tiny,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/port)
 "pZl" = (
@@ -37393,19 +37585,27 @@
 /turf/open/floor/plating,
 /area/hallway/primary/aft)
 "qaX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/delivery,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "qbg" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -37448,9 +37648,6 @@
 "qbJ" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/bridge)
 "qbY" = (
@@ -37458,9 +37655,6 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "qbZ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
@@ -37548,15 +37742,15 @@
 /turf/open/floor/plating,
 /area/science/robotics/lab)
 "qeH" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/closed/wall/r_wall,
-/area/janitor)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/paramedic)
 "qeL" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -37651,11 +37845,28 @@
 /turf/closed/wall/r_wall,
 /area/engine/supermatter)
 "qhf" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/turf/open/floor/engine,
-/area/engine/engineering)
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/door/airlock/medical/glass{
+	id_tag = "MedbayFoyer";
+	name = "Paramedic Garage";
+	req_access_txt = "5"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/medical/paramedic)
 "qhx" = (
 /turf/open/floor/plasteel/median/darktogrime/corner{
 	dir = 8
@@ -37737,11 +37948,20 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/paramedic)
 "qjA" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/medical/paramedic)
 "qjQ" = (
 /obj/item/hatchet,
 /turf/open/floor/grass,
@@ -37763,16 +37983,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"qkx" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "qle" = (
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
@@ -37812,7 +38022,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "qlY" = (
@@ -37901,11 +38110,14 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/landmark/event_spawn,
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -37929,13 +38141,16 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
 /obj/machinery/disposal/bin,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engine/atmospherics_engine)
 "qpo" = (
@@ -37945,7 +38160,9 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
-/obj/structure/closet/crate/trashcart,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "qpE" = (
@@ -37971,7 +38188,6 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "qpW" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
@@ -38090,20 +38306,20 @@
 /turf/closed/mineral/random/snow/no_caves,
 /area/icemoon/surface/outdoors/unexplored/rivers/no_monsters)
 "qrS" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
 	},
-/obj/machinery/door/airlock{
-	name = "Custodial Closet";
-	req_access_txt = "26"
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1;
-	name = "north facing firelock"
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8
 	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/janitor)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/medical/paramedic)
 "qsm" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -38139,9 +38355,6 @@
 /area/maintenance/disposal/incinerator)
 "qtG" = (
 /obj/structure/bed,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
 /obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/pool)
@@ -38205,9 +38418,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "qve" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 10
 	},
 /turf/open/floor/plating,
 /area/hallway/primary/aft)
@@ -38278,12 +38493,6 @@
 	},
 /turf/open/floor/carpet/eighties,
 /area/crew_quarters/fitness)
-"qxw" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "qxM" = (
 /obj/machinery/door/airlock/public/glass{
 	id_tag = null;
@@ -38328,7 +38537,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
@@ -38338,6 +38546,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "qyK" = (
@@ -38448,9 +38658,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 4
 	},
@@ -38468,7 +38675,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
@@ -38493,15 +38700,17 @@
 /turf/closed/wall,
 /area/hallway/secondary/entry)
 "qCo" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/effect/landmark/xeno_spawn,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
-/area/storage/eva)
+/area/medical/paramedic)
 "qCF" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -38683,7 +38892,6 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
 "qHh" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/sign/poster/random{
 	pixel_x = 32
 	},
@@ -38691,6 +38899,8 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/lumos/loading_area/white,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "qHq" = (
@@ -38703,9 +38913,6 @@
 /turf/open/floor/plating,
 /area/engine/atmos)
 "qHL" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
@@ -38741,9 +38948,6 @@
 "qIP" = (
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
 	},
 /obj/machinery/camera{
 	c_tag = "Dorms Central"
@@ -38789,7 +38993,6 @@
 	dir = 4;
 	pixel_x = -22
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "qJL" = (
@@ -38837,21 +39040,16 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
 /obj/structure/sign/warning/fire{
 	pixel_x = 32
 	},
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
 /area/hallway/primary/aft)
 "qKA" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -38872,9 +39070,6 @@
 	},
 /area/hallway/primary/fore)
 "qKP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/computer/security{
 	dir = 8
 	},
@@ -38930,11 +39125,12 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "qLM" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/surface/outdoors)
 "qMn" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -39028,7 +39224,7 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "qQb" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
 	},
 /turf/open/floor/engine,
@@ -39077,9 +39273,6 @@
 /turf/open/floor/plasteel/dark,
 /area/teleporter)
 "qRe" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8;
 	name = "west facing firelock"
@@ -39091,19 +39284,26 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "qRy" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/hallway/primary/aft)
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/surface/outdoors)
 "qRF" = (
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
 /area/engine/storage)
 "qRH" = (
@@ -39176,9 +39376,11 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "qSS" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible,
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 5
+	},
 /turf/open/floor/engine,
 /area/engine/engineering)
 "qTb" = (
@@ -39322,12 +39524,6 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/chapel/main)
-"qWa" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "qWg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -39345,8 +39541,13 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -39417,9 +39618,6 @@
 /area/hallway/secondary/exit/departure_lounge)
 "qYD" = (
 /obj/machinery/vending/security,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/bridge)
 "qYN" = (
@@ -39459,13 +39657,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"qZO" = (
-/obj/machinery/atmospherics/pipe/simple/supply/visible{
-	dir = 4
-	},
-/obj/machinery/light/floor,
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/surface/outdoors)
 "qZP" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -39522,8 +39713,13 @@
 /turf/open/floor/plasteel/checker,
 /area/crew_quarters/heads/hor)
 "raA" = (
-/turf/closed/wall/r_wall,
-/area/maintenance/starboard)
+/obj/machinery/door/poddoor/shutters{
+	id = "jangarage";
+	name = "Custodial Closet Shutters"
+	},
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
+/area/janitor)
 "raM" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 4
@@ -39642,10 +39838,13 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -39695,7 +39894,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "reT" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/weightmachine/weightlifter,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
@@ -39742,12 +39940,6 @@
 	},
 /turf/open/floor/wood,
 /area/security/courtroom)
-"rgm" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
-/turf/closed/wall,
-/area/hydroponics)
 "rgC" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
@@ -39755,7 +39947,8 @@
 /obj/machinery/door/firedoor/border_only{
 	name = "south facing firelock"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "rgG" = (
@@ -39855,10 +40048,6 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "rjQ" = (
@@ -39875,12 +40064,15 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
@@ -39888,8 +40080,11 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
 	},
 /turf/open/floor/plasteel/white,
 /area/hallway/primary/port)
@@ -39947,8 +40142,9 @@
 /turf/open/floor/plasteel/white,
 /area/security/brig)
 "rlC" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/zone3)
@@ -39971,9 +40167,8 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "rlW" = (
@@ -40034,30 +40229,31 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "rnk" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
@@ -40074,24 +40270,30 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/landmark/event_spawn,
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "rom" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -40152,10 +40354,6 @@
 /obj/item/pickaxe,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"rph" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "rpT" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -40222,16 +40420,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/crew_quarters/fitness)
-"rqN" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "rqQ" = (
 /turf/closed/wall,
 /area/medical/genetics)
@@ -40280,12 +40468,6 @@
 	},
 /turf/open/floor/plasteel/chapel,
 /area/chapel/main)
-"rrm" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
 "rrC" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/plasteel,
@@ -40323,10 +40505,12 @@
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "rta" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/airalarm{
 	dir = 8;
 	pixel_x = 24
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
 	},
 /turf/open/floor/plasteel/yellowsiding/corner{
 	dir = 1
@@ -40354,9 +40538,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
@@ -40366,6 +40547,12 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
@@ -40422,9 +40609,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/machinery/light{
 	dir = 1
 	},
@@ -40472,13 +40656,10 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/solars/port/aft)
 "rwq" = (
+/obj/effect/landmark/event_spawn,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "rww" = (
@@ -40508,16 +40689,12 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "rxf" = (
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/visible,
 /obj/structure/reagent_dispensers/fueltank,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"rxt" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/crew_quarters/heads/hop)
 "rxu" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -40701,12 +40878,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"rDE" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/sorting)
 "rDG" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/open/floor/plasteel,
@@ -40749,9 +40920,6 @@
 /area/icemoon/surface/outdoors)
 "rFB" = (
 /obj/effect/turf_decal/tile/yellow,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_y = -35
@@ -40797,10 +40965,8 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
 "rGy" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "rGP" = (
@@ -40868,6 +41034,10 @@
 /obj/machinery/status_display/supply{
 	pixel_x = -32
 	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "rIB" = (
@@ -41058,7 +41228,6 @@
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "rNP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/airlock/command{
 	name = "Head of Personnel";
 	req_access_txt = "57"
@@ -41069,6 +41238,8 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hop)
 "rNS" = (
@@ -41108,12 +41279,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/server)
-"rPs" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/closed/wall,
-/area/maintenance/starboard)
 "rPD" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -41162,7 +41327,6 @@
 /area/hallway/primary/fore)
 "rQH" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -41208,9 +41372,6 @@
 "rRk" = (
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -41295,12 +41456,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
-"rTv" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
 "rTz" = (
 /obj/structure/fireplace/fireplace_metal,
 /turf/open/floor/carpet,
@@ -41314,9 +41469,6 @@
 "rTG" = (
 /obj/structure/cable{
 	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
 	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
@@ -41422,8 +41574,8 @@
 /area/engine/engineering)
 "rXo" = (
 /obj/machinery/power/emitter,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/engine/storage)
@@ -41433,12 +41585,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
-"rXw" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "rYc" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
@@ -41585,10 +41731,13 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -41615,18 +41764,7 @@
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "sdq" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/structure/closet/l3closet/janitor,
-/turf/open/floor/plasteel,
+/turf/open/floor/carpet/purple,
 /area/janitor)
 "sdr" = (
 /turf/open/floor/plasteel,
@@ -41658,12 +41796,15 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/machinery/door/airlock/mining/glass{
 	name = "Delivery Office";
 	req_access_txt = "50"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/starboard)
@@ -41719,9 +41860,6 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "sgL" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/window/reinforced{
 	dir = 8
 	},
@@ -41739,8 +41877,11 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
@@ -41776,9 +41917,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8;
 	name = "west facing firelock"
@@ -41794,6 +41932,12 @@
 	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -41828,7 +41972,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "sjB" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 9
 	},
 /turf/closed/wall,
@@ -41847,8 +41991,8 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
@@ -41899,17 +42043,23 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "skE" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -41922,27 +42072,31 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
-"skK" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "skT" = (
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "skZ" = (
-/turf/closed/wall/r_wall,
+/obj/vehicle/ridden/janicart,
+/obj/structure/sink{
+	pixel_y = 20
+	},
+/obj/machinery/button/door{
+	id = "custodialwagon";
+	name = "Custodial Bay Toggle";
+	pixel_x = 8;
+	pixel_y = 28;
+	req_one_access_txt = "26"
+	},
+/obj/machinery/light_switch{
+	pixel_x = -8;
+	pixel_y = 28
+	},
+/turf/open/floor/carpet/purple,
 /area/janitor)
 "slc" = (
 /obj/structure/cable{
@@ -41986,10 +42140,13 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "slO" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hop)
 "sma" = (
@@ -42049,10 +42206,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
-"smY" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "snb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/computer/card,
@@ -42082,12 +42235,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"soW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/visible{
-	dir = 10
-	},
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/surface/outdoors)
 "spa" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -42215,10 +42362,13 @@
 	dir = 1;
 	pixel_y = -22
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -42348,9 +42498,6 @@
 /area/chapel/office)
 "svp" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /turf/open/floor/engine,
 /area/engine/engineering)
 "svr" = (
@@ -42392,15 +42539,18 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "sxb" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -42474,15 +42624,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/engine,
 /area/engine/engineering)
-"szi" = (
-/obj/machinery/atmospherics/components/binary/valve{
-	dir = 4
-	},
-/turf/open/floor/plating/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors)
 "szD" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -42598,9 +42741,6 @@
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/bridge)
 "sBs" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/fore)
@@ -42615,10 +42755,10 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
 "sBB" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "sBN" = (
@@ -42648,6 +42788,9 @@
 	icon_state = "1-4"
 	},
 /obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
 "sDD" = (
@@ -42728,9 +42871,6 @@
 "sGC" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /turf/open/floor/engine,
 /area/engine/engineering)
 "sGE" = (
@@ -42738,7 +42878,6 @@
 	name = "Service Hall";
 	req_one_access_txt = "25;26;35;28"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal)
 "sGL" = (
@@ -42791,7 +42930,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "sHJ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/airlock/public/glass{
 	name = "Snow Airlock"
 	},
@@ -42803,6 +42941,8 @@
 	},
 /obj/structure/fans/tiny,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/fore)
 "sHK" = (
@@ -42919,9 +43059,6 @@
 /obj/machinery/airalarm{
 	pixel_y = 28
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
@@ -42956,12 +43093,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"sLT" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/maintenance/disposal)
 "sMa" = (
 /turf/open/floor/engine,
 /area/engine/atmospherics_engine)
@@ -43061,8 +43192,11 @@
 /turf/open/floor/plating,
 /area/security/brig)
 "sOo" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
 	},
 /turf/open/floor/carpet,
 /area/security/vacantoffice/b)
@@ -43158,9 +43292,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "sRM" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
 /obj/machinery/light{
 	dir = 1
 	},
@@ -43182,7 +43313,6 @@
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/bridge)
 "sSj" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/bot,
 /obj/effect/landmark/start/cargo_technician,
 /obj/structure/disposalpipe/segment{
@@ -43270,24 +43400,14 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/bridge)
-"sTR" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "sTX" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -43338,14 +43458,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmospherics_engine)
-"sVB" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
-/area/hallway/primary/aft)
 "sVL" = (
 /obj/structure/table,
 /obj/machinery/microwave{
@@ -43429,7 +43541,12 @@
 /area/medical/genetics)
 "sXs" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
+	},
 /turf/open/floor/plasteel,
 /area/engine/atmospherics_engine)
 "sXy" = (
@@ -43544,16 +43661,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
-"tat" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/structure/bed/roller,
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/zone3)
 "taP" = (
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hop)
@@ -43591,11 +43698,14 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -43663,10 +43773,13 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "tdy" = (
@@ -43686,12 +43799,6 @@
 /obj/structure/closet/l3closet,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"tdL" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/closed/wall,
-/area/janitor)
 "tdX" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -43756,7 +43863,10 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/secure_construction)
 "tft" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -43783,9 +43893,6 @@
 	dir = 1;
 	pixel_y = -22
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/table,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -43808,15 +43915,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
-"tgd" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/chair{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "tgj" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -43837,10 +43935,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"thu" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall,
-/area/hallway/primary/fore)
 "thy" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -43873,14 +43967,6 @@
 "tif" = (
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
-"tio" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "tiN" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -44021,9 +44107,6 @@
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/miningdock)
 "tmt" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -44110,9 +44193,6 @@
 /turf/closed/wall,
 /area/maintenance/central)
 "tos" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
@@ -44175,7 +44255,10 @@
 /turf/open/floor/plating,
 /area/library)
 "tpf" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /turf/open/floor/wood,
@@ -44271,11 +44354,12 @@
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
 "trj" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 2;
 	sortType = 16
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "trn" = (
@@ -44351,7 +44435,12 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
 "ttl" = (
@@ -44441,15 +44530,6 @@
 /obj/machinery/vending/sustenance,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
-"tvF" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/paramedic)
 "tvI" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/disposalpipe/segment{
@@ -44509,10 +44589,13 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -44580,9 +44663,6 @@
 /turf/open/floor/plasteel/dark,
 /area/science/server)
 "tzL" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
 /obj/machinery/power/apc{
 	areastring = "/area/crew_quarters/heads/hop";
 	dir = 1;
@@ -44594,11 +44674,6 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hop)
-"tzP" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
 "tAa" = (
 /obj/structure/closet/secure_closet/personal/patient,
 /obj/effect/turf_decal/tile/green{
@@ -44635,15 +44710,11 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "tAY" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
 "tBl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
 /obj/machinery/pipedispenser,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -44758,9 +44829,6 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/paramedic)
 "tEl" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/table/reinforced,
 /obj/machinery/light_switch{
 	name = "Bar Lights";
@@ -44932,10 +45000,13 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -45083,10 +45154,6 @@
 /obj/item/wrench/medical,
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
-"tML" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall,
-/area/crew_quarters/kitchen)
 "tMR" = (
 /obj/machinery/vending/hydronutrients,
 /obj/machinery/requests_console{
@@ -45136,11 +45203,15 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/pool)
 "tOE" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
+/obj/machinery/door/poddoor/shutters{
+	id = "jangarage";
+	name = "Custodial Closet Shutters"
 	},
-/turf/closed/wall/r_wall,
-/area/maintenance/starboard)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
+/area/janitor)
 "tOP" = (
 /obj/machinery/atmospherics/components/binary/valve/digital/layer3{
 	name = "scrubbers valve"
@@ -45217,30 +45288,14 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "tQv" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/structure/table,
-/obj/item/storage/box/lights/mixed,
-/obj/item/storage/box/lights/mixed,
-/obj/item/reagent_containers/spray/cleaner,
-/obj/item/grenade/chem_grenade/cleaner,
-/obj/item/grenade/chem_grenade/cleaner,
-/obj/item/grenade/chem_grenade/cleaner,
-/turf/open/floor/plasteel,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
 /area/janitor)
 "tQy" = (
 /obj/structure/closet,
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
 "tQG" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 4;
 	name = "east facing firelock"
@@ -45250,6 +45305,12 @@
 	name = "warehouse shutters"
 	},
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -45265,7 +45326,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -45279,9 +45343,11 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "tRv" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hop)
@@ -45320,33 +45386,24 @@
 /obj/item/pen,
 /turf/open/floor/plasteel/dark,
 /area/science/server)
-"tTo" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/closed/wall,
-/area/janitor)
 "tTt" = (
 /obj/effect/decal/cleanable/femcum,
 /turf/open/floor/plating,
 /area/maintenance/aft/secondary)
 "tTO" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+/obj/effect/landmark/xeno_spawn,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
-/obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plating,
 /area/engine/storage)
 "tTQ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/landmark/event_spawn,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "tTS" = (
@@ -45392,9 +45449,6 @@
 "tVh" = (
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8;
@@ -45532,9 +45586,6 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -45543,6 +45594,12 @@
 	},
 /obj/structure/disposalpipe/junction/flip{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
@@ -45572,14 +45629,17 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/landmark/start/station_engineer,
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -45607,9 +45667,6 @@
 "uap" = (
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
 	},
 /obj/machinery/door/window/northright{
 	name = "Engineering Production";
@@ -45690,8 +45747,8 @@
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
 "ubH" = (
-/obj/effect/spawner/lootdrop/grille_or_trash,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/hallway/primary/aft)
 "ubL" = (
@@ -45821,10 +45878,6 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "ueO" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/keycard_auth{
 	pixel_x = 26
@@ -45868,7 +45921,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/bridge)
 "ugj" = (
@@ -45891,10 +45944,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
-"ugk" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/carpet,
-/area/crew_quarters/dorms)
 "ugr" = (
 /obj/machinery/button/door{
 	id = "Bath1";
@@ -45952,12 +46001,6 @@
 "uid" = (
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
-"uim" = (
-/obj/machinery/atmospherics/pipe/simple/supply/visible{
-	dir = 5
-	},
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/surface/outdoors)
 "uiO" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -45965,9 +46008,6 @@
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -46021,12 +46061,11 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
 "ukJ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/closet/secure_closet/freezer/kitchen,
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_y = 28
 	},
+/obj/structure/closet/secure_closet/freezer/fridge,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "ukV" = (
@@ -46037,18 +46076,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
-"ulh" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "ulr" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/plasma{
 	dir = 1
@@ -46076,11 +46103,16 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "umD" = (
@@ -46101,9 +46133,6 @@
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
 "unt" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/table,
 /obj/structure/bedsheetbin/towel,
 /turf/open/floor/plasteel/white,
@@ -46203,21 +46232,12 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/storage/eva)
-"uqu" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
 "uqy" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -46261,14 +46281,15 @@
 	name = "Tech Storage";
 	req_access_txt = "23"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "ust" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/light{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/fore)
 "usE" = (
@@ -46277,7 +46298,6 @@
 /area/hallway/primary/port)
 "usN" = (
 /obj/structure/chair/stool,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
 "utd" = (
@@ -46348,9 +46368,6 @@
 "uvB" = (
 /obj/structure/cable{
 	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
 	},
 /obj/structure/chair{
 	dir = 4
@@ -46483,10 +46500,6 @@
 /obj/machinery/vending/cola/random,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"uzI" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall/r_wall,
-/area/engine/secure_construction)
 "uzT" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -46630,16 +46643,14 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "uEB" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "uEG" = (
@@ -46655,6 +46666,10 @@
 	name = "Dormitory APC";
 	pixel_y = 24
 	},
+/obj/structure/disposalpipe/trunk{
+	dir = 2
+	},
+/obj/machinery/disposal/bin,
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
 "uFq" = (
@@ -46698,15 +46713,6 @@
 	},
 /turf/open/floor/plating,
 /area/chapel/main)
-"uGQ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hydroponics)
 "uGY" = (
 /obj/structure/chair/comfy/brown,
 /obj/structure/disposalpipe/segment{
@@ -46748,9 +46754,6 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/light{
 	dir = 1
 	},
@@ -46782,9 +46785,6 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /turf/open/floor/engine,
 /area/engine/engineering)
 "uIZ" = (
@@ -46834,8 +46834,11 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
@@ -46848,9 +46851,6 @@
 "uKr" = (
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
 	},
 /obj/structure/window/plasma/reinforced{
 	dir = 4
@@ -46970,7 +46970,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "uLX" = (
@@ -46988,9 +46990,6 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
@@ -47040,11 +47039,6 @@
 /obj/structure/reflector/box,
 /turf/open/floor/plating,
 /area/engine/storage)
-"uPe" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/hallway/primary/aft)
 "uPn" = (
 /obj/effect/landmark/start/paramedic,
 /obj/machinery/vending/wallmed{
@@ -47056,12 +47050,6 @@
 /obj/structure/sink/puddle,
 /turf/open/floor/grass,
 /area/chapel/main)
-"uPI" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "uPJ" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin{
@@ -47153,21 +47141,24 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "uTk" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "uTm" = (
@@ -47334,9 +47325,10 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
 "uWW" = (
-/obj/structure/closet/crate/internals,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/carpet/purple,
+/area/janitor)
 "uWY" = (
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = "MedbayFoyer";
@@ -47415,6 +47407,12 @@
 /area/security/courtroom)
 "uXL" = (
 /obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
+	},
 /turf/open/floor/plasteel/white/corner{
 	dir = 8
 	},
@@ -47466,7 +47464,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "uYE" = (
@@ -47484,10 +47481,11 @@
 	},
 /area/chapel/main)
 "uYQ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
 "uZd" = (
@@ -47533,9 +47531,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -47544,11 +47539,17 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
@@ -47573,7 +47574,7 @@
 /area/medical/genetics)
 "vaB" = (
 /obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -47637,10 +47638,13 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -47714,6 +47718,12 @@
 	location = "Dorm"
 	},
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/carpet,
@@ -47806,9 +47816,6 @@
 /turf/open/floor/engine/airless,
 /area/engine/atmos)
 "vgo" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
@@ -47826,9 +47833,6 @@
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -47856,9 +47860,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/machinery/light{
 	dir = 1
 	},
@@ -47869,9 +47870,6 @@
 /area/crew_quarters/dorms)
 "vhf" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/checkpoint/supply)
@@ -47934,10 +47932,6 @@
 /turf/open/floor/plating,
 /area/medical/virology)
 "vjV" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -47945,7 +47939,7 @@
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/techstorage/command,
 /obj/effect/landmark/blobstart,
-/turf/open/floor/plating,
+/turf/open/floor/pod,
 /area/storage/tech)
 "vjY" = (
 /obj/effect/turf_decal/tile/blue,
@@ -48048,12 +48042,6 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/dorms)
-"vlC" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "vlN" = (
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plasteel,
@@ -48118,9 +48106,6 @@
 /turf/closed/wall/r_wall,
 /area/medical/chemistry)
 "vnn" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
 /obj/structure/closet/secure_closet/hydroponics,
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
@@ -48129,16 +48114,22 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "vnM" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
 /obj/effect/landmark/xeno_spawn,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "vob" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/landmark/event_spawn,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "vor" = (
@@ -48218,10 +48209,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
-"vqv" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall,
-/area/crew_quarters/bar)
 "vqD" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/cobweb,
@@ -48321,7 +48308,7 @@
 /turf/closed/wall/r_wall,
 /area/crew_quarters/dorms)
 "vrG" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
 	},
 /turf/open/floor/carpet/eighties,
@@ -48347,9 +48334,6 @@
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_y = -35
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -48407,6 +48391,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
 "vun" = (
@@ -48510,9 +48495,6 @@
 /turf/open/floor/carpet,
 /area/bridge)
 "vxI" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/sink/kitchen{
 	pixel_y = 28
 	},
@@ -48553,7 +48535,6 @@
 /turf/open/floor/plasteel,
 /area/storage/auxiliary)
 "vyb" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/closet/crate,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
@@ -48707,8 +48688,13 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/yellow,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -48719,9 +48705,6 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "vBa" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
@@ -48783,19 +48766,19 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "vCv" = (
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
@@ -48805,6 +48788,8 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "vCE" = (
@@ -48840,9 +48825,8 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
 "vDI" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
 "vEd" = (
@@ -48857,11 +48841,14 @@
 /turf/open/floor/grass,
 /area/hallway/primary/fore)
 "vEe" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
@@ -49031,7 +49018,10 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
 "vJt" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
 	},
 /turf/open/floor/plating{
@@ -49039,9 +49029,6 @@
 	},
 /area/hallway/primary/aft)
 "vJG" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -49068,9 +49055,6 @@
 "vKo" = (
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
 	},
 /obj/machinery/light{
 	dir = 1
@@ -49290,9 +49274,6 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "vOS" = (
@@ -49313,6 +49294,12 @@
 /area/security/brig)
 "vPB" = (
 /obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "vPD" = (
@@ -49416,12 +49403,15 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 4;
 	sortType = 26
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
@@ -49509,7 +49499,12 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/visible,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
 "vTP" = (
@@ -49529,15 +49524,18 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
@@ -49604,14 +49602,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
-"vVN" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/maintenance/department/bridge)
 "vVZ" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
+/obj/machinery/airalarm{
+	pixel_y = 23
+	},
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
 "vWf" = (
@@ -49715,10 +49710,13 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/fore)
 "vZl" = (
@@ -49754,9 +49752,6 @@
 "vZY" = (
 /obj/machinery/light{
 	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
 	},
 /obj/item/kirbyplants/random,
 /turf/open/floor/plasteel/dark,
@@ -49826,7 +49821,6 @@
 /turf/open/floor/plasteel/white,
 /area/security/brig)
 "waC" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/window/reinforced{
@@ -49894,9 +49888,6 @@
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "wbJ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "kitchen";
@@ -49990,7 +49981,8 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "wdv" = (
@@ -50001,10 +49993,10 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+/obj/machinery/portable_atmospherics/pump,
+/obj/machinery/atmospherics/components/unary/portables_connector/layer1{
 	dir = 1
 	},
-/obj/machinery/portable_atmospherics/pump,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "wdY" = (
@@ -50066,20 +50058,19 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
 "wgH" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
 /obj/structure/chair/stool/bar,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "wgO" = (
 /turf/open/openspace,
 /area/chapel/main)
 "wgP" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "wha" = (
@@ -50145,10 +50136,6 @@
 /turf/closed/wall/r_wall,
 /area/crew_quarters/heads/hop)
 "wjK" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/light{
 	dir = 1
 	},
@@ -50161,6 +50148,12 @@
 	dir = 4;
 	name = "east facing firelock"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "wjL" = (
@@ -50170,10 +50163,13 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -50182,16 +50178,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/carpet,
 /area/chapel/main)
-"wjW" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "wkg" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -50238,6 +50224,10 @@
 	dir = 8;
 	name = "Cargo Security APC";
 	pixel_x = -24
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
@@ -50305,7 +50295,6 @@
 /turf/open/floor/wood,
 /area/library)
 "wmx" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
@@ -50321,6 +50310,9 @@
 	},
 /obj/item/folder/yellow{
 	pixel_x = 4
+	},
+/obj/machinery/airalarm{
+	pixel_y = 28
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
@@ -50386,6 +50378,8 @@
 	name = "Security Office";
 	req_access_txt = "63"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
 "woM" = (
@@ -50430,10 +50424,10 @@
 	department = "Tool Storage";
 	pixel_x = 30
 	},
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/machinery/atmospherics/components/unary/portables_connector/layer3{
 	dir = 8
 	},
-/obj/machinery/portable_atmospherics/scrubber,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "wqe" = (
@@ -50476,8 +50470,11 @@
 /area/maintenance/department/electrical)
 "wsj" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmospherics_engine)
@@ -50589,8 +50586,8 @@
 /obj/machinery/plantgenes{
 	pixel_y = 6
 	},
-/obj/machinery/camera{
-	c_tag = "Hydroponics Storage"
+/obj/machinery/light{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
@@ -50804,13 +50801,6 @@
 /obj/machinery/nuclearbomb/beer,
 /turf/open/floor/wood,
 /area/maintenance/bar)
-"wAQ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/pod/dark,
-/area/maintenance/starboard)
 "wAW" = (
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
@@ -50962,7 +50952,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/railing/corner{
 	dir = 8
 	},
@@ -51096,9 +51085,6 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "wHQ" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/item/statuebust,
@@ -51130,8 +51116,11 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
 /turf/open/floor/carpet/orange,
 /area/engine/secure_construction)
@@ -51220,10 +51209,12 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "wLh" = (
@@ -51235,13 +51226,6 @@
 	dir = 4
 	},
 /area/chapel/main)
-"wLm" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/storage/primary)
 "wLs" = (
 /obj/structure/sign/departments/medbay/alt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -51282,7 +51266,15 @@
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors)
 "wMw" = (
-/obj/machinery/chem_master/condimaster,
+/obj/machinery/door/window/eastright{
+	dir = 2;
+	name = "Hydroponics Delivery";
+	req_access_txt = "35"
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "wMJ" = (
@@ -51366,6 +51358,12 @@
 	dir = 4;
 	name = "east facing firelock"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/bridge)
 "wQG" = (
@@ -51380,6 +51378,7 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
+/obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/quartermaster/sorting)
 "wRb" = (
@@ -51396,9 +51395,6 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "wRv" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
@@ -51435,9 +51431,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
@@ -51447,6 +51440,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "wRX" = (
@@ -51474,7 +51469,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating{
 	icon_state = "platingdmg2"
 	},
@@ -51490,11 +51484,11 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "wSA" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/structure/grille/broken,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
 /area/hallway/primary/aft)
 "wSI" = (
@@ -51504,11 +51498,14 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
 "wTe" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/landmark/start/station_engineer,
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -51549,17 +51546,14 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "wUj" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
@@ -51644,7 +51638,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "wXe" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -51687,12 +51680,6 @@
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
-"wXZ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/open/floor/carpet/orange,
-/area/engine/secure_construction)
 "wYe" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/dark,
@@ -51740,6 +51727,9 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/depsec/engineering,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
 "wZV" = (
@@ -51779,7 +51769,10 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -51828,13 +51821,6 @@
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/engine/atmospherics_engine)
-"xbm" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
 "xbp" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
@@ -51956,14 +51942,17 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/dorms)
 "xfD" = (
 /obj/structure/cable{
 	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -51975,6 +51964,12 @@
 	pixel_x = -27
 	},
 /obj/structure/disposalpipe/junction/flip,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "xfE" = (
@@ -52025,22 +52020,11 @@
 /area/medical/surgery)
 "xgu" = (
 /obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = 28
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/machinery/disposal/bin,
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "xgB" = (
@@ -52262,12 +52246,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"xmC" = (
-/obj/structure/closet/jcloset,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/mop,
-/turf/open/floor/plasteel,
-/area/janitor)
 "xmP" = (
 /obj/structure/closet/l3closet/virology,
 /turf/open/floor/plasteel/white,
@@ -52283,7 +52261,10 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/visible{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
@@ -52321,21 +52302,22 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
 /obj/structure/disposalpipe/sorting/mail{
 	dir = 4;
 	sortType = 20
 	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "xop" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/bar)
 "xou" = (
@@ -52357,10 +52339,13 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -52368,12 +52353,6 @@
 "xoS" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
@@ -52403,7 +52382,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "xqV" = (
@@ -52550,7 +52530,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
@@ -52562,14 +52541,11 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
-	icon_state = "2-4"
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
@@ -52652,7 +52628,9 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "xzn" = (
@@ -52676,9 +52654,6 @@
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "xzM" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
 /obj/effect/turf_decal/arrows/red,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -52742,12 +52717,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
-"xBk" = (
-/obj/machinery/atmospherics/pipe/simple/supply/visible{
-	dir = 4
-	},
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/surface/outdoors)
 "xBv" = (
 /obj/item/clothing/suit/armor/riot{
 	pixel_x = -4;
@@ -52840,9 +52809,6 @@
 "xCU" = (
 /obj/structure/cable{
 	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
 	},
 /obj/machinery/light{
 	dir = 4
@@ -52977,10 +52943,13 @@
 	dir = 1
 	},
 /obj/effect/landmark/start/station_engineer,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -53022,17 +52991,11 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
-"xGU" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 10
-	},
-/turf/open/floor/plating/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors)
 "xGX" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/binary/valve/digital,
+/obj/machinery/atmospherics/components/binary/valve/digital/on,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/engine/atmos)
 "xHk" = (
@@ -53138,9 +53101,6 @@
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/bridge)
 "xJD" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
 /obj/structure/table,
 /obj/machinery/photocopier/faxmachine,
 /turf/open/floor/carpet,
@@ -53152,9 +53112,6 @@
 "xKa" = (
 /obj/structure/window/reinforced{
 	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
@@ -53186,20 +53143,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"xKv" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/plasteel/dark,
-/area/engine/secure_construction)
 "xKE" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/bridge)
@@ -53249,14 +53201,17 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -53302,7 +53257,6 @@
 	dir = 1;
 	pixel_y = -24
 	},
-/obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/bridge)
 "xOV" = (
@@ -53395,6 +53349,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
 "xQH" = (
@@ -53458,6 +53418,8 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "xSP" = (
@@ -53508,9 +53470,6 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "xUy" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/camera{
 	c_tag = "Bar North"
 	},
@@ -53518,6 +53477,12 @@
 	dir = 4
 	},
 /obj/machinery/disposal/bin,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "xUD" = (
@@ -53546,8 +53511,11 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/bridge)
@@ -53562,12 +53530,15 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
 /obj/structure/disposalpipe/sorting/mail{
 	dir = 4;
 	sortType = 19
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -53815,10 +53786,10 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "yeA" = (
@@ -53837,12 +53808,15 @@
 /turf/open/floor/plating,
 /area/hallway/primary/aft)
 "yfp" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/starboard)
@@ -53948,10 +53922,13 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/light/small,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/machinery/light/small,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/port)
 "yij" = (
@@ -54021,9 +53998,6 @@
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -74006,7 +73980,7 @@ dGH
 iJl
 iJl
 xUe
-iJl
+mRx
 luO
 mGe
 hIM
@@ -74263,7 +74237,7 @@ iJl
 tmI
 rTG
 uYp
-kxU
+uYp
 wSv
 uYp
 afq
@@ -75289,7 +75263,7 @@ ydp
 avT
 avT
 avT
-ace
+bBh
 avT
 avT
 avT
@@ -75303,7 +75277,7 @@ iJl
 uWA
 wje
 hBQ
-aNf
+qmO
 xrU
 yij
 iWY
@@ -75546,7 +75520,7 @@ ydp
 avT
 avT
 avT
-ace
+bBh
 avT
 avT
 avT
@@ -75561,7 +75535,7 @@ tmO
 hvX
 aYf
 xSN
-wje
+pQd
 jrH
 rke
 vJG
@@ -75803,7 +75777,7 @@ avT
 avT
 avT
 avT
-ace
+bBh
 avT
 avT
 avT
@@ -75816,7 +75790,7 @@ xUL
 cNd
 tmO
 fYx
-aYf
+pIm
 rhX
 rhX
 rhX
@@ -76060,7 +76034,7 @@ ydp
 avT
 avT
 avT
-ace
+bBh
 avT
 avT
 avT
@@ -76317,7 +76291,7 @@ ydp
 avT
 avT
 avT
-ace
+bBh
 avT
 avT
 avT
@@ -76330,12 +76304,12 @@ xUL
 xUL
 tmO
 fYx
-oDm
+pIm
 xVn
 vFd
 por
 jEb
-tvF
+xQF
 nEt
 rhX
 anO
@@ -76587,7 +76561,7 @@ tmO
 tmO
 tmO
 bhZ
-oDm
+pIm
 xVn
 uUC
 iop
@@ -76831,7 +76805,7 @@ avT
 avT
 avT
 avT
-ace
+bBh
 avT
 avT
 avT
@@ -76844,7 +76818,7 @@ xUL
 cNd
 tmO
 fYx
-oDm
+pIm
 xVn
 vTP
 vTP
@@ -77088,7 +77062,7 @@ avT
 avT
 avT
 avT
-ace
+bBh
 avT
 avT
 avT
@@ -77101,7 +77075,7 @@ xUL
 tKV
 aFB
 fYx
-oDm
+pIm
 rhX
 oDH
 sHd
@@ -77345,7 +77319,7 @@ avT
 avT
 avT
 avT
-ace
+bBh
 avT
 avT
 avT
@@ -77358,12 +77332,12 @@ xUL
 xUL
 tmO
 fYx
-oDm
+pIm
 rhX
 quh
 kHd
 jkO
-vTP
+qeH
 ubd
 xVn
 xUL
@@ -77602,7 +77576,7 @@ avT
 avT
 avT
 avT
-ace
+bBh
 avT
 avT
 avT
@@ -77620,7 +77594,7 @@ rhX
 uPn
 asy
 vTP
-vTP
+qeH
 vGn
 xVn
 xUL
@@ -77859,7 +77833,7 @@ avT
 avT
 avT
 avT
-ace
+bBh
 avT
 avT
 avT
@@ -77877,7 +77851,7 @@ rhX
 tII
 lXR
 vTP
-vTP
+qeH
 vGn
 xVn
 xUL
@@ -78116,7 +78090,7 @@ avT
 avT
 avT
 avT
-ace
+bBh
 avT
 avT
 avT
@@ -78134,7 +78108,7 @@ rhX
 rhX
 rhX
 qje
-qje
+qhf
 byt
 rhX
 xUL
@@ -78391,7 +78365,7 @@ rhX
 eTu
 tEb
 wOn
-wOn
+qjA
 sIT
 xVn
 xUL
@@ -78630,7 +78604,7 @@ avT
 avT
 avT
 avT
-ace
+bBh
 avT
 avT
 avT
@@ -78648,7 +78622,7 @@ cSj
 wOn
 kQC
 ckz
-wOn
+qrS
 wOn
 xVn
 xUL
@@ -78887,7 +78861,7 @@ ydp
 avT
 avT
 avT
-ace
+bBh
 avT
 avT
 avT
@@ -78905,7 +78879,7 @@ cSj
 wOn
 wOn
 jzb
-wOn
+qCo
 wOn
 xVn
 avT
@@ -79144,7 +79118,7 @@ ydp
 avT
 avT
 avT
-ace
+bBh
 avT
 avT
 avT
@@ -79401,7 +79375,7 @@ ydp
 avT
 avT
 avT
-ace
+bBh
 xUL
 vBe
 xUL
@@ -79658,9 +79632,9 @@ ydp
 avT
 avT
 avT
-pQd
+rUq
 kLh
-kQr
+lZn
 lZn
 lZn
 lZn
@@ -79916,8 +79890,8 @@ ydp
 avT
 avT
 avT
-xZL
-xBk
+vTL
+xUL
 avT
 avT
 avT
@@ -80173,8 +80147,8 @@ ydp
 avT
 avT
 avT
-xZL
-qZO
+vTL
+vBe
 avT
 avT
 avT
@@ -80430,8 +80404,8 @@ ydp
 avT
 avT
 avT
-xZL
-xBk
+vTL
+xUL
 avT
 avT
 avT
@@ -80687,8 +80661,8 @@ ydp
 avT
 avT
 avT
-xZL
-xBk
+vTL
+xUL
 avT
 avT
 avT
@@ -80944,8 +80918,8 @@ ydp
 avT
 avT
 avT
-xZL
-xBk
+vTL
+xUL
 avT
 avT
 avT
@@ -81201,8 +81175,8 @@ ydp
 avT
 avT
 avT
-xZL
-xBk
+vTL
+xUL
 avT
 avT
 avT
@@ -81458,8 +81432,8 @@ ydp
 avT
 avT
 avT
-xZL
-xBk
+vTL
+xUL
 avT
 avT
 avT
@@ -81715,8 +81689,8 @@ ydp
 avT
 avT
 avT
-xZL
-xBk
+vTL
+xUL
 avT
 avT
 avT
@@ -81972,8 +81946,8 @@ ydp
 avT
 avT
 avT
-xZL
-xBk
+vTL
+xUL
 avT
 avT
 avT
@@ -82229,8 +82203,8 @@ ydp
 avT
 avT
 avT
-xZL
-xBk
+vTL
+xUL
 avT
 avT
 avT
@@ -82486,8 +82460,8 @@ ydp
 avT
 avT
 avT
-xZL
-xBk
+vTL
+xUL
 avT
 avT
 avT
@@ -82743,8 +82717,8 @@ avT
 avT
 avT
 avT
-xZL
-qZO
+vTL
+vBe
 avT
 avT
 avT
@@ -83000,8 +82974,8 @@ avT
 avT
 avT
 avT
-xZL
-xBk
+vTL
+xUL
 avT
 avT
 avT
@@ -83253,12 +83227,12 @@ ydp
 ydp
 ydp
 ydp
-bHt
-nZE
-nZE
-nZE
-bVj
-xBk
+avT
+avT
+avT
+avT
+vTL
+xUL
 avT
 avT
 avT
@@ -83510,12 +83484,12 @@ ydp
 avT
 avT
 avT
-szi
-mRx
-etV
-etV
+avT
+avT
+avT
+avT
 vTL
-aUb
+xUL
 avT
 avT
 avT
@@ -83767,10 +83741,10 @@ avT
 avT
 avT
 avT
-xGU
-hyl
-nZE
-nZE
+avT
+avT
+avT
+avT
 hIR
 vBe
 avT
@@ -84025,11 +83999,11 @@ xUL
 xUL
 xUL
 xUL
-soW
-vsM
-vsM
-aAh
-uim
+xUL
+xUL
+xUL
+xnm
+xUL
 avT
 avT
 avT
@@ -84285,8 +84259,8 @@ xUL
 xUL
 xUL
 xUL
-xZL
-xBk
+xnm
+xUL
 avT
 avT
 avT
@@ -84542,8 +84516,8 @@ iHM
 avT
 avT
 avT
-xZL
-xBk
+mvA
+xUL
 avT
 avT
 avT
@@ -84799,8 +84773,8 @@ iHM
 avT
 avT
 avT
-xZL
-qZO
+xnm
+vBe
 avT
 avT
 avT
@@ -85056,8 +85030,8 @@ iHM
 avT
 avT
 avT
-xZL
-xBk
+xnm
+xUL
 avT
 avT
 avT
@@ -85313,8 +85287,8 @@ axL
 axL
 axL
 axL
-xZL
-xBk
+xnm
+xUL
 avT
 avT
 avT
@@ -85556,7 +85530,7 @@ lkI
 mZh
 mic
 mzB
-fHG
+mZh
 qxq
 pgp
 xAv
@@ -85570,8 +85544,8 @@ xAv
 xAv
 xAv
 axL
-xZL
-xBk
+xnm
+xUL
 avT
 avT
 avT
@@ -85813,7 +85787,7 @@ lkI
 mZh
 qAY
 vrG
-ohS
+mZh
 ero
 pgp
 xAv
@@ -85827,8 +85801,8 @@ xAv
 xAv
 xAv
 axL
-xZL
-xBk
+xnm
+xUL
 avT
 avT
 avT
@@ -86069,8 +86043,8 @@ mZh
 mZh
 iDh
 mZh
-vrG
-ohS
+gZo
+mZh
 lgJ
 pgp
 xAv
@@ -86084,8 +86058,8 @@ xAv
 xAv
 xAv
 axL
-xZL
-xBk
+xnm
+xUL
 avT
 avT
 avT
@@ -86326,8 +86300,8 @@ lkI
 lkI
 lkI
 mZh
-vrG
-pIm
+haU
+iDh
 ajP
 pgp
 xAv
@@ -86341,8 +86315,8 @@ xAv
 xAv
 xAv
 axL
-xZL
-xBk
+xnm
+xUL
 avT
 avT
 ydp
@@ -86583,7 +86557,7 @@ gum
 nHI
 jKx
 byI
-vrG
+haU
 nGR
 wWt
 pgp
@@ -86598,8 +86572,8 @@ xAv
 xAv
 xAv
 axL
-xZL
-xBk
+xnm
+xUL
 avT
 avT
 avT
@@ -86855,8 +86829,8 @@ axL
 axL
 eGo
 eGo
-xZL
-xBk
+xnm
+xUL
 avT
 avT
 avT
@@ -87099,7 +87073,7 @@ uEz
 bqE
 bcy
 nXL
-pBx
+wWl
 wWl
 blD
 aez
@@ -87112,8 +87086,8 @@ tOz
 axN
 qwY
 abU
-xZL
-xBk
+xnm
+xUL
 avT
 ydp
 ydp
@@ -87353,10 +87327,10 @@ gls
 mSU
 ptU
 uEz
-uEz
-pvs
+dGc
+lZO
 igK
-bcA
+wIx
 wIx
 yjJ
 aDb
@@ -87369,8 +87343,8 @@ kRk
 kqE
 tOz
 acQ
-xZL
-xBk
+xnm
+xUL
 avT
 ydp
 ydp
@@ -87610,10 +87584,10 @@ blD
 pwB
 blD
 mau
-uEz
-pvs
+dGc
+lZO
 igK
-lsK
+xPB
 xPB
 yjJ
 aDo
@@ -87626,8 +87600,8 @@ vQk
 muX
 nsK
 acQ
-xZL
-xBk
+xnm
+xUL
 avT
 ydp
 ydp
@@ -87868,7 +87842,7 @@ blD
 blD
 uTm
 dGc
-hch
+lZO
 lba
 xKa
 xeQ
@@ -87883,8 +87857,8 @@ vQk
 muX
 tOz
 acQ
-xZL
-xBk
+xnm
+xUL
 avT
 ydp
 ydp
@@ -88125,9 +88099,9 @@ vVp
 rqJ
 bJz
 fXv
-lZO
+hch
 uEz
-rTv
+uEz
 tOf
 yjJ
 tOz
@@ -88140,8 +88114,8 @@ gEZ
 muX
 nsK
 acQ
-xZL
-xBk
+xnm
+xUL
 avT
 ydp
 ydp
@@ -88381,10 +88355,10 @@ avT
 avT
 rqJ
 bYe
-fXv
+dGc
 lZO
 qrN
-rTv
+uEz
 uEz
 wyk
 tOz
@@ -88394,11 +88368,11 @@ vQk
 vQk
 vQk
 vQk
-muX
-tOz
+lsK
+lQJ
 acQ
-xZL
-xBk
+xnm
+xUL
 avT
 ydp
 ydp
@@ -88638,11 +88612,11 @@ avT
 avT
 rqJ
 peK
-fXv
-hlh
+dGc
+lZO
 reT
-gZo
-uqu
+uEz
+uEz
 uEz
 eYq
 eei
@@ -88654,8 +88628,8 @@ vQk
 lNN
 qtG
 acQ
-xZL
-xBk
+xnm
+xUL
 vBe
 ydp
 ydp
@@ -88895,7 +88869,7 @@ gHH
 xUL
 rqJ
 lel
-fXv
+gzt
 iNK
 uEz
 uEz
@@ -88908,11 +88882,11 @@ vQk
 vQk
 vQk
 vQk
-muX
-iaL
+lxL
+tOz
 acQ
-xZL
-xBk
+xnm
+xUL
 xUL
 xUL
 ydp
@@ -89152,8 +89126,8 @@ xUL
 xUL
 blD
 jan
-fXv
-kge
+dGc
+lZO
 pgk
 ylW
 uEz
@@ -89165,11 +89139,11 @@ vQk
 vQk
 vQk
 gEZ
-muX
-erb
+lxL
+nsK
 acQ
-xZL
-xBk
+xnm
+xUL
 avT
 wdv
 ydp
@@ -89409,8 +89383,8 @@ xUL
 xUL
 blD
 vbe
-fXv
-kge
+dGc
+lZO
 ylW
 xcL
 ylW
@@ -89422,11 +89396,11 @@ vQk
 vQk
 vQk
 vQk
-muX
-iaL
+lxL
+tOz
 acQ
-xZL
-xBk
+xnm
+xUL
 avT
 wdv
 ydp
@@ -89666,8 +89640,8 @@ xUL
 xUL
 blD
 uEz
-fXv
-kge
+dGc
+lZO
 uEz
 ylW
 uEz
@@ -89679,11 +89653,11 @@ vQk
 cOb
 vQk
 vQk
-muX
-erb
+lxL
+nsK
 acQ
-xZL
-xBk
+xnm
+xUL
 avT
 wdv
 xUL
@@ -89923,7 +89897,7 @@ hop
 xUL
 blD
 uEz
-fXv
+dGc
 cvB
 lgw
 uaM
@@ -89935,12 +89909,12 @@ bUO
 eAo
 eJC
 pko
-cqx
+pko
 rta
 dot
 abU
-xZL
-xBk
+xnm
+xUL
 iSB
 wdv
 xUL
@@ -90196,8 +90170,8 @@ rWi
 pgp
 pgp
 pgp
-xZL
-xBk
+xnm
+xUL
 avT
 xUL
 xUL
@@ -90439,22 +90413,22 @@ feF
 mtP
 gRt
 kbr
-ugk
+vDI
 uYQ
 dAi
-ugk
-ugk
-ugk
-ugk
+jXL
+jXL
+jXL
+jXL
 mOk
-ugk
+hIG
 usN
 oBD
 pgp
 kql
 pgp
-xZL
-xBk
+xnm
+xUL
 avT
 xUL
 xUL
@@ -90706,12 +90680,12 @@ dEt
 duB
 tsK
 aKB
-tsK
+aKB
 iuC
 ahU
 pXb
-aSE
-xBk
+myq
+xUL
 xUL
 xUL
 xUL
@@ -90961,14 +90935,14 @@ pgp
 pgp
 pgp
 vhb
-mtP
+hVt
 vDI
-ugk
+vDI
 hAx
 aiH
 nrY
-vsM
-aUb
+mGp
+xUL
 xUL
 xUL
 xUL
@@ -91218,7 +91192,7 @@ qFH
 nBd
 wfS
 hUx
-mtP
+iaL
 sgL
 qxk
 pgp
@@ -91475,7 +91449,7 @@ vVZ
 mWy
 pgp
 hUx
-mtP
+iaL
 inA
 qMn
 pgp
@@ -91734,12 +91708,12 @@ pgp
 ruG
 hNT
 mLK
-raA
-raA
-raA
-raA
-raA
-raA
+mSt
+mSt
+mSt
+mSt
+mSt
+dSQ
 iOe
 iOe
 ycl
@@ -91975,7 +91949,7 @@ avT
 xUL
 xUL
 iOG
-mKL
+nmM
 kJz
 aEW
 gga
@@ -91991,11 +91965,11 @@ dJb
 iJs
 veC
 unt
-raA
+mSt
 lfV
 eAR
-eAR
-raA
+mqb
+mSt
 hzh
 wDI
 wrN
@@ -92247,16 +92221,16 @@ mWy
 pgp
 qIP
 iZc
-pfZ
+mtP
 raA
-qxw
+sdq
 mZk
 hsl
-cOn
+pax
 klc
 ocY
 ijz
-cUV
+jJd
 omQ
 jJd
 njd
@@ -92509,11 +92483,11 @@ tOE
 uWW
 pyW
 dwS
-cOn
-klc
+mSt
+mVo
 exi
 yfp
-wAQ
+vfp
 vfp
 vfp
 vfp
@@ -92762,12 +92736,12 @@ ukI
 vuh
 jjB
 cNm
-qeH
-skZ
-skZ
-skZ
-skZ
 mSt
+skZ
+lUu
+msN
+mSt
+mWD
 geO
 cQv
 nGa
@@ -93003,7 +92977,7 @@ ydp
 xUL
 xUL
 iOG
-vVN
+iOG
 eVi
 wju
 wju
@@ -93023,11 +92997,11 @@ pax
 sdq
 iux
 aFA
-mNq
+mSt
 mSt
 dSQ
 seo
-rPs
+dSQ
 dSQ
 dSQ
 dSQ
@@ -93276,12 +93250,12 @@ vrx
 vrx
 ptl
 hKs
-tTo
+mSt
 oEf
 efF
 lSt
-klo
 mSt
+now
 xgu
 rtm
 aCV
@@ -93519,9 +93493,9 @@ xUL
 iOG
 hNZ
 sTI
-hHW
+wju
 tzL
-taP
+gBk
 aug
 taP
 cnk
@@ -93533,11 +93507,11 @@ qva
 pWS
 cLq
 oje
-tdL
+mSt
 mSt
 cRa
-eua
-phq
+mSt
+mSt
 nwR
 xoS
 rnk
@@ -93778,9 +93752,9 @@ nmM
 cPn
 wju
 pIP
-fuB
+taP
 emd
-mVo
+taP
 xJD
 ajD
 pqj
@@ -93791,10 +93765,10 @@ pWS
 trU
 xvj
 eha
-qrS
+mSt
 ngj
 jNK
-xmC
+mSt
 mSt
 ads
 qoh
@@ -94048,15 +94022,15 @@ pWS
 vuO
 vaj
 mcU
-mSt
+lEU
 dWt
 fyr
 tQv
-mSt
+nrg
 qpo
 adT
 tos
-qxX
+nWP
 xYJ
 avT
 avT
@@ -94292,7 +94266,7 @@ gyk
 xUU
 wju
 sRM
-kDy
+taP
 nVY
 ueO
 pPL
@@ -94303,8 +94277,8 @@ oEO
 oOR
 pWS
 trU
-vaj
-mcU
+itw
+kPn
 mSt
 mSt
 mSt
@@ -94314,10 +94288,10 @@ kdm
 ecN
 vBa
 jfi
-uZz
-wdv
-wdv
-wdv
+hRt
+hRt
+hRt
+hRt
 avT
 avT
 avT
@@ -94551,8 +94525,8 @@ wju
 wju
 wju
 wju
-rxt
-ojs
+wju
+wju
 wju
 uSe
 pWS
@@ -94562,11 +94536,11 @@ pWS
 jQp
 vCr
 eiz
-mvA
+pJS
 vyb
 eWW
-vyb
-ogX
+mHU
+uZz
 wmx
 xoH
 bSO
@@ -94809,7 +94783,7 @@ qgm
 qgm
 jen
 vOB
-ddh
+vOB
 pqj
 trU
 pqj
@@ -95062,10 +95036,10 @@ cuL
 nZQ
 giv
 erL
-ixf
-ixf
+rjP
+rjP
 pss
-mWD
+iqH
 xCU
 iqH
 cqL
@@ -95075,16 +95049,16 @@ iqH
 qSh
 egJ
 vSc
-mcU
+pqj
 pJS
 iwk
 dsX
-xbm
-dBR
+bNF
+uZz
 qpW
-adV
-rDE
-dFF
+xoH
+vFM
+hRt
 sLn
 acv
 xEf
@@ -95314,16 +95288,16 @@ xUL
 qaO
 qTo
 xzM
-pFu
-mGp
-mGp
-mGp
-iqT
-mGp
-mGp
-iqT
-mGp
-rgm
+txL
+wAx
+wAx
+wAx
+wAx
+wAx
+wAx
+wAx
+wAx
+wAx
 wAx
 wAx
 wAx
@@ -95331,19 +95305,19 @@ wAx
 wAx
 wzf
 pqj
-vaj
-mcU
+iJS
+pqj
 pJS
 pJS
 abX
 acx
-khy
+uZz
 adt
 adU
 vFM
 hRt
 hCL
-jmU
+oXi
 oJX
 krH
 avT
@@ -95570,15 +95544,15 @@ xUL
 dns
 iRF
 qgm
-gNI
+qgm
 mqc
 wAx
 vwV
-qss
+fuj
 kRX
 wAx
 tMR
-uGQ
+hru
 qss
 aRq
 fsA
@@ -95594,7 +95568,7 @@ cSv
 pJS
 pJS
 tQG
-dBR
+uZz
 uZz
 adX
 uZz
@@ -95827,7 +95801,7 @@ xUL
 xUL
 qaO
 nqx
-gNI
+qgm
 axg
 wAx
 lzW
@@ -95835,7 +95809,7 @@ qss
 vnn
 wAx
 ijV
-now
+qss
 sYv
 qss
 qss
@@ -95844,7 +95818,7 @@ qss
 qss
 urI
 hrS
-lQJ
+pqj
 lia
 uvB
 tOY
@@ -96084,7 +96058,7 @@ xUL
 xUL
 qaO
 qAq
-gNI
+qgm
 fJc
 lfy
 fWB
@@ -96093,7 +96067,7 @@ wAx
 wAx
 gto
 qss
-qss
+hiO
 sAh
 fsA
 fsA
@@ -96108,11 +96082,11 @@ rlo
 pJS
 tfx
 lrV
-iLi
+wIA
 hTO
-lrV
-wIA
-wIA
+bNF
+nWO
+ogX
 wIA
 yeg
 sSy
@@ -96341,16 +96315,16 @@ cfp
 xac
 cfp
 cfp
-gNI
-skK
+qgm
+txL
 wAx
 nij
 fzT
 ltY
 duX
 lmy
-ezO
-vPB
+lmy
+hlh
 qss
 qss
 qss
@@ -96360,17 +96334,17 @@ ukv
 hsQ
 pqj
 bKl
-tgd
+tRC
 tRC
 pJS
 sWD
-bNF
-rrm
-dWI
+lrV
+wIA
+hTO
 sSj
-kPn
-tzP
-juI
+wIA
+adY
+wIA
 wIA
 jTl
 vyf
@@ -96599,7 +96573,7 @@ dpp
 jvV
 cfp
 eue
-skK
+erb
 wAx
 wuQ
 vnM
@@ -96607,7 +96581,7 @@ wAx
 mQo
 mbE
 qss
-qss
+hrc
 sAh
 fsA
 fsA
@@ -96616,18 +96590,18 @@ qss
 urI
 hsQ
 pqj
-meG
-nWO
+iLi
+pqj
 gUa
 pJS
 cjE
-bNF
-nrg
+lrV
+wIA
 hTO
 dUV
 wIA
 adY
-iLi
+wIA
 wIA
 sSy
 gpe
@@ -96853,10 +96827,10 @@ cfp
 pWc
 cfp
 aHU
-sLT
+aHU
 sGE
-rph
-skK
+qgm
+txL
 wAx
 wxZ
 vPB
@@ -96873,18 +96847,18 @@ qss
 fFY
 hsQ
 pqj
-meG
-mcU
+juI
+kPn
 pqj
 pJS
 mhq
-bNF
+mLO
 wIA
 hTO
 noB
 wIA
 kti
-nrg
+wIA
 goW
 pUf
 kcM
@@ -97114,7 +97088,7 @@ gxY
 cfp
 gNI
 moX
-wAx
+etV
 wMw
 kox
 wAx
@@ -97130,12 +97104,12 @@ qss
 fFY
 hsQ
 pqj
-meG
+iLi
 nmL
 vKP
 pJS
 hNg
-bNF
+lrV
 wIA
 hTO
 dUV
@@ -97369,7 +97343,7 @@ jLG
 eai
 rUa
 cfp
-gNI
+qgm
 mqc
 vKa
 vKa
@@ -97386,13 +97360,13 @@ wAx
 wAx
 wAx
 qrg
-pqj
-meG
-oqr
+igi
+jzx
+rlo
 rlo
 pJS
 hNg
-bNF
+lrV
 wIA
 hTO
 bNF
@@ -97626,11 +97600,11 @@ piu
 pWc
 nGi
 cfp
-gNI
+lOs
 lNK
-vKa
+eua
 lVd
-vgH
+fuB
 qzP
 vKa
 nIU
@@ -97645,11 +97619,11 @@ iIf
 pqj
 pqj
 meG
-tgd
+tRC
 tRC
 pJS
 jiY
-bNF
+mLO
 wIA
 frL
 ndQ
@@ -97883,8 +97857,8 @@ cfp
 mQV
 cfp
 cfp
-hAw
-skK
+rai
+txL
 vKa
 gdg
 pkh
@@ -97900,14 +97874,14 @@ sup
 xkW
 qkg
 rhU
-tio
+lIJ
 umC
-hiO
+lIJ
 lIJ
 pJS
 leq
-qxT
-wIA
+mNq
+nGh
 iCO
 pJS
 pJS
@@ -98140,7 +98114,7 @@ eYe
 hmP
 cfp
 jZl
-gNI
+qgm
 xol
 cYj
 lBT
@@ -98160,11 +98134,11 @@ cKk
 cKk
 bxf
 jeo
-thu
-mvA
+pFR
+pJS
 cWG
 gdL
-wIA
+nMJ
 iCO
 pJS
 wYk
@@ -98397,18 +98371,18 @@ gph
 evO
 cfp
 aMR
-msN
-pFu
-tML
+qgm
+erG
+vKa
 ukJ
 puA
 jcr
 rck
 vgo
-nMJ
+fTy
 lBF
 jHF
-fTy
+hAw
 jvb
 xZp
 dVr
@@ -98417,7 +98391,7 @@ msK
 cKk
 dNB
 rmV
-dDf
+rmV
 gaf
 pMD
 shN
@@ -98655,25 +98629,25 @@ evO
 cfp
 gmH
 okq
-skK
+erG
 vKa
 lLD
-vgH
-vgH
+fHG
+fKE
 vKa
 vxI
-haU
+fTy
 keI
 odN
-fTy
+hDk
 stW
 iKV
 hFj
 oNv
 vUF
 cKk
-meG
-mcU
+iLi
+pqj
 pLd
 pJS
 jjn
@@ -98911,17 +98885,17 @@ huF
 cCA
 cfp
 hPO
-gNI
-skK
+qgm
+erG
 vKa
+fjw
 vgH
-vgH
-vgH
+ggD
 vKa
 hFG
 fTy
 ohk
-pWa
+fTy
 eJY
 iJK
 iKV
@@ -98930,7 +98904,7 @@ fPD
 fPD
 cKk
 mjH
-mcU
+pqj
 qHq
 vyf
 vyf
@@ -98944,7 +98918,7 @@ acu
 gOi
 qal
 pqj
-uXL
+phq
 izV
 fwU
 enN
@@ -99154,7 +99128,7 @@ clf
 ego
 hYN
 llu
-qKJ
+crg
 hLE
 hLE
 kVO
@@ -99168,7 +99142,7 @@ jlQ
 mQC
 cfp
 rDv
-hDk
+kwl
 cjP
 vKa
 miu
@@ -99187,8 +99161,8 @@ oNv
 wqe
 hbb
 rkd
-nWO
-gBk
+pqj
+jTs
 vyf
 fmW
 uWC
@@ -99201,7 +99175,7 @@ oYU
 oYU
 pqj
 pqj
-uXL
+phq
 wvj
 vgW
 sDu
@@ -99410,7 +99384,7 @@ kVO
 cqM
 ftV
 jji
-mHU
+ftV
 ohF
 kVO
 msR
@@ -99425,15 +99399,15 @@ cfp
 nFS
 cfp
 hWW
-gNI
-skK
+qgm
+erG
 vKa
 vKa
 vKa
 vKa
 vKa
-oTv
-tML
+vKa
+vKa
 wjK
 wbJ
 bqx
@@ -99443,8 +99417,8 @@ hFj
 oNv
 guV
 hbb
-jxZ
-nWP
+rkd
+pqj
 rlo
 vyf
 cLC
@@ -99458,9 +99432,9 @@ oYU
 oYU
 pqj
 pqj
-uXL
+phq
 dGO
-crg
+fwU
 nhr
 hsu
 lmm
@@ -99667,7 +99641,7 @@ kVO
 tcH
 iWf
 kVO
-mLO
+iWf
 qve
 ubH
 vJt
@@ -99682,12 +99656,12 @@ cfp
 vra
 cfp
 jwD
-qLM
-pFu
-itw
-uPe
+qgm
+erG
+jZl
+qaO
 abQ
-jzx
+lGc
 waC
 mrW
 cKk
@@ -99701,7 +99675,7 @@ fPD
 fPD
 jHT
 rkd
-mcU
+pqj
 rNS
 vyf
 vyf
@@ -99710,12 +99684,12 @@ nsf
 vyf
 pJS
 ddi
-pqj
 oNT
+pqj
 pqj
 oNT
 vWg
-uXL
+phq
 gwY
 pdD
 hMM
@@ -99925,7 +99899,7 @@ kVO
 kVO
 kVO
 kVO
-qRy
+gEq
 iWf
 oBs
 wzl
@@ -99947,9 +99921,9 @@ mKD
 lGc
 wcS
 wHQ
-vqv
-gOp
-nGh
+cKk
+tpf
+fPD
 fPD
 fPD
 fPD
@@ -99957,7 +99931,7 @@ qQC
 fPD
 fPD
 iSv
-rkd
+kge
 dhX
 vkk
 vkk
@@ -99967,12 +99941,12 @@ qSi
 vkk
 vkk
 pUz
+ohS
 pqj
-mcU
 pqj
-mcU
+ohS
 vWg
-uXL
+phq
 jIt
 dMR
 sve
@@ -100182,7 +100156,7 @@ rrC
 wFD
 xAT
 kVO
-hIG
+kVO
 kVO
 amJ
 kVO
@@ -100196,8 +100170,8 @@ cfp
 bkI
 cfp
 kVO
-uPI
-lNK
+qgm
+erG
 jPI
 qaO
 nEI
@@ -100206,29 +100180,29 @@ aQr
 fmv
 cKk
 xUy
-rXw
-smY
+fPD
+fPD
 fQs
 fPD
 fPD
 fPD
 bAP
 fzG
-rkd
-pSO
-fjw
-fjw
-fjw
-mqb
-fjw
-fjw
-mqb
+khy
+trU
+pqj
+pqj
+pqj
+pqj
+pqj
+pqj
+pqj
 jkw
-gmr
 sBB
-gmr
+vWg
+vWg
 sBB
-gmr
+vWg
 kYg
 pVW
 sBs
@@ -100236,9 +100210,9 @@ uMF
 jsl
 gFM
 cuY
-nGx
-nGx
-nGx
+qLM
+qLM
+qLM
 nGx
 xtV
 lzB
@@ -100433,14 +100407,14 @@ aJb
 bEb
 eKc
 pAi
-bnA
-qkx
+rQH
+rQH
 rQH
 xyT
-xyT
-xyT
 rjP
-xyT
+rjP
+rjP
+rjP
 tQR
 qJz
 dop
@@ -100451,41 +100425,41 @@ wFv
 gvB
 nJV
 eLy
-haX
+qlX
 vfx
 fQI
 mWc
 iFF
 pCU
 kcn
-ixf
+rjP
 xve
 gJP
 eGi
 mIe
-qWa
-cZI
+fPD
+fPD
 kHI
 fPD
 fPD
 fPD
 fIU
 cKk
-jxZ
+kjh
 tTQ
-jgz
+rGy
 uTk
 trj
 jFl
 lVS
-jgz
+rGy
 rGy
 mbt
 qaX
 khw
-qaX
 khw
 qaX
+khw
 lnx
 jXa
 vYP
@@ -100493,9 +100467,9 @@ dks
 nEl
 ust
 sHJ
-sLv
-sLv
-sLv
+qRy
+qRy
+irt
 sLv
 ybT
 asr
@@ -100688,22 +100662,22 @@ xUL
 aBq
 iWf
 cuC
-msN
+qgm
 gkl
+qgm
 lOs
-lOs
-lOs
-lOs
+aiU
+aNf
 tft
-lOs
+bcA
 rlS
 dHf
-lOs
+cUd
 jwW
 wgP
-lOs
-lOs
-tft
+bcA
+bcA
+cUV
 eGH
 dDs
 dDs
@@ -100713,16 +100687,16 @@ rgC
 wKU
 czA
 nOu
-dDs
+fqj
 hwd
-lOs
-lOs
+bcA
+bcA
 cKl
 npv
 uJV
 wgH
-iKV
-iKV
+wgH
+hHW
 fPD
 fPD
 fPD
@@ -100736,17 +100710,17 @@ rpT
 uqy
 nQi
 ltG
-rqN
 iqH
 iqH
 yes
+iqH
 iqH
 yes
 lgn
 euW
 jJu
 cJp
-par
+xuB
 xuB
 jJu
 jJu
@@ -100945,7 +100919,7 @@ avT
 kVO
 boK
 kVO
-hIG
+kVO
 hqx
 saN
 saN
@@ -100986,25 +100960,25 @@ fPD
 fPD
 iSv
 vUq
-kjh
+eMl
 jTs
 jtb
 nwF
 tVh
 phu
 jtb
-lUu
+sEa
 xaI
-pqj
 gvP
+pqj
 pqj
 gvP
 vWg
-oaF
+pvs
 xuB
 dbc
 rlC
-fDJ
+pSO
 lGB
 jJu
 avT
@@ -101234,7 +101208,7 @@ qgm
 txL
 cKk
 dFa
-myq
+hMy
 vZR
 fYa
 iKV
@@ -101242,8 +101216,8 @@ fPD
 fPD
 fpF
 hbb
-jxZ
-ulh
+khy
+trU
 rlo
 jtb
 pGe
@@ -101257,11 +101231,11 @@ oYU
 oYU
 pqj
 nHX
-oaF
+pvs
 xuB
-tat
+kFF
 ceZ
-fDJ
+pWa
 vjY
 xuB
 avT
@@ -101482,9 +101456,9 @@ dri
 uot
 kag
 wIT
-grM
-grM
-wXZ
+bZI
+bZI
+bZI
 msi
 xFZ
 qgm
@@ -101499,22 +101473,22 @@ eOt
 eFy
 oNv
 hbb
-rkd
-pSO
-gzt
+khy
+trU
+rNS
 jtb
 cDW
 pOU
 ond
 dsi
-cBa
+hVk
 hUF
 pqj
 oYU
 oYU
 pqj
 pqj
-oaF
+pvs
 xuB
 kFF
 bow
@@ -101722,7 +101696,7 @@ saN
 pjA
 bil
 kfI
-kfI
+aUb
 sdR
 egk
 cQd
@@ -101738,7 +101712,7 @@ rww
 rww
 rww
 ttQ
-lNU
+wIT
 bZI
 bZI
 nNV
@@ -101764,14 +101738,14 @@ hoD
 rwq
 iGS
 oUV
-wLm
+jtb
 wtp
 eOd
 hwG
 azJ
 czu
 pqj
-oaF
+pvs
 xuB
 xpU
 fDJ
@@ -101995,13 +101969,13 @@ jrq
 wJf
 eQd
 wwh
-lNU
+dFF
 bZI
 bZI
 bZI
-xKv
-uzI
-lOs
+msi
+xFZ
+qgm
 mYB
 cKk
 kCI
@@ -102014,21 +101988,21 @@ tAm
 fPD
 cKk
 meG
-ggD
+trU
 uzf
 sEa
 hgb
 fzg
 kyc
 tfP
-iJS
+dQz
 pFR
 rQs
 rQs
 rQs
 pFR
 oRc
-oaF
+pvs
 hHy
 gZb
 bVv
@@ -102230,7 +102204,7 @@ dwT
 ydp
 ydp
 kVO
-sVB
+qKJ
 edo
 saN
 saN
@@ -102252,7 +102226,7 @@ rww
 rww
 rww
 pAN
-lNU
+dWI
 ttU
 cKD
 cKD
@@ -102281,11 +102255,11 @@ iyq
 mLP
 gOr
 mwQ
-jDD
-jDD
+oqr
+par
 cAq
-pqj
-oaF
+rGy
+pBx
 sFc
 sFc
 sFc
@@ -102516,9 +102490,9 @@ qsm
 olW
 xFZ
 qgm
-txL
+erG
 cKk
-ouE
+cKk
 cKk
 cKk
 cKk
@@ -102535,9 +102509,9 @@ iWd
 mWJ
 mWJ
 dsi
-iJS
+dQz
 ltk
-qCo
+jDD
 iBl
 egM
 dQz
@@ -102750,7 +102724,7 @@ isz
 qcX
 qcX
 qcX
-dlK
+aWr
 jLV
 kVO
 xUL
@@ -102776,11 +102750,11 @@ ohv
 gjA
 cFP
 hPt
-ixf
-ixf
-ixf
+hyl
+hyl
+hyl
 pDu
-ixf
+hyl
 oLo
 mRZ
 xfD
@@ -102792,10 +102766,10 @@ gXj
 ksI
 lRe
 jNI
-fuj
-hOw
+dQz
+mwQ
 pcs
-eIN
+iBl
 vBS
 dQz
 pFR
@@ -103000,14 +102974,14 @@ ydp
 ydp
 ydp
 ydp
-bCC
+ace
 lqx
 wad
 cGD
 ovy
 nGp
 mde
-dlK
+ace
 qcX
 qcX
 xUL
@@ -103030,7 +103004,7 @@ wKL
 hjw
 bKI
 hpg
-gNI
+qgm
 fyz
 qgm
 qgm
@@ -103042,7 +103016,7 @@ hcu
 vju
 eYu
 aWM
-nWO
+pqj
 gUa
 sda
 sda
@@ -103052,7 +103026,7 @@ sda
 sda
 sda
 pgG
-jDD
+ouE
 jDD
 jDD
 qzz
@@ -103287,7 +103261,7 @@ wKL
 hjw
 bKI
 bKI
-lEU
+bKI
 dxF
 bKI
 mMs
@@ -103297,9 +103271,9 @@ qRe
 mMs
 mMs
 fPd
-eYu
+iqT
 xOj
-mcU
+pqj
 jKb
 wdR
 sda
@@ -103309,7 +103283,7 @@ sde
 vUE
 sda
 kdR
-jDD
+oTv
 xZx
 jDD
 jDD
@@ -103554,9 +103528,9 @@ nzK
 hZy
 iBL
 vju
-hrc
+trU
 edW
-mcU
+pqj
 cJL
 wdR
 sda
@@ -103802,14 +103776,14 @@ sbo
 idb
 egk
 puf
-sLN
-igi
+sdr
+vhT
 nPF
 mzj
 giZ
 oQg
-erG
-nPF
+sPt
+iBL
 sjE
 pMf
 pbc
@@ -104069,9 +104043,9 @@ sPt
 iBL
 wqd
 pHH
-xOj
-mcU
-qjA
+klo
+pqj
+pqj
 sHl
 sda
 uXO
@@ -104327,7 +104301,7 @@ iBL
 bnU
 fNd
 bDg
-fKE
+yjK
 iod
 yjK
 jWr
@@ -104839,8 +104813,8 @@ tZO
 dUI
 hoq
 oUs
-oXi
 gQZ
+kDy
 cOl
 dxV
 uSV
@@ -105098,8 +105072,8 @@ hoq
 cfN
 tht
 nRS
-wjW
-dbl
+gCd
+vjV
 sxb
 uap
 rxc
@@ -105589,7 +105563,7 @@ ccG
 ckm
 iro
 fDt
-pRV
+dBR
 tEt
 fJg
 iYF
@@ -106130,15 +106104,15 @@ pTq
 aQA
 tcW
 vjV
-cuO
-cuO
-cuO
+vjV
+vjV
+vjV
 aaP
 vAF
 mZp
 ubQ
 fBS
-fBS
+pfZ
 fBS
 fBS
 mZp
@@ -106392,9 +106366,9 @@ oJp
 mmQ
 gfC
 fve
-aWr
-fqj
-fqj
+mZp
+fZA
+fZA
 rXo
 mzs
 xiL
@@ -106872,7 +106846,7 @@ fRQ
 xII
 xII
 xII
-xII
+cZI
 eus
 bYY
 cSi
@@ -106883,7 +106857,7 @@ bGW
 tpD
 cSi
 bGW
-bYY
+grM
 cSi
 bGW
 bYY
@@ -106900,7 +106874,7 @@ bnU
 oJa
 cNE
 tcq
-sTR
+ftM
 xPK
 bnU
 bnU
@@ -107152,12 +107126,12 @@ xUL
 pvL
 bnU
 szX
-aiU
-lxL
+ijZ
+bnU
 cjH
-hVt
+cLO
 fVT
-vlC
+cLO
 fQc
 bnU
 bnU
@@ -107414,7 +107388,7 @@ bnU
 dLj
 cLO
 qQb
-qhf
+cLO
 uIU
 bnU
 bnU
@@ -107934,7 +107908,7 @@ nUN
 sza
 owk
 bnU
-mDW
+ojs
 rFB
 bnU
 eEK
@@ -108191,7 +108165,7 @@ gel
 rXn
 sGC
 bnU
-mDW
+ojs
 jOI
 bnU
 ijZ
@@ -109990,7 +109964,7 @@ eOZ
 gOM
 fKl
 bnU
-mDW
+ojs
 jzc
 bnU
 avT
@@ -110245,7 +110219,7 @@ slc
 qYN
 sbS
 iyL
-aHt
+svp
 bnU
 pGs
 jzc
@@ -110761,7 +110735,7 @@ eKO
 wkg
 vZl
 bnU
-mDW
+ojs
 jzc
 ucC
 avT
@@ -111785,7 +111759,7 @@ ppl
 afn
 ppl
 jZW
-eMQ
+jZW
 rdn
 hBq
 bnU
@@ -112042,7 +112016,7 @@ ppl
 afn
 ppl
 jZW
-eMQ
+jZW
 cOR
 ioJ
 avT
@@ -112299,7 +112273,7 @@ ppl
 lsh
 ppl
 jZW
-eMQ
+jZW
 qpb
 ioJ
 avT
@@ -112556,7 +112530,7 @@ ppl
 toL
 eQC
 kGo
-eMQ
+jZW
 jPm
 hBq
 avT
@@ -112813,7 +112787,7 @@ ppl
 sMa
 ppl
 jZW
-eMQ
+jZW
 hdn
 hBq
 avT
@@ -113070,7 +113044,7 @@ ppl
 ppl
 ppl
 jZW
-eMQ
+jZW
 cSY
 hBq
 avT
@@ -113327,7 +113301,7 @@ ppl
 ppl
 ppl
 jZW
-eMQ
+jZW
 bTR
 ioJ
 avT
@@ -113584,7 +113558,7 @@ lkQ
 lkQ
 lkQ
 lkQ
-cUd
+lkQ
 lXT
 hBq
 avT


### PR DESCRIPTION
## About The Pull Request
Long time coming, but this was really needed for this map before I did anything else for it. All the supply pipes were changed to layer 1, and scrubbers to layer 3, fixing most if not all wall pipes on the map.
There was some feedback about the south port's main hallway being bland, so I put a bit of stuff to make it look nicer for those CC visits near the bridge.
I also decided to remake xenoarch, making it accessible on the south port near the garden and chapel, with a telepad to it as well. 
## Why It's Good For The Game
With all the pipes set to something mentally bearable, new additions to the main station will be easier, while the other additions I put in will make the least popular port a little bit more interesting. This will also be the second map we have that features a dedicated xenoarch space (fridgestation was first), so i'm excited to see how people use it. 
## Changelog
:cl:
add: Xenoarch, south port decor
tweak: The entirety of the station's piping
/:cl: