### PR TITLE
Gives Survival box a name and illustration

### DIFF
--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -102,6 +102,10 @@
 		new /obj/item/disk/nanite_program(src)
 
 // Ordinary survival box
+/obj/item/storage/box/survival/
+	name = "emergency internals box"
+	illustration = "O2"
+
 /obj/item/storage/box/survival/PopulateContents()
 	new /obj/item/clothing/mask/breath(src)
 	new /obj/item/reagent_containers/hypospray/medipen(src)


### PR DESCRIPTION
## About The Pull Request

title

## Why It's Good For The Game

Krome wanted it, and it's not a bad suggestion. Better player discovery.

## Changelog
:cl:
add: name and illustration for internals box
/:cl: