### PR TITLE
Snaxi mega patch

### DIFF
--- a/_maps/map_files/Snaxi/IcemoonUnderground_Above_Lumos.dmm
+++ b/_maps/map_files/Snaxi/IcemoonUnderground_Above_Lumos.dmm
@@ -6,13 +6,26 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
+"ad" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/machinery/power/deck_relay,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/effect/turf_decal/stripes/box,
+/turf/open/floor/plasteel/elevatorshaft,
+/area/engine/atmos)
 "ag" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard{
+	name = "Service Basement"
+	})
 "ah" = (
 /turf/closed/mineral/random/snow,
 /area/icemoon/underground/unexplored/rivers)
@@ -58,7 +71,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/stairs/medium,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "ax" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
@@ -95,7 +110,9 @@
 	name = "Bathroom"
 	},
 /turf/open/floor/plasteel/grimy,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "aH" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
@@ -105,7 +122,9 @@
 "aJ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "aK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/fluff/broken_flooring,
@@ -119,7 +138,9 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard{
+	name = "Service Basement"
+	})
 "aR" = (
 /obj/machinery/light/small/broken,
 /turf/open/floor/plasteel,
@@ -129,7 +150,9 @@
 	pixel_y = -32
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/maintenance/starboard{
+	name = "Service Basement"
+	})
 "aT" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel/white,
@@ -147,7 +170,9 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/maintenance/starboard{
+	name = "Service Basement"
+	})
 "bc" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -164,8 +189,13 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 1
 	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard{
+	name = "Service Basement"
+	})
 "bh" = (
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
@@ -181,13 +211,17 @@
 "bj" = (
 /obj/machinery/door/airlock/glass_large,
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard{
+	name = "Service Basement"
+	})
 "bk" = (
 /obj/machinery/atmospherics/components/unary/tank/air{
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "bl" = (
 /turf/closed/wall/r_wall,
 /area/science/storage)
@@ -199,9 +233,24 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
+"bn" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard{
+	name = "Service Basement"
+	})
 "bo" = (
 /turf/closed/wall/r_wall,
 /area/science/misc_lab)
+"bs" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engine/atmos)
 "bt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/warning/securearea{
@@ -217,7 +266,9 @@
 	pixel_x = 32
 	},
 /turf/open/floor/plasteel/cafeteria,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "by" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/light/small{
@@ -225,13 +276,17 @@
 	light_color = "#ffc1c1"
 	},
 /turf/open/floor/plasteel/dark,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "bG" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard{
+	name = "Service Basement"
+	})
 "bI" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
@@ -241,34 +296,48 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/primary/port)
+"bM" = (
+/turf/open/floor/plating,
+/area/engine/atmos)
+"bU" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "bZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
 	},
 /obj/machinery/light/small,
 /turf/open/floor/carpet,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "ca" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/plasteel/cafeteria,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "cb" = (
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
 	},
+/obj/machinery/power/deck_relay,
+/obj/effect/turf_decal/stripes/box,
 /turf/open/floor/plating,
 /area/xenoarch/arch)
 "cd" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/structure/closet,
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard{
+	name = "Service Basement"
+	})
 "ce" = (
 /obj/structure/table,
 /obj/item/storage/bag/strangerock,
@@ -290,7 +359,9 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "cj" = (
 /obj/effect/decal/cleanable/blood/gibs/human/body,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
@@ -304,7 +375,9 @@
 	},
 /obj/machinery/chem_master/condimaster,
 /turf/open/floor/plasteel/cafeteria,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "cq" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /obj/structure/cable{
@@ -316,6 +389,11 @@
 /obj/structure/target_stake,
 /turf/open/floor/plasteel,
 /area/science/circuit)
+"cs" = (
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
+	},
+/area/engine/atmos)
 "cv" = (
 /obj/structure/railing/corner{
 	dir = 4
@@ -411,6 +489,10 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"cW" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/plating,
+/area/engine/atmos)
 "cX" = (
 /obj/structure/trash_pile,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -431,7 +513,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/mineral/iron,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "de" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -541,7 +625,9 @@
 	dir = 9
 	},
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard{
+	name = "Service Basement"
+	})
 "dR" = (
 /obj/machinery/door/airlock{
 	name = "Kitchen"
@@ -551,7 +637,9 @@
 	name = "west facing firelock"
 	},
 /turf/open/floor/plasteel/cafeteria,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "dS" = (
 /obj/structure/table/reinforced,
 /obj/item/stack/sheet/metal/ten,
@@ -591,7 +679,9 @@
 /obj/structure/bed,
 /obj/item/bedsheet/blue,
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard{
+	name = "Service Basement"
+	})
 "ea" = (
 /obj/effect/turf_decal/trimline/brown/filled/corner,
 /obj/effect/turf_decal/tile/neutral{
@@ -602,6 +692,11 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
+"eb" = (
+/turf/open/floor/plasteel/dark/corner{
+	dir = 1
+	},
+/area/engine/atmos)
 "ec" = (
 /obj/structure/table,
 /obj/item/clothing/glasses/science,
@@ -744,6 +839,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"eE" = (
+/obj/structure/closet/emcloset/anchored,
+/turf/open/floor/plating,
+/area/engine/atmos)
 "eF" = (
 /turf/closed/wall,
 /area/hallway/primary/port)
@@ -837,6 +936,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/hallway/primary/aft)
@@ -1044,8 +1146,13 @@
 /area/xenoarch/arch)
 "fy" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard{
+	name = "Service Basement"
+	})
 "fz" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
@@ -1138,6 +1245,7 @@
 /obj/machinery/atmospherics/pipe/simple/multiz{
 	piping_layer = 1
 	},
+/obj/effect/turf_decal/stripes/box,
 /turf/open/floor/plating,
 /area/xenoarch/arch)
 "fM" = (
@@ -1177,14 +1285,18 @@
 	icon_state = "cobweb2"
 	},
 /turf/open/floor/plasteel/dark,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "fV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/poster/contraband/billyh{
 	pixel_x = -32
 	},
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard{
+	name = "Service Basement"
+	})
 "fW" = (
 /obj/machinery/door/airlock/maintenance_hatch/abandoned{
 	use_power = 0
@@ -1259,8 +1371,18 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plating,
 /area/hallway/primary/aft)
+"gv" = (
+/obj/machinery/atmospherics/pipe/simple/multiz{
+	piping_layer = 1
+	},
+/obj/effect/turf_decal/stripes/box,
+/turf/open/floor/plasteel/elevatorshaft,
+/area/engine/atmos)
 "gy" = (
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /obj/machinery/light,
@@ -1279,7 +1401,9 @@
 "gA" = (
 /obj/item/toy/lumosplush/lennox,
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard{
+	name = "Service Basement"
+	})
 "gC" = (
 /turf/open/floor/engine,
 /area/science/storage)
@@ -1292,14 +1416,18 @@
 	},
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/grass,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "gG" = (
 /obj/structure/sign/departments/showers{
 	dir = 1;
 	pixel_x = -28
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/maintenance/starboard{
+	name = "Service Basement"
+	})
 "gI" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -1325,7 +1453,9 @@
 /obj/structure/curtain,
 /obj/effect/spawner/lootdrop/soap/seventyfive_percent,
 /turf/open/floor/plasteel/showroomfloor,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "gS" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -1335,7 +1465,9 @@
 "gU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/cafeteria,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "gW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/structure/cable{
@@ -1366,7 +1498,9 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "hd" = (
 /obj/machinery/button/door{
 	id = "Cell1";
@@ -1377,7 +1511,9 @@
 	},
 /obj/structure/closet/cabinet,
 /turf/open/floor/plasteel/grimy,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "hh" = (
 /obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable{
@@ -1395,7 +1531,9 @@
 	light_color = "#ffc1c1"
 	},
 /turf/open/floor/plasteel/dark,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "hn" = (
 /obj/structure/rack,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -1431,7 +1569,9 @@
 	},
 /obj/structure/closet/crate/bin,
 /turf/open/floor/plasteel/cafeteria,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "hz" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -1462,7 +1602,9 @@
 	dir = 4
 	},
 /turf/open/floor/grass,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "hJ" = (
 /obj/effect/spawner/structure/window/ice,
 /obj/structure/barricade/wooden/crude/snow,
@@ -1499,7 +1641,9 @@
 	dir = 8
 	},
 /turf/open/floor/carpet,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "ik" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 9
@@ -1518,7 +1662,9 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "iq" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/structure/cable{
@@ -1563,7 +1709,9 @@
 "iN" = (
 /obj/structure/table,
 /turf/open/floor/carpet,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "iO" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -1601,7 +1749,9 @@
 	light_color = "#d8b1b1"
 	},
 /turf/open/floor/plating,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "jk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -1619,10 +1769,22 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"jm" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/stairs{
+	dir = 1;
+	icon_state = "stairs_t"
+	},
+/turf/open/floor/plating,
+/area/engine/atmos)
 "jn" = (
 /obj/machinery/light/small,
 /turf/open/floor/plasteel/dark,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "jo" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
@@ -1761,6 +1923,15 @@
 /obj/machinery/light/small,
 /turf/open/floor/plasteel,
 /area/mine/eva)
+"jX" = (
+/obj/machinery/power/apc/auto_name/south,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard{
+	name = "Service Basement"
+	})
 "kb" = (
 /obj/structure/ore_box,
 /turf/open/floor/plasteel,
@@ -1779,7 +1950,13 @@
 	name = "north facing firelock"
 	},
 /turf/open/floor/plasteel/stairs/left,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
+"ki" = (
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "ks" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
@@ -1821,7 +1998,15 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/barricade/wooden/crude,
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard{
+	name = "Service Basement"
+	})
+"kG" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/underground/unexplored/rivers)
 "kI" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -1857,9 +2042,6 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/machinery/power/terminal{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
 	},
@@ -1867,7 +2049,9 @@
 /area/xenoarch/arch)
 "kS" = (
 /turf/closed/wall/mineral/iron,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "kT" = (
 /obj/structure/ladder,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -1884,7 +2068,9 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard{
+	name = "Service Basement"
+	})
 "la" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -1930,7 +2116,9 @@
 	},
 /obj/item/kirbyplants/random,
 /turf/open/floor/plasteel/dark,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "lj" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -1950,7 +2138,9 @@
 "lB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/cafeteria,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "lF" = (
 /obj/effect/turf_decal/stripes/box,
 /obj/machinery/atmospherics/pipe/simple/multiz,
@@ -2005,7 +2195,9 @@
 	light_color = "#ffc1c1"
 	},
 /turf/open/floor/plasteel/dark,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "lR" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio4";
@@ -2018,7 +2210,9 @@
 "lS" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel/cafeteria,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "lT" = (
 /turf/open/floor/plasteel,
 /area/science/mixing)
@@ -2031,7 +2225,9 @@
 /area/xenoarch/arch)
 "lV" = (
 /turf/open/floor/plasteel/grimy,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "ma" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 5
@@ -2045,7 +2241,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "mc" = (
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_y = -32
@@ -2068,7 +2266,9 @@
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/grass,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "mh" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio4";
@@ -2081,10 +2281,16 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"mj" = (
+/obj/structure/railing/corner,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "ml" = (
 /obj/structure/table,
 /turf/open/floor/plasteel/dark,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "mm" = (
 /obj/machinery/power/smes{
 	charge = 5e+006
@@ -2108,7 +2314,18 @@
 "mo" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/plasteel/grimy,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
+"ms" = (
+/obj/effect/turf_decal/vg_decals/atmos/mix{
+	pixel_x = -16
+	},
+/obj/effect/turf_decal/vg_decals/numbers/two{
+	pixel_x = 16
+	},
+/turf/open/floor/engine/airless,
+/area/engine/atmos)
 "mt" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/atmos_waste{
 	dir = 1;
@@ -2116,10 +2333,18 @@
 	},
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/hallway/primary/port)
+"mv" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 4
+	},
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/underground/unexplored/rivers)
 "mw" = (
 /obj/machinery/vending/sustenance,
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard{
+	name = "Service Basement"
+	})
 "mA" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood/old,
@@ -2129,7 +2354,9 @@
 /obj/structure/rack,
 /obj/item/stack/sheet/glass/fifty,
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard{
+	name = "Service Basement"
+	})
 "mG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
@@ -2163,7 +2390,9 @@
 "mP" = (
 /obj/structure/weightmachine/stacklifter,
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard{
+	name = "Service Basement"
+	})
 "mQ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -2185,7 +2414,9 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard{
+	name = "Service Basement"
+	})
 "mV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -2242,7 +2473,9 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard{
+	name = "Service Basement"
+	})
 "nm" = (
 /obj/item/radio/intercom{
 	dir = 8;
@@ -2262,7 +2495,9 @@
 	dir = 4
 	},
 /turf/closed/wall/mineral/iron,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "nq" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 30
@@ -2287,7 +2522,9 @@
 	dir = 8
 	},
 /turf/open/floor/carpet,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "nE" = (
 /obj/item/bikehorn{
 	color = "#000";
@@ -2296,6 +2533,11 @@
 	},
 /turf/closed/mineral/random/snow,
 /area/icemoon/surface/outdoors)
+"nH" = (
+/turf/open/floor/plasteel/dark/corner{
+	dir = 4
+	},
+/area/engine/atmos)
 "nI" = (
 /mob/living/simple_animal/hostile/asteroid/wolf{
 	desc = "A captive winter hound with bits of flesh sticking from its jaws, that explains all the remains.";
@@ -2305,7 +2547,9 @@
 /area/security/execution/education)
 "nJ" = (
 /turf/open/floor/plasteel/cafeteria,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "nN" = (
 /obj/effect/turf_decal/trimline/brown/filled/corner,
 /obj/structure/ore_box,
@@ -2331,6 +2575,10 @@
 "nV" = (
 /turf/closed/wall/r_wall,
 /area/mine/maintenance)
+"nX" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/engine/atmos)
 "oa" = (
 /obj/machinery/monkey_recycler,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -2403,7 +2651,9 @@
 	name = "east facing firelock"
 	},
 /turf/open/floor/plasteel/grimy,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "op" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -2445,7 +2695,9 @@
 "oF" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/plasteel/dark,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "oH" = (
 /obj/machinery/door/window/northleft{
 	name = "Containment Pen";
@@ -2493,6 +2745,11 @@
 "oS" = (
 /turf/open/floor/engine,
 /area/science/explab)
+"oT" = (
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
+/area/engine/atmos)
 "oU" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
@@ -2540,7 +2797,9 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard{
+	name = "Service Basement"
+	})
 "pf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -2595,6 +2854,14 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/plasteel,
 /area/science/test_area)
+"pt" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard{
+	name = "Service Basement"
+	})
 "pu" = (
 /obj/machinery/mineral/mint,
 /turf/open/floor/plasteel,
@@ -2681,6 +2948,16 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/mine/production)
+"pZ" = (
+/obj/machinery/computer/atmos_control/tank/mix_tank{
+	dir = 8;
+	input_tag = "mix_in2";
+	name = "Aux Gas Mix Tank Control";
+	output_tag = "mix_out2";
+	sensors = list("mix_sensor2" = "Aux Gas Mix Tank ")
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "qa" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -5;
@@ -2700,7 +2977,9 @@
 	dir = 1
 	},
 /turf/closed/wall/mineral/iron,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "qg" = (
 /obj/machinery/button/electrochromatic{
 	id = "xenoarch";
@@ -2730,7 +3009,9 @@
 /area/science/test_area)
 "qm" = (
 /turf/open/floor/plating,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "qo" = (
 /obj/structure/railing{
 	dir = 4
@@ -2755,6 +3036,13 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/mine/production)
+"qw" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engine/atmos)
 "qy" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -2770,12 +3058,28 @@
 /obj/structure/trash_pile,
 /turf/open/floor/plating,
 /area/hallway/primary/port)
+"qB" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/mix_output{
+	dir = 8
+	},
+/turf/open/floor/engine/airless,
+/area/engine/atmos)
+"qD" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard{
+	name = "Service Basement"
+	})
 "qE" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard{
+	name = "Service Basement"
+	})
 "qF" = (
 /obj/item/clothing/head/cone,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
@@ -2808,7 +3112,9 @@
 	},
 /obj/machinery/processor,
 /turf/open/floor/plasteel/cafeteria,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "qN" = (
 /obj/structure/table,
 /obj/item/cigbutt,
@@ -2819,7 +3125,9 @@
 /obj/machinery/reagentgrinder,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/cafeteria,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "qQ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -2838,7 +3146,9 @@
 	dir = 6
 	},
 /turf/open/floor/plating,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "qS" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
@@ -2863,7 +3173,9 @@
 	pixel_y = -32
 	},
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard{
+	name = "Service Basement"
+	})
 "qU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -2901,6 +3213,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plating,
 /area/hallway/primary/aft)
 "rh" = (
@@ -2916,7 +3231,9 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "rj" = (
 /obj/structure/chair{
 	dir = 8
@@ -2935,6 +3252,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/circuit)
+"ro" = (
+/turf/open/floor/engine/airless,
+/area/engine/atmos)
 "rp" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
@@ -3011,7 +3331,9 @@
 	dir = 6
 	},
 /turf/open/floor/carpet,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "rX" = (
 /obj/machinery/holopad,
 /turf/open/floor/plasteel/white,
@@ -3038,7 +3360,9 @@
 /area/mine/living_quarters)
 "si" = (
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard{
+	name = "Service Basement"
+	})
 "sj" = (
 /turf/open/floor/circuit,
 /area/mine/maintenance)
@@ -3055,7 +3379,9 @@
 /obj/effect/decal/cleanable/cobweb,
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "sn" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -3158,8 +3484,13 @@
 /area/mine/living_quarters)
 "sD" = (
 /obj/machinery/light/small,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard{
+	name = "Service Basement"
+	})
 "sE" = (
 /obj/structure/table_frame,
 /obj/effect/decal/cleanable/dirt,
@@ -3172,7 +3503,9 @@
 	pixel_y = 2
 	},
 /turf/open/floor/plasteel/showroomfloor,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "sH" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -3227,7 +3560,9 @@
 	dir = 4
 	},
 /turf/open/floor/carpet,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "sR" = (
 /obj/structure/chair/comfy/black{
 	dir = 8
@@ -3241,7 +3576,9 @@
 	pixel_y = 6
 	},
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard{
+	name = "Service Basement"
+	})
 "sW" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/plasteel/dark,
@@ -3272,7 +3609,9 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/grimy,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "tb" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -3292,12 +3631,18 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"tf" = (
+/obj/effect/landmark/start/atmospheric_technician,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "ti" = (
 /obj/structure/chair/comfy/brown{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "tk" = (
 /obj/structure/railing/corner{
 	dir = 8
@@ -3350,6 +3695,16 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/primary/port)
+"ty" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/stairs{
+	dir = 1;
+	icon_state = "stairs_t"
+	},
+/turf/open/floor/plating,
+/area/engine/atmos)
 "tA" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
@@ -3360,7 +3715,9 @@
 	},
 /obj/machinery/light/small,
 /turf/open/floor/plasteel/showroomfloor,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "tH" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -3453,10 +3810,24 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/misc_lab)
+"uc" = (
+/obj/structure/closet/secure_closet/atmospherics,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "ud" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /turf/open/floor/plasteel/white,
 /area/science/misc_lab)
+"ue" = (
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/obj/machinery/light,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "ui" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -3471,12 +3842,16 @@
 /obj/structure/dresser,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/grimy,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "um" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard{
+	name = "Service Basement"
+	})
 "uq" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -3509,6 +3884,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"ux" = (
+/turf/open/floor/plasteel/dark/corner{
+	dir = 8
+	},
+/area/engine/atmos)
 "uD" = (
 /obj/machinery/door/airlock{
 	id_tag = "Cell2";
@@ -3519,7 +3899,9 @@
 	name = "north facing firelock"
 	},
 /turf/open/floor/plasteel/grimy,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "uG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -3546,7 +3928,9 @@
 "uM" = (
 /obj/machinery/door/airlock/maintenance,
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard{
+	name = "Service Basement"
+	})
 "uN" = (
 /obj/structure/table,
 /obj/machinery/airalarm/directional/north,
@@ -3575,6 +3959,12 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/engine,
 /area/science/storage)
+"uT" = (
+/obj/structure/railing/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "uV" = (
 /obj/machinery/vending/wardrobe/science_wardrobe,
 /turf/open/floor/plasteel/white,
@@ -3607,7 +3997,9 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/grimy,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "vi" = (
 /mob/living/simple_animal/hostile/asteroid/wolf{
 	desc = "A captive winter hound with bits of flesh sticking from its jaws, that explains all the remains.";
@@ -3697,11 +4089,15 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard{
+	name = "Service Basement"
+	})
 "vU" = (
 /obj/effect/spawner/blocker,
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard{
+	name = "Service Basement"
+	})
 "vW" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -3724,6 +4120,9 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"wa" = (
+/turf/open/floor/plasteel/dark/side,
+/area/engine/atmos)
 "we" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio7";
@@ -3740,7 +4139,9 @@
 	dir = 4
 	},
 /turf/open/floor/carpet,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "wh" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
@@ -3760,7 +4161,9 @@
 /area/mine/maintenance)
 "wl" = (
 /turf/closed/wall,
-/area/hallway/primary/aft)
+/area/maintenance/starboard{
+	name = "Service Basement"
+	})
 "wm" = (
 /obj/machinery/portable_atmospherics/canister,
 /obj/effect/turf_decal/delivery,
@@ -3775,7 +4178,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/cafeteria,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "wq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
@@ -3807,7 +4212,9 @@
 	dir = 4
 	},
 /turf/open/floor/carpet,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "wA" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 6
@@ -3819,6 +4226,13 @@
 /obj/item/pen,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
+"wD" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engine/atmos)
 "wF" = (
 /obj/structure/frame/machine,
 /turf/open/floor/plating,
@@ -3854,7 +4268,9 @@
 	name = "Gym Locker"
 	},
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard{
+	name = "Service Basement"
+	})
 "wU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/fluff/broken_flooring{
@@ -3907,11 +4323,15 @@
 	dir = 4
 	},
 /turf/closed/wall/mineral/iron,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "xh" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/closed/wall/mineral/iron,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "xi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 5
@@ -3950,7 +4370,9 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "xs" = (
 /obj/item/assembly/timer{
 	pixel_x = 5;
@@ -4032,6 +4454,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/mine/living_quarters)
+"xV" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/engine/airless,
+/area/engine/atmos)
 "yf" = (
 /obj/structure/table,
 /obj/item/storage/firstaid/regular,
@@ -4111,7 +4539,9 @@
 "yz" = (
 /obj/structure/closet/cabinet,
 /turf/open/floor/plasteel/grimy,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "yA" = (
 /obj/machinery/light{
 	dir = 4
@@ -4175,7 +4605,15 @@
 "yS" = (
 /obj/structure/easel,
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard{
+	name = "Service Basement"
+	})
+"yT" = (
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/engine/atmos)
 "yU" = (
 /turf/closed/mineral/random/snow/no_caves,
 /area/icemoon/underground/unexplored/rivers)
@@ -4214,7 +4652,9 @@
 	dir = 4
 	},
 /turf/open/floor/carpet,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "zk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel,
@@ -4239,7 +4679,9 @@
 "zo" = (
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plasteel/dark,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "zp" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio1";
@@ -4325,7 +4767,9 @@
 "zS" = (
 /obj/structure/trash_pile,
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard{
+	name = "Service Basement"
+	})
 "zU" = (
 /obj/item/clothing/under/color/jumpskirt/random,
 /obj/structure/table,
@@ -4386,6 +4830,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"Ao" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "Ap" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -4426,7 +4877,9 @@
 	dir = 4
 	},
 /turf/open/floor/carpet,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "AB" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -4437,7 +4890,9 @@
 	icon_state = "stairs_t"
 	},
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard{
+	name = "Service Basement"
+	})
 "AG" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced{
@@ -4466,7 +4921,9 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "AR" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/poddoor/preopen{
@@ -4537,7 +4994,9 @@
 	dir = 4
 	},
 /turf/closed/wall/mineral/iron,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "Bl" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -4552,7 +5011,15 @@
 /obj/structure/table,
 /obj/item/storage/crayons,
 /turf/open/floor/plasteel/dark,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
+"Bo" = (
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "Bq" = (
 /obj/machinery/light{
 	dir = 1
@@ -4566,7 +5033,9 @@
 	},
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "Bs" = (
 /obj/effect/decal/cleanable/blood/gibs/human,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
@@ -4576,7 +5045,9 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard{
+	name = "Service Basement"
+	})
 "Bw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
@@ -4625,7 +5096,9 @@
 	name = "west facing firelock"
 	},
 /turf/open/floor/plasteel/dark,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "BL" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -4658,14 +5131,18 @@
 	},
 /obj/item/reagent_containers/food/condiment/sugar,
 /turf/open/floor/plasteel/cafeteria,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "BW" = (
 /obj/structure/bed{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/grimy,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "BY" = (
 /turf/closed/wall/r_wall,
 /area/hallway/primary/port)
@@ -4741,6 +5218,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/test_area)
+"Cp" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "Cr" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -4764,7 +5247,9 @@
 	on = 1
 	},
 /turf/open/floor/grass,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "Cw" = (
 /obj/machinery/chem_master,
 /obj/machinery/airalarm/directional/north,
@@ -4784,7 +5269,9 @@
 	name = "north facing firelock"
 	},
 /turf/open/floor/plasteel/cafeteria,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "CB" = (
 /obj/structure/table,
 /obj/structure/light_construct{
@@ -4847,7 +5334,9 @@
 /obj/effect/turf_decal/vg_decals/radiation,
 /obj/item/reagent_containers/glass/beaker/waterbottle/wataur,
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard{
+	name = "Service Basement"
+	})
 "CT" = (
 /obj/effect/landmark/start/scientist,
 /turf/open/floor/plasteel/white,
@@ -4860,14 +5349,18 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard{
+	name = "Service Basement"
+	})
 "Dc" = (
 /turf/closed/indestructible/rock/snow/ice,
 /area/icemoon/surface/outdoors)
 "Dd" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/dark,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "Df" = (
 /obj/item/relic,
 /obj/structure/table,
@@ -4909,7 +5402,9 @@
 "Dm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/carpet,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "Dn" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -4922,7 +5417,9 @@
 	name = "Air Out"
 	},
 /turf/open/floor/plating,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "Du" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -4939,7 +5436,9 @@
 "Dy" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard{
+	name = "Service Basement"
+	})
 "DB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/brown{
@@ -5001,7 +5500,9 @@
 	dir = 1
 	},
 /turf/open/floor/carpet,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "DN" = (
 /obj/machinery/light/floor,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
@@ -5047,7 +5548,9 @@
 	dir = 1
 	},
 /turf/open/floor/carpet,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "DT" = (
 /obj/machinery/door/airlock/external{
 	name = "Lavaland Shuttle Airlock"
@@ -5072,10 +5575,18 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
+"Ea" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/maintenance/starboard{
+	name = "Service Basement"
+	})
 "Ed" = (
 /obj/structure/stairs,
 /turf/open/floor/plasteel/dark,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "Ee" = (
 /obj/machinery/airalarm{
 	pixel_y = 23
@@ -5142,7 +5653,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "Ew" = (
 /turf/open/floor/engine/vacuum,
 /area/science/mixing)
@@ -5179,7 +5692,9 @@
 /obj/effect/turf_decal/vg_decals/numbers/four,
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard{
+	name = "Service Basement"
+	})
 "EG" = (
 /obj/machinery/camera{
 	c_tag = "Crew Area Hallway East";
@@ -5202,7 +5717,9 @@
 "EO" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/plasteel/dark,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "EQ" = (
 /obj/structure/bed,
 /turf/open/floor/plasteel,
@@ -5230,6 +5747,7 @@
 /obj/machinery/atmospherics/pipe/simple/multiz{
 	piping_layer = 3
 	},
+/obj/effect/turf_decal/stripes/box,
 /turf/open/floor/plating,
 /area/xenoarch/arch)
 "Fd" = (
@@ -5249,7 +5767,9 @@
 "Ff" = (
 /obj/structure/chair/wood/normal,
 /turf/open/floor/plasteel/grimy,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "Fo" = (
 /obj/structure/table/reinforced,
 /obj/item/stack/sheet/glass/fifty,
@@ -5359,7 +5879,9 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/maintenance/starboard{
+	name = "Service Basement"
+	})
 "FU" = (
 /obj/machinery/mineral/processing_unit_console,
 /turf/closed/wall,
@@ -5369,7 +5891,9 @@
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/maintenance/starboard{
+	name = "Service Basement"
+	})
 "Gb" = (
 /obj/machinery/door/airlock/hatch{
 	use_power = 0
@@ -5394,7 +5918,9 @@
 /obj/structure/chair/sofa/right,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/carpet,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "Gh" = (
 /obj/structure/table/reinforced,
 /obj/item/integrated_electronics/analyzer,
@@ -5415,11 +5941,22 @@
 	name = "north facing firelock"
 	},
 /turf/open/floor/plasteel/stairs/right,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "Gk" = (
 /obj/structure/closet/bombcloset,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"Gm" = (
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating,
+/area/engine/atmos)
 "Gn" = (
 /obj/machinery/mineral/processing_unit{
 	dir = 1
@@ -5474,6 +6011,12 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/mine/living_quarters)
+"Gx" = (
+/obj/machinery/air_sensor/atmos/mix_tank{
+	pixel_x = -8
+	},
+/turf/open/floor/engine/airless,
+/area/engine/atmos)
 "GA" = (
 /obj/machinery/firealarm{
 	pixel_y = 24
@@ -5607,7 +6150,15 @@
 /area/science/misc_lab)
 "Hf" = (
 /turf/open/floor/plasteel/dark,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
+"Hg" = (
+/obj/structure/table,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "Hm" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/syringes{
@@ -5632,7 +6183,9 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard{
+	name = "Service Basement"
+	})
 "Ho" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -5650,7 +6203,9 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard{
+	name = "Service Basement"
+	})
 "Hx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -5701,7 +6256,9 @@
 /obj/effect/turf_decal/box,
 /obj/effect/turf_decal/vg_decals/numbers/two,
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard{
+	name = "Service Basement"
+	})
 "HI" = (
 /obj/machinery/light/small,
 /obj/machinery/door/firedoor/border_only{
@@ -5709,7 +6266,9 @@
 	name = "west facing firelock"
 	},
 /turf/open/floor/plasteel/dark,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "HM" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
@@ -5744,7 +6303,17 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/carpet,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
+"HU" = (
+/obj/machinery/door/airlock/external{
+	name = "Atmospherics External Access";
+	req_access_txt = "24"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/plating,
+/area/engine/atmos)
 "HV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -6020,7 +6589,9 @@
 	dir = 4
 	},
 /turf/open/floor/carpet,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "IP" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -6038,7 +6609,9 @@
 /obj/effect/turf_decal/box,
 /obj/effect/turf_decal/vg_decals/numbers/one,
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard{
+	name = "Service Basement"
+	})
 "IS" = (
 /obj/structure/table,
 /turf/open/floor/plating,
@@ -6097,7 +6670,9 @@
 	},
 /obj/machinery/light/small,
 /turf/open/floor/carpet,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "Jr" = (
 /obj/machinery/atmospherics/pipe/simple/multiz{
 	piping_layer = 3
@@ -6110,7 +6685,9 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/grimy,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "Jv" = (
 /obj/structure/stairs{
 	dir = 4;
@@ -6130,7 +6707,9 @@
 /area/hallway/primary/port)
 "Jz" = (
 /turf/open/floor/carpet,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "JC" = (
 /obj/machinery/door/firedoor/border_only{
 	name = "south facing firelock"
@@ -6147,7 +6726,9 @@
 "JI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "JK" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 9
@@ -6186,7 +6767,9 @@
 	dir = 1
 	},
 /turf/open/floor/carpet,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "JP" = (
 /obj/machinery/portable_atmospherics/pump,
 /obj/effect/turf_decal/bot,
@@ -6215,7 +6798,9 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/cafeteria,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "Kb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -6302,6 +6887,13 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/primary/port)
+"KJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating,
+/area/hallway/primary/aft)
 "KO" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
@@ -6331,7 +6923,9 @@
 	name = "\improper Plasteel Chef's Chapel Dinnerware Vendor"
 	},
 /turf/open/floor/plasteel/cafeteria,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "KV" = (
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 4
@@ -6350,6 +6944,12 @@
 	dir = 4
 	},
 /area/xenoarch/arch)
+"Lc" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/mix_input{
+	dir = 8
+	},
+/turf/open/floor/engine/airless,
+/area/engine/atmos)
 "Le" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -6359,7 +6959,9 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard{
+	name = "Service Basement"
+	})
 "Lf" = (
 /obj/machinery/computer/camera_advanced/xenobio{
 	dir = 4
@@ -6414,7 +7016,9 @@
 /obj/structure/table/wood,
 /obj/machinery/light/small,
 /turf/open/floor/plasteel/grimy,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "Lq" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio6";
@@ -6430,7 +7034,9 @@
 	},
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard{
+	name = "Service Basement"
+	})
 "Ls" = (
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
@@ -6561,7 +7167,9 @@
 "Me" = (
 /obj/structure/railing/corner,
 /turf/open/floor/plasteel/dark,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "Mf" = (
 /obj/effect/turf_decal/delivery/red,
 /obj/structure/fans/tiny,
@@ -6584,7 +7192,9 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "Mn" = (
 /obj/machinery/light{
 	dir = 1
@@ -6634,12 +7244,18 @@
 /obj/machinery/door/airlock/glass,
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
+"MJ" = (
+/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "MK" = (
 /obj/machinery/shower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/freezer,
-/area/hallway/primary/aft)
+/area/maintenance/starboard{
+	name = "Service Basement"
+	})
 "ML" = (
 /obj/machinery/requests_console{
 	department = "Science";
@@ -6656,7 +7272,9 @@
 	dir = 4
 	},
 /turf/open/floor/carpet,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "MQ" = (
 /obj/machinery/door/airlock/research/glass/incinerator/toxmix_exterior,
 /turf/open/floor/engine,
@@ -6668,6 +7286,16 @@
 /obj/machinery/vending/cola/random,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
+"MS" = (
+/obj/machinery/door/airlock/external{
+	name = "Atmospherics External Access";
+	req_access_txt = "24"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/engine/atmos)
 "MT" = (
 /obj/machinery/vending/assist,
 /obj/structure/cable{
@@ -6801,7 +7429,9 @@
 "NQ" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "NS" = (
 /obj/structure/stairs{
 	dir = 1;
@@ -6826,7 +7456,9 @@
 	},
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "NY" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 8
@@ -6868,7 +7500,9 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/grimy,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "Of" = (
 /obj/machinery/conveyor{
 	dir = 8;
@@ -6908,7 +7542,9 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "Ol" = (
 /obj/machinery/conveyor{
 	dir = 8;
@@ -6922,11 +7558,15 @@
 "Oo" = (
 /obj/structure/grille/broken,
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard{
+	name = "Service Basement"
+	})
 "Op" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel/grimy,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "Ou" = (
 /obj/machinery/conveyor{
 	dir = 10;
@@ -6968,25 +7608,33 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard{
+	name = "Service Basement"
+	})
 "OA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /turf/closed/wall/mineral/iron,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "OC" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-03"
 	},
 /turf/open/floor/plasteel/dark,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "OE" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "OG" = (
 /obj/structure/railing{
 	dir = 8
@@ -7088,7 +7736,9 @@
 /obj/effect/decal/cleanable/cobweb,
 /obj/item/kirbyplants/random,
 /turf/open/floor/plasteel/dark,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "PA" = (
 /obj/structure/flora/rock/icy,
 /turf/open/floor/plating/asteroid/snow/icemoon,
@@ -7136,7 +7786,9 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "PN" = (
 /obj/structure/closet/crate,
 /obj/item/reagent_containers/glass/beaker/waterbottle/wataur,
@@ -7147,7 +7799,9 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "PP" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
@@ -7163,7 +7817,9 @@
 	dir = 5
 	},
 /turf/open/floor/carpet,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "PV" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio4";
@@ -7192,22 +7848,26 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard{
+	name = "Service Basement"
+	})
 "Qb" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/dark,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "Qd" = (
-/obj/effect/spawner/blocker,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/door/airlock/maintenance,
 /turf/open/floor/plating,
 /area/hallway/primary/port)
 "Qe" = (
@@ -7230,7 +7890,9 @@
 /obj/structure/table,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/carpet,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "Qw" = (
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 8
@@ -7249,6 +7911,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
+"QE" = (
+/obj/effect/turf_decal/stripes/box,
+/obj/machinery/power/deck_relay,
+/obj/structure/cable{
+	icon_state = "0-2";
+	pixel_y = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard{
+	name = "Service Basement"
+	})
 "QH" = (
 /obj/effect/decal/remains/human,
 /obj/item/pipe{
@@ -7279,6 +7952,9 @@
 "QJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/hallway/primary/aft)
@@ -7371,13 +8047,17 @@
 /obj/item/canvas/nineteenXnineteen,
 /obj/item/canvas/nineteenXnineteen,
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard{
+	name = "Service Basement"
+	})
 "Rj" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard{
+	name = "Service Basement"
+	})
 "Rm" = (
 /mob/living/carbon/human/species/ipc{
 	fireloss = 205;
@@ -7417,7 +8097,9 @@
 "Rt" = (
 /obj/structure/weightmachine/weightlifter,
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/maintenance/starboard{
+	name = "Service Basement"
+	})
 "Rx" = (
 /obj/structure/chair{
 	dir = 4
@@ -7588,7 +8270,9 @@
 "Sv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/mineral/iron,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "Sw" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -7608,6 +8292,13 @@
 	},
 /turf/open/floor/plating,
 /area/mine/production)
+"Sz" = (
+/obj/machinery/atmospherics/pipe/simple/multiz{
+	piping_layer = 3
+	},
+/obj/effect/turf_decal/stripes/box,
+/turf/open/floor/plasteel/elevatorshaft,
+/area/engine/atmos)
 "SA" = (
 /obj/item/kirbyplants/dead{
 	name = "potted plant"
@@ -7621,7 +8312,9 @@
 "SF" = (
 /obj/machinery/door/airlock,
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard{
+	name = "Service Basement"
+	})
 "SG" = (
 /obj/item/tank/internals/emergency_oxygen/empty,
 /turf/open/floor/plating,
@@ -7697,7 +8390,9 @@
 "SY" = (
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard{
+	name = "Service Basement"
+	})
 "Tb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
@@ -7787,7 +8482,17 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/grimy,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
+"Tt" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard{
+	name = "Service Basement"
+	})
 "Tu" = (
 /obj/effect/spawner/structure/window/ice,
 /turf/open/floor/plating,
@@ -7824,7 +8529,9 @@
 /obj/structure/closet/cardboard,
 /obj/item/reagent_containers/food/snacks/beans,
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard{
+	name = "Service Basement"
+	})
 "TJ" = (
 /obj/machinery/airalarm{
 	pixel_y = 23
@@ -7879,7 +8586,9 @@
 /obj/effect/turf_decal/vg_decals/numbers/three,
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard{
+	name = "Service Basement"
+	})
 "Ua" = (
 /obj/machinery/door/poddoor{
 	id = "toxinsdriver";
@@ -7893,7 +8602,9 @@
 	icon_state = "cobweb2"
 	},
 /turf/open/floor/plasteel/dark,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "Ue" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -7942,7 +8653,9 @@
 	volume_rate = 200
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "Up" = (
 /turf/open/floor/plating,
 /area/security/execution/education)
@@ -8027,7 +8740,7 @@
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
 "UN" = (
-/turf/closed/wall,
+/turf/closed/wall/r_wall,
 /area/engine/atmos)
 "UO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -8134,11 +8847,15 @@
 "Vh" = (
 /obj/machinery/pipedispenser,
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard{
+	name = "Service Basement"
+	})
 "Vj" = (
 /obj/effect/spawner/structure/window/ice,
 /turf/open/floor/plating,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "Vm" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -8177,11 +8894,15 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard{
+	name = "Service Basement"
+	})
 "Vu" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard{
+	name = "Service Basement"
+	})
 "Vv" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
@@ -8189,6 +8910,9 @@
 "Vw" = (
 /turf/open/openspace/icemoon,
 /area/icemoon/surface/outdoors)
+"VA" = (
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "VB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 6
@@ -8213,7 +8937,9 @@
 /obj/item/stack/sheet/metal/fifty,
 /obj/structure/rack,
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard{
+	name = "Service Basement"
+	})
 "VE" = (
 /turf/closed/mineral/random/snow,
 /area/icemoon/surface/outdoors)
@@ -8229,12 +8955,16 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "VI" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "VK" = (
 /obj/machinery/atmospherics/components/binary/pump/on,
 /obj/structure/cable,
@@ -8250,7 +8980,9 @@
 	dir = 6
 	},
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard{
+	name = "Service Basement"
+	})
 "VM" = (
 /obj/structure/frame/computer{
 	dir = 4
@@ -8320,6 +9052,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
+"Wf" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "Wg" = (
 /obj/structure/chair{
 	dir = 1
@@ -8344,17 +9080,24 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "Wl" = (
 /obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
 	},
 /turf/open/floor/plating,
 /area/security/execution/education)
+"Wo" = (
+/turf/open/floor/plasteel/dark/corner,
+/area/engine/atmos)
 "Wp" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard{
+	name = "Service Basement"
+	})
 "Wz" = (
 /obj/structure/grille,
 /turf/closed/mineral/random/snow,
@@ -8383,7 +9126,9 @@
 /obj/structure/closet/cardboard,
 /obj/item/reagent_containers/food/snacks/cannedpeaches,
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard{
+	name = "Service Basement"
+	})
 "WF" = (
 /obj/structure/closet/l3closet/scientist{
 	pixel_x = -2
@@ -8427,7 +9172,9 @@
 /obj/machinery/atmospherics/pipe/simple/multiz,
 /obj/effect/turf_decal/stripes/box,
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard{
+	name = "Service Basement"
+	})
 "WO" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -8447,6 +9194,12 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/primary/port)
+"WQ" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "WT" = (
 /obj/structure/sign/warning/securearea,
 /turf/closed/wall/r_wall,
@@ -8468,10 +9221,16 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard{
+	name = "Service Basement"
+	})
 "Xc" = (
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"Xd" = (
+/obj/machinery/light/floor,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/underground/unexplored/rivers)
 "Xe" = (
 /obj/machinery/atmospherics/components/trinary/mixer/flipped{
 	dir = 8
@@ -8484,7 +9243,9 @@
 	},
 /obj/effect/turf_decal/stripes/box,
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard{
+	name = "Service Basement"
+	})
 "Xg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/light_construct{
@@ -8537,7 +9298,9 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/grimy,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "Xr" = (
 /obj/structure/table,
 /obj/item/pipe_dispenser,
@@ -8554,7 +9317,9 @@
 /obj/structure/closet/cardboard,
 /obj/item/reagent_containers/glass/beaker/waterbottle/wataur,
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard{
+	name = "Service Basement"
+	})
 "Xx" = (
 /obj/machinery/door/window/southleft,
 /obj/machinery/shower{
@@ -8608,7 +9373,9 @@
 	},
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard{
+	name = "Service Basement"
+	})
 "XL" = (
 /obj/structure/table/wood,
 /obj/structure/window/reinforced{
@@ -8650,7 +9417,9 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/freezer,
-/area/hallway/primary/aft)
+/area/maintenance/starboard{
+	name = "Service Basement"
+	})
 "Ya" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 1
@@ -8707,7 +9476,9 @@
 	name = "3maintenance loot spawner"
 	},
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard{
+	name = "Service Basement"
+	})
 "Yq" = (
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/security/execution/education)
@@ -8730,7 +9501,9 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "Yv" = (
 /obj/structure/toilet{
 	dir = 8
@@ -8788,7 +9561,9 @@
 "YD" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard{
+	name = "Service Basement"
+	})
 "YG" = (
 /obj/structure/easel,
 /obj/item/canvas/twentythreeXnineteen,
@@ -8796,13 +9571,17 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "YI" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard{
+	name = "Service Basement"
+	})
 "YK" = (
 /obj/machinery/button/massdriver{
 	id = "toxinsdriver";
@@ -8849,6 +9628,17 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/storage)
+"YU" = (
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
+"YV" = (
+/obj/machinery/light,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "YW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -8893,6 +9683,10 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/mine/living_quarters)
+"Ze" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "Zf" = (
 /obj/machinery/button/door{
 	id = "miningbathroom";
@@ -8909,6 +9703,11 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/mine/living_quarters)
+"Zg" = (
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
+/area/engine/atmos)
 "Zk" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -8959,11 +9758,15 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "Zz" = (
 /obj/structure/chair/stool,
 /turf/open/floor/plasteel/dark,
-/area/chapel/main)
+/area/chapel/main/monastery{
+	name = "Monastery Basement"
+	})
 "ZF" = (
 /obj/machinery/atmospherics/pipe/simple/multiz,
 /obj/effect/turf_decal/stripes/box,
@@ -20726,7 +21529,7 @@ VE
 VE
 VE
 eF
-ID
+Eo
 Gs
 Gs
 Gs
@@ -22811,7 +23614,7 @@ oS
 oS
 oS
 XR
-ID
+Eo
 eF
 VE
 VE
@@ -26663,7 +27466,7 @@ lJ
 lJ
 lJ
 lJ
-ID
+Eo
 eF
 VE
 VE
@@ -30773,7 +31576,7 @@ lJ
 lJ
 lJ
 lJ
-ID
+Eo
 eF
 eF
 eF
@@ -51517,7 +52320,7 @@ si
 si
 si
 kE
-si
+jX
 wl
 wl
 wl
@@ -51774,7 +52577,7 @@ si
 si
 si
 bj
-si
+pt
 wl
 VL
 Rj
@@ -52036,7 +52839,7 @@ wl
 CY
 YI
 si
-fy
+Ea
 si
 bG
 si
@@ -52545,7 +53348,7 @@ wl
 wl
 wl
 wl
-si
+pt
 wl
 aO
 wl
@@ -53059,7 +53862,7 @@ wl
 Wp
 Wp
 wl
-si
+pt
 si
 Le
 kE
@@ -53316,12 +54119,12 @@ SF
 si
 si
 SF
-si
-si
+Tt
+bn
 bf
 WY
 dN
-QJ
+qD
 aS
 wl
 XZ
@@ -54602,8 +55405,8 @@ VE
 VE
 wl
 TI
-si
-fy
+QE
+KJ
 si
 sS
 wl
@@ -57435,7 +58238,7 @@ ah
 ah
 ah
 VE
-VE
+hS
 vI
 vI
 GK
@@ -57443,16 +58246,16 @@ cY
 aC
 UN
 VE
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
+UN
+UN
+UN
+UN
+UN
+UN
+UN
+UN
+UN
+UN
 ah
 ah
 ah
@@ -57692,24 +58495,24 @@ ah
 ah
 ah
 VE
-VE
+hS
 vI
 vI
 UN
 UN
 UN
 UN
-VE
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
+UN
+UN
+Wf
+Ze
+Wo
+Zg
+nH
+mj
+WQ
+uT
+UN
 ah
 ah
 ah
@@ -57949,24 +58752,24 @@ ah
 ah
 ah
 VE
-VE
 hS
 vI
 vI
 vI
-hS
-VE
-VE
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
+vI
+vI
+UN
+eE
+UN
+Ao
+Ze
+wa
+gv
+oT
+UN
+ty
+ue
+UN
 ah
 ah
 ah
@@ -58207,23 +59010,23 @@ ah
 ah
 VE
 VE
-VE
-VE
-VE
-VE
-VE
-VE
-VE
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
+vI
+vI
+vI
+vI
+vI
+HU
+bM
+MS
+VA
+VA
+wa
+Sz
+oT
+UN
+jm
+uT
+UN
 ah
 ah
 ah
@@ -58464,24 +59267,24 @@ ah
 ah
 VE
 VE
-VE
-VE
-VE
-VE
-VE
-VE
-VE
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
+hS
+hS
+vI
+vI
+vI
+UN
+UN
+UN
+VA
+VA
+ux
+cs
+eb
+Bo
+ad
+Gm
+UN
+FC
 ah
 ah
 ah
@@ -58722,23 +59525,23 @@ ah
 ah
 ah
 ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
+FK
+FK
+FK
+FC
+FC
+FC
+nX
+Hg
+VA
+VA
+VA
+VA
+VA
+VA
+yT
+nX
+FK
 ah
 ah
 ah
@@ -58981,21 +59784,21 @@ ah
 ah
 ah
 ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
+FK
+FK
+Xd
+FC
+UN
+uc
+VA
+tf
+VA
+VA
+VA
+VA
+YV
+UN
+FC
 ah
 ah
 ah
@@ -59240,19 +60043,19 @@ ah
 ah
 ah
 ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
+FK
+FC
+nX
+VA
+VA
+VA
+VA
+VA
+VA
+VA
+VA
+nX
+FC
 ah
 ah
 ah
@@ -59498,18 +60301,18 @@ ah
 ah
 ah
 ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
+FC
+UN
+MJ
+VA
+VA
+VA
+VA
+VA
+VA
+VA
+UN
+FK
 ah
 ah
 ah
@@ -59755,18 +60558,18 @@ ah
 ah
 ah
 ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
+FC
+nX
+MJ
+VA
+VA
+VA
+VA
+VA
+VA
+VA
+nX
+FC
 ah
 ah
 ah
@@ -60011,19 +60814,19 @@ ah
 ah
 ah
 ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
+FK
+FC
+UN
+YU
+VA
+VA
+VA
+VA
+VA
+VA
+YV
+UN
+FC
 ah
 ah
 ah
@@ -60269,18 +61072,18 @@ ah
 ah
 ah
 ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
+FC
+nX
+ki
+VA
+VA
+VA
+VA
+Cp
+pZ
+bU
+nX
+FC
 ah
 ah
 ah
@@ -60525,19 +61328,19 @@ ah
 ah
 ah
 ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
+FK
+FC
+nX
+nX
+nX
+nX
+nX
+nX
+wD
+nX
+wD
+nX
+FC
 ah
 ah
 ah
@@ -60783,18 +61586,18 @@ ah
 ah
 ah
 ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
+FC
+FC
+FC
+FC
+FC
+Xd
+FC
+mv
+FC
+kG
+FC
+FC
 ah
 ah
 ah
@@ -61041,17 +61844,17 @@ ah
 ah
 ah
 ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
+FK
+FK
+FK
+FK
+FK
+UN
+qw
+cW
+bs
+UN
+FK
 ah
 ah
 ah
@@ -61300,15 +62103,15 @@ ah
 ah
 ah
 ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
+FK
+FK
+FK
+UN
+qB
+Gx
+Lc
+UN
+FK
 ah
 ah
 ah
@@ -61558,13 +62361,13 @@ ah
 ah
 ah
 ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
+FK
+FK
+UN
+ro
+ms
+ro
+UN
 ah
 ah
 ah
@@ -61815,14 +62618,14 @@ ah
 ah
 ah
 ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
+FK
+FK
+UN
+ro
+xV
+ro
+UN
+FK
 ah
 ah
 ah
@@ -62071,14 +62874,14 @@ ah
 ah
 ah
 ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
+FK
+FK
+FK
+UN
+UN
+UN
+UN
+UN
 ah
 ah
 ah
@@ -62329,6 +63132,13 @@ ah
 ah
 ah
 ah
+FK
+FK
+FK
+FK
+FK
+FK
+FK
 ah
 ah
 ah
@@ -62432,13 +63242,6 @@ ah
 ah
 ah
 ah
-ah
-ah
-ah
-ah
-ah
-ah
-VE
 Dc
 kS
 kS
@@ -62587,7 +63390,7 @@ ah
 ah
 ah
 ah
-ah
+FK
 ah
 ah
 ah
@@ -62952,7 +63755,7 @@ ah
 ah
 ah
 ah
-aZ
+Dc
 Dc
 Vj
 Xp

--- a/_maps/map_files/Snaxi/IcemoonUnderground_Above_Lumos.dmm
+++ b/_maps/map_files/Snaxi/IcemoonUnderground_Above_Lumos.dmm
@@ -6,17 +6,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
-"ad" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/machinery/power/deck_relay,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/effect/turf_decal/stripes/box,
-/turf/open/floor/plasteel/elevatorshaft,
-/area/engine/atmos)
 "ag" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -83,6 +72,11 @@
 	},
 /turf/open/floor/plating,
 /area/security/execution/education)
+"aB" = (
+/turf/open/floor/plasteel/dark/corner{
+	dir = 8
+	},
+/area/engine/atmos)
 "aC" = (
 /obj/structure/stairs,
 /obj/structure/railing{
@@ -130,6 +124,11 @@
 /obj/structure/fluff/broken_flooring,
 /turf/open/floor/plating,
 /area/icemoon/surface/outdoors)
+"aL" = (
+/turf/open/floor/plasteel/dark/corner{
+	dir = 4
+	},
+/area/engine/atmos)
 "aO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -234,23 +233,15 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "bn" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/closet/secure_closet/atmospherics,
+/obj/machinery/light{
+	dir = 1
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard{
-	name = "Service Basement"
-	})
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "bo" = (
 /turf/closed/wall/r_wall,
 /area/science/misc_lab)
-"bs" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/engine/atmos)
 "bt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/warning/securearea{
@@ -296,15 +287,10 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/primary/port)
-"bM" = (
-/turf/open/floor/plating,
-/area/engine/atmos)
 "bU" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
+/obj/machinery/light/floor,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/underground/unexplored/rivers)
 "bZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
@@ -389,11 +375,6 @@
 /obj/structure/target_stake,
 /turf/open/floor/plasteel,
 /area/science/circuit)
-"cs" = (
-/turf/open/floor/plasteel/dark/side{
-	dir = 8
-	},
-/area/engine/atmos)
 "cv" = (
 /obj/structure/railing/corner{
 	dir = 4
@@ -422,6 +403,14 @@
 /obj/item/stack/sheet/glass/fifty,
 /turf/open/floor/plating,
 /area/hallway/primary/port)
+"cz" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard{
+	name = "Service Basement"
+	})
 "cA" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 9
@@ -447,6 +436,14 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"cD" = (
+/obj/machinery/door/airlock/external{
+	name = "Atmospherics External Access";
+	req_access_txt = "24"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/plating,
+/area/engine/atmos)
 "cH" = (
 /obj/machinery/mass_driver{
 	dir = 1;
@@ -454,6 +451,16 @@
 	},
 /turf/open/floor/plating,
 /area/science/test_area)
+"cI" = (
+/obj/machinery/computer/atmos_control/tank/mix_tank{
+	dir = 8;
+	input_tag = "mix_in2";
+	name = "Aux Gas Mix Tank Control";
+	output_tag = "mix_out2";
+	sensors = list("mix_sensor2" = "Aux Gas Mix Tank ")
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "cJ" = (
 /obj/effect/turf_decal/trimline/brown,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -489,8 +496,10 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"cW" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
+"cU" = (
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
 /turf/open/floor/plating,
 /area/engine/atmos)
 "cX" = (
@@ -692,11 +701,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
-"eb" = (
-/turf/open/floor/plasteel/dark/corner{
-	dir = 1
-	},
-/area/engine/atmos)
 "ec" = (
 /obj/structure/table,
 /obj/item/clothing/glasses/science,
@@ -839,10 +843,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
-"eE" = (
-/obj/structure/closet/emcloset/anchored,
-/turf/open/floor/plating,
-/area/engine/atmos)
 "eF" = (
 /turf/closed/wall,
 /area/hallway/primary/port)
@@ -1139,6 +1139,12 @@
 	dir = 4
 	},
 /area/xenoarch/arch)
+"fr" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "fw" = (
 /turf/open/floor/plasteel/median/whitetodark{
 	dir = 8
@@ -1376,13 +1382,6 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/primary/aft)
-"gv" = (
-/obj/machinery/atmospherics/pipe/simple/multiz{
-	piping_layer = 1
-	},
-/obj/effect/turf_decal/stripes/box,
-/turf/open/floor/plasteel/elevatorshaft,
-/area/engine/atmos)
 "gy" = (
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /obj/machinery/light,
@@ -1419,6 +1418,11 @@
 /area/chapel/main/monastery{
 	name = "Monastery Basement"
 	})
+"gF" = (
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
+	},
+/area/engine/atmos)
 "gG" = (
 /obj/structure/sign/departments/showers{
 	dir = 1;
@@ -1521,6 +1525,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
+"hj" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "hk" = (
 /obj/structure/lattice,
 /turf/open/openspace/icemoon,
@@ -1579,6 +1590,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/production)
+"hC" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 4
+	},
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/underground/unexplored/rivers)
 "hD" = (
 /obj/machinery/button/door{
 	id = "misclab";
@@ -1651,6 +1668,15 @@
 /obj/machinery/meter,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"im" = (
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating,
+/area/engine/atmos)
 "io" = (
 /turf/open/floor/engine,
 /area/science/xenobiology)
@@ -1672,6 +1698,9 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"iu" = (
+/turf/open/floor/plasteel/dark/side,
+/area/engine/atmos)
 "iy" = (
 /turf/open/floor/plating,
 /area/science/test_area)
@@ -1706,6 +1735,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
+"iK" = (
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "iN" = (
 /obj/structure/table,
 /turf/open/floor/carpet,
@@ -1770,14 +1803,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "jm" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/structure/stairs{
-	dir = 1;
-	icon_state = "stairs_t"
-	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "jn" = (
 /obj/machinery/light/small,
@@ -1923,15 +1949,6 @@
 /obj/machinery/light/small,
 /turf/open/floor/plasteel,
 /area/mine/eva)
-"jX" = (
-/obj/machinery/power/apc/auto_name/south,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard{
-	name = "Service Basement"
-	})
 "kb" = (
 /obj/structure/ore_box,
 /turf/open/floor/plasteel,
@@ -1953,10 +1970,6 @@
 /area/chapel/main/monastery{
 	name = "Monastery Basement"
 	})
-"ki" = (
-/obj/machinery/portable_atmospherics/canister/nitrogen,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "ks" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
@@ -1967,6 +1980,12 @@
 	dir = 1
 	},
 /area/xenoarch/arch)
+"kt" = (
+/obj/structure/railing/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "ku" = (
 /obj/machinery/portable_atmospherics/canister,
 /obj/effect/turf_decal/bot,
@@ -2001,12 +2020,6 @@
 /area/maintenance/starboard{
 	name = "Service Basement"
 	})
-"kG" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/underground/unexplored/rivers)
 "kI" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -2028,6 +2041,13 @@
 	},
 /turf/open/floor/plating,
 /area/xenoarch/arch)
+"kN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating,
+/area/hallway/primary/aft)
 "kQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
@@ -2096,6 +2116,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/icemoon/surface/outdoors)
+"ld" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/machinery/power/deck_relay,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/effect/turf_decal/stripes/box,
+/turf/open/floor/plasteel/elevatorshaft,
+/area/engine/atmos)
 "lf" = (
 /obj/machinery/suit_storage_unit/mining,
 /obj/effect/turf_decal/tile/neutral{
@@ -2281,10 +2312,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"mj" = (
-/obj/structure/railing/corner,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "ml" = (
 /obj/structure/table,
 /turf/open/floor/plasteel/dark,
@@ -2317,15 +2344,6 @@
 /area/chapel/main/monastery{
 	name = "Monastery Basement"
 	})
-"ms" = (
-/obj/effect/turf_decal/vg_decals/atmos/mix{
-	pixel_x = -16
-	},
-/obj/effect/turf_decal/vg_decals/numbers/two{
-	pixel_x = 16
-	},
-/turf/open/floor/engine/airless,
-/area/engine/atmos)
 "mt" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/atmos_waste{
 	dir = 1;
@@ -2333,12 +2351,6 @@
 	},
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/hallway/primary/port)
-"mv" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4
-	},
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/underground/unexplored/rivers)
 "mw" = (
 /obj/machinery/vending/sustenance,
 /turf/open/floor/plating,
@@ -2468,6 +2480,10 @@
 	},
 /turf/open/floor/carpet,
 /area/hallway/primary/port)
+"ng" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/engine/atmos)
 "nj" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -2476,6 +2492,16 @@
 /area/maintenance/starboard{
 	name = "Service Basement"
 	})
+"nk" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/stairs{
+	dir = 1;
+	icon_state = "stairs_t"
+	},
+/turf/open/floor/plating,
+/area/engine/atmos)
 "nm" = (
 /obj/item/radio/intercom{
 	dir = 8;
@@ -2517,6 +2543,13 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating/airless,
 /area/icemoon/underground/unexplored/rivers)
+"nB" = (
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "nC" = (
 /obj/structure/chair/sofa/right{
 	dir = 8
@@ -2533,11 +2566,6 @@
 	},
 /turf/closed/mineral/random/snow,
 /area/icemoon/surface/outdoors)
-"nH" = (
-/turf/open/floor/plasteel/dark/corner{
-	dir = 4
-	},
-/area/engine/atmos)
 "nI" = (
 /mob/living/simple_animal/hostile/asteroid/wolf{
 	desc = "A captive winter hound with bits of flesh sticking from its jaws, that explains all the remains.";
@@ -2575,10 +2603,6 @@
 "nV" = (
 /turf/closed/wall/r_wall,
 /area/mine/maintenance)
-"nX" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/engine/atmos)
 "oa" = (
 /obj/machinery/monkey_recycler,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -2725,6 +2749,12 @@
 	},
 /turf/open/floor/plating,
 /area/mine/living_quarters)
+"oM" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "oO" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/structure/cable{
@@ -2745,11 +2775,6 @@
 "oS" = (
 /turf/open/floor/engine,
 /area/science/explab)
-"oT" = (
-/turf/open/floor/plasteel/dark/side{
-	dir = 1
-	},
-/area/engine/atmos)
 "oU" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
@@ -2854,14 +2879,12 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/plasteel,
 /area/science/test_area)
-"pt" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+"pq" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard{
-	name = "Service Basement"
-	})
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/underground/unexplored/rivers)
 "pu" = (
 /obj/machinery/mineral/mint,
 /turf/open/floor/plasteel,
@@ -2948,16 +2971,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/mine/production)
-"pZ" = (
-/obj/machinery/computer/atmos_control/tank/mix_tank{
-	dir = 8;
-	input_tag = "mix_in2";
-	name = "Aux Gas Mix Tank Control";
-	output_tag = "mix_out2";
-	sensors = list("mix_sensor2" = "Aux Gas Mix Tank ")
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "qa" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -5;
@@ -3037,11 +3050,11 @@
 /turf/open/floor/plasteel,
 /area/mine/production)
 "qw" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4
+/obj/structure/railing/corner{
+	dir = 1
 	},
-/turf/open/floor/plating,
+/obj/machinery/light,
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "qy" = (
 /obj/machinery/door/airlock/maintenance{
@@ -3058,20 +3071,6 @@
 /obj/structure/trash_pile,
 /turf/open/floor/plating,
 /area/hallway/primary/port)
-"qB" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/mix_output{
-	dir = 8
-	},
-/turf/open/floor/engine/airless,
-/area/engine/atmos)
-"qD" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard{
-	name = "Service Basement"
-	})
 "qE" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -3252,9 +3251,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/circuit)
-"ro" = (
-/turf/open/floor/engine/airless,
-/area/engine/atmos)
 "rp" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
@@ -3334,6 +3330,13 @@
 /area/chapel/main/monastery{
 	name = "Monastery Basement"
 	})
+"rW" = (
+/obj/machinery/atmospherics/pipe/simple/multiz{
+	piping_layer = 1
+	},
+/obj/effect/turf_decal/stripes/box,
+/turf/open/floor/plasteel/elevatorshaft,
+/area/engine/atmos)
 "rX" = (
 /obj/machinery/holopad,
 /turf/open/floor/plasteel/white,
@@ -3540,6 +3543,11 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"sL" = (
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
+/area/engine/atmos)
 "sM" = (
 /obj/structure/table,
 /obj/item/storage/firstaid/toxin{
@@ -3579,6 +3587,16 @@
 /area/maintenance/starboard{
 	name = "Service Basement"
 	})
+"sU" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/stairs{
+	dir = 1;
+	icon_state = "stairs_t"
+	},
+/turf/open/floor/plating,
+/area/engine/atmos)
 "sW" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/plasteel/dark,
@@ -3631,10 +3649,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"tf" = (
-/obj/effect/landmark/start/atmospheric_technician,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "ti" = (
 /obj/structure/chair/comfy/brown{
 	dir = 1
@@ -3695,16 +3709,6 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/primary/port)
-"ty" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/stairs{
-	dir = 1;
-	icon_state = "stairs_t"
-	},
-/turf/open/floor/plating,
-/area/engine/atmos)
 "tA" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
@@ -3810,24 +3814,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/misc_lab)
-"uc" = (
-/obj/structure/closet/secure_closet/atmospherics,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "ud" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /turf/open/floor/plasteel/white,
 /area/science/misc_lab)
-"ue" = (
-/obj/structure/railing/corner{
-	dir = 1
-	},
-/obj/machinery/light,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "ui" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -3884,11 +3874,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"ux" = (
-/turf/open/floor/plasteel/dark/corner{
-	dir = 8
-	},
-/area/engine/atmos)
 "uD" = (
 /obj/machinery/door/airlock{
 	id_tag = "Cell2";
@@ -3913,6 +3898,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/production)
+"uH" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "uI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -3959,12 +3948,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/engine,
 /area/science/storage)
-"uT" = (
-/obj/structure/railing/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "uV" = (
 /obj/machinery/vending/wardrobe/science_wardrobe,
 /turf/open/floor/plasteel/white,
@@ -3980,6 +3963,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/production)
+"vc" = (
+/turf/open/floor/engine/airless,
+/area/engine/atmos)
 "vg" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/stripes/line{
@@ -4040,6 +4026,13 @@
 /obj/effect/turf_decal/loading_area,
 /turf/open/floor/plasteel,
 /area/mine/production)
+"vy" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engine/atmos)
 "vz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/delivery,
@@ -4057,6 +4050,10 @@
 	},
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/xenoarch/arch)
+"vC" = (
+/obj/machinery/light,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "vD" = (
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /obj/machinery/firealarm{
@@ -4065,6 +4062,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
+"vE" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard{
+	name = "Service Basement"
+	})
 "vG" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 4
@@ -4120,9 +4125,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
-"wa" = (
-/turf/open/floor/plasteel/dark/side,
-/area/engine/atmos)
 "we" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio7";
@@ -4226,13 +4228,6 @@
 /obj/item/pen,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
-"wD" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/layer_manifold{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/engine/atmos)
 "wF" = (
 /obj/structure/frame/machine,
 /turf/open/floor/plating,
@@ -4390,6 +4385,10 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"xv" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/plating,
+/area/engine/atmos)
 "xx" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/machinery/firealarm{
@@ -4454,12 +4453,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/mine/living_quarters)
-"xV" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/engine/airless,
-/area/engine/atmos)
 "yf" = (
 /obj/structure/table,
 /obj/item/storage/firstaid/regular,
@@ -4527,6 +4520,15 @@
 	},
 /turf/open/floor/plating,
 /area/mine/living_quarters)
+"yu" = (
+/obj/machinery/power/apc/auto_name/south,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard{
+	name = "Service Basement"
+	})
 "yy" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -4609,10 +4611,8 @@
 	name = "Service Basement"
 	})
 "yT" = (
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plating,
+/obj/structure/railing/corner,
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "yU" = (
 /turf/closed/mineral/random/snow/no_caves,
@@ -4830,13 +4830,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
-"Ao" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "Ap" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -5014,12 +5007,6 @@
 /area/chapel/main/monastery{
 	name = "Monastery Basement"
 	})
-"Bo" = (
-/obj/structure/railing/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "Bq" = (
 /obj/machinery/light{
 	dir = 1
@@ -5076,6 +5063,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/production)
+"BA" = (
+/turf/open/floor/plasteel/dark/corner{
+	dir = 1
+	},
+/area/engine/atmos)
+"BB" = (
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
+/area/engine/atmos)
+"BC" = (
+/obj/machinery/air_sensor/atmos/mix_tank{
+	pixel_x = -8
+	},
+/turf/open/floor/engine/airless,
+/area/engine/atmos)
 "BE" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /turf/open/floor/plasteel/white,
@@ -5218,12 +5221,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/test_area)
-"Cp" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "Cr" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -5575,12 +5572,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
-"Ea" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/starboard{
-	name = "Service Basement"
-	})
 "Ed" = (
 /obj/structure/stairs,
 /turf/open/floor/plasteel/dark,
@@ -5695,6 +5686,9 @@
 /area/maintenance/starboard{
 	name = "Service Basement"
 	})
+"EF" = (
+/turf/open/floor/plating,
+/area/engine/atmos)
 "EG" = (
 /obj/machinery/camera{
 	c_tag = "Crew Area Hallway East";
@@ -5777,6 +5771,13 @@
 /obj/item/pen,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
+"Fp" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engine/atmos)
 "Fy" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /obj/effect/turf_decal/tile/purple{
@@ -5796,6 +5797,14 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
+"FA" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard{
+	name = "Service Basement"
+	})
 "FB" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -5831,6 +5840,12 @@
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/security/execution/education)
+"FI" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/mix_output{
+	dir = 8
+	},
+/turf/open/floor/engine/airless,
+/area/engine/atmos)
 "FK" = (
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/underground/unexplored/rivers)
@@ -5948,15 +5963,6 @@
 /obj/structure/closet/bombcloset,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
-"Gm" = (
-/obj/structure/railing/corner{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plating,
-/area/engine/atmos)
 "Gn" = (
 /obj/machinery/mineral/processing_unit{
 	dir = 1
@@ -6011,12 +6017,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/mine/living_quarters)
-"Gx" = (
-/obj/machinery/air_sensor/atmos/mix_tank{
-	pixel_x = -8
-	},
-/turf/open/floor/engine/airless,
-/area/engine/atmos)
 "GA" = (
 /obj/machinery/firealarm{
 	pixel_y = 24
@@ -6153,12 +6153,6 @@
 /area/chapel/main/monastery{
 	name = "Monastery Basement"
 	})
-"Hg" = (
-/obj/structure/table,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "Hm" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/syringes{
@@ -6206,6 +6200,10 @@
 /area/maintenance/starboard{
 	name = "Service Basement"
 	})
+"Hq" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "Hx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -6306,14 +6304,6 @@
 /area/chapel/main/monastery{
 	name = "Monastery Basement"
 	})
-"HU" = (
-/obj/machinery/door/airlock/external{
-	name = "Atmospherics External Access";
-	req_access_txt = "24"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/floor/plating,
-/area/engine/atmos)
 "HV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -6811,6 +6801,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/production)
+"Kf" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engine/atmos)
 "Kk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
@@ -6842,6 +6839,12 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"Ko" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "Kp" = (
 /obj/machinery/atmospherics/components/trinary/filter/flipped{
 	dir = 8
@@ -6860,6 +6863,25 @@
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
+"Ku" = (
+/obj/machinery/door/airlock/external{
+	name = "Atmospherics External Access";
+	req_access_txt = "24"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/engine/atmos)
+"Kw" = (
+/obj/effect/turf_decal/vg_decals/atmos/mix{
+	pixel_x = -16
+	},
+/obj/effect/turf_decal/vg_decals/numbers/two{
+	pixel_x = 16
+	},
+/turf/open/floor/engine/airless,
+/area/engine/atmos)
 "KE" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
@@ -6887,13 +6909,6 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/primary/port)
-"KJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plating,
-/area/hallway/primary/aft)
 "KO" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
@@ -6944,12 +6959,6 @@
 	dir = 4
 	},
 /area/xenoarch/arch)
-"Lc" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/mix_input{
-	dir = 8
-	},
-/turf/open/floor/engine/airless,
-/area/engine/atmos)
 "Le" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -7244,10 +7253,6 @@
 /obj/machinery/door/airlock/glass,
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
-"MJ" = (
-/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "MK" = (
 /obj/machinery/shower{
 	dir = 8
@@ -7286,16 +7291,6 @@
 /obj/machinery/vending/cola/random,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
-"MS" = (
-/obj/machinery/door/airlock/external{
-	name = "Atmospherics External Access";
-	req_access_txt = "24"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/engine/atmos)
 "MT" = (
 /obj/machinery/vending/assist,
 /obj/structure/cable{
@@ -7315,6 +7310,10 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"Na" = (
+/obj/structure/closet/emcloset/anchored,
+/turf/open/floor/plating,
+/area/engine/atmos)
 "Ne" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
@@ -7450,6 +7449,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/misc_lab)
+"NW" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/maintenance/starboard{
+	name = "Service Basement"
+	})
 "NX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
@@ -7567,6 +7572,12 @@
 /area/chapel/main/monastery{
 	name = "Monastery Basement"
 	})
+"Oq" = (
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "Ou" = (
 /obj/machinery/conveyor{
 	dir = 10;
@@ -7707,6 +7718,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
+"Pq" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard{
+	name = "Service Basement"
+	})
 "Ps" = (
 /obj/machinery/camera{
 	c_tag = "Public Shuttle Lobby";
@@ -7886,6 +7905,12 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/primary/port)
+"Qq" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/engine/airless,
+/area/engine/atmos)
 "Qv" = (
 /obj/structure/table,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -7911,17 +7936,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
-"QE" = (
-/obj/effect/turf_decal/stripes/box,
-/obj/machinery/power/deck_relay,
-/obj/structure/cable{
-	icon_state = "0-2";
-	pixel_y = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard{
-	name = "Service Basement"
-	})
 "QH" = (
 /obj/effect/decal/remains/human,
 /obj/item/pipe{
@@ -7981,6 +7995,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
+"QR" = (
+/obj/structure/table,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "QS" = (
 /obj/machinery/atmospherics/components/unary/tank/air{
 	dir = 8
@@ -8131,6 +8151,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"RC" = (
+/obj/effect/landmark/start/atmospheric_technician,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "RE" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -8214,6 +8238,17 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"RU" = (
+/obj/effect/turf_decal/stripes/box,
+/obj/machinery/power/deck_relay,
+/obj/structure/cable{
+	icon_state = "0-2";
+	pixel_y = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard{
+	name = "Service Basement"
+	})
 "RX" = (
 /obj/machinery/smartfridge/extract/preloaded,
 /turf/open/floor/plasteel/white,
@@ -8292,13 +8327,6 @@
 	},
 /turf/open/floor/plating,
 /area/mine/production)
-"Sz" = (
-/obj/machinery/atmospherics/pipe/simple/multiz{
-	piping_layer = 3
-	},
-/obj/effect/turf_decal/stripes/box,
-/turf/open/floor/plasteel/elevatorshaft,
-/area/engine/atmos)
 "SA" = (
 /obj/item/kirbyplants/dead{
 	name = "potted plant"
@@ -8485,14 +8513,6 @@
 /area/chapel/main/monastery{
 	name = "Monastery Basement"
 	})
-"Tt" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard{
-	name = "Service Basement"
-	})
 "Tu" = (
 /obj/effect/spawner/structure/window/ice,
 /turf/open/floor/plating,
@@ -8611,6 +8631,10 @@
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/hallway/primary/aft)
+"Uf" = (
+/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "Uh" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/beer{
@@ -8910,9 +8934,6 @@
 "Vw" = (
 /turf/open/openspace/icemoon,
 /area/icemoon/surface/outdoors)
-"VA" = (
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "VB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 6
@@ -9052,10 +9073,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
-"Wf" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "Wg" = (
 /obj/structure/chair{
 	dir = 1
@@ -9194,12 +9211,6 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/primary/port)
-"WQ" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "WT" = (
 /obj/structure/sign/warning/securearea,
 /turf/closed/wall/r_wall,
@@ -9227,10 +9238,6 @@
 "Xc" = (
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"Xd" = (
-/obj/machinery/light/floor,
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/underground/unexplored/rivers)
 "Xe" = (
 /obj/machinery/atmospherics/components/trinary/mixer/flipped{
 	dir = 8
@@ -9320,6 +9327,12 @@
 /area/maintenance/starboard{
 	name = "Service Basement"
 	})
+"Xw" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/mix_input{
+	dir = 8
+	},
+/turf/open/floor/engine/airless,
+/area/engine/atmos)
 "Xx" = (
 /obj/machinery/door/window/southleft,
 /obj/machinery/shower{
@@ -9605,6 +9618,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
+"YM" = (
+/obj/machinery/atmospherics/pipe/simple/multiz{
+	piping_layer = 3
+	},
+/obj/effect/turf_decal/stripes/box,
+/turf/open/floor/plasteel/elevatorshaft,
+/area/engine/atmos)
 "YP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -9628,17 +9648,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/storage)
-"YU" = (
-/obj/machinery/portable_atmospherics/canister/nitrogen,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"YV" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "YW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -9683,10 +9692,6 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/mine/living_quarters)
-"Ze" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "Zf" = (
 /obj/machinery/button/door{
 	id = "miningbathroom";
@@ -9703,11 +9708,6 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/mine/living_quarters)
-"Zg" = (
-/turf/open/floor/plasteel/dark/side{
-	dir = 4
-	},
-/area/engine/atmos)
 "Zk" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -52320,7 +52320,7 @@ si
 si
 si
 kE
-jX
+yu
 wl
 wl
 wl
@@ -52577,7 +52577,7 @@ si
 si
 si
 bj
-pt
+Pq
 wl
 VL
 Rj
@@ -52839,7 +52839,7 @@ wl
 CY
 YI
 si
-Ea
+NW
 si
 bG
 si
@@ -53348,7 +53348,7 @@ wl
 wl
 wl
 wl
-pt
+Pq
 wl
 aO
 wl
@@ -53862,7 +53862,7 @@ wl
 Wp
 Wp
 wl
-pt
+Pq
 si
 Le
 kE
@@ -54119,12 +54119,12 @@ SF
 si
 si
 SF
-Tt
-bn
+cz
+FA
 bf
 WY
 dN
-qD
+vE
 aS
 wl
 XZ
@@ -55405,8 +55405,8 @@ VE
 VE
 wl
 TI
-QE
-KJ
+RU
+kN
 si
 sS
 wl
@@ -58504,14 +58504,14 @@ UN
 UN
 UN
 UN
-Wf
-Ze
+uH
+Hq
 Wo
-Zg
-nH
-mj
-WQ
-uT
+sL
+aL
+yT
+Ko
+kt
 UN
 ah
 ah
@@ -58759,16 +58759,16 @@ vI
 vI
 vI
 UN
-eE
+Na
 UN
-Ao
-Ze
-wa
-gv
-oT
+hj
+Hq
+iu
+rW
+BB
 UN
-ty
-ue
+nk
+qw
 UN
 ah
 ah
@@ -59015,17 +59015,17 @@ vI
 vI
 vI
 vI
-HU
-bM
-MS
-VA
-VA
-wa
-Sz
-oT
-UN
+cD
+EF
+Ku
 jm
-uT
+jm
+iu
+YM
+BB
+UN
+sU
+kt
 UN
 ah
 ah
@@ -59275,14 +59275,14 @@ vI
 UN
 UN
 UN
-VA
-VA
-ux
-cs
-eb
-Bo
-ad
-Gm
+jm
+jm
+aB
+gF
+BA
+Oq
+ld
+im
 UN
 FC
 ah
@@ -59531,16 +59531,16 @@ FK
 FC
 FC
 FC
-nX
-Hg
-VA
-VA
-VA
-VA
-VA
-VA
-yT
-nX
+ng
+QR
+jm
+jm
+jm
+jm
+jm
+jm
+cU
+ng
 FK
 ah
 ah
@@ -59786,17 +59786,17 @@ ah
 ah
 FK
 FK
-Xd
+bU
 FC
 UN
-uc
-VA
-tf
-VA
-VA
-VA
-VA
-YV
+bn
+jm
+RC
+jm
+jm
+jm
+jm
+vC
 UN
 FC
 ah
@@ -60045,16 +60045,16 @@ ah
 ah
 FK
 FC
-nX
-VA
-VA
-VA
-VA
-VA
-VA
-VA
-VA
-nX
+ng
+jm
+jm
+jm
+jm
+jm
+jm
+jm
+jm
+ng
 FC
 ah
 ah
@@ -60303,14 +60303,14 @@ ah
 ah
 FC
 UN
-MJ
-VA
-VA
-VA
-VA
-VA
-VA
-VA
+Uf
+jm
+jm
+jm
+jm
+jm
+jm
+jm
 UN
 FK
 ah
@@ -60559,16 +60559,16 @@ ah
 ah
 ah
 FC
-nX
-MJ
-VA
-VA
-VA
-VA
-VA
-VA
-VA
-nX
+ng
+Uf
+jm
+jm
+jm
+jm
+jm
+jm
+jm
+ng
 FC
 ah
 ah
@@ -60817,14 +60817,14 @@ ah
 FK
 FC
 UN
-YU
-VA
-VA
-VA
-VA
-VA
-VA
-YV
+nB
+jm
+jm
+jm
+jm
+jm
+jm
+vC
 UN
 FC
 ah
@@ -61073,16 +61073,16 @@ ah
 ah
 ah
 FC
-nX
-ki
-VA
-VA
-VA
-VA
-Cp
-pZ
-bU
-nX
+ng
+iK
+jm
+jm
+jm
+jm
+oM
+cI
+fr
+ng
 FC
 ah
 ah
@@ -61330,16 +61330,16 @@ ah
 ah
 FK
 FC
-nX
-nX
-nX
-nX
-nX
-nX
-wD
-nX
-wD
-nX
+ng
+ng
+ng
+ng
+ng
+ng
+Kf
+ng
+Kf
+ng
 FC
 ah
 ah
@@ -61591,11 +61591,11 @@ FC
 FC
 FC
 FC
-Xd
+bU
 FC
-mv
+hC
 FC
-kG
+pq
 FC
 FC
 ah
@@ -61850,9 +61850,9 @@ FK
 FK
 FK
 UN
-qw
-cW
-bs
+Fp
+xv
+vy
 UN
 FK
 ah
@@ -62107,9 +62107,9 @@ FK
 FK
 FK
 UN
-qB
-Gx
-Lc
+FI
+BC
+Xw
 UN
 FK
 ah
@@ -62364,9 +62364,9 @@ ah
 FK
 FK
 UN
-ro
-ms
-ro
+vc
+Kw
+vc
 UN
 ah
 ah
@@ -62621,9 +62621,9 @@ ah
 FK
 FK
 UN
-ro
-xV
-ro
+vc
+Qq
+vc
 UN
 FK
 ah

--- a/_maps/map_files/Snaxi/IcemoonUnderground_Above_Lumos.dmm
+++ b/_maps/map_files/Snaxi/IcemoonUnderground_Above_Lumos.dmm
@@ -1080,6 +1080,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/plasteel,
 /area/mine/eva)
 "fk" = (
@@ -1119,6 +1120,7 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/plasteel,
 /area/mine/eva)
 "fo" = (
@@ -8052,6 +8054,7 @@
 	opacity = 0
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/structure/fans/tiny,
 /turf/open/floor/plasteel,
 /area/mine/production)
 "Rg" = (
@@ -8951,6 +8954,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/plasteel,
 /area/mine/production)
 "VD" = (

--- a/_maps/map_files/Snaxi/IcemoonUnderground_Above_Lumos.dmm
+++ b/_maps/map_files/Snaxi/IcemoonUnderground_Above_Lumos.dmm
@@ -675,7 +675,7 @@
 /obj/structure/railing{
 	dir = 1
 	},
-/turf/open/space/basic,
+/turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "dW" = (
 /turf/closed/wall,
@@ -2055,7 +2055,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 5
 	},
-/turf/open/floor/plating/asteroid/snow/icemoon,
+/turf/open/floor/plasteel/white,
 /area/xenoarch/arch)
 "kR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -3745,7 +3745,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
 	},
-/turf/open/floor/plating/asteroid/snow/icemoon,
+/turf/open/floor/plasteel/white,
 /area/xenoarch/arch)
 "tL" = (
 /obj/machinery/atmospherics/components/unary/tank/air{
@@ -4048,7 +4048,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
-/turf/open/floor/plating/asteroid/snow/icemoon,
+/turf/open/floor/plasteel/white,
 /area/xenoarch/arch)
 "vC" = (
 /obj/machinery/light,
@@ -6683,7 +6683,7 @@
 	dir = 4;
 	icon_state = "stairs_t"
 	},
-/turf/closed/wall,
+/turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "Jy" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
@@ -7220,7 +7220,7 @@
 /area/science/xenobiology)
 "Ms" = (
 /obj/structure/chair/office/dark,
-/turf/open/floor/plating/asteroid/snow/icemoon,
+/turf/open/floor/plasteel/white,
 /area/xenoarch/arch)
 "Mt" = (
 /obj/machinery/light/small,
@@ -8563,7 +8563,7 @@
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
 "TK" = (
-/turf/open/floor/plating/asteroid/snow/icemoon,
+/turf/open/floor/plasteel/white,
 /area/xenoarch/arch)
 "TN" = (
 /obj/structure/trash_pile,

--- a/_maps/map_files/Snaxi/IcemoonUnderground_Above_Lumos.dmm
+++ b/_maps/map_files/Snaxi/IcemoonUnderground_Above_Lumos.dmm
@@ -2259,6 +2259,10 @@
 /area/chapel/main/monastery{
 	name = "Monastery Basement"
 	})
+"lY" = (
+/obj/effect/turf_decal/vg_decals/numbers/two,
+/turf/open/floor/engine/airless,
+/area/engine/atmos)
 "ma" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 5
@@ -6874,12 +6878,7 @@
 /turf/open/floor/plating,
 /area/engine/atmos)
 "Kw" = (
-/obj/effect/turf_decal/vg_decals/atmos/mix{
-	pixel_x = -16
-	},
-/obj/effect/turf_decal/vg_decals/numbers/two{
-	pixel_x = 16
-	},
+/obj/effect/turf_decal/vg_decals/atmos/mix,
 /turf/open/floor/engine/airless,
 /area/engine/atmos)
 "KE" = (
@@ -62364,9 +62363,9 @@ ah
 FK
 FK
 UN
-vc
 Kw
 vc
+lY
 UN
 ah
 ah

--- a/_maps/map_files/Snaxi/Snaxi_Lumos.dmm
+++ b/_maps/map_files/Snaxi/Snaxi_Lumos.dmm
@@ -23422,12 +23422,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
 "jdS" = (
-/obj/effect/turf_decal/vg_decals/atmos/mix{
-	pixel_x = -16
-	},
-/obj/effect/turf_decal/vg_decals/numbers/one{
-	pixel_x = 16
-	},
+/obj/effect/turf_decal/vg_decals/atmos/mix,
 /turf/open/floor/engine/airless,
 /area/engine/atmos)
 "jdY" = (
@@ -51341,6 +51336,10 @@
 /obj/item/restraints/handcuffs,
 /turf/open/floor/plasteel/dark,
 /area/security/main)
+"wcs" = (
+/obj/effect/turf_decal/vg_decals/numbers/one,
+/turf/open/floor/engine/airless,
+/area/engine/atmos)
 "wcB" = (
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
@@ -105547,7 +105546,7 @@ dwT
 xUL
 bKI
 bYZ
-bYZ
+jdS
 vgm
 ccI
 xUL
@@ -105804,7 +105803,7 @@ dwT
 vBe
 bKI
 ntX
-jdS
+bYZ
 cha
 luf
 gNM
@@ -106061,7 +106060,7 @@ dwT
 xUL
 bKI
 bYZ
-bYZ
+wcs
 ciG
 caS
 bZU

--- a/_maps/map_files/Snaxi/Snaxi_Lumos.dmm
+++ b/_maps/map_files/Snaxi/Snaxi_Lumos.dmm
@@ -1,4 +1,13 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"aao" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "aaH" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -609,12 +618,6 @@
 	dir = 8
 	},
 /area/chapel/main/monastery)
-"ahY" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/miningdock)
 "air" = (
 /obj/machinery/bloodbankgen,
 /turf/open/floor/plasteel/white,
@@ -1193,6 +1196,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"aqT" = (
+/obj/structure/railing/corner,
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
 "are" = (
 /obj/structure/chair/sofa{
 	dir = 4
@@ -1658,11 +1665,6 @@
 /obj/item/paper/pamphlet/gateway,
 /turf/open/floor/plasteel/dark,
 /area/teleporter)
-"axd" = (
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "axg" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -2056,28 +2058,6 @@
 /obj/structure/closet/wardrobe/black,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"azY" = (
-/obj/item/tank/internals/emergency_oxygen/double{
-	pixel_x = 3
-	},
-/obj/item/tank/internals/emergency_oxygen/double{
-	pixel_x = 3
-	},
-/obj/item/clothing/mask/breath{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/item/clothing/mask/breath{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/structure/closet/crate/internals,
-/obj/machinery/light/small{
-	dir = 1;
-	light_color = "#ffc1c1"
-	},
-/turf/open/floor/plasteel,
-/area/maintenance/aft)
 "aAe" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -3608,6 +3588,17 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"aSJ" = (
+/obj/structure/chair/pew/left{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/chapel{
+	dir = 8
+	},
+/area/chapel/main/monastery)
 "aSN" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 9
@@ -3696,6 +3687,11 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
+"aVs" = (
+/turf/open/floor/plating{
+	icon_state = "platingdmg2"
+	},
+/area/maintenance/aft)
 "aVt" = (
 /obj/structure/closet/emcloset,
 /obj/structure/cable{
@@ -3713,12 +3709,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
-"aVw" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/maintenance/aft)
 "aVC" = (
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 8;
@@ -3819,6 +3809,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port/fore)
+"aYt" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/railing/corner,
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "aYB" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
@@ -4044,6 +4044,10 @@
 	},
 /turf/open/floor/plating,
 /area/medical/virology)
+"bfa" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "bff" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
@@ -4625,20 +4629,6 @@
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"btd" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/public/glass{
-	name = "Aft Primary Hallway"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1;
-	name = "north facing firelock"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "btf" = (
 /obj/structure/cable,
 /obj/machinery/power/apc{
@@ -6036,6 +6026,14 @@
 	},
 /turf/open/floor/wood,
 /area/library)
+"bFR" = (
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/structure/closet/secure_closet/blueshield,
+/turf/open/floor/plasteel/dark,
+/area/blueshield)
 "bFT" = (
 /obj/structure/table/wood,
 /turf/open/floor/plasteel,
@@ -7043,6 +7041,9 @@
 	dir = 4
 	},
 /obj/structure/railing/corner,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/carpet,
 /area/library)
 "bRN" = (
@@ -7092,12 +7093,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
-"bSR" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "bTh" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -7312,6 +7307,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
+"bWL" = (
+/obj/structure/closet/crate{
+	icon_state = "crateopen"
+	},
+/obj/item/reagent_containers/glass/beaker/waterbottle/wataur,
+/obj/item/bonesetter,
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "bWM" = (
 /turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
@@ -7857,6 +7860,13 @@
 /obj/structure/bookcase/random/nonfiction,
 /turf/open/floor/wood,
 /area/library)
+"chq" = (
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc/auto_name/north,
+/turf/open/floor/plasteel/dark,
+/area/hydroponics/garden/monastery)
 "chA" = (
 /obj/structure/loot_pile/maint,
 /turf/open/floor/plating,
@@ -7928,6 +7938,15 @@
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/mix_input,
 /turf/open/floor/engine/airless,
 /area/engine/atmos)
+"ciN" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	desc = "Privacy shutters for the Private Study. Stops people spying in on your game.";
+	id = "PrivateStudy1";
+	name = "Privacy Shutters"
+	},
+/turf/open/floor/plating,
+/area/library/lounge)
 "ciO" = (
 /obj/machinery/light,
 /obj/structure/chair{
@@ -8014,6 +8033,12 @@
 /obj/item/storage/firstaid/regular,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"cjT" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft/secondary)
 "cjX" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -8704,13 +8729,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
-"cwU" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Blueshield's Office Maintenance";
-	req_access_txt = "71"
-	},
-/turf/open/floor/plating,
-/area/blueshield)
 "cwV" = (
 /obj/structure/chair{
 	dir = 1
@@ -8728,10 +8746,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"cxe" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/maintenance/port/central)
 "cxX" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -8909,7 +8923,7 @@
 	dir = 4
 	},
 /turf/open/floor/wood,
-/area/library)
+/area/library/lounge)
 "cAo" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
@@ -8977,6 +8991,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"cBH" = (
+/turf/closed/wall,
+/area/crew_quarters/cryopod)
 "cBJ" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/air_input,
 /obj/machinery/air_sensor/atmos/air_tank{
@@ -9054,6 +9071,10 @@
 "cDm" = (
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"cDF" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/hallway/primary/aft)
 "cDL" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -9460,7 +9481,7 @@
 	dir = 4
 	},
 /turf/open/floor/wood,
-/area/library)
+/area/library/lounge)
 "cNm" = (
 /obj/effect/landmark/start/assistant,
 /obj/machinery/button/door{
@@ -9594,15 +9615,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/medical/chemistry)
-"cQo" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/railing/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "cQp" = (
 /obj/structure/railing/corner{
 	dir = 8
@@ -9812,6 +9824,10 @@
 "cSJ" = (
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
+"cSW" = (
+/obj/structure/loot_pile/maint,
+/turf/open/floor/plating,
+/area/maintenance/port/central)
 "cSY" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -10233,10 +10249,6 @@
 /obj/item/assembly/signaler,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"daG" = (
-/obj/item/clothing/head/cone,
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "daH" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -10316,6 +10328,10 @@
 	},
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors)
+"dcd" = (
+/obj/structure/girder,
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "dcg" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -10486,9 +10502,6 @@
 "dhg" = (
 /turf/closed/wall,
 /area/construction/storage)
-"dhs" = (
-/turf/closed/wall,
-/area/crew_quarters/cryopod)
 "dhX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -10588,7 +10601,7 @@
 	dir = 4
 	},
 /turf/open/floor/wood,
-/area/library)
+/area/library/lounge)
 "dkQ" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -10734,6 +10747,11 @@
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
+"dnY" = (
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/port/central)
 "dop" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -10853,8 +10871,11 @@
 "dri" = (
 /turf/closed/indestructible/rock/glacierrock/blue,
 /area/engine/secure_construction)
-"drq" = (
-/turf/open/floor/plasteel/stairs,
+"drn" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
 /area/maintenance/aft)
 "drK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -10972,13 +10993,6 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/carpet,
 /area/hallway/secondary/exit/departure_lounge)
-"dui" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/stairs/medium,
-/area/hallway/primary/port)
 "duu" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -11206,13 +11220,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"dyM" = (
-/obj/machinery/power/apc/auto_name/south,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "dyW" = (
 /obj/machinery/light{
 	dir = 8
@@ -11230,7 +11237,7 @@
 	dir = 8
 	},
 /turf/open/floor/wood,
-/area/library)
+/area/library/lounge)
 "dzh" = (
 /obj/machinery/suit_storage_unit/security,
 /obj/effect/turf_decal/stripes/line{
@@ -11301,15 +11308,6 @@
 "dAV" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
-"dBC" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "dBL" = (
 /obj/structure/closet/secure_closet/medical1,
 /obj/structure/extinguisher_cabinet{
@@ -11624,6 +11622,10 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"dJh" = (
+/obj/item/lighter/gold,
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors)
 "dJB" = (
 /obj/machinery/telecomms/bus/preset_four,
 /turf/open/floor/plasteel/dark/telecomms,
@@ -11747,6 +11749,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"dNY" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/stairs/right{
+	dir = 4
+	},
+/area/maintenance/aft)
+"dOi" = (
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "dOP" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/purple{
@@ -11811,15 +11826,6 @@
 "dQz" = (
 /turf/closed/wall,
 /area/storage/eva)
-"dQF" = (
-/obj/machinery/power/apc/auto_name/north,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
-	},
-/area/maintenance/port/central)
 "dQW" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 10
@@ -12014,6 +12020,10 @@
 /obj/item/storage/fancy/donut_box,
 /turf/open/floor/carpet,
 /area/bridge/meeting_room)
+"dVP" = (
+/obj/machinery/mech_bay_recharge_port,
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "dVV" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -12110,13 +12120,6 @@
 /obj/machinery/computer/scan_consolenew,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
-"dYb" = (
-/obj/machinery/light/small{
-	dir = 1;
-	light_color = "#ffc1c1"
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "dYl" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -12481,6 +12484,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"ehJ" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "ehL" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -12791,14 +12803,6 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"erl" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/stairs/right{
-	dir = 4
-	},
-/area/maintenance/aft)
 "ero" = (
 /obj/machinery/computer/arcade{
 	dir = 8
@@ -13550,13 +13554,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/science/lab)
-"eGY" = (
-/obj/structure/reagent_dispensers/fueltank,
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel,
-/area/maintenance/aft)
 "eHa" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/plasteel/dark,
@@ -13573,6 +13570,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"eHq" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "eHF" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -13626,12 +13627,6 @@
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
 /area/chapel/main/monastery)
-"eJg" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel/dark,
-/area/hydroponics/garden/monastery)
 "eJp" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -13867,6 +13862,13 @@
 /obj/effect/spawner/structure/window/ice,
 /turf/open/floor/plating,
 /area/chapel/main/monastery)
+"eNj" = (
+/obj/effect/decal/cleanable/oil,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/aft)
 "eNu" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -13944,6 +13946,14 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"eOy" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/external{
+	req_access_txt = "13"
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft/secondary)
 "eOK" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -14381,6 +14391,13 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
+"eZt" = (
+/obj/machinery/power/apc/auto_name/south,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "eZA" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -14413,18 +14430,6 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"faF" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/door/airlock/public/glass{
-	name = "Aft Primary Hallway"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1;
-	name = "north facing firelock"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "faJ" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -15752,17 +15757,6 @@
 /obj/machinery/meter,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
-"fIs" = (
-/obj/structure/rack,
-/obj/item/radio,
-/obj/structure/sign/warning/electricshock{
-	pixel_x = 32
-	},
-/obj/item/clothing/suit/hooded/wintercoat,
-/obj/item/pickaxe,
-/obj/item/clothing/shoes/winterboots/ice_boots,
-/turf/open/floor/plasteel,
-/area/maintenance/aft)
 "fIu" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -15835,6 +15829,14 @@
 /obj/machinery/meter,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"fJr" = (
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 2;
+	name = "2maintenance loot spawner"
+	},
+/obj/structure/closet,
+/turf/open/floor/plating,
+/area/maintenance/aft/secondary)
 "fJs" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -16030,7 +16032,7 @@
 	pixel_y = 6
 	},
 /turf/open/floor/wood,
-/area/library)
+/area/library/lounge)
 "fNH" = (
 /turf/open/floor/plasteel/median/darktogrime/fullcorner{
 	dir = 8
@@ -16343,6 +16345,13 @@
 "fTy" = (
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"fTD" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/railing/corner,
+/turf/open/floor/plasteel/white/side,
+/area/hallway/primary/port)
 "fTM" = (
 /obj/structure/fence/door,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
@@ -16566,6 +16575,15 @@
 /obj/machinery/photocopier,
 /turf/open/floor/wood,
 /area/bridge/meeting_room)
+"fZr" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/aft)
 "fZA" = (
 /obj/machinery/field/generator,
 /turf/open/floor/plating,
@@ -16829,12 +16847,6 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/disposal)
-"gfL" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/dark,
-/area/chapel/main/monastery)
 "gfN" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -16965,6 +16977,12 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
+"gje" = (
+/obj/structure/railing/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
 "gjA" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -17268,15 +17286,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"gpc" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/railing/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/port)
 "gpe" = (
 /obj/machinery/door/airlock/external{
 	name = "Supply Dock Airlock";
@@ -17312,11 +17321,6 @@
 /obj/structure/chair/comfy/brown,
 /turf/open/floor/wood,
 /area/library)
-"grm" = (
-/turf/open/floor/plating{
-	icon_state = "platingdmg2"
-	},
-/area/maintenance/aft)
 "grs" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -17336,13 +17340,6 @@
 /obj/machinery/meter,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
-"grO" = (
-/obj/machinery/cryopod,
-/obj/machinery/airalarm{
-	pixel_y = 26
-	},
-/turf/open/floor/circuit/green,
-/area/crew_quarters/cryopod)
 "grV" = (
 /turf/closed/wall,
 /area/security/courtroom)
@@ -17363,21 +17360,19 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
+"gsf" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "gsg" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"gsq" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "gsr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -17669,6 +17664,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/bar)
+"gAP" = (
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white/side,
+/area/hallway/primary/port)
 "gBk" = (
 /obj/machinery/holopad,
 /turf/open/floor/carpet,
@@ -18098,6 +18099,12 @@
 "gLH" = (
 /turf/closed/wall/r_wall,
 /area/teleporter)
+"gMm" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/carpet,
+/area/library/lounge)
 "gMD" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -18128,6 +18135,12 @@
 /obj/machinery/computer/pandemic,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"gNc" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/spawner/lootdrop/gloves,
+/turf/open/floor/plating,
+/area/maintenance/aft/secondary)
 "gNq" = (
 /obj/structure/chair/sofa/left{
 	dir = 4
@@ -18149,6 +18162,9 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
+"gOb" = (
+/turf/open/floor/plasteel,
+/area/maintenance/aft)
 "gOd" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -18451,12 +18467,13 @@
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
-"gTx" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+"gTB" = (
+/obj/machinery/cryopod,
+/obj/machinery/airalarm{
+	pixel_y = 26
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/turf/open/floor/circuit/green,
+/area/crew_quarters/cryopod)
 "gTH" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -18502,6 +18519,12 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
+"gUS" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel/dark,
+/area/hydroponics/garden/monastery)
 "gUW" = (
 /obj/structure/transit_tube/curved{
 	dir = 8
@@ -18555,6 +18578,20 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/computer)
+"gXc" = (
+/obj/machinery/door/firedoor/border_only{
+	name = "south facing firelock"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1;
+	name = "north facing firelock"
+	},
+/obj/machinery/door/airlock/public/glass,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/carpet,
+/area/library/lounge)
 "gXj" = (
 /obj/machinery/vending/tool,
 /obj/effect/turf_decal/tile/yellow,
@@ -18588,12 +18625,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"gYK" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft/secondary)
 "gZb" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -18645,10 +18676,6 @@
 /obj/structure/fans/tiny,
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
-"gZV" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "gZX" = (
 /turf/closed/wall,
 /area/medical/morgue)
@@ -18792,6 +18819,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"heG" = (
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/maintenance/port/central)
 "heM" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -18875,10 +18906,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"hgw" = (
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/maintenance/port/central)
 "hgJ" = (
 /obj/structure/chair{
 	dir = 8
@@ -19009,6 +19036,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"hkL" = (
+/obj/item/clothing/head/cone,
+/turf/open/floor/plating,
+/area/maintenance/aft)
+"hkO" = (
+/obj/machinery/computer/mech_bay_power_console{
+	dir = 1
+	},
+/turf/open/floor/circuit,
+/area/maintenance/aft)
 "hkX" = (
 /obj/machinery/button/crematorium{
 	id = "foo";
@@ -19534,6 +19571,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"hvx" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "hvX" = (
 /obj/machinery/camera{
 	c_tag = "Northwestern Hall 9";
@@ -20043,9 +20086,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
-"hGv" = (
-/turf/open/floor/plasteel/dark,
-/area/hydroponics/garden/monastery)
 "hGy" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
@@ -20276,6 +20316,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
+"hLv" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/hydroponics/garden/monastery)
 "hLC" = (
 /obj/structure/fans/tiny,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -20548,13 +20594,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
-"hQO" = (
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/miningdock)
 "hRe" = (
 /obj/structure/chair/office/dark{
 	dir = 8
@@ -21284,12 +21323,6 @@
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
-"ifE" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "ifQ" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8;
@@ -21474,11 +21507,12 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "ikt" = (
-/obj/machinery/newscaster{
-	pixel_x = 32
+/obj/structure/cable{
+	icon_state = "0-8"
 	},
+/obj/machinery/power/apc/auto_name/east,
 /turf/open/floor/wood,
-/area/library)
+/area/library/lounge)
 "ikA" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -22003,13 +22037,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"iws" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "ixd" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
@@ -22117,6 +22144,11 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"iAd" = (
+/obj/structure/reagent_dispensers/watertank,
+/obj/machinery/light/small,
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "iAt" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -22164,10 +22196,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
-"iAI" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "iAO" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /turf/open/floor/plating,
@@ -22266,10 +22294,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"iDe" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/chapel/dock)
 "iDh" = (
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/carpet/eighties,
@@ -22794,9 +22818,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"iNY" = (
-/turf/closed/wall,
-/area/chapel/dock)
 "iOd" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -23550,6 +23571,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft/secondary)
+"jia" = (
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/aft)
 "jie" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -24141,12 +24167,6 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard/fore)
-"jwE" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "jwW" = (
 /obj/structure/sign/poster/random{
 	pixel_x = 32
@@ -24155,6 +24175,12 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard/fore)
+"jxp" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft/secondary)
 "jxr" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -24490,10 +24516,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"jEG" = (
-/obj/structure/tank_dispenser/oxygen,
-/turf/open/floor/plasteel,
-/area/quartermaster/miningdock)
 "jER" = (
 /obj/machinery/vending/kink,
 /turf/open/floor/plating,
@@ -24855,6 +24877,15 @@
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall/mineral/wood,
 /area/icemoon/surface/outdoors)
+"jOq" = (
+/obj/machinery/power/apc/auto_name/north,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/port/central)
 "jOy" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -25007,6 +25038,13 @@
 /obj/machinery/power/apc/auto_name/east,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
+"jRq" = (
+/obj/structure/reagent_dispensers/fueltank,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/aft)
 "jRB" = (
 /obj/structure/table,
 /obj/item/storage/belt/utility,
@@ -25215,6 +25253,10 @@
 /obj/item/book/manual/wiki/security_space_law,
 /turf/open/floor/plasteel/dark,
 /area/security/main)
+"jVC" = (
+/obj/item/kirbyplants/random,
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "jWr" = (
 /turf/closed/wall/r_wall,
 /area/storage/tech)
@@ -25304,6 +25346,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
+"jXV" = (
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/cryopod)
 "jYf" = (
 /obj/docking_port/stationary{
 	dir = 2;
@@ -25358,6 +25403,14 @@
 	},
 /turf/open/floor/carpet,
 /area/hallway/primary/fore)
+"jZR" = (
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/deck_relay,
+/obj/effect/turf_decal/stripes/box,
+/turf/open/floor/plating,
+/area/maintenance/aft/secondary)
 "jZW" = (
 /turf/open/floor/plasteel,
 /area/engine/atmospherics_engine)
@@ -25367,6 +25420,9 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/secure_construction)
+"kaF" = (
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "kaK" = (
 /obj/effect/turf_decal/vg_decals/atmos/air,
 /obj/machinery/light/small{
@@ -25615,11 +25671,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"kgg" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "kgo" = (
 /obj/machinery/door/poddoor{
 	id = "chapelgun";
@@ -25752,6 +25803,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"kkm" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
 "kkn" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -25916,15 +25976,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
-"knk" = (
-/obj/structure/table/reinforced,
-/obj/item/stack/sheet/metal{
-	amount = 30
-	},
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/cable_coil/white,
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "knn" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Security Lobby"
@@ -26039,6 +26090,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
+"kpG" = (
+/turf/closed/wall,
+/area/chapel/dock)
 "kpO" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -26538,6 +26592,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
+"kCa" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/carpet,
+/area/library)
 "kCi" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -26600,6 +26660,20 @@
 /obj/structure/closet/cardboard,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"kDK" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/public/glass{
+	name = "Aft Primary Hallway"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1;
+	name = "north facing firelock"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "kDT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -26672,10 +26746,28 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"kGD" = (
-/obj/effect/spawner/blocker,
-/turf/open/floor/plating,
-/area/maintenance/port/central)
+"kGS" = (
+/obj/item/tank/internals/emergency_oxygen/double{
+	pixel_x = 3
+	},
+/obj/item/tank/internals/emergency_oxygen/double{
+	pixel_x = 3
+	},
+/obj/item/clothing/mask/breath{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/clothing/mask/breath{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/structure/closet/crate/internals,
+/obj/machinery/light/small{
+	dir = 1;
+	light_color = "#ffc1c1"
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/aft)
 "kGX" = (
 /obj/structure/transit_tube/curved{
 	dir = 4
@@ -26735,15 +26827,6 @@
 	},
 /turf/open/floor/wood,
 /area/medical/psych)
-"kIb" = (
-/obj/machinery/airalarm{
-	pixel_y = 26
-	},
-/obj/structure/railing/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "kIl" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -27160,10 +27243,6 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/wood,
 /area/hallway/primary/port)
-"kRR" = (
-/obj/item/lighter/gold,
-/turf/open/floor/plating/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors)
 "kRX" = (
 /obj/structure/closet/secure_closet/hydroponics,
 /turf/open/floor/plasteel,
@@ -27226,6 +27305,15 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
+"kTT" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "kTY" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -27364,12 +27452,6 @@
 	dir = 8
 	},
 /area/hallway/primary/starboard)
-"kYp" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft/secondary)
 "kYs" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -27504,9 +27586,6 @@
 	},
 /turf/open/floor/plating/asteroid/snow/ice/icemoon/solarpanel,
 /area/icemoon/surface/outdoors)
-"lbD" = (
-/turf/open/floor/mech_bay_recharge_floor,
-/area/maintenance/aft)
 "lck" = (
 /turf/open/floor/plasteel/chapel{
 	dir = 1
@@ -27770,6 +27849,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"lhM" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel/stairs/medium{
+	dir = 4
+	},
+/area/hallway/primary/aft)
 "lhQ" = (
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -27861,6 +27951,9 @@
 /obj/structure/loot_pile/maint,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"llo" = (
+/turf/closed/wall/r_wall,
+/area/crew_quarters/cryopod)
 "llu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
@@ -27974,14 +28067,6 @@
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
-"lnU" = (
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 2;
-	name = "2maintenance loot spawner"
-	},
-/obj/structure/closet,
-/turf/open/floor/plating,
-/area/maintenance/aft/secondary)
 "lnV" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 8
@@ -28406,6 +28491,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"lyD" = (
+/obj/structure/rack,
+/obj/item/radio,
+/obj/item/clothing/suit/hooded/wintercoat,
+/obj/item/pickaxe,
+/obj/item/clothing/shoes/winterboots/ice_boots,
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "lyV" = (
 /obj/machinery/light,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
@@ -28555,6 +28648,15 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"lBL" = (
+/obj/machinery/airalarm{
+	pixel_y = 26
+	},
+/obj/structure/railing/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "lBT" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -28633,7 +28735,7 @@
 	name = "gambling valuables spawner"
 	},
 /turf/open/floor/wood,
-/area/library)
+/area/library/lounge)
 "lDV" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -28828,12 +28930,10 @@
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
-"lHz" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
+"lHM" = (
+/obj/structure/chair/stool,
 /turf/open/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/aft/secondary)
 "lHZ" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -28873,6 +28973,9 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"lIT" = (
+/turf/open/floor/mech_bay_recharge_floor,
+/area/maintenance/aft)
 "lJe" = (
 /turf/open/floor/circuit,
 /area/maintenance/aft)
@@ -28930,6 +29033,12 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
+"lLH" = (
+/obj/structure/table/reinforced,
+/obj/item/clothing/gloves/color/black,
+/obj/item/multitool,
+/turf/open/floor/plasteel,
+/area/maintenance/aft)
 "lMx" = (
 /obj/structure/table/glass,
 /obj/structure/disposalpipe/segment,
@@ -29021,10 +29130,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
-"lPe" = (
-/obj/structure/chair/stool,
-/turf/open/floor/plating,
-/area/maintenance/aft/secondary)
 "lPB" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/floor/plasteel,
@@ -29070,12 +29175,6 @@
 	},
 /turf/open/floor/carpet,
 /area/hallway/primary/aft)
-"lQA" = (
-/obj/structure/table/reinforced,
-/obj/item/clothing/gloves/color/black,
-/obj/item/multitool,
-/turf/open/floor/plasteel,
-/area/maintenance/aft)
 "lQJ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
@@ -29140,16 +29239,6 @@
 /obj/machinery/rnd/production/techfab/department/medical,
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
-"lSS" = (
-/obj/machinery/door/airlock/command{
-	name = "Auxiliary E.V.A. Storage";
-	req_access_txt = "18"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "lTp" = (
 /obj/structure/closet,
 /turf/open/floor/plating,
@@ -29208,12 +29297,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
-"lTV" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel/stairs/medium,
-/area/hallway/primary/port)
 "lUb" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -29618,6 +29701,18 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"mbu" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "mbE" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -29867,17 +29962,6 @@
 /obj/machinery/gibber,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
-"mjw" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/plasteel/stairs/medium{
-	dir = 4
-	},
-/area/hallway/primary/aft)
 "mjH" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -30339,6 +30423,9 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"muw" = (
+/turf/open/floor/carpet,
+/area/library/lounge)
 "muN" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -30369,6 +30456,12 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"mvW" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/chapel/main/monastery)
 "mwQ" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -30584,20 +30677,10 @@
 	dir = 8
 	},
 /area/chapel/main/monastery)
-"mBe" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "evashutters2";
-	name = "E.V.A. Storage Shutters"
-	},
-/obj/machinery/button/door{
-	id = "evashutters2";
-	name = "E.V.A. Shutters";
-	pixel_x = 1;
-	pixel_y = 26;
-	req_access_txt = "19"
-	},
+"mBi" = (
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/port/central)
 "mBv" = (
 /turf/open/openspace/icemoon,
 /area/maintenance/starboard/fore)
@@ -30694,6 +30777,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmospherics_engine)
+"mEi" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/chapel/dock)
 "mEo" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -31175,15 +31262,6 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"mOV" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/maintenance/aft)
 "mPA" = (
 /obj/machinery/atmospherics/components/unary/tank/air{
 	dir = 4
@@ -31304,16 +31382,6 @@
 /obj/structure/closet/crate/bin,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
-"mRE" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/railing/corner,
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "mRZ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -31578,9 +31646,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"mXE" = (
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/cryopod)
 "mXT" = (
 /obj/machinery/computer/communications{
 	dir = 4
@@ -33165,14 +33230,6 @@
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
-"nJv" = (
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/power/deck_relay,
-/obj/effect/turf_decal/stripes/box,
-/turf/open/floor/plating,
-/area/maintenance/aft/secondary)
 "nJI" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4;
@@ -33398,6 +33455,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"nOO" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/wood,
+/area/library/lounge)
 "nOR" = (
 /obj/machinery/atmospherics/components/unary/cryo_cell{
 	dir = 4
@@ -33890,6 +33953,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/warden)
+"nYT" = (
+/obj/machinery/door/airlock/command{
+	name = "Auxiliary E.V.A. Storage";
+	req_access_txt = "18"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "nYZ" = (
 /turf/closed/wall/r_wall,
 /area/medical/genetics)
@@ -33942,6 +34015,10 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"oau" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "oaC" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
@@ -34586,6 +34663,10 @@
 /obj/effect/landmark/start/cargo_technician,
 /turf/open/floor/pod/dark,
 /area/quartermaster/sorting)
+"onc" = (
+/obj/effect/spawner/structure/window/ice,
+/turf/open/floor/plating,
+/area/hydroponics/garden/monastery)
 "ond" = (
 /obj/effect/landmark/start/assistant,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -34641,6 +34722,12 @@
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
+"oox" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft/secondary)
 "ooy" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -34842,6 +34929,10 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"osl" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plating,
+/area/maintenance/port/central)
 "osC" = (
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
@@ -35281,6 +35372,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
+"oDM" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Blueshield's Office Maintenance";
+	req_access_txt = "71"
+	},
+/turf/open/floor/plating,
+/area/blueshield)
 "oEa" = (
 /obj/machinery/airalarm{
 	dir = 1;
@@ -35581,21 +35679,6 @@
 	dir = 4
 	},
 /area/hallway/secondary/exit/departure_lounge)
-"oMe" = (
-/obj/item/kirbyplants/random,
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"oMD" = (
-/obj/structure/chair/pew/left{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/chapel{
-	dir = 8
-	},
-/area/chapel/main/monastery)
 "oME" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -35666,13 +35749,6 @@
 /obj/machinery/holopad,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
-"oOq" = (
-/obj/effect/decal/cleanable/oil,
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel,
-/area/maintenance/aft)
 "oOu" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -35938,10 +36014,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"oXh" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/hallway/primary/aft)
 "oXi" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -35963,19 +36035,6 @@
 /obj/machinery/hydroponics/constructable,
 /turf/open/floor/plasteel/dark,
 /area/hydroponics)
-"oXu" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1;
-	name = "north facing firelock"
-	},
-/obj/machinery/door/airlock/glass{
-	name = "Chapel Garden"
-	},
-/turf/open/floor/plasteel/dark,
-/area/chapel/main/monastery)
 "oXI" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -35991,7 +36050,7 @@
 	dir = 1
 	},
 /turf/open/floor/wood,
-/area/library)
+/area/library/lounge)
 "oYn" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -36010,6 +36069,12 @@
 /obj/machinery/holopad,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"oZi" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/wood,
+/area/library/lounge)
 "oZC" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger{
@@ -36366,12 +36431,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"pfU" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "pfY" = (
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
@@ -36630,6 +36689,27 @@
 	icon_state = "wood-broken6"
 	},
 /area/maintenance/bar)
+"pkQ" = (
+/obj/item/tank/internals/emergency_oxygen/double{
+	pixel_x = 3
+	},
+/obj/item/tank/internals/emergency_oxygen/double{
+	pixel_x = 3
+	},
+/obj/item/clothing/mask/breath{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/clothing/mask/breath{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/structure/closet/crate/internals,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "plc" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/research/glass{
@@ -36655,6 +36735,15 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/warden)
+"plM" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/library/lounge)
 "plP" = (
 /obj/structure/bookcase/random/religion,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -36729,27 +36818,6 @@
 /obj/structure/railing/corner,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
-"pop" = (
-/obj/item/tank/internals/emergency_oxygen/double{
-	pixel_x = 3
-	},
-/obj/item/tank/internals/emergency_oxygen/double{
-	pixel_x = 3
-	},
-/obj/item/clothing/mask/breath{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/item/clothing/mask/breath{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/structure/closet/crate/internals,
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "por" = (
 /obj/machinery/computer/crew{
 	dir = 1
@@ -36990,12 +37058,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
-"pud" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/hydroponics/garden/monastery)
 "puf" = (
 /obj/machinery/pipedispenser/disposal,
 /obj/structure/fireaxecabinet{
@@ -37574,6 +37636,9 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
+"pDN" = (
+/turf/closed/wall,
+/area/library/lounge)
 "pDS" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -38200,17 +38265,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/detectives_office)
-"pSo" = (
-/obj/structure/chair/pew/right{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/chapel{
-	dir = 1
-	},
-/area/chapel/main/monastery)
 "pSC" = (
 /obj/structure/rack,
 /obj/item/stack/cable_coil,
@@ -38365,11 +38419,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
-"pWF" = (
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
-	},
-/area/maintenance/aft)
 "pWS" = (
 /turf/closed/wall/r_wall,
 /area/hallway/primary/starboard)
@@ -38707,10 +38756,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
-"qfw" = (
-/obj/structure/railing/corner,
-/turf/open/floor/plasteel,
-/area/hallway/primary/port)
 "qfB" = (
 /obj/machinery/door/airlock/public/glass/incinerator/atmos_exterior,
 /obj/effect/mapping_helpers/airlock/locked,
@@ -38824,6 +38869,11 @@
 	},
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/medical/virology)
+"qiw" = (
+/turf/open/floor/plasteel/stairs/left{
+	dir = 4
+	},
+/area/maintenance/aft)
 "qiF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -39964,11 +40014,6 @@
 /obj/item/clothing/shoes/winterboots/ice_boots,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
-"qKg" = (
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/structure/closet,
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "qKq" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -40067,10 +40112,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
-"qLP" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "qMn" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -40092,6 +40133,20 @@
 /obj/effect/landmark/start/librarian,
 /turf/open/floor/carpet,
 /area/library)
+"qMY" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "evashutters2";
+	name = "E.V.A. Storage Shutters"
+	},
+/obj/machinery/button/door{
+	id = "evashutters2";
+	name = "E.V.A. Shutters";
+	pixel_x = 1;
+	pixel_y = 26;
+	req_access_txt = "19"
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "qNz" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -40333,6 +40388,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"qTB" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/plasteel/stairs/medium,
+/area/hallway/primary/port)
 "qTG" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -40562,6 +40623,17 @@
 	dir = 4
 	},
 /area/hallway/secondary/exit/departure_lounge)
+"qXT" = (
+/obj/structure/chair/pew/right{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/chapel{
+	dir = 1
+	},
+/area/chapel/main/monastery)
 "qYD" = (
 /obj/machinery/vending/security,
 /turf/open/floor/plasteel/dark,
@@ -41110,6 +41182,18 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/security/brig)
+"rlv" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/door/airlock/public/glass{
+	name = "Aft Primary Hallway"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1;
+	name = "north facing firelock"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "rlC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -41644,10 +41728,6 @@
 /obj/structure/reagent_dispensers/watertank/high,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"rxk" = (
-/obj/structure/girder,
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "rxu" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -41778,6 +41858,12 @@
 	},
 /turf/open/floor/circuit/off,
 /area/ai_monitored/turret_protected/ai)
+"rBD" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "rBG" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -41858,13 +41944,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
-"rEX" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/railing/corner,
-/turf/open/floor/plasteel/white/side,
-/area/hallway/primary/port)
 "rFk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -41964,8 +42043,12 @@
 	dir = 8;
 	pixel_x = 24
 	},
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -22
+	},
 /turf/open/floor/wood,
-/area/library)
+/area/library/lounge)
 "rHo" = (
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/plating,
@@ -42086,13 +42169,6 @@
 	},
 /turf/open/floor/circuit/off,
 /area/ai_monitored/turret_protected/ai)
-"rKz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "rKG" = (
 /obj/structure/table/wood,
 /obj/item/clothing/under/misc/burial,
@@ -42175,6 +42251,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/white,
 /area/science/lab)
+"rNI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "rNM" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -42213,6 +42296,13 @@
 /obj/structure/railing/corner,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"rOa" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "rOd" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -42428,10 +42518,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
-"rTB" = (
-/obj/structure/loot_pile/maint,
-/turf/open/floor/plating,
-/area/maintenance/port/central)
 "rTG" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -42506,6 +42592,10 @@
 /obj/item/reagent_containers/glass/bucket,
 /turf/open/floor/grass,
 /area/hydroponics/garden/monastery)
+"rVt" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/crew_quarters/cryopod)
 "rVy" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
@@ -42538,6 +42628,13 @@
 /obj/effect/turf_decal/tile/brown,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"rWZ" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/stairs/medium,
+/area/hallway/primary/port)
 "rXn" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -42779,10 +42876,6 @@
 /obj/item/hand_labeler,
 /turf/open/floor/wood,
 /area/security/vacantoffice/b)
-"sec" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/crew_quarters/cryopod)
 "seo" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -43177,11 +43270,6 @@
 /obj/item/pickaxe,
 /turf/open/floor/carpet,
 /area/hallway/secondary/exit/departure_lounge)
-"smo" = (
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/maintenance/port/central)
 "smp" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -43197,13 +43285,6 @@
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"smK" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "smP" = (
 /turf/closed/wall/r_wall,
 /area/security/detectives_office)
@@ -43905,18 +43986,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"sFJ" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/railing/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "sGC" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/effect/turf_decal/stripes/line,
@@ -43948,6 +44017,13 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
+"sGR" = (
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -22
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
 "sGT" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -44439,6 +44515,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
+"sTc" = (
+/obj/structure/chair/comfy/brown,
+/turf/open/floor/wood,
+/area/library/lounge)
 "sTe" = (
 /obj/machinery/door/airlock/medical{
 	name = "Operating Theatre";
@@ -44723,12 +44803,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engine/atmospherics_engine)
-"sZX" = (
-/obj/structure/railing/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/port)
 "tad" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/aft)
@@ -45457,12 +45531,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"trk" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft/secondary)
 "trn" = (
 /obj/machinery/telecomms/broadcaster/preset_right,
 /turf/open/floor/plasteel/dark/telecomms,
@@ -45534,6 +45602,14 @@
 /obj/item/pen,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"tss" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/plating,
+/area/maintenance/department/security)
 "tsK" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -45799,7 +45875,7 @@
 "tAM" = (
 /obj/structure/bookcase/random,
 /turf/open/floor/wood,
-/area/library)
+/area/library/lounge)
 "tAX" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -46054,12 +46130,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port/fore)
-"tHw" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/effect/spawner/lootdrop/gloves,
+"tHE" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"tHR" = (
+/obj/effect/spawner/blocker,
 /turf/open/floor/plating,
-/area/maintenance/aft/secondary)
+/area/maintenance/port/central)
 "tHU" = (
 /obj/machinery/camera{
 	c_tag = "Escape Arm Southeast";
@@ -46294,16 +46373,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"tNi" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/structure/fans/tiny,
-/obj/machinery/door/airlock/external{
-	req_access_txt = "13"
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft/secondary)
 "tNp" = (
 /obj/machinery/airalarm{
 	pixel_y = 23
@@ -46595,14 +46664,6 @@
 	dir = 4
 	},
 /area/hallway/primary/port)
-"tUP" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/structure/closet/secure_closet/blueshield,
-/turf/open/floor/plasteel/dark,
-/area/blueshield)
 "tVh" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -46691,11 +46752,20 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/paramedic)
+"tWa" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/aft)
 "tWj" = (
 /obj/structure/chair/comfy/brown,
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/wood,
 /area/library)
+"tWs" = (
+/turf/open/floor/plasteel/stairs,
+/area/maintenance/aft)
 "tWx" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
@@ -46745,6 +46815,11 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
+"tYN" = (
+/obj/structure/table,
+/obj/item/reagent_containers/glass/beaker/waterbottle/wataur,
+/turf/open/floor/plating,
+/area/maintenance/aft/secondary)
 "tYT" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -46937,12 +47012,6 @@
 	},
 /turf/open/floor/plating,
 /area/engine/storage)
-"ubS" = (
-/obj/structure/railing/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white/side,
-/area/hallway/primary/port)
 "uca" = (
 /obj/structure/mopbucket,
 /turf/open/floor/plating,
@@ -47205,14 +47274,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"ujj" = (
-/obj/structure/rack,
-/obj/item/radio,
-/obj/item/clothing/suit/hooded/wintercoat,
-/obj/item/pickaxe,
-/obj/item/clothing/shoes/winterboots/ice_boots,
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "ujD" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -47271,13 +47332,6 @@
 /obj/structure/closet/secure_closet/freezer/fridge,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
-"ukK" = (
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc/auto_name/north,
-/turf/open/floor/plasteel/dark,
-/area/hydroponics/garden/monastery)
 "ukV" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/airlock/external{
@@ -47331,6 +47385,16 @@
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/engine/atmospherics_engine)
+"umN" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/external{
+	req_access_txt = "13"
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft/secondary)
 "umX" = (
 /obj/structure/table,
 /obj/structure/cable{
@@ -47418,11 +47482,6 @@
 /obj/structure/closet/secure_closet/engineering_personal,
 /turf/open/floor/plasteel/dark,
 /area/engine/secure_construction)
-"upt" = (
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/structure/rack,
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "upH" = (
 /obj/structure/bedsheetbin,
 /obj/structure/table,
@@ -47536,6 +47595,12 @@
 /obj/machinery/power/smes,
 /turf/open/floor/plating,
 /area/storage/atmos)
+"utw" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "utS" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -47656,7 +47721,7 @@
 	pixel_x = 25
 	},
 /turf/open/floor/wood,
-/area/library)
+/area/library/lounge)
 "uxn" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -47725,6 +47790,17 @@
 /obj/machinery/vending/cola/random,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"uzD" = (
+/obj/structure/rack,
+/obj/item/radio,
+/obj/structure/sign/warning/electricshock{
+	pixel_x = 32
+	},
+/obj/item/clothing/suit/hooded/wintercoat,
+/obj/item/pickaxe,
+/obj/item/clothing/shoes/winterboots/ice_boots,
+/turf/open/floor/plasteel,
+/area/maintenance/aft)
 "uzT" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -47870,9 +47946,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/teleporter)
-"uEc" = (
-/turf/closed/wall/r_wall,
-/area/crew_quarters/cryopod)
 "uEd" = (
 /obj/effect/turf_decal/tile/red,
 /obj/machinery/space_heater,
@@ -48857,15 +48930,6 @@
 /obj/machinery/vending/cigarette,
 /turf/open/floor/plating,
 /area/maintenance/bar)
-"vaS" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "vbe" = (
 /obj/machinery/firealarm{
 	pixel_y = 29
@@ -49185,14 +49249,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
-"viZ" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plating,
-/area/maintenance/department/security)
 "vju" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -49290,7 +49346,7 @@
 	dir = 4
 	},
 /turf/open/floor/wood,
-/area/library)
+/area/library/lounge)
 "vkY" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
@@ -49700,6 +49756,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"vve" = (
+/obj/machinery/light/small{
+	dir = 1;
+	light_color = "#ffc1c1"
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "vvH" = (
 /obj/effect/landmark/start/medical_doctor,
 /obj/structure/disposalpipe/segment,
@@ -49802,7 +49865,7 @@
 	dir = 4
 	},
 /turf/open/floor/wood,
-/area/library)
+/area/library/lounge)
 "vxP" = (
 /obj/structure/tank_dispenser/oxygen,
 /obj/effect/turf_decal/stripes/line{
@@ -49892,9 +49955,6 @@
 	},
 /turf/open/floor/plasteel/stairs/right,
 /area/hallway/primary/starboard)
-"vyQ" = (
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "vyV" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -50035,6 +50095,15 @@
 "vBx" = (
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
+"vBQ" = (
+/obj/machinery/cryopod,
+/obj/structure/cable{
+	icon_state = "0-2";
+	pixel_y = 1
+	},
+/obj/machinery/power/apc/auto_name/north,
+/turf/open/floor/circuit/green,
+/area/crew_quarters/cryopod)
 "vBS" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -50052,7 +50121,7 @@
 	},
 /obj/machinery/door/airlock/public/glass,
 /turf/open/floor/carpet,
-/area/library)
+/area/library/lounge)
 "vCr" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -50083,11 +50152,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"vCA" = (
-/obj/structure/table,
-/obj/item/reagent_containers/glass/beaker/waterbottle/wataur,
-/turf/open/floor/plating,
-/area/maintenance/aft/secondary)
 "vCE" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -50275,6 +50339,9 @@
 /obj/item/pickaxe,
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
+"vGT" = (
+/turf/open/floor/wood,
+/area/library/lounge)
 "vHb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/dark,
@@ -50581,15 +50648,6 @@
 	},
 /turf/open/floor/wood,
 /area/security/vacantoffice/a)
-"vOn" = (
-/obj/machinery/cryopod,
-/obj/structure/cable{
-	icon_state = "0-2";
-	pixel_y = 1
-	},
-/obj/machinery/power/apc/auto_name/north,
-/turf/open/floor/circuit/green,
-/area/crew_quarters/cryopod)
 "vOo" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -51263,6 +51321,12 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"wbT" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
 "wck" = (
 /obj/structure/table/wood,
 /obj/item/camera,
@@ -51361,20 +51425,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"weD" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"weI" = (
-/obj/structure/closet/crate{
-	icon_state = "crateopen"
-	},
-/obj/item/reagent_containers/glass/beaker/waterbottle/wataur,
-/obj/item/bonesetter,
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "weS" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -51449,6 +51499,13 @@
 /obj/machinery/light/small,
 /turf/open/floor/plating,
 /area/maintenance/department/security)
+"whF" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "whR" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
@@ -52025,9 +52082,6 @@
 /obj/machinery/bookbinder,
 /turf/open/floor/carpet,
 /area/library)
-"wvh" = (
-/turf/closed/wall,
-/area/hallway/primary/aft)
 "wvj" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -52168,14 +52222,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
-"wzT" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/structure/fans/tiny,
-/obj/machinery/door/airlock/external{
-	req_access_txt = "13"
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft/secondary)
 "wAx" = (
 /turf/closed/wall,
 /area/hydroponics)
@@ -52317,6 +52363,15 @@
 /obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
+"wEZ" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "wFc" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -52476,6 +52531,12 @@
 /obj/item/statuebust,
 /turf/open/floor/grass,
 /area/hallway/primary/starboard)
+"wHR" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "wHX" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -52664,6 +52725,12 @@
 /obj/item/clothing/under/suit/waiter,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"wMO" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "wNf" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -52689,6 +52756,22 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/paramedic)
+"wOP" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1;
+	name = "north facing firelock"
+	},
+/obj/machinery/door/airlock/glass{
+	name = "Chapel Garden"
+	},
+/turf/open/floor/plasteel/dark,
+/area/chapel/main/monastery)
+"wPs" = (
+/turf/closed/wall,
+/area/hallway/primary/aft)
 "wPD" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -53057,11 +53140,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
-"wXE" = (
-/obj/structure/reagent_dispensers/watertank,
-/obj/machinery/light/small,
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "wXR" = (
 /obj/structure/transit_tube/curved/flipped{
 	dir = 1
@@ -53223,9 +53301,6 @@
 /obj/effect/turf_decal/bot_white,
 /turf/open/floor/plasteel/dark,
 /area/teleporter)
-"xci" = (
-/turf/open/floor/plasteel,
-/area/maintenance/aft)
 "xcA" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -53321,11 +53396,6 @@
 /obj/structure/reagent_dispensers/foamtank,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"xfj" = (
-/turf/open/floor/plasteel/stairs/left{
-	dir = 4
-	},
-/area/maintenance/aft)
 "xfs" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -53392,6 +53462,9 @@
 /obj/structure/displaycase/trophy,
 /turf/open/floor/wood,
 /area/library)
+"xfZ" = (
+/turf/open/floor/plasteel/dark,
+/area/hydroponics/garden/monastery)
 "xgh" = (
 /obj/item/stack/rods,
 /turf/open/floor/plating/asteroid/snow/icemoon,
@@ -53799,10 +53872,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
-"xrv" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plating,
-/area/maintenance/port/central)
 "xrL" = (
 /obj/machinery/light{
 	dir = 1
@@ -53838,6 +53907,11 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/hallway/primary/port)
+"xsS" = (
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/closet,
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "xsZ" = (
 /obj/structure/table/wood,
 /obj/item/toy/plush/nukeplushie,
@@ -54213,6 +54287,12 @@
 "xCr" = (
 /turf/open/openspace,
 /area/medical/medbay/central)
+"xCz" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "xCC" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -54241,10 +54321,6 @@
 "xDu" = (
 /turf/open/floor/plasteel/grimy,
 /area/chapel/main/monastery)
-"xDz" = (
-/obj/machinery/mech_bay_recharge_port,
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "xDQ" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Port Quarter Solar Access";
@@ -54434,10 +54510,6 @@
 /obj/structure/grille/broken,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"xHB" = (
-/obj/effect/spawner/structure/window/ice,
-/turf/open/floor/plating,
-/area/hydroponics/garden/monastery)
 "xHE" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -54544,13 +54616,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
-"xKb" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "xKn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/structure/extinguisher_cabinet{
@@ -55009,6 +55074,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"xWY" = (
+/obj/structure/tank_dispenser/oxygen,
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
 "xXS" = (
 /obj/machinery/rnd/server,
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
@@ -55148,6 +55217,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
+"ycc" = (
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/rack,
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "ycl" = (
 /obj/structure/fans/tiny,
 /obj/machinery/door/firedoor/border_only{
@@ -55198,12 +55272,6 @@
 "yds" = (
 /turf/open/floor/plasteel,
 /area/medical/chemistry)
-"ydO" = (
-/obj/machinery/computer/mech_bay_power_console{
-	dir = 1
-	},
-/turf/open/floor/circuit,
-/area/maintenance/aft)
 "ydQ" = (
 /obj/machinery/power/apc{
 	areastring = "/area/maintenance/solars/starboard/aft";
@@ -55413,6 +55481,15 @@
 /obj/effect/landmark/start/cyborg,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/service)
+"yiX" = (
+/obj/structure/table/reinforced,
+/obj/item/stack/sheet/metal{
+	amount = 30
+	},
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/cable_coil/white,
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "yiZ" = (
 /obj/machinery/door/airlock/command{
 	name = "Conference Room";
@@ -67764,7 +67841,7 @@ opq
 aHu
 llj
 nhd
-dyM
+eZt
 aIP
 avT
 avT
@@ -68021,7 +68098,7 @@ puk
 puk
 puk
 puk
-jwE
+rBD
 aIP
 avT
 avT
@@ -68278,7 +68355,7 @@ kex
 sCz
 fWC
 puk
-jwE
+rBD
 aIP
 avT
 avT
@@ -68535,8 +68612,8 @@ twZ
 jar
 erx
 lpR
-jwE
-iAI
+rBD
+eHq
 avT
 avT
 ydp
@@ -68792,8 +68869,8 @@ itn
 cSJ
 cSJ
 lpR
-jwE
-iAI
+rBD
+eHq
 avT
 avT
 avT
@@ -69049,8 +69126,8 @@ loD
 fXs
 cZu
 lpR
-jwE
-iAI
+rBD
+eHq
 avT
 avT
 avT
@@ -69306,8 +69383,8 @@ aGF
 cSJ
 cSJ
 lpR
-jwE
-iAI
+rBD
+eHq
 avT
 avT
 avT
@@ -69563,8 +69640,8 @@ rJQ
 hoe
 erx
 lpR
-jwE
-iAI
+rBD
+eHq
 avT
 avT
 avT
@@ -72124,7 +72201,7 @@ avX
 pdo
 wnO
 jil
-rEX
+fTD
 otz
 bxk
 bxk
@@ -72381,7 +72458,7 @@ axi
 kTI
 wje
 rBc
-gpc
+kkm
 vfr
 xok
 wje
@@ -72639,7 +72716,7 @@ kTI
 wje
 etM
 oNR
-lTV
+qTB
 mNo
 mNo
 mJq
@@ -72896,7 +72973,7 @@ qAx
 wje
 ouH
 ndX
-dui
+rWZ
 gKt
 gKt
 aFR
@@ -73152,9 +73229,9 @@ axi
 axi
 wje
 xSH
-qfw
+aqT
 nRA
-sZX
+gje
 wje
 rbo
 nuS
@@ -73409,7 +73486,7 @@ avX
 axj
 wnO
 lgq
-ubS
+gAP
 sxt
 bxk
 bxk
@@ -77786,7 +77863,7 @@ vor
 fEQ
 cKe
 dhg
-rTB
+cSW
 nLS
 avT
 avT
@@ -78301,7 +78378,7 @@ jLI
 dhg
 dhg
 gdQ
-cxe
+mBi
 avT
 avT
 avT
@@ -78555,10 +78632,10 @@ qUr
 aBG
 bff
 gdQ
-rTB
+cSW
 nLS
 gdQ
-cxe
+mBi
 avT
 avT
 avT
@@ -78806,14 +78883,14 @@ nLS
 nLS
 nLS
 nLS
-kGD
+tHR
 nLS
 nLS
 nLS
-dQF
+jOq
 vGj
 gdQ
-hgw
+heG
 gdQ
 nLS
 avT
@@ -79061,11 +79138,11 @@ iPX
 vTF
 xKO
 nLS
-rTB
+cSW
 nLS
 iaJ
 rad
-smo
+dnY
 gdQ
 gdQ
 gdQ
@@ -79575,17 +79652,17 @@ uUZ
 uUZ
 uUZ
 nLS
-smo
+dnY
 uca
 nLS
 gdQ
-xrv
+osl
 nLS
 nog
 nog
 nog
 nLS
-rTB
+cSW
 nLS
 avT
 avT
@@ -86026,12 +86103,12 @@ bok
 sLq
 wcB
 wcB
-uEc
-sec
-sec
-sec
-sec
-uEc
+llo
+rVt
+rVt
+rVt
+rVt
+llo
 sPF
 buZ
 dWF
@@ -86283,12 +86360,12 @@ bok
 cwo
 wcB
 wcB
-uEc
+llo
 wrh
 cFO
 eWp
 wvL
-uEc
+llo
 ewK
 fPN
 msA
@@ -86540,12 +86617,12 @@ bok
 uxF
 wcB
 wcB
-uEc
-vOn
+llo
+vBQ
 dno
 fcu
 wVg
-uEc
+llo
 aNw
 hRe
 buZ
@@ -86569,7 +86646,7 @@ uWQ
 fKC
 giT
 xkT
-viZ
+tss
 dYl
 rYN
 qOb
@@ -86797,12 +86874,12 @@ bok
 sLq
 wcB
 wcB
-uEc
-grO
+llo
+gTB
 drK
-mXE
+jXV
 nUk
-uEc
+llo
 cTD
 cTD
 iQv
@@ -87054,12 +87131,12 @@ bok
 unA
 uFq
 uFq
-uEc
-sec
+llo
+rVt
 dTo
 bmA
-sec
-dhs
+rVt
+cBH
 xTL
 lHn
 bsk
@@ -87604,9 +87681,9 @@ bPq
 nzn
 tod
 cii
-vyQ
-smK
-vyQ
+kaF
+rOa
+kaF
 bsy
 dMj
 cex
@@ -87861,9 +87938,9 @@ sdN
 sdN
 tod
 wFU
-vyQ
+kaF
 sAw
-vyQ
+kaF
 rka
 dMj
 riE
@@ -88118,9 +88195,9 @@ tod
 tod
 tod
 wHB
-vyQ
-dBC
-vyQ
+kaF
+ehJ
+kaF
 jIb
 dMj
 dMj
@@ -88357,14 +88434,14 @@ mbh
 bBB
 lhQ
 lhQ
-oXh
+cDF
 cGQ
-gTx
-gTx
+hvx
+hvx
 bNn
-gTx
+hvx
 qQt
-gTx
+hvx
 bJF
 bVX
 mqq
@@ -88375,10 +88452,10 @@ sUX
 toP
 pjn
 tNf
-vyQ
+kaF
 haj
-gTx
-gTx
+hvx
+hvx
 iwd
 ykt
 jIj
@@ -88614,33 +88691,33 @@ bAj
 ezY
 wZl
 wZl
-btd
-xKb
-xKb
-xKb
-xKb
-xKb
+kDK
+whF
+whF
+whF
+whF
+whF
 uZd
-xKb
+whF
 bPa
 fZV
 bCT
 msm
 qCa
-xKb
-xKb
-xKb
-xKb
+whF
+whF
+whF
+whF
 xXV
-xKb
+whF
 fZV
 ilF
-xKb
-xKb
-xKb
+whF
+whF
+whF
 hvr
-xKb
-xKb
+whF
+whF
 iau
 hKc
 olx
@@ -88871,33 +88948,33 @@ nRt
 xmB
 tys
 tys
-faF
-kgg
-kgg
-kgg
-kgg
-kgg
-kgg
-kgg
+rlv
+tHE
+tHE
+tHE
+tHE
+tHE
+tHE
+tHE
 tXn
 mhH
 bCW
 ndS
 qUY
-kgg
-kgg
-kgg
-kgg
-kgg
-kgg
+tHE
+tHE
+tHE
+tHE
+tHE
+tHE
 xtq
 bPd
-kgg
-kgg
-kgg
+tHE
+tHE
+tHE
 jhe
-kgg
-kgg
+tHE
+tHE
 civ
 fJW
 ina
@@ -89128,28 +89205,28 @@ pBU
 reS
 lhQ
 czY
-oXh
-pfU
-pfU
-pfU
-pfU
-pfU
+cDF
+wHR
+wHR
+wHR
+wHR
+wHR
 sOv
 wLU
 lQs
-pfU
+wHR
 bDI
 nCU
 rwR
-vyQ
-vyQ
-pfU
-pfU
+kaF
+kaF
+wHR
+wHR
 fsF
-pfU
+wHR
 gkX
 bPc
-pfU
+wHR
 bUL
 rmB
 tNf
@@ -89384,15 +89461,15 @@ lhQ
 bxa
 byZ
 caJ
-srk
-srk
-xjF
-xjF
-xjF
-xjF
-xjF
-srk
-srk
+pDN
+pDN
+ciN
+ciN
+ciN
+ciN
+ciN
+pDN
+pDN
 srk
 srk
 bDU
@@ -89641,15 +89718,15 @@ ceA
 bwZ
 byY
 bCD
-srk
+pDN
 dzf
 vkW
-agy
-agy
-agy
+vGT
+vGT
+vGT
 fNE
 tAM
-srk
+pDN
 wvg
 lBE
 xyA
@@ -89662,8 +89739,8 @@ njU
 cfm
 srk
 gtG
-vaS
-vyQ
+wEZ
+kaF
 chb
 vam
 gsr
@@ -89898,14 +89975,14 @@ ceA
 bxc
 bzb
 bCD
-xjF
-gpN
+ciN
+sTc
 lDD
 oXZ
-agy
-agy
-agy
-xTI
+vGT
+vGT
+vGT
+muw
 vBV
 xTI
 xTI
@@ -89919,7 +89996,7 @@ njU
 agy
 xjF
 xZL
-vaS
+wEZ
 bwr
 chb
 eZA
@@ -90155,17 +90232,17 @@ ceA
 bxb
 fkN
 bCD
-xjF
-gpN
+ciN
+sTc
 cAe
 oXZ
-agy
-agy
-agy
-xTI
-vBV
-xTI
-xTI
+vGT
+nOO
+oZi
+gMm
+gXc
+kCa
+kCa
 bRH
 oME
 sjk
@@ -90177,7 +90254,7 @@ sRh
 eDu
 gpp
 bXU
-weD
+utw
 vBo
 gMD
 pIz
@@ -90412,15 +90489,15 @@ heM
 mIz
 cSG
 bzS
-xjF
-agy
+ciN
+vGT
 dkP
-agy
+vGT
 cNg
 ikt
 fNE
 tAM
-srk
+pDN
 mdG
 mdG
 rxu
@@ -90433,8 +90510,8 @@ agy
 agy
 xjF
 cZk
-vaS
-oMe
+wEZ
+jVC
 chb
 pXW
 hZU
@@ -90669,15 +90746,15 @@ eHn
 oxh
 osc
 bCD
-xjF
-agy
-pyI
-agy
-srk
-srk
-srk
-srk
-srk
+ciN
+vGT
+plM
+vGT
+pDN
+pDN
+pDN
+pDN
+pDN
 gdd
 njU
 bFL
@@ -90690,8 +90767,8 @@ agy
 cfm
 srk
 mql
-vaS
-vyQ
+wEZ
+kaF
 chb
 qbv
 ayP
@@ -90926,9 +91003,9 @@ bze
 bAp
 dvw
 bCG
-srk
+pDN
 uxk
-pyI
+plM
 rHk
 srk
 mgD
@@ -90947,8 +91024,8 @@ jTc
 srk
 srk
 qZs
-vaS
-vyQ
+wEZ
+kaF
 cdD
 eyS
 vfd
@@ -91183,10 +91260,10 @@ bBL
 bAr
 teC
 jcT
-srk
-srk
+pDN
+pDN
 vxO
-srk
+pDN
 srk
 foJ
 eLf
@@ -91202,10 +91279,10 @@ iJX
 iJX
 iJX
 srk
-vyQ
-gsq
-vaS
-vyQ
+kaF
+kTT
+wEZ
+kaF
 cdD
 uQR
 bDB
@@ -91213,7 +91290,7 @@ edH
 mAK
 chb
 avT
-kRR
+dJh
 avT
 avT
 avT
@@ -91459,10 +91536,10 @@ agy
 agy
 agy
 xjF
-vyQ
-gsq
-vaS
-vyQ
+kaF
+kTT
+wEZ
+kaF
 cdD
 ebq
 fZn
@@ -91716,9 +91793,9 @@ wVP
 bVZ
 vKc
 xjF
-vyQ
-gsq
-vaS
+kaF
+kTT
+wEZ
 xRq
 chb
 chb
@@ -91973,9 +92050,9 @@ agy
 nHQ
 agy
 xjF
-vyQ
-gsq
-vaS
+kaF
+kTT
+wEZ
 xRq
 djx
 gEi
@@ -91984,7 +92061,7 @@ kuU
 djw
 xRq
 wGq
-lPe
+lHM
 rqf
 avT
 avT
@@ -92230,9 +92307,9 @@ xfW
 plP
 gVL
 xjF
-vyQ
-gsq
-vaS
+kaF
+kTT
+wEZ
 rdu
 fsT
 pfk
@@ -92487,7 +92564,7 @@ agy
 nHQ
 agy
 xjF
-vyQ
+kaF
 ydo
 kSP
 oBj
@@ -92497,7 +92574,7 @@ pbs
 gEi
 szD
 xRq
-vCA
+tYN
 wGq
 wTK
 avT
@@ -92744,9 +92821,9 @@ chp
 cLD
 chp
 srk
-kIb
-gsq
-mRE
+lBL
+kTT
+aYt
 tDn
 gEi
 hQl
@@ -92754,7 +92831,7 @@ gEi
 gEi
 uZI
 xRq
-lnU
+fJr
 wGq
 wTK
 avT
@@ -93002,17 +93079,17 @@ nEy
 sMR
 srk
 hNt
-mjw
+lhM
 qdi
 xRq
 ryA
 mqC
-tUP
+bFR
 uxn
 uxn
-cwU
+oDM
 wGq
-kYp
+cjT
 wTK
 avT
 avT
@@ -93259,7 +93336,7 @@ vwq
 pSX
 srk
 hNt
-mjw
+lhM
 qdi
 xRq
 xRq
@@ -93500,9 +93577,9 @@ tRe
 bLT
 dDe
 giD
-ifE
+xCz
 sOH
-ifE
+xCz
 phd
 vQm
 vQm
@@ -93515,9 +93592,9 @@ are
 qoT
 sdM
 srk
-cQo
-gsq
-sFJ
+aao
+kTT
+mbu
 xTw
 jSV
 ilM
@@ -93745,7 +93822,7 @@ avT
 avT
 avT
 bLT
-jEG
+xWY
 suL
 bEi
 jkL
@@ -93756,7 +93833,7 @@ bEi
 afp
 bLT
 doP
-lHz
+drn
 mLS
 aIf
 bhC
@@ -93773,8 +93850,8 @@ xTI
 pSX
 srk
 hIC
-gsq
-vaS
+kTT
+wEZ
 xTw
 uid
 uid
@@ -93786,9 +93863,9 @@ wGq
 wTK
 wGq
 wGq
-wzT
+eOy
 wGq
-tNi
+umN
 avT
 avT
 avT
@@ -94009,11 +94086,11 @@ bra
 xRH
 xRH
 bri
-ahY
+wbT
 aDM
 bLT
 dFp
-lHz
+drn
 oHa
 tnd
 fDk
@@ -94270,8 +94347,8 @@ bEi
 bLT
 bLT
 tad
-erl
-xfj
+dNY
+qiw
 doP
 doP
 doP
@@ -94287,7 +94364,7 @@ srk
 srk
 srk
 jCF
-gsq
+kTT
 tNf
 xTw
 uid
@@ -94296,9 +94373,9 @@ jTE
 uid
 azs
 wTK
-gYK
+jxp
 wTK
-trk
+oox
 wGq
 rqf
 avT
@@ -94525,26 +94602,26 @@ bLT
 bBJ
 wmG
 bLT
-rxk
-bSR
+dcd
+wMO
 gKR
 hAb
-rKz
+rNI
 wlV
 mzv
 wlV
 wlV
-drq
+tWs
 wlV
 wlV
 wlV
-grm
+aVs
 wlV
 wlV
 doP
 doP
-vyQ
-gsq
+kaF
+kTT
 tNf
 xTw
 jpS
@@ -94783,11 +94860,11 @@ bzd
 hGr
 bLT
 bPn
-lHz
+drn
 hyd
 wlV
 wlV
-upt
+ycc
 doP
 wlV
 wlV
@@ -94800,8 +94877,8 @@ doP
 wlV
 doP
 wJb
-vyQ
-gsq
+kaF
+kTT
 uBW
 sqH
 sqH
@@ -95040,10 +95117,10 @@ bBN
 bEi
 bLT
 tad
-lSS
+nYT
 tad
 tad
-mBe
+qMY
 tad
 tad
 doP
@@ -95051,24 +95128,24 @@ mzv
 doP
 mGa
 wlV
-qKg
-xDz
+xsS
+dVP
 doP
-pWF
+jia
 doP
 wRX
-vyQ
+kaF
 hSV
 tNf
-oXh
+cDF
 wkv
 ehW
 tJJ
 tJJ
 tnV
 wTK
-gYK
-lnU
+jxp
+fJr
 wTK
 avT
 avT
@@ -95296,25 +95373,25 @@ bLT
 hrN
 vER
 bLT
-lQA
-lHz
+lLH
+drn
 aMs
 aMs
-xci
-knk
+gOb
+yiX
 tad
-weI
+bWL
 wlV
 doP
-axd
-daG
+dOi
+hkL
 lJe
-lbD
+lIT
 doP
-dYb
+vve
 doP
 doP
-vyQ
+kaF
 ydo
 pYH
 oud
@@ -95324,8 +95401,8 @@ tJJ
 tJJ
 ciA
 wTK
-gYK
-tHw
+jxp
+gNc
 wTK
 avT
 avT
@@ -95551,30 +95628,30 @@ avT
 bLT
 kEz
 bBN
-hQO
+sGR
 bLT
-azY
+kGS
 lYJ
-aVw
-aVw
-oOq
-wXE
+tWa
+tWa
+eNj
+iAd
 tad
-gZV
+oau
 wlV
 doP
 noG
 rHo
 lJe
-ydO
+hkO
 doP
 wlV
 wlV
 doP
-vyQ
+kaF
 hDf
 tNf
-oXh
+cDF
 szC
 sHj
 tJJ
@@ -95810,12 +95887,12 @@ uhD
 aFa
 bCY
 bLT
-pop
-mOV
-ujj
-fIs
+pkQ
+fZr
+lyD
+uzD
 lYJ
-eGY
+jRq
 tad
 doP
 doP
@@ -95831,7 +95908,7 @@ doP
 bdm
 ehp
 tNf
-wvh
+wPs
 pLg
 wiD
 iFj
@@ -95839,7 +95916,7 @@ tmx
 lPR
 wTK
 ekJ
-nJv
+jZR
 wTK
 avT
 avT
@@ -96067,33 +96144,33 @@ mcy
 bBP
 ojY
 bLT
-iws
-iws
+gsf
+gsf
 tad
 tad
-iws
-iws
+gsf
+gsf
 tad
 avT
 avT
 avT
 avT
-oXh
+cDF
 uon
 eBo
 vKN
-qLP
-qLP
-qLP
-qLP
-qLP
+bfa
+bfa
+bfa
+bfa
+bfa
 wEn
-wvh
-wvh
-oXh
-wvh
-oXh
-wvh
+wPs
+wPs
+cDF
+wPs
+cDF
+wPs
 wTK
 kfl
 wTK
@@ -96335,17 +96412,17 @@ avT
 avT
 avT
 avT
-oXh
+cDF
 hpA
-vyQ
-vyQ
-vyQ
-vyQ
-vyQ
-vyQ
-vyQ
+kaF
+kaF
+kaF
+kaF
+kaF
+kaF
+kaF
 aet
-wvh
+wPs
 avT
 avT
 avT
@@ -96592,17 +96669,17 @@ avT
 avT
 avT
 avT
-oXh
+cDF
 riR
-vyQ
-vyQ
-vyQ
+kaF
+kaF
+kaF
 cgQ
 bRm
 bRm
 bRm
 dzq
-wvh
+wPs
 avT
 avT
 avT
@@ -96847,19 +96924,19 @@ avT
 avT
 avT
 avT
-wvh
-oXh
-wvh
+wPs
+cDF
+wPs
 deU
-vyQ
-vyQ
-vyQ
-wvh
-oXh
+kaF
+kaF
+kaF
+wPs
+cDF
 tiV
 gTH
-oXh
-wvh
+cDF
+wPs
 avT
 avT
 avT
@@ -97104,18 +97181,18 @@ avT
 avT
 avT
 avT
-oXh
+cDF
 jee
 jBo
-vyQ
-vyQ
-vyQ
+kaF
+kaF
+kaF
 svv
-wvh
-oXh
+wPs
+cDF
 hRG
 hfk
-oXh
+cDF
 avT
 avT
 avT
@@ -97361,18 +97438,18 @@ avT
 avT
 avT
 avT
-oXh
+cDF
 wIu
 jBo
-vyQ
-vyQ
-vyQ
+kaF
+kaF
+kaF
 sqs
-wvh
-oXh
+wPs
+cDF
 joE
 dgo
-oXh
+cDF
 avT
 avT
 avT
@@ -97618,14 +97695,14 @@ avT
 avT
 avT
 avT
-oXh
+cDF
 wIu
 nQT
 icA
 icA
-vyQ
+kaF
 jRX
-wvh
+wPs
 avT
 xUL
 xUL
@@ -97875,14 +97952,14 @@ avT
 avT
 avT
 avT
-wvh
+wPs
 wgj
-wvh
-oXh
-oXh
-oXh
-wvh
-wvh
+wPs
+cDF
+cDF
+cDF
+wPs
+wPs
 avT
 xUL
 xUL
@@ -100972,10 +101049,10 @@ ydp
 ydp
 ydp
 ydp
-iDe
+mEi
 hLC
 gmZ
-iDe
+mEi
 avT
 ydp
 ydp
@@ -101229,10 +101306,10 @@ ydp
 ydp
 ydp
 ydp
-iDe
+mEi
 dRM
 hPA
-iDe
+mEi
 avT
 ydp
 ydp
@@ -101483,20 +101560,20 @@ nbC
 gUW
 ydp
 ydp
-iNY
-iDe
-iNY
-iDe
+kpG
+mEi
+kpG
+mEi
 lNj
 hHZ
-iDe
-iNY
-iNY
-iNY
-iNY
-iNY
-iNY
-iNY
+mEi
+kpG
+kpG
+kpG
+kpG
+kpG
+kpG
+kpG
 ydp
 ydp
 ydp
@@ -101748,12 +101825,12 @@ dNf
 dNf
 kef
 sQi
-iNY
+kpG
 mPA
 fCK
 mWW
 wdY
-iNY
+kpG
 ydp
 ydp
 ydp
@@ -101997,7 +102074,7 @@ avT
 vBe
 avT
 avT
-iDe
+mEi
 kGX
 teB
 uza
@@ -102010,7 +102087,7 @@ uGE
 crr
 sIl
 sIl
-iNY
+kpG
 ydp
 ydp
 ydp
@@ -102267,7 +102344,7 @@ hDU
 bXQ
 huU
 ruk
-iNY
+kpG
 ydp
 ydp
 ydp
@@ -102520,11 +102597,11 @@ pCd
 gSE
 wcK
 wcK
-iNY
-iNY
-iNY
-iNY
-iNY
+kpG
+kpG
+kpG
+kpG
+kpG
 ydp
 ydp
 ydp
@@ -105348,11 +105425,11 @@ pAF
 nVs
 nQW
 wcK
-xHB
-xHB
-xHB
-xHB
-xHB
+onc
+onc
+onc
+onc
+onc
 ydp
 ydp
 qrR
@@ -105605,12 +105682,12 @@ qqE
 saj
 nVs
 gSE
-hGv
-hGv
-hGv
+xfZ
+xfZ
+xfZ
 epT
-hGv
-xHB
+xfZ
+onc
 ydp
 ydp
 qrR
@@ -105862,12 +105939,12 @@ fiE
 sYT
 nVs
 gSE
-hGv
+xfZ
 eXS
 dzF
 pWT
-hGv
-xHB
+xfZ
+onc
 ydp
 ydp
 ydp
@@ -106119,13 +106196,13 @@ qqE
 saj
 nVs
 wcK
-hGv
+xfZ
 ggg
 ggg
 ggg
-hGv
+xfZ
 jJG
-xHB
+onc
 ydp
 ydp
 qrR
@@ -106376,13 +106453,13 @@ fiE
 sYT
 nVs
 kGt
-hGv
+xfZ
 pWT
 iUV
 fPO
-hGv
+xfZ
 aSk
-xHB
+onc
 ydp
 ydp
 qrR
@@ -106629,17 +106706,17 @@ uYE
 hEC
 hFZ
 cPC
-pSo
-oMD
-gfL
-oXu
-eJg
+qXT
+aSJ
+mvW
+wOP
+gUS
 jYW
 rVg
 qjQ
-hGv
+xfZ
 xMo
-xHB
+onc
 ydp
 qrR
 qrR
@@ -106890,13 +106967,13 @@ fiE
 sYT
 nVs
 wcK
-ukK
+chq
 ggg
 uPx
 ggg
-hGv
+xfZ
 tjC
-xHB
+onc
 ydp
 ydp
 qrR
@@ -107147,12 +107224,12 @@ lck
 rYK
 nVs
 gSE
-hGv
+xfZ
 wsK
 ggg
 wsK
-hGv
-xHB
+xfZ
+onc
 ydp
 ydp
 qrR
@@ -107404,12 +107481,12 @@ fiE
 sYT
 whw
 gSE
-hGv
-hGv
-hGv
-pud
-hGv
-xHB
+xfZ
+xfZ
+xfZ
+hLv
+xfZ
+onc
 ydp
 ydp
 ydp
@@ -107661,11 +107738,11 @@ nVs
 wUb
 bWk
 wcK
-xHB
-xHB
-xHB
-xHB
-xHB
+onc
+onc
+onc
+onc
+onc
 ydp
 ydp
 ydp

--- a/_maps/map_files/Snaxi/Snaxi_Lumos.dmm
+++ b/_maps/map_files/Snaxi/Snaxi_Lumos.dmm
@@ -94,7 +94,7 @@
 /obj/structure/table/wood/fancy,
 /obj/item/flashlight/lamp,
 /turf/open/floor/carpet,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard)
 "abU" = (
 /turf/closed/wall,
 /area/crew_quarters/fitness/pool)
@@ -139,7 +139,7 @@
 	},
 /obj/structure/chair,
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "acv" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -446,7 +446,7 @@
 	pixel_y = -32
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "aez" = (
 /obj/machinery/button/door{
 	id = "PoolShut";
@@ -492,16 +492,11 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "afq" = (
-/obj/machinery/power/apc{
-	areastring = "/area/maintenance/port/fore";
-	dir = 4;
-	name = "Port Bow Maintenance APC";
-	pixel_x = 24
-	},
 /obj/structure/cable,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/power/apc/auto_name/east,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "afU" = (
@@ -531,6 +526,10 @@
 	},
 /obj/structure/cable{
 	icon_state = "2-8"
+	},
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = 28
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
@@ -609,7 +608,13 @@
 /turf/open/floor/plasteel/median/darktogrime/corner{
 	dir = 8
 	},
-/area/chapel/main)
+/area/chapel/main/monastery)
+"ahY" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
 "air" = (
 /obj/machinery/bloodbankgen,
 /turf/open/floor/plasteel/white,
@@ -637,7 +642,7 @@
 "aiU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard/fore)
 "ajg" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/northleft{
@@ -662,7 +667,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/carpet,
-/area/chapel/main)
+/area/chapel/main/monastery)
 "ajl" = (
 /obj/machinery/light{
 	dir = 8
@@ -685,7 +690,7 @@
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/dark,
-/area/chapel/main)
+/area/chapel/main/monastery)
 "ajD" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -712,8 +717,12 @@
 /area/ai_monitored/security/armory)
 "ajP" = (
 /obj/item/kirbyplants/random,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/south,
 /turf/open/floor/carpet/eighties,
-/area/crew_quarters/fitness)
+/area/crew_quarters/fitness/recreation{
+	name = "Arcade Room"
+	})
 "ajV" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -845,12 +854,12 @@
 	dir = 5
 	},
 /turf/open/floor/plating,
-/area/maintenance/aft/secondary)
+/area/maintenance/aft)
 "ami" = (
 /turf/open/floor/plasteel/median/darktogrime/fullcorner{
 	dir = 4
 	},
-/area/chapel/main)
+/area/chapel/main/monastery)
 "amm" = (
 /obj/machinery/atmospherics/components/binary/valve/layer1{
 	dir = 4
@@ -914,8 +923,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard/fore)
 "anh" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -1164,7 +1176,7 @@
 /obj/structure/table/wood,
 /obj/item/storage/fancy/candle_box,
 /turf/open/floor/plasteel/dark,
-/area/chapel/main)
+/area/chapel/main/monastery)
 "aqd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -1187,14 +1199,6 @@
 	},
 /turf/open/floor/carpet,
 /area/library)
-"arl" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/airlock/external,
-/obj/structure/fans/tiny,
-/turf/open/floor/plating,
-/area/hallway/primary/port)
 "arE" = (
 /obj/structure/table,
 /obj/structure/extinguisher_cabinet{
@@ -1283,14 +1287,8 @@
 /turf/closed/wall,
 /area/medical/medbay/central)
 "asn" = (
-/obj/structure/chair/wood{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft/secondary)
+/turf/closed/wall,
+/area/maintenance/starboard/fore)
 "asr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -1341,16 +1339,12 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "atb" = (
-/obj/machinery/light{
+/obj/structure/railing{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/stairs/right{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "atp" = (
 /obj/structure/cable{
@@ -1368,7 +1362,7 @@
 	},
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard/fore)
 "atr" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -1568,10 +1562,9 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
 "avR" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/maintenance/aft/secondary)
+/area/hallway/primary/starboard/fore)
 "avS" = (
 /obj/structure/cable,
 /obj/machinery/power/apc{
@@ -1620,6 +1613,7 @@
 	max_integrity = 10;
 	obj_integrity = 10
 	},
+/obj/effect/turf_decal/weather/snow/corner,
 /turf/open/floor/wood,
 /area/maintenance/bar)
 "awB" = (
@@ -1664,6 +1658,11 @@
 /obj/item/paper/pamphlet/gateway,
 /turf/open/floor/plasteel/dark,
 /area/teleporter)
+"axd" = (
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "axg" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -1681,7 +1680,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard)
 "axi" = (
 /turf/open/floor/wood,
 /area/hallway/primary/port)
@@ -2056,7 +2055,29 @@
 "azJ" = (
 /obj/structure/closet/wardrobe/black,
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
+"azY" = (
+/obj/item/tank/internals/emergency_oxygen/double{
+	pixel_x = 3
+	},
+/obj/item/tank/internals/emergency_oxygen/double{
+	pixel_x = 3
+	},
+/obj/item/clothing/mask/breath{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/clothing/mask/breath{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/structure/closet/crate/internals,
+/obj/machinery/light/small{
+	dir = 1;
+	light_color = "#ffc1c1"
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/aft)
 "aAe" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -2199,12 +2220,11 @@
 "aAP" = (
 /obj/machinery/vending/clothing,
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "aAQ" = (
 /obj/structure/chair,
-/obj/effect/landmark/start/assistant,
 /turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
+/area/hallway/primary/port)
 "aAT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -2232,16 +2252,19 @@
 	},
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard/fore)
 "aBw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
+/area/hallway/primary/port)
 "aBG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating,
-/area/hallway/primary/port)
+/area/maintenance/port/central)
 "aBH" = (
 /obj/machinery/vending/wardrobe/science_wardrobe,
 /turf/open/floor/plasteel/white,
@@ -2329,7 +2352,7 @@
 	},
 /obj/machinery/vending/autodrobe,
 /turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
+/area/hallway/primary/port)
 "aDb" = (
 /obj/structure/table/glass,
 /obj/item/paicard,
@@ -2364,7 +2387,7 @@
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
+/area/hallway/primary/port)
 "aDf" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/white,
@@ -2388,7 +2411,7 @@
 /obj/item/pickaxe,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
+/area/hallway/primary/port)
 "aDk" = (
 /obj/machinery/space_heater,
 /obj/machinery/status_display{
@@ -2397,7 +2420,7 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
+/area/hallway/primary/port)
 "aDm" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -2420,14 +2443,11 @@
 /obj/item/pickaxe,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
+/area/hallway/primary/port)
 "aDn" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
+/obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
-/area/maintenance/disposal)
+/area/maintenance/starboard/fore)
 "aDo" = (
 /obj/structure/chair/comfy/black{
 	dir = 8
@@ -2439,12 +2459,11 @@
 	icon_state = "4-8"
 	},
 /obj/structure/chair,
-/obj/effect/landmark/start/assistant,
 /obj/machinery/newscaster{
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
+/area/hallway/primary/port)
 "aDJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
@@ -2473,9 +2492,16 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/maintenance/department/electrical)
 "aDM" = (
-/obj/structure/tank_dispenser/oxygen,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/disposal/bin,
+/obj/structure/cable,
+/obj/machinery/power/apc{
+	areastring = "/area/quartermaster/miningdock";
+	dir = 4;
+	name = "Mining Dock APC";
+	pixel_x = 26
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
@@ -2527,7 +2553,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
+/area/hallway/primary/port)
 "aEE" = (
 /obj/machinery/rnd/destructive_analyzer,
 /turf/open/floor/circuit,
@@ -2560,7 +2586,7 @@
 /area/science/lab)
 "aEJ" = (
 /turf/closed/wall/r_wall,
-/area/hallway/secondary/entry)
+/area/maintenance/port/aft)
 "aEK" = (
 /obj/machinery/rnd/production/circuit_imprinter/department/science,
 /obj/item/reagent_containers/glass/beaker/sulphuric,
@@ -2579,7 +2605,7 @@
 /turf/open/floor/plasteel/median/darktogrime{
 	dir = 1
 	},
-/area/chapel/main)
+/area/chapel/main/monastery)
 "aEV" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -2612,7 +2638,7 @@
 "aFn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
-/area/chapel/main)
+/area/chapel/main/monastery)
 "aFA" = (
 /obj/machinery/airalarm{
 	dir = 1;
@@ -2631,7 +2657,7 @@
 	},
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
-/area/hallway/primary/port)
+/area/hallway/primary/port/fore)
 "aFI" = (
 /turf/closed/wall/r_wall,
 /area/science/lab)
@@ -2643,14 +2669,14 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "aFO" = (
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "aFQ" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "aFR" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -2665,26 +2691,26 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
+/area/hallway/primary/port)
 "aFT" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
+/area/hallway/primary/port)
 "aFU" = (
 /obj/structure/chair{
 	dir = 1
 	},
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
+/area/hallway/primary/port)
 "aFY" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
+/area/hallway/primary/port)
 "aFZ" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -2699,19 +2725,12 @@
 /turf/open/floor/plating,
 /area/construction/storage)
 "aGl" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/machinery/disposal/bin,
-/obj/machinery/power/apc{
-	areastring = "/area/quartermaster/miningdock";
-	dir = 4;
-	name = "Mining Dock APC";
-	pixel_x = 26
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/quartermaster/miningdock)
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "aGD" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -2738,10 +2757,13 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/white/corner{
 	dir = 8
 	},
-/area/hallway/secondary/entry)
+/area/hallway/primary/port)
 "aHk" = (
 /obj/structure/barricade/wooden/snowed,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
@@ -2754,10 +2776,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/white/corner{
 	dir = 8
 	},
-/area/hallway/secondary/entry)
+/area/hallway/primary/port)
 "aHD" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -2769,7 +2794,7 @@
 /turf/open/floor/plasteel/white/corner{
 	dir = 8
 	},
-/area/hallway/secondary/entry)
+/area/hallway/primary/port)
 "aHE" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -2795,12 +2820,17 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "aHU" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/obj/item/radio/intercom{
+	name = "Station Intercom";
+	pixel_x = 26
+	},
 /turf/open/floor/plasteel,
-/area/maintenance/disposal)
+/area/hallway/secondary/service)
 "aIf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall,
-/area/maintenance/aft/secondary)
+/area/maintenance/aft)
 "aIt" = (
 /obj/structure/trash_pile,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
@@ -2835,10 +2865,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
-/area/hallway/secondary/entry)
+/area/hallway/primary/port/aft)
 "aIP" = (
 /turf/closed/wall,
-/area/hallway/secondary/entry)
+/area/maintenance/port/aft)
 "aIS" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -2849,7 +2879,7 @@
 "aJb" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard/fore)
 "aJe" = (
 /obj/machinery/light{
 	dir = 4
@@ -2889,7 +2919,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/hallway/secondary/entry)
+/area/hallway/primary/port/aft)
 "aKa" = (
 /obj/machinery/atmospherics/components/binary/valve/digital{
 	dir = 4
@@ -2897,10 +2927,11 @@
 /turf/closed/wall/r_wall,
 /area/storage/atmos)
 "aKf" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plating,
-/area/maintenance/disposal)
+/area/maintenance/starboard/fore)
 "aKm" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -2928,7 +2959,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
-/area/hallway/secondary/entry)
+/area/hallway/primary/port/aft)
 "aKs" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
@@ -2962,7 +2993,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/hallway/secondary/entry)
+/area/hallway/primary/port/aft)
 "aLp" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -2979,6 +3010,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
 	},
+/obj/structure/railing/corner,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "aLD" = (
@@ -3084,11 +3116,9 @@
 /turf/open/floor/plasteel/white,
 /area/security/brig)
 "aMs" = (
-/obj/structure/chair{
-	dir = 8
-	},
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/plating,
-/area/maintenance/aft/secondary)
+/area/maintenance/aft)
 "aMu" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -3131,7 +3161,7 @@
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/soda_cans/cola,
 /turf/open/floor/carpet,
-/area/hallway/primary/aft)
+/area/hallway/primary/fore)
 "aNe" = (
 /obj/structure/closet/secure_closet/genpop,
 /obj/item/radio/headset{
@@ -3157,7 +3187,7 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard/fore)
 "aNg" = (
 /obj/machinery/light,
 /turf/open/floor/plating/asteroid/snow/icemoon,
@@ -3203,7 +3233,7 @@
 "aNo" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
-/area/hallway/secondary/entry)
+/area/hallway/primary/port/aft)
 "aNr" = (
 /obj/structure/chair/office/dark{
 	dir = 4
@@ -3286,7 +3316,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
-/area/hallway/secondary/entry)
+/area/hallway/primary/port/aft)
 "aOp" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -3367,7 +3397,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
+/area/hallway/primary/port)
 "aPA" = (
 /turf/closed/wall/r_wall,
 /area/security/checkpoint/medical)
@@ -3454,7 +3484,7 @@
 	dir = 1
 	},
 /turf/open/floor/grass,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard)
 "aQs" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -3548,7 +3578,7 @@
 "aSk" = (
 /obj/machinery/biogenerator,
 /turf/open/floor/plasteel/dark,
-/area/chapel/main)
+/area/hydroponics/garden/monastery)
 "aSl" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -3565,14 +3595,12 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
 "aSE" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "aSI" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -3585,7 +3613,7 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
+/area/hallway/primary/port)
 "aTc" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -3685,6 +3713,12 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
+"aVw" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/aft)
 "aVC" = (
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 8;
@@ -3718,7 +3752,7 @@
 	location = "Stbd"
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "aWO" = (
 /obj/item/kirbyplants/random,
 /obj/structure/window/reinforced{
@@ -3750,6 +3784,12 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "aYe" = (
@@ -3778,7 +3818,7 @@
 	dir = 6
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/port)
+/area/hallway/primary/port/fore)
 "aYB" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
@@ -3882,9 +3922,11 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "bcl" = (
-/obj/structure/closet/crate/bin,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4
+	},
 /turf/open/floor/plating,
-/area/hallway/primary/port)
+/area/maintenance/disposal)
 "bcq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -3901,14 +3943,14 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
@@ -3918,12 +3960,12 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
-/area/chapel/main)
+/area/chapel/main/monastery)
 "bcA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard/fore)
 "bcK" = (
 /obj/structure/transit_tube/curved{
 	dir = 4
@@ -3954,7 +3996,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "bdM" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -3965,12 +4007,11 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "bei" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/obj/machinery/camera{
-	c_tag = "Atmospherics North West";
-	dir = 4
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -22
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark/side,
 /area/engine/atmos)
 "beo" = (
 /obj/structure/cable{
@@ -4010,8 +4051,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 9
 	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
 /turf/open/floor/plating,
-/area/hallway/primary/port)
+/area/maintenance/port/central)
 "bfg" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -4035,7 +4079,6 @@
 /turf/open/floor/plating,
 /area/quartermaster/storage)
 "bfB" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
@@ -4076,12 +4119,12 @@
 	pixel_x = 27
 	},
 /turf/open/floor/wood,
-/area/chapel/main)
+/area/chapel/dock)
 "bhC" = (
 /obj/effect/landmark/blobstart,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
-/area/maintenance/aft/secondary)
+/area/maintenance/aft)
 "bhX" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -4114,18 +4157,10 @@
 /turf/open/floor/plasteel/white/corner{
 	dir = 4
 	},
-/area/hallway/primary/port)
+/area/hallway/primary/port/fore)
 "bif" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/machinery/door/airlock/external{
-	name = "External Access";
-	req_access_txt = "13"
-	},
-/obj/structure/fans/tiny,
-/turf/open/floor/plating,
-/area/maintenance/aft/secondary)
+/turf/closed/wall,
+/area/hallway/secondary/service)
 "bii" = (
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
@@ -4180,21 +4215,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"bkz" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/door/airlock/external{
-	name = "External Access";
-	req_access_txt = "13"
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft/secondary)
 "bkI" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
@@ -4208,8 +4238,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
 	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
 /turf/open/floor/plating,
-/area/hallway/secondary/entry)
+/area/maintenance/port/aft)
 "blg" = (
 /obj/docking_port/stationary{
 	dir = 2;
@@ -4231,15 +4264,16 @@
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "blR" = (
-/obj/structure/grille,
+/obj/machinery/door/airlock/maintenance,
+/obj/structure/barricade/wooden/crude,
 /turf/open/floor/plating,
-/area/maintenance/aft/secondary)
+/area/maintenance/aft)
 "bmA" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Cryogenic Storage"
 	},
 /turf/open/floor/plasteel/dark,
-/area/hallway/secondary/exit/departure_lounge)
+/area/crew_quarters/cryopod)
 "bmP" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 4
@@ -4281,7 +4315,7 @@
 	req_access_txt = "22"
 	},
 /turf/open/floor/plasteel/dark,
-/area/chapel/main)
+/area/chapel/main/monastery)
 "bnw" = (
 /obj/structure/chair/wood/normal{
 	dir = 4
@@ -4325,7 +4359,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard/fore)
 "bpB" = (
 /obj/machinery/light{
 	dir = 4
@@ -4460,6 +4494,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "brB" = (
@@ -4565,7 +4602,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "bsL" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/neutral{
@@ -4574,10 +4611,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/white/corner{
 	dir = 8
 	},
-/area/hallway/secondary/entry)
+/area/hallway/primary/port)
 "bsU" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -4585,6 +4625,20 @@
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"btd" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/public/glass{
+	name = "Aft Primary Hallway"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1;
+	name = "north facing firelock"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "btf" = (
 /obj/structure/cable,
 /obj/machinery/power/apc{
@@ -4626,7 +4680,7 @@
 "buj" = (
 /obj/structure/grille/broken,
 /turf/open/floor/plating,
-/area/hallway/primary/port)
+/area/maintenance/port/central)
 "bum" = (
 /turf/open/openspace/icemoon,
 /area/icemoon/surface/outdoors)
@@ -4666,9 +4720,7 @@
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors)
 "buO" = (
-/obj/machinery/computer/shuttle/snow_taxi{
-	dir = 8
-	},
+/obj/machinery/computer/shuttle/snow_taxi,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "buX" = (
@@ -4696,16 +4748,17 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/white/corner{
 	dir = 8
 	},
-/area/hallway/secondary/entry)
+/area/hallway/primary/port)
 "bvq" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/miningdock)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/hallway/secondary/service)
 "bvw" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1;
@@ -4780,7 +4833,7 @@
 	},
 /obj/item/kirbyplants/random,
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "bwt" = (
 /turf/closed/wall/r_wall,
 /area/security/courtroom)
@@ -4875,7 +4928,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "bxh" = (
 /obj/machinery/camera{
 	c_tag = "AI Chamber - Starboard";
@@ -4890,7 +4943,7 @@
 "bxk" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/hallway/secondary/entry)
+/area/hallway/primary/port)
 "bxG" = (
 /obj/machinery/firealarm{
 	pixel_y = 29
@@ -4956,7 +5009,9 @@
 "byu" = (
 /obj/machinery/computer/arcade,
 /turf/open/floor/carpet/eighties,
-/area/crew_quarters/fitness)
+/area/crew_quarters/fitness/recreation{
+	name = "Arcade Room"
+	})
 "byI" = (
 /obj/machinery/camera{
 	dir = 8
@@ -4966,7 +5021,9 @@
 	},
 /obj/machinery/vending/cola/random,
 /turf/open/floor/carpet/eighties,
-/area/crew_quarters/fitness)
+/area/crew_quarters/fitness/recreation{
+	name = "Arcade Room"
+	})
 "byW" = (
 /obj/effect/turf_decal/arrows/red{
 	dir = 4
@@ -5617,8 +5674,11 @@
 /area/science/lab)
 "bCQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating,
-/area/hallway/secondary/entry)
+/area/maintenance/port/aft)
 "bCT" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -5638,7 +5698,7 @@
 	name = "north facing firelock"
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "bCW" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -5654,15 +5714,14 @@
 	name = "north facing firelock"
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "bCY" = (
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
-/obj/machinery/light/small,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
+	},
+/obj/item/radio/intercom{
+	name = "Station Intercom";
+	pixel_y = -32
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
@@ -5754,7 +5813,7 @@
 /obj/structure/flora/grass/jungle,
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/grass,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "bDR" = (
 /obj/structure/table/wood,
 /obj/item/instrument/trumpet,
@@ -5808,7 +5867,7 @@
 	name = "south facing firelock"
 	},
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard/fore)
 "bEe" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 5
@@ -6215,7 +6274,7 @@
 "bIq" = (
 /obj/structure/ladder,
 /turf/open/floor/plating,
-/area/maintenance/aft/secondary)
+/area/maintenance/aft)
 "bIF" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Chapel"
@@ -6228,7 +6287,7 @@
 	name = "east facing firelock"
 	},
 /turf/open/floor/plasteel/dark,
-/area/chapel/main)
+/area/chapel/main/monastery)
 "bIJ" = (
 /obj/structure/table,
 /obj/item/stack/sheet/plasteel{
@@ -6440,7 +6499,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "bJG" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -6470,7 +6529,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "bKo" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Courtroom"
@@ -6505,7 +6564,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/maintenance/central)
+/area/maintenance/department/security)
 "bKZ" = (
 /obj/structure/punching_bag,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
@@ -6587,7 +6646,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/maintenance/central)
+/area/maintenance/department/security)
 "bLS" = (
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/miningdock)
@@ -6692,7 +6751,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "bNF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -6786,6 +6845,12 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -31
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "bOT" = (
@@ -6812,7 +6877,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "bPc" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -6824,7 +6889,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "bPd" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -6835,7 +6900,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "bPk" = (
 /obj/machinery/airalarm{
 	pixel_y = 26
@@ -6851,15 +6916,14 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bPn" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/item/flashlight/lantern,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/maintenance/aft/secondary)
+/area/maintenance/aft)
 "bPq" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
-/area/maintenance/central)
+/area/maintenance/department/security)
 "bPu" = (
 /obj/structure/chair/stool,
 /turf/open/floor/plating/asteroid/snow/icemoon,
@@ -6874,7 +6938,7 @@
 	map_pad_link_id = "3"
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard)
 "bQg" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -6903,13 +6967,13 @@
 	pixel_y = 24
 	},
 /turf/open/floor/plating,
-/area/maintenance/central)
+/area/maintenance/department/security)
 "bQm" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
-/area/maintenance/central)
+/area/maintenance/department/security)
 "bQn" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -6921,7 +6985,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/maintenance/central)
+/area/maintenance/department/security)
 "bQs" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -6940,8 +7004,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plating,
-/area/hallway/secondary/entry)
+/area/maintenance/port/aft)
 "bQL" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
@@ -6954,7 +7021,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "bRy" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
@@ -7025,6 +7092,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
+"bSR" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "bTh" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -7040,7 +7113,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/port)
+/area/hallway/primary/port/fore)
 "bTC" = (
 /obj/structure/grille,
 /turf/open/floor/plating/asteroid/snow/icemoon,
@@ -7136,7 +7209,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "bUO" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -7222,7 +7295,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "bVZ" = (
 /obj/structure/bookcase/random/reference,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -7238,7 +7311,7 @@
 	pixel_y = -31
 	},
 /turf/open/floor/plasteel/dark,
-/area/chapel/main)
+/area/chapel/main/monastery)
 "bWM" = (
 /turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
@@ -7287,7 +7360,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard)
 "bXL" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
@@ -7310,7 +7383,7 @@
 /obj/structure/mopbucket,
 /obj/item/mop,
 /turf/open/floor/plating,
-/area/chapel/main)
+/area/chapel/dock)
 "bXU" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -7325,7 +7398,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "bXW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/wood,
@@ -7472,7 +7545,7 @@
 "cbQ" = (
 /obj/structure/loot_pile/maint,
 /turf/open/floor/plating,
-/area/maintenance/aft/secondary)
+/area/maintenance/aft)
 "cci" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 6
@@ -7563,7 +7636,7 @@
 	name = "west facing firelock"
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "cep" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -7581,7 +7654,7 @@
 /area/crew_quarters/heads/captain)
 "cer" = (
 /turf/closed/wall/r_wall,
-/area/maintenance/central)
+/area/maintenance/department/security)
 "ces" = (
 /obj/machinery/light,
 /obj/item/radio/intercom{
@@ -7693,7 +7766,7 @@
 	dir = 5
 	},
 /turf/open/floor/plating,
-/area/maintenance/central)
+/area/maintenance/department/security)
 "cgp" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -7706,9 +7779,17 @@
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
 "cgB" = (
-/obj/structure/closet/firecloset/full,
-/turf/open/floor/plating,
-/area/maintenance/aft/secondary)
+/obj/structure/table,
+/obj/item/storage/bag/plants,
+/obj/item/reagent_containers/glass/beaker/waterbottle/wataur,
+/obj/machinery/airalarm{
+	pixel_y = 25
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/service)
 "cgH" = (
 /obj/structure/disposalpipe/junction/flip{
 	dir = 4
@@ -7721,7 +7802,7 @@
 	pixel_x = 32
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "cgY" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -7732,7 +7813,7 @@
 /obj/effect/turf_decal/tile/blue,
 /obj/item/kirbyplants/random,
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "cgZ" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -7743,7 +7824,7 @@
 	},
 /obj/item/kirbyplants/random,
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "cha" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/mix_output,
 /turf/open/floor/engine/airless,
@@ -7779,7 +7860,7 @@
 "chA" = (
 /obj/structure/loot_pile/maint,
 /turf/open/floor/plating,
-/area/maintenance/central)
+/area/maintenance/department/security)
 "chN" = (
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/dorms)
@@ -7793,7 +7874,7 @@
 	},
 /obj/machinery/disposal/bin,
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "cio" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -7827,7 +7908,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/maintenance/central)
+/area/maintenance/department/security)
 "ciA" = (
 /obj/structure/railing{
 	dir = 1
@@ -7842,7 +7923,7 @@
 	pixel_y = -22
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "ciG" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/mix_input,
 /turf/open/floor/engine/airless,
@@ -7861,12 +7942,8 @@
 /turf/open/floor/wood,
 /area/security/courtroom)
 "cjt" = (
-/obj/item/clothing/head/ushanka,
-/obj/effect/decal/remains/human,
-/turf/open/floor/wood{
-	icon_state = "wood-broken5"
-	},
-/area/hallway/primary/port)
+/turf/open/floor/plasteel,
+/area/hallway/secondary/service)
 "cjE" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -7925,7 +8002,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard)
 "cjS" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -8067,7 +8144,7 @@
 /obj/machinery/atmospherics/pipe/simple/multiz,
 /obj/effect/turf_decal/stripes/box,
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard/fore)
 "clq" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -8138,7 +8215,7 @@
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
-/area/hallway/primary/aft)
+/area/maintenance/starboard/fore)
 "cmU" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -8192,11 +8269,12 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hop)
 "cnB" = (
-/obj/structure/light_construct{
-	dir = 8
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
 	},
-/turf/open/floor/plating,
-/area/maintenance/aft/secondary)
+/turf/open/floor/plasteel,
+/area/hallway/secondary/service)
 "cnI" = (
 /obj/docking_port/stationary{
 	dheight = 1;
@@ -8275,7 +8353,7 @@
 	dir = 9
 	},
 /turf/open/floor/plating,
-/area/maintenance/aft/secondary)
+/area/maintenance/aft)
 "cpC" = (
 /obj/effect/turf_decal/arrows/red,
 /turf/open/floor/plasteel,
@@ -8353,9 +8431,6 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 1;
 	name = "north facing firelock"
@@ -8384,14 +8459,14 @@
 	sortType = 15
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "cqM" = (
 /obj/machinery/atmospherics/pipe/simple/multiz{
 	piping_layer = 3
 	},
 /obj/effect/turf_decal/stripes/box,
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard/fore)
 "crg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
@@ -8399,14 +8474,14 @@
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
-/area/hallway/primary/aft)
+/area/maintenance/starboard/fore)
 "crr" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plating,
-/area/chapel/main)
+/area/chapel/dock)
 "crw" = (
 /obj/structure/closet/secure_closet{
 	name = "contraband locker";
@@ -8480,12 +8555,12 @@
 	dir = 9
 	},
 /turf/open/floor/plating,
-/area/maintenance/aft/secondary)
+/area/maintenance/aft)
 "ctW" = (
 /obj/structure/table/wood,
 /obj/item/storage/photo_album,
 /turf/open/floor/plasteel/grimy,
-/area/chapel/main)
+/area/chapel/main/monastery)
 "cux" = (
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
@@ -8504,7 +8579,7 @@
 	name = "south facing firelock"
 	},
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard/fore)
 "cuL" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -8517,7 +8592,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard)
 "cuX" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -8546,7 +8621,7 @@
 /obj/structure/fans/tiny,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard/aft)
 "cvB" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -8629,6 +8704,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
+"cwU" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Blueshield's Office Maintenance";
+	req_access_txt = "71"
+	},
+/turf/open/floor/plating,
+/area/blueshield)
 "cwV" = (
 /obj/structure/chair{
 	dir = 1
@@ -8646,6 +8728,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"cxe" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/maintenance/port/central)
 "cxX" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -8781,12 +8867,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"czu" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "czA" = (
 /obj/structure/sign/directions/engineering{
 	pixel_x = 32;
@@ -8799,7 +8879,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard)
 "czF" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -8956,16 +9036,7 @@
 /turf/open/floor/wood,
 /area/library)
 "cCv" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/maintenance/disposal)
-"cCA" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "cCT" = (
@@ -9101,7 +9172,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/hallway/secondary/exit/departure_lounge)
+/area/crew_quarters/cryopod)
 "cFP" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -9112,7 +9183,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard)
 "cGu" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 5
@@ -9144,7 +9215,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "cHu" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -9183,7 +9254,7 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/structure/closet/crate,
 /turf/open/floor/plating,
-/area/maintenance/central)
+/area/maintenance/department/security)
 "cIP" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -9239,7 +9310,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "cKe" = (
 /obj/structure/cable,
 /obj/machinery/power/smes,
@@ -9266,7 +9337,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard)
 "cKD" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -9305,7 +9376,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "cLC" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -9319,6 +9390,7 @@
 /obj/machinery/autolathe/secure{
 	name = "public autolathe"
 	},
+/obj/structure/railing/corner,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "cLD" = (
@@ -9463,8 +9535,11 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
 /turf/open/floor/carpet,
-/area/chapel/main)
+/area/chapel/main/monastery)
 "cPI" = (
 /obj/structure/disposalpipe/junction/flip{
 	dir = 8
@@ -9488,7 +9563,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
+/area/hallway/primary/port)
 "cQa" = (
 /obj/machinery/quantumpad{
 	map_pad_id = "6";
@@ -9508,16 +9583,30 @@
 /area/engine/atmos)
 "cQl" = (
 /obj/structure/railing/corner,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plating,
-/area/hallway/secondary/entry)
+/area/maintenance/port/aft)
 "cQm" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/medical/chemistry)
+"cQo" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "cQp" = (
-/obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/structure/railing/corner{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "cQr" = (
@@ -9542,6 +9631,10 @@
 	},
 /obj/item/multitool,
 /obj/item/clothing/glasses/welding,
+/obj/machinery/camera{
+	c_tag = "Atmospherics North West";
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "cQv" = (
@@ -9562,13 +9655,13 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/maintenance/starboard)
+/area/quartermaster/sorting)
 "cQU" = (
 /obj/structure/sink{
 	pixel_y = 20
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "cRa" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Custodial Maintenance";
@@ -9698,7 +9791,7 @@
 	},
 /obj/machinery/disposal/bin,
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "cSC" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
@@ -9742,8 +9835,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
@@ -9782,7 +9878,7 @@
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "cTQ" = (
 /obj/structure/railing{
 	dir = 1
@@ -9799,7 +9895,7 @@
 	name = "north facing firelock"
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "cUd" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
@@ -9808,7 +9904,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard/fore)
 "cUm" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Starboard Quarter Solar Access";
@@ -9824,7 +9920,7 @@
 /area/mine/living_quarters)
 "cUP" = (
 /turf/closed/wall/r_wall,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard/fore)
 "cUS" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/ladder,
@@ -9836,7 +9932,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard/fore)
 "cVc" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Garden"
@@ -9859,7 +9955,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "cVL" = (
 /obj/machinery/light,
 /turf/open/floor/plating/asteroid/snow/icemoon,
@@ -9901,7 +9997,7 @@
 /obj/structure/table,
 /obj/item/reagent_containers/glass/beaker/waterbottle/wataur,
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "cXi" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -10057,7 +10153,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "cZq" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
@@ -10137,6 +10233,10 @@
 /obj/item/assembly/signaler,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"daG" = (
+/obj/item/clothing/head/cone,
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "daH" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -10254,7 +10354,7 @@
 	},
 /obj/machinery/disposal/bin,
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "ddA" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -10267,7 +10367,7 @@
 	},
 /obj/item/kirbyplants/photosynthetic,
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "dfa" = (
 /obj/structure/table/glass,
 /obj/item/stack/sheet/metal/fifty,
@@ -10368,9 +10468,13 @@
 /turf/open/floor/plasteel/freezer,
 /area/medical/surgery)
 "dgi" = (
-/obj/structure/barricade/wooden,
-/turf/open/floor/plating,
-/area/maintenance/aft/secondary)
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/service)
 "dgo" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -10378,10 +10482,13 @@
 /obj/structure/fans/tiny,
 /obj/machinery/door/airlock/external,
 /turf/open/floor/plating,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "dhg" = (
 /turf/closed/wall,
 /area/construction/storage)
+"dhs" = (
+/turf/closed/wall,
+/area/crew_quarters/cryopod)
 "dhX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -10390,7 +10497,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "dij" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-10"
@@ -10449,7 +10556,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard/aft)
 "dkD" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
@@ -10612,8 +10719,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 6
 	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
 /turf/open/floor/plasteel/dark,
-/area/hallway/secondary/exit/departure_lounge)
+/area/crew_quarters/cryopod)
 "dns" = (
 /obj/docking_port/stationary{
 	dwidth = 3;
@@ -10632,7 +10742,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard/fore)
 "dot" = (
 /obj/machinery/button/door{
 	id = "PoolShut";
@@ -10662,15 +10772,8 @@
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
 "doP" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/machinery/door/airlock/external{
-	name = "External Access";
-	req_access_txt = "13"
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft/secondary)
+/turf/closed/wall,
+/area/maintenance/aft)
 "doV" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -10683,7 +10786,7 @@
 "dpp" = (
 /obj/machinery/rnd/production/techfab/department/service,
 /turf/open/floor/plasteel,
-/area/maintenance/disposal)
+/area/hallway/secondary/service)
 "dpS" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -10750,6 +10853,9 @@
 "dri" = (
 /turf/closed/indestructible/rock/glacierrock/blue,
 /area/engine/secure_construction)
+"drq" = (
+/turf/open/floor/plasteel/stairs,
+/area/maintenance/aft)
 "drK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -10757,8 +10863,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/dark,
-/area/hallway/secondary/exit/departure_lounge)
+/area/crew_quarters/cryopod)
 "dsi" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -10854,7 +10963,7 @@
 	name = "north facing firelock"
 	},
 /turf/open/floor/plasteel/dark,
-/area/chapel/main)
+/area/chapel/main/monastery)
 "dtQ" = (
 /obj/structure/chair/comfy/black,
 /obj/structure/window/reinforced{
@@ -10863,6 +10972,13 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/carpet,
 /area/hallway/secondary/exit/departure_lounge)
+"dui" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/stairs/medium,
+/area/hallway/primary/port)
 "duu" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -11083,13 +11199,20 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "dyb" = (
 /obj/structure/chair/sofa/left{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"dyM" = (
+/obj/machinery/power/apc/auto_name/south,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "dyW" = (
 /obj/machinery/light{
 	dir = 8
@@ -11121,7 +11244,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard/fore)
 "dzq" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-08"
@@ -11133,12 +11256,12 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "dzF" = (
 /obj/machinery/hydroponics/soil,
 /obj/item/seeds/carrot,
 /turf/open/floor/grass,
-/area/chapel/main)
+/area/hydroponics/garden/monastery)
 "dzS" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/navbeacon{
@@ -11148,13 +11271,17 @@
 	location = "QM #4"
 	},
 /turf/open/floor/pod/dark,
-/area/maintenance/starboard)
+/area/quartermaster/sorting)
 "dAi" = (
 /obj/structure/sign/warning/pods{
 	pixel_x = -32
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
+	},
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
 "dAM" = (
@@ -11174,6 +11301,15 @@
 "dAV" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
+"dBC" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "dBL" = (
 /obj/structure/closet/secure_closet/medical1,
 /obj/structure/extinguisher_cabinet{
@@ -11206,7 +11342,7 @@
 /turf/open/floor/plating{
 	icon_state = "platingdmg2"
 	},
-/area/maintenance/central)
+/area/maintenance/department/security)
 "dCs" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -11244,7 +11380,7 @@
 	},
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
-/area/maintenance/aft/secondary)
+/area/maintenance/aft)
 "dDs" = (
 /obj/structure/railing{
 	dir = 4
@@ -11252,7 +11388,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel/stairs/right,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard/fore)
 "dDv" = (
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plasteel/cult,
@@ -11262,7 +11398,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/hallway/primary/fore)
+/area/maintenance/starboard/aft)
 "dDC" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -11353,7 +11489,7 @@
 /obj/item/storage/box,
 /obj/item/storage/toolbox/emergency,
 /turf/open/floor/plating,
-/area/maintenance/aft/secondary)
+/area/maintenance/aft)
 "dFt" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -11447,7 +11583,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard/fore)
 "dHP" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -11589,13 +11725,7 @@
 /area/security/checkpoint/supply)
 "dNf" = (
 /turf/open/floor/wood,
-/area/chapel/main)
-"dNo" = (
-/obj/machinery/airalarm{
-	pixel_y = 26
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/chapel/dock)
 "dNB" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -11616,7 +11746,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "dOP" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/purple{
@@ -11643,7 +11773,7 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
-/area/hallway/secondary/entry)
+/area/hallway/primary/port/aft)
 "dPL" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -11681,6 +11811,15 @@
 "dQz" = (
 /turf/closed/wall,
 /area/storage/eva)
+"dQF" = (
+/obj/machinery/power/apc/auto_name/north,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/port/central)
 "dQW" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 10
@@ -11692,7 +11831,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/chapel/main)
+/area/chapel/dock)
 "dSb" = (
 /obj/machinery/light{
 	dir = 4
@@ -11700,7 +11839,7 @@
 /turf/open/floor/plasteel/median/darktogrime{
 	dir = 8
 	},
-/area/chapel/main)
+/area/chapel/main/monastery)
 "dSp" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -11731,8 +11870,11 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "dSQ" = (
-/turf/closed/wall,
-/area/maintenance/starboard)
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "dTm" = (
 /obj/structure/sign/poster/official/random{
 	pixel_y = -32
@@ -11749,8 +11891,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/dark,
-/area/hallway/secondary/exit/departure_lounge)
+/area/crew_quarters/cryopod)
 "dTy" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/solars/starboard/fore)
@@ -11885,8 +12030,11 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating,
-/area/janitor)
+/area/maintenance/starboard/central)
 "dWF" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/wood,
@@ -11962,6 +12110,13 @@
 /obj/machinery/computer/scan_consolenew,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
+"dYb" = (
+/obj/machinery/light/small{
+	dir = 1;
+	light_color = "#ffc1c1"
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "dYl" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -12019,12 +12174,17 @@
 /obj/structure/mirror{
 	pixel_x = -28
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
+	},
 /turf/open/floor/plasteel/freezer,
-/area/crew_quarters/dorms)
+/area/crew_quarters/toilet)
 "eai" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plating,
-/area/maintenance/disposal)
+/obj/machinery/atmospherics/pipe/simple/supply/visible{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "eaX" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -12121,7 +12281,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard/fore)
 "edH" = (
 /obj/machinery/holopad,
 /turf/open/floor/wood,
@@ -12142,7 +12302,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "eed" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -12180,15 +12340,6 @@
 /obj/machinery/atmospherics/pipe/simple/dark/visible,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
-"eex" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plating,
-/area/hallway/primary/port)
 "eeE" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -12210,7 +12361,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "eeM" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4;
@@ -12298,14 +12449,14 @@
 "ego" = (
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard/fore)
 "egJ" = (
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 1;
 	sortType = 26
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "egM" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -12318,7 +12469,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "ehh" = (
 /obj/effect/spawner/lootdrop/bedsheet,
 /obj/structure/bed,
@@ -12329,7 +12480,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "ehL" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -12344,7 +12495,7 @@
 	name = "south facing firelock"
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "ehX" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/closed/wall/r_wall,
@@ -12401,7 +12552,7 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "eiL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -12535,6 +12686,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "eoT" = (
@@ -12567,6 +12721,9 @@
 /obj/structure/sign/poster/random{
 	pixel_y = 32
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plating,
 /area/maintenance/aft/secondary)
 "epK" = (
@@ -12581,7 +12738,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/chapel/main)
+/area/hydroponics/garden/monastery)
 "epU" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
@@ -12613,7 +12770,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard)
 "erc" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -12631,18 +12788,25 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "eri" = (
-/obj/structure/closet/crate,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
+/obj/structure/closet/emcloset,
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"erl" = (
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/area/maintenance/aft/secondary)
+/turf/open/floor/plasteel/stairs/right{
+	dir = 4
+	},
+/area/maintenance/aft)
 "ero" = (
 /obj/machinery/computer/arcade{
 	dir = 8
 	},
 /turf/open/floor/carpet/eighties,
-/area/crew_quarters/fitness)
+/area/crew_quarters/fitness/recreation{
+	name = "Arcade Room"
+	})
 "erx" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/dark,
@@ -12667,21 +12831,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
-"erG" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "erL" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -12691,7 +12840,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard)
 "esi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -12770,10 +12919,8 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "etQ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/barricade/wooden/crude,
-/turf/open/floor/plating,
-/area/maintenance/aft/secondary)
+/turf/closed/wall,
+/area/hallway/primary/fore)
 "etV" = (
 /obj/structure/plasticflaps/opaque,
 /obj/machinery/navbeacon{
@@ -12794,12 +12941,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
-"eue" = (
-/obj/machinery/atm{
-	pixel_y = 28
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "eus" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
@@ -12820,7 +12961,7 @@
 "euz" = (
 /obj/structure/closet/wardrobe/mixed,
 /turf/open/floor/plating,
-/area/hallway/primary/fore)
+/area/maintenance/starboard/aft)
 "euQ" = (
 /obj/machinery/light{
 	dir = 4
@@ -12850,13 +12991,13 @@
 /turf/open/floor/plasteel/white/corner{
 	dir = 8
 	},
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "euY" = (
 /obj/machinery/camera{
 	c_tag = "Northwestern Hall 10"
 	},
 /turf/open/floor/plasteel/dark,
-/area/hallway/primary/port)
+/area/hallway/primary/port/fore)
 "evb" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Cleaning Closet"
@@ -12885,11 +13026,8 @@
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "evO" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /turf/open/floor/plating,
-/area/maintenance/disposal)
+/area/hallway/primary/starboard)
 "evU" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -12926,8 +13064,11 @@
 /turf/open/floor/wood,
 /area/hallway/primary/central)
 "exi" = (
+/obj/machinery/atm{
+	pixel_y = 28
+	},
 /turf/open/floor/plasteel,
-/area/maintenance/starboard)
+/area/hallway/primary/starboard)
 "exq" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -12950,17 +13091,13 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "exE" = (
-/obj/structure/closet/crate/wooden,
-/obj/item/storage/box/lights/mixed,
-/obj/item/stack/sheet/mineral/wood/twenty,
-/obj/item/circuitboard/machine/chem_dispenser/drinks,
-/obj/item/circuitboard/machine/chem_dispenser/drinks/beer,
-/obj/item/stock_parts/cell/high/plus,
-/obj/item/stock_parts/cell/high/plus,
-/obj/item/storage/toolbox/mechanical/old,
-/obj/item/electronics/airlock,
-/turf/open/floor/plating,
-/area/maintenance/aft/secondary)
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "eya" = (
 /obj/structure/rack,
 /obj/item/tank/internals/plasmaman/belt,
@@ -13118,7 +13255,7 @@
 	dir = 4
 	},
 /turf/open/floor/grass,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "eBq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
@@ -13187,8 +13324,11 @@
 /area/maintenance/port/fore)
 "eEa" = (
 /obj/machinery/light,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/freezer,
-/area/crew_quarters/dorms)
+/area/crew_quarters/toilet)
 "eEe" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/machinery/airalarm{
@@ -13373,7 +13513,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard/fore)
 "eGJ" = (
 /obj/effect/landmark/start/mime,
 /turf/open/floor/wood,
@@ -13384,6 +13524,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/wood,
 /area/hallway/secondary/exit/departure_lounge)
@@ -13407,6 +13550,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/science/lab)
+"eGY" = (
+/obj/structure/reagent_dispensers/fueltank,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/aft)
 "eHa" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/plasteel/dark,
@@ -13475,7 +13625,13 @@
 "eJa" = (
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
-/area/chapel/main)
+/area/chapel/main/monastery)
+"eJg" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel/dark,
+/area/hydroponics/garden/monastery)
 "eJp" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -13516,7 +13672,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard/fore)
 "eKe" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/brigdoor{
@@ -13552,7 +13708,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
-/area/hallway/primary/port)
+/area/maintenance/port/central)
 "eKy" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -13624,15 +13780,12 @@
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
 "eLp" = (
-/obj/machinery/button/door{
-	id = "bardorm2";
-	name = "Dorm Bolt Control";
-	normaldoorcontrol = 1;
-	pixel_x = 25;
-	specialfunctions = 4
+/obj/machinery/atmospherics/pipe/simple/multiz{
+	piping_layer = 3
 	},
-/turf/open/floor/plating,
-/area/maintenance/aft/secondary)
+/obj/effect/turf_decal/stripes/box,
+/turf/open/floor/plasteel/elevatorshaft,
+/area/engine/atmos)
 "eLy" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -13644,8 +13797,14 @@
 /obj/structure/railing/corner{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard/fore)
 "eLQ" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
@@ -13693,7 +13852,7 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "eMQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 6
@@ -13707,17 +13866,21 @@
 "eNc" = (
 /obj/effect/spawner/structure/window/ice,
 /turf/open/floor/plating,
-/area/chapel/main)
+/area/chapel/main/monastery)
 "eNu" = (
-/obj/docking_port/stationary{
-	dwidth = 3;
-	height = 4;
-	id = "snaxi_nw";
-	name = "Northwest Taxi Port";
-	width = 6
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/surface/outdoors)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "eNG" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -13732,6 +13895,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/wood,
 /area/hallway/secondary/exit/departure_lounge)
 "eNK" = (
@@ -13743,7 +13909,7 @@
 "eOd" = (
 /obj/structure/closet/wardrobe/green,
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "eOn" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -13756,6 +13922,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/wood,
 /area/hallway/secondary/exit/departure_lounge)
@@ -13883,7 +14052,7 @@
 /turf/open/floor/plasteel/median/darktogrime{
 	dir = 4
 	},
-/area/chapel/main)
+/area/chapel/main/monastery)
 "eSq" = (
 /obj/machinery/hydroponics/constructable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -14103,7 +14272,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/hallway/secondary/exit/departure_lounge)
+/area/crew_quarters/cryopod)
 "eWw" = (
 /obj/machinery/door/airlock/external{
 	name = "Solar Maintenance";
@@ -14137,12 +14306,16 @@
 /obj/machinery/hydroponics/soil,
 /obj/item/seeds/poppy,
 /turf/open/floor/grass,
-/area/chapel/main)
+/area/hydroponics/garden/monastery)
 "eXT" = (
-/turf/open/floor/wood{
-	icon_state = "wood-broken6"
+/obj/machinery/atmospherics/pipe/simple/dark/visible{
+	dir = 4
 	},
-/area/maintenance/aft/secondary)
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
+/area/engine/atmos)
 "eXZ" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -14157,9 +14330,11 @@
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "eYe" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plating,
-/area/maintenance/disposal)
+/obj/structure/chair/comfy/brown{
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/hallway/primary/starboard)
 "eYq" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel,
@@ -14175,7 +14350,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "eZe" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -14192,7 +14367,7 @@
 "eZi" = (
 /obj/structure/table,
 /turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
+/area/hallway/primary/port)
 "eZj" = (
 /obj/machinery/biogenerator,
 /obj/structure/cable{
@@ -14238,6 +14413,18 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"faF" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/door/airlock/public/glass{
+	name = "Aft Primary Hallway"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1;
+	name = "north facing firelock"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "faJ" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -14292,7 +14479,7 @@
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/grass,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "fcj" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -14332,7 +14519,7 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
-/area/hallway/secondary/exit/departure_lounge)
+/area/crew_quarters/cryopod)
 "fcJ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel/dark,
@@ -14340,7 +14527,7 @@
 "fcU" = (
 /obj/machinery/vending/kink,
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "fdu" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -14401,7 +14588,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/closet/firecloset,
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/fore)
 "ffA" = (
 /obj/effect/landmark/blobstart,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
@@ -14474,7 +14661,7 @@
 "fgV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall,
-/area/chapel/main)
+/area/chapel/dock)
 "fhf" = (
 /obj/machinery/door/poddoor/incinerator_atmos_aux,
 /turf/open/floor/engine/vacuum,
@@ -14547,7 +14734,7 @@
 /obj/structure/table,
 /obj/item/circuitboard/computer/operating,
 /turf/open/floor/plating,
-/area/hallway/primary/fore)
+/area/maintenance/starboard/aft)
 "fhK" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "Skynet_launch";
@@ -14595,7 +14782,7 @@
 /turf/open/floor/plasteel/chapel{
 	dir = 4
 	},
-/area/chapel/main)
+/area/chapel/main/monastery)
 "fiG" = (
 /obj/structure/filingcabinet,
 /turf/open/floor/plasteel/grimy,
@@ -14627,9 +14814,9 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "fjW" = (
-/obj/item/lighter/gold,
-/turf/open/floor/plating/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors)
+/obj/structure/railing/corner,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "fkr" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
@@ -14728,7 +14915,7 @@
 	},
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/floor/grass,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard)
 "fmw" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
@@ -14796,7 +14983,7 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/item/storage/toolbox/emergency,
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "fnQ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
@@ -14844,7 +15031,7 @@
 /turf/open/floor/plasteel/chapel{
 	dir = 8
 	},
-/area/chapel/main)
+/area/chapel/main/monastery)
 "foJ" = (
 /obj/structure/table/wood/fancy,
 /obj/machinery/computer/libraryconsole/bookmanagement,
@@ -14898,7 +15085,7 @@
 	dir = 8
 	},
 /turf/open/floor/pod/dark,
-/area/maintenance/starboard)
+/area/quartermaster/sorting)
 "fqj" = (
 /obj/structure/railing{
 	dir = 4
@@ -14906,7 +15093,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/stairs/right,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard)
 "fqE" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -15011,7 +15198,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "fsH" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 5
@@ -15058,8 +15245,11 @@
 /area/engine/engineering)
 "ftV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard/fore)
 "fuj" = (
 /obj/structure/closet/crate/hydroponics,
 /obj/item/wirecutters,
@@ -15178,7 +15368,7 @@
 /turf/open/floor/plasteel/median/darktogrime/corner{
 	dir = 4
 	},
-/area/chapel/main)
+/area/chapel/main/monastery)
 "fvp" = (
 /obj/machinery/conveyor_switch/oneway{
 	dir = 4;
@@ -15236,18 +15426,11 @@
 /turf/open/floor/engine/plasma,
 /area/engine/atmos)
 "fyr" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/east,
 /turf/open/floor/plating,
-/area/janitor)
-"fyz" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/maintenance/starboard/central)
 "fyV" = (
 /obj/machinery/door/firedoor/border_only{
 	name = "south facing firelock"
@@ -15336,8 +15519,11 @@
 /area/medical/genetics)
 "fBg" = (
 /obj/machinery/light/small,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plating,
-/area/hallway/primary/fore)
+/area/maintenance/starboard/aft)
 "fBk" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
 	dir = 8
@@ -15350,12 +15536,15 @@
 	c_tag = "Bathrooms";
 	dir = 1
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/freezer,
-/area/crew_quarters/dorms)
+/area/crew_quarters/toilet)
 "fBv" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/plasteel/grimy,
-/area/chapel/main)
+/area/chapel/main/monastery)
 "fBG" = (
 /obj/structure/grille/broken,
 /turf/open/floor/plating/asteroid/snow/icemoon,
@@ -15382,7 +15571,7 @@
 	icon_state = "2-4"
 	},
 /turf/open/floor/plating,
-/area/chapel/main)
+/area/chapel/dock)
 "fCQ" = (
 /obj/structure/toilet/secret/low_loot{
 	pixel_y = 14
@@ -15400,7 +15589,7 @@
 	},
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plasteel/freezer,
-/area/crew_quarters/dorms)
+/area/crew_quarters/toilet)
 "fDi" = (
 /turf/closed/wall,
 /area/medical/psych)
@@ -15408,7 +15597,7 @@
 /obj/structure/reagent_dispensers/watertank,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
-/area/maintenance/aft/secondary)
+/area/maintenance/aft)
 "fDl" = (
 /obj/structure/bodycontainer/morgue{
 	dir = 8
@@ -15455,6 +15644,7 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
+/obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "fFG" = (
@@ -15525,7 +15715,7 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/structure/closet/crate,
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard/fore)
 "fHa" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -15551,9 +15741,10 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "fHK" = (
-/obj/machinery/vending/boozeomat,
 /turf/closed/wall,
-/area/maintenance/aft/secondary)
+/area/crew_quarters/fitness/recreation{
+	name = "Arcade Room"
+	})
 "fIn" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 1
@@ -15561,6 +15752,17 @@
 /obj/machinery/meter,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
+"fIs" = (
+/obj/structure/rack,
+/obj/item/radio,
+/obj/structure/sign/warning/electricshock{
+	pixel_x = 32
+	},
+/obj/item/clothing/suit/hooded/wintercoat,
+/obj/item/pickaxe,
+/obj/item/clothing/shoes/winterboots/ice_boots,
+/turf/open/floor/plasteel,
+/area/maintenance/aft)
 "fIu" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -15581,7 +15783,7 @@
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/grass,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "fIS" = (
 /obj/structure/table,
 /obj/machinery/chem_dispenser/drinks/beer{
@@ -15627,7 +15829,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard)
 "fJg" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/machinery/meter,
@@ -15760,7 +15962,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard/fore)
 "fLK" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -15878,6 +16080,9 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -31
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "fOC" = (
@@ -15907,7 +16112,7 @@
 	pixel_y = 25
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "fPp" = (
 /obj/machinery/light{
 	dir = 8
@@ -15931,8 +16136,17 @@
 	dir = 8;
 	name = "west facing firelock"
 	},
-/turf/open/floor/plating,
-/area/crew_quarters/dorms)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/freezer,
+/area/crew_quarters/toilet)
 "fPN" = (
 /obj/structure/table/wood,
 /obj/item/book/manual/wiki/security_space_law,
@@ -15946,7 +16160,7 @@
 /obj/machinery/hydroponics/soil,
 /obj/item/seeds/watermelon/holy,
 /turf/open/floor/grass,
-/area/chapel/main)
+/area/hydroponics/garden/monastery)
 "fQe" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Auxiliary Tool Storage";
@@ -15969,7 +16183,7 @@
 /obj/structure/bed,
 /obj/machinery/iv_drip,
 /turf/open/floor/plating,
-/area/hallway/primary/fore)
+/area/maintenance/starboard/aft)
 "fQx" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -15979,11 +16193,16 @@
 /turf/open/floor/plasteel/dark,
 /area/teleporter)
 "fQz" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/visible,
+/obj/structure/railing{
+	dir = 8
 	},
-/turf/open/floor/plating,
-/area/maintenance/aft/secondary)
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "fQI" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -15992,7 +16211,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard)
 "fQM" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -16020,7 +16239,9 @@
 	name = "Arcade"
 	},
 /turf/open/floor/carpet/eighties,
-/area/crew_quarters/fitness)
+/area/crew_quarters/fitness/recreation{
+	name = "Arcade Room"
+	})
 "fRI" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -16031,10 +16252,11 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "fRK" = (
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/area/maintenance/aft/secondary)
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "fRQ" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
@@ -16062,6 +16284,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8;
+	name = "west facing firelock"
 	},
 /turf/open/floor/plasteel,
 /area/security/vacantoffice/b)
@@ -16113,7 +16339,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard/fore)
 "fTy" = (
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
@@ -16295,10 +16521,14 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc/auto_name/north,
 /turf/open/floor/plasteel/white/corner{
 	dir = 4
 	},
-/area/hallway/primary/port)
+/area/hallway/primary/port/fore)
 "fYH" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 6
@@ -16352,7 +16582,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "gaf" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -16394,8 +16624,12 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard/fore)
 "gbg" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -16409,7 +16643,7 @@
 	},
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/plasteel/grimy,
-/area/chapel/main)
+/area/chapel/main/monastery)
 "gbN" = (
 /obj/structure/fence/corner{
 	dir = 5
@@ -16445,7 +16679,7 @@
 "gct" = (
 /obj/machinery/computer/shuttle/snow_taxi,
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard)
 "gcw" = (
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
@@ -16453,7 +16687,7 @@
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "gcS" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/stripes/line{
@@ -16517,7 +16751,7 @@
 "gdq" = (
 /obj/structure/ladder,
 /turf/open/floor/plating,
-/area/hallway/primary/port)
+/area/maintenance/port/central)
 "gdE" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -16539,7 +16773,7 @@
 /area/quartermaster/storage)
 "gdQ" = (
 /turf/open/floor/plating,
-/area/hallway/primary/port)
+/area/maintenance/port/central)
 "gel" = (
 /obj/machinery/atmospherics/components/trinary/filter/critical{
 	dir = 1
@@ -16567,7 +16801,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/maintenance/starboard)
+/area/quartermaster/sorting)
 "gfe" = (
 /obj/structure/table/wood,
 /obj/item/clothing/under/misc/burial,
@@ -16588,13 +16822,19 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "gfE" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/structure/railing{
+	dir = 8
 	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/disposal)
+"gfL" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/chapel/main/monastery)
 "gfN" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -16622,13 +16862,12 @@
 /obj/structure/chair{
 	dir = 4
 	},
-/obj/effect/landmark/start/assistant,
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_x = -28
 	},
 /turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
+/area/hallway/primary/port)
 "gga" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
@@ -16638,7 +16877,7 @@
 /area/maintenance/department/bridge)
 "ggg" = (
 /turf/open/floor/grass,
-/area/chapel/main)
+/area/hydroponics/garden/monastery)
 "ggl" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -16692,12 +16931,15 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard)
 "giD" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg2"
 	},
-/area/maintenance/aft/secondary)
+/area/maintenance/aft)
 "giT" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -16712,7 +16954,7 @@
 	dir = 6
 	},
 /turf/open/floor/plating,
-/area/maintenance/central)
+/area/maintenance/department/security)
 "giZ" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -16740,7 +16982,7 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard)
 "gjW" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/engine_waste{
 	dir = 8
@@ -16759,7 +17001,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard/fore)
 "gkt" = (
 /obj/machinery/light{
 	dir = 4
@@ -16821,7 +17063,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "glg" = (
 /obj/structure/closet/crate/solarpanel_small,
 /obj/effect/turf_decal/tile/yellow{
@@ -16844,7 +17086,7 @@
 /area/crew_quarters/fitness)
 "glJ" = (
 /turf/open/floor/carpet,
-/area/chapel/main)
+/area/chapel/main/monastery)
 "gmf" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet,
@@ -16892,11 +17134,11 @@
 	dir = 8
 	},
 /turf/open/floor/carpet,
-/area/hallway/primary/aft)
+/area/hallway/primary/fore)
 "gmU" = (
 /obj/structure/chair/stool,
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard/fore)
 "gmZ" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -16904,7 +17146,7 @@
 /obj/structure/fans/tiny,
 /obj/machinery/door/airlock/external,
 /turf/open/floor/plating,
-/area/chapel/main)
+/area/chapel/dock)
 "gnf" = (
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 8;
@@ -16950,17 +17192,18 @@
 /turf/open/floor/circuit,
 /area/science/robotics/mechbay)
 "gnS" = (
-/obj/structure/chair,
-/turf/open/floor/wood{
-	icon_state = "wood-broken4"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/area/hallway/primary/port)
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "goj" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
-/turf/open/floor/plating,
-/area/maintenance/aft/secondary)
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "gop" = (
 /obj/machinery/camera{
 	c_tag = "Brig Gen-Pop Access"
@@ -17004,7 +17247,7 @@
 	},
 /obj/structure/closet/emcloset,
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "goK" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -17025,6 +17268,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"gpc" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
 "gpe" = (
 /obj/machinery/door/airlock/external{
 	name = "Supply Dock Airlock";
@@ -17039,6 +17291,7 @@
 /area/quartermaster/storage)
 "gph" = (
 /obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "gpp" = (
@@ -17054,11 +17307,16 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "gpN" = (
 /obj/structure/chair/comfy/brown,
 /turf/open/floor/wood,
 /area/library)
+"grm" = (
+/turf/open/floor/plating{
+	icon_state = "platingdmg2"
+	},
+/area/maintenance/aft)
 "grs" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -17070,10 +17328,6 @@
 /area/bridge)
 "grz" = (
 /obj/structure/reagent_dispensers/fueltank,
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_x = 29
-	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/storage/auxiliary)
@@ -17082,6 +17336,13 @@
 /obj/machinery/meter,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
+"grO" = (
+/obj/machinery/cryopod,
+/obj/machinery/airalarm{
+	pixel_y = 26
+	},
+/turf/open/floor/circuit/green,
+/area/crew_quarters/cryopod)
 "grV" = (
 /turf/closed/wall,
 /area/security/courtroom)
@@ -17108,6 +17369,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"gsq" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "gsr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -17142,7 +17412,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "gtO" = (
 /obj/machinery/light{
 	dir = 1
@@ -17168,7 +17438,9 @@
 	dir = 8
 	},
 /turf/open/floor/carpet/eighties,
-/area/crew_quarters/fitness)
+/area/crew_quarters/fitness/recreation{
+	name = "Arcade Room"
+	})
 "guv" = (
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/disposal/bin,
@@ -17271,13 +17543,13 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/stairs/left,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard/fore)
 "gvI" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/open/floor/wood,
-/area/chapel/main)
+/area/chapel/dock)
 "gvM" = (
 /turf/open/floor/plasteel/cult,
 /area/library)
@@ -17286,7 +17558,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "gwY" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -17315,15 +17587,12 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "gxY" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/machinery/door/airlock{
 	name = "Service Hall";
 	req_one_access_txt = "25;26;35;28"
 	},
 /turf/open/floor/plating,
-/area/maintenance/disposal)
+/area/hallway/secondary/service)
 "gyk" = (
 /obj/machinery/light{
 	dir = 4
@@ -17430,7 +17699,12 @@
 /area/bridge)
 "gCM" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/obj/machinery/computer/atmos_control/tank/mix_tank,
+/obj/machinery/computer/atmos_control/tank/mix_tank{
+	input_tag = "mix_in2";
+	name = "Aux Gas Mix Tank Control";
+	output_tag = "mix_out2";
+	sensors = list("mix_sensor2" = "Aux Gas Mix Tank ")
+	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "gCS" = (
@@ -17458,11 +17732,11 @@
 	dir = 6
 	},
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard/fore)
 "gDm" = (
 /obj/structure/loot_pile/maint,
 /turf/open/floor/plating,
-/area/hallway/secondary/entry)
+/area/maintenance/port/aft)
 "gDE" = (
 /obj/machinery/photocopier,
 /turf/open/floor/wood,
@@ -17494,7 +17768,7 @@
 "gEq" = (
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard/fore)
 "gEz" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -17509,11 +17783,10 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/grille/broken,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
-/area/hallway/primary/port)
+/area/maintenance/port/central)
 "gEZ" = (
 /obj/structure/pool/ladder{
 	dir = 1;
@@ -17554,7 +17827,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard/aft)
 "gFP" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 9
@@ -17575,10 +17848,13 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/white/corner{
 	dir = 8
 	},
-/area/hallway/secondary/entry)
+/area/hallway/primary/port)
 "gGs" = (
 /obj/machinery/turretid{
 	control_area = "/area/ai_monitored/turret_protected/ai_upload";
@@ -17703,7 +17979,7 @@
 	dir = 5
 	},
 /turf/open/floor/plating,
-/area/hallway/secondary/entry)
+/area/maintenance/port/aft)
 "gJi" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /obj/machinery/atmospherics/pipe/simple/green/visible{
@@ -17736,7 +18012,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard)
 "gJQ" = (
 /obj/machinery/light{
 	dir = 4
@@ -17756,11 +18032,6 @@
 /obj/item/pen,
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
-"gKp" = (
-/obj/structure/table,
-/obj/item/export/bottle/rum,
-/turf/open/floor/plating,
-/area/maintenance/aft/secondary)
 "gKs" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -17786,10 +18057,13 @@
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "gKR" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
-/area/maintenance/aft/secondary)
+/area/maintenance/aft)
 "gKY" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -17813,8 +18087,14 @@
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "gLk" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
+	},
 /turf/open/floor/plasteel/freezer,
-/area/crew_quarters/dorms)
+/area/crew_quarters/toilet)
 "gLH" = (
 /turf/closed/wall/r_wall,
 /area/teleporter)
@@ -17864,7 +18144,7 @@
 "gNI" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard)
 "gNM" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
@@ -17885,7 +18165,7 @@
 	pixel_x = -25
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "gOr" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -17935,7 +18215,9 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/visible{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
+	},
 /area/engine/atmos)
 "gPb" = (
 /obj/structure/cable{
@@ -18128,7 +18410,7 @@
 "gSE" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/chapel/main)
+/area/chapel/main/monastery)
 "gSY" = (
 /obj/structure/chair/comfy/black{
 	dir = 4
@@ -18169,6 +18451,12 @@
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
+"gTx" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "gTH" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -18176,11 +18464,11 @@
 /obj/structure/fans/tiny,
 /obj/machinery/door/airlock/external,
 /turf/open/floor/plating,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "gUa" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "gUb" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -18259,7 +18547,7 @@
 "gWx" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating,
-/area/hallway/primary/fore)
+/area/maintenance/starboard/aft)
 "gWZ" = (
 /obj/machinery/computer/telecomms/monitor,
 /obj/effect/turf_decal/tile/green{
@@ -18300,6 +18588,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"gYK" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft/secondary)
 "gZb" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -18320,7 +18614,9 @@
 	dir = 4
 	},
 /turf/open/floor/carpet/eighties,
-/area/crew_quarters/fitness)
+/area/crew_quarters/fitness/recreation{
+	name = "Arcade Room"
+	})
 "gZQ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -18335,7 +18631,7 @@
 "gZR" = (
 /obj/structure/table,
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard/fore)
 "gZS" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Snow Airlock"
@@ -18349,6 +18645,10 @@
 /obj/structure/fans/tiny,
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
+"gZV" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "gZX" = (
 /turf/closed/wall,
 /area/medical/morgue)
@@ -18363,7 +18663,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "hap" = (
 /obj/machinery/space_heater,
 /turf/open/floor/wood,
@@ -18384,7 +18684,7 @@
 /turf/open/floor/plasteel/median/darktogrime{
 	dir = 4
 	},
-/area/chapel/main)
+/area/chapel/main/monastery)
 "haU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -18392,8 +18692,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
 /turf/open/floor/carpet/eighties,
-/area/crew_quarters/fitness)
+/area/crew_quarters/fitness/recreation{
+	name = "Arcade Room"
+	})
 "hbb" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -18438,7 +18743,7 @@
 	name = "Central Access"
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard)
 "hcz" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -18507,7 +18812,7 @@
 "hfk" = (
 /obj/machinery/light/small,
 /turf/open/floor/plating,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "hfp" = (
 /obj/machinery/vending/wardrobe/bar_wardrobe,
 /turf/open/floor/wood,
@@ -18565,18 +18870,22 @@
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "hgu" = (
-/obj/structure/table_frame/wood,
-/obj/item/reagent_containers/food/drinks/bottle/vodka,
-/turf/open/floor/wood,
-/area/hallway/primary/port)
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
+"hgw" = (
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/maintenance/port/central)
 "hgJ" = (
 /obj/structure/chair{
 	dir = 8
 	},
-/obj/effect/landmark/start/assistant,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
+/area/hallway/primary/port)
 "hgM" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -18612,7 +18921,7 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "hhz" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -18667,10 +18976,6 @@
 	},
 /turf/open/floor/wood,
 /area/maintenance/bar)
-"hjw" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "hjQ" = (
 /turf/open/openspace,
 /area/chapel/office)
@@ -18767,11 +19072,19 @@
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors)
 "hmP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/maintenance/disposal)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/carpet/eighties,
+/area/crew_quarters/fitness/recreation{
+	name = "Arcade Room"
+	})
 "hnc" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -18881,15 +19194,16 @@
 	pixel_x = 24
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard)
 "hps" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
+/obj/effect/landmark/start/assistant,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/structure/closet/secure_closet/blueshield,
-/turf/open/floor/plasteel/dark,
-/area/blueshield)
+/turf/open/floor/carpet/eighties,
+/area/crew_quarters/fitness/recreation{
+	name = "Arcade Room"
+	})
 "hpw" = (
 /obj/structure/table/wood,
 /obj/item/folder/blue,
@@ -18911,7 +19225,7 @@
 	},
 /obj/structure/window/reinforced,
 /turf/open/floor/grass,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "hpC" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -18977,7 +19291,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard/fore)
 "hqD" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -19053,7 +19367,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "hse" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -19126,7 +19440,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "hta" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -19157,7 +19471,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/grimy,
-/area/chapel/main)
+/area/chapel/main/monastery)
 "hui" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -19175,8 +19489,10 @@
 /area/engine/atmos)
 "huF" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/grille_or_trash,
-/turf/open/floor/plating,
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/floor/plasteel/stairs/left,
 /area/maintenance/disposal)
 "huQ" = (
 /obj/machinery/power/terminal{
@@ -19193,7 +19509,7 @@
 "huU" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
-/area/chapel/main)
+/area/chapel/dock)
 "hva" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -19217,14 +19533,14 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "hvX" = (
 /obj/machinery/camera{
 	c_tag = "Northwestern Hall 9";
 	dir = 6
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/port)
+/area/hallway/primary/port/fore)
 "hwd" = (
 /obj/effect/turf_decal/lumos/loading_area/white,
 /obj/structure/railing/corner{
@@ -19233,7 +19549,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard)
 "hwg" = (
 /obj/machinery/computer/teleporter{
 	dir = 8
@@ -19257,7 +19573,7 @@
 "hwG" = (
 /obj/structure/closet/wardrobe/mixed,
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "hwL" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -19350,11 +19666,11 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "hyd" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/item/instrument/harmonica,
+/obj/structure/sign/nanotrasen{
+	pixel_x = 32
+	},
 /turf/open/floor/plating,
-/area/maintenance/aft/secondary)
+/area/maintenance/aft)
 "hyl" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -19363,11 +19679,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard)
 "hyz" = (
 /obj/machinery/vending/autodrobe,
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "hyK" = (
 /obj/effect/turf_decal/trimline/yellow/filled,
 /obj/machinery/light{
@@ -19410,7 +19726,7 @@
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel,
-/area/maintenance/starboard)
+/area/quartermaster/sorting)
 "hzs" = (
 /obj/machinery/button/door{
 	id = "PrivateStudy1";
@@ -19432,7 +19748,7 @@
 /turf/open/floor/plasteel/dark,
 /area/security/execution/education)
 "hzL" = (
-/obj/structure/table/wood,
+/obj/structure/chair,
 /turf/open/floor/plating,
 /area/maintenance/aft/secondary)
 "hAa" = (
@@ -19444,7 +19760,7 @@
 "hAb" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/maintenance/aft/secondary)
+/area/maintenance/aft)
 "hAf" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -19530,7 +19846,7 @@
 	dir = 5
 	},
 /turf/closed/wall,
-/area/chapel/main)
+/area/chapel/main/monastery)
 "hBH" = (
 /obj/machinery/vending/medical,
 /turf/open/floor/plasteel/white,
@@ -19543,7 +19859,7 @@
 	pixel_x = -28
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/port)
+/area/hallway/primary/port/fore)
 "hCD" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -19615,7 +19931,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "hDj" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/effect/turf_decal/tile/green{
@@ -19649,7 +19965,7 @@
 	name = "Air Out"
 	},
 /turf/open/floor/plating,
-/area/chapel/main)
+/area/chapel/dock)
 "hEf" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -19664,9 +19980,8 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "hEm" = (
-/obj/structure/closet/emcloset,
-/turf/open/floor/plating,
-/area/maintenance/aft/secondary)
+/turf/closed/wall,
+/area/crew_quarters/toilet)
 "hEC" = (
 /obj/structure/chair/pew/left{
 	dir = 4
@@ -19680,7 +19995,7 @@
 /turf/open/floor/plasteel/chapel{
 	dir = 8
 	},
-/area/chapel/main)
+/area/chapel/main/monastery)
 "hEQ" = (
 /obj/effect/landmark/blobstart,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
@@ -19717,7 +20032,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/carpet,
-/area/chapel/main)
+/area/chapel/main/monastery)
 "hGr" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -19728,6 +20043,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
+"hGv" = (
+/turf/open/floor/plasteel/dark,
+/area/hydroponics/garden/monastery)
 "hGy" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
@@ -19746,7 +20064,7 @@
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/freezer,
-/area/crew_quarters/dorms)
+/area/crew_quarters/toilet)
 "hGU" = (
 /obj/structure/closet/secure_closet/personal/cabinet{
 	pixel_x = -8
@@ -19803,7 +20121,7 @@
 /obj/structure/fans/tiny,
 /obj/machinery/door/airlock/external,
 /turf/open/floor/plating,
-/area/chapel/main)
+/area/chapel/dock)
 "hIa" = (
 /obj/structure/closet/secure_closet/hop,
 /obj/machinery/light,
@@ -19820,36 +20138,29 @@
 /turf/open/floor/plasteel/freezer,
 /area/medical/surgery)
 "hIl" = (
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -22
+/obj/machinery/atmospherics/pipe/simple/multiz{
+	piping_layer = 1
 	},
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/stripes/box,
+/turf/open/floor/plasteel/elevatorshaft,
 /area/engine/atmos)
 "hIC" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "hIG" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
 "hIH" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
+/turf/open/floor/plasteel/freezer,
+/area/crew_quarters/toilet)
 "hIM" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
@@ -19891,7 +20202,7 @@
 "hJm" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
-/area/hallway/primary/fore)
+/area/maintenance/starboard/aft)
 "hJw" = (
 /obj/structure/chair/comfy/black,
 /obj/structure/window/reinforced{
@@ -19972,25 +20283,29 @@
 	},
 /obj/machinery/door/airlock/external,
 /turf/open/floor/plating,
-/area/chapel/main)
+/area/chapel/dock)
 "hLE" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard/fore)
 "hLQ" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/floor/plasteel/stairs/right{
+	dir = 4
+	},
 /area/quartermaster/storage)
 "hLZ" = (
 /obj/structure/chair{
 	dir = 4
 	},
-/obj/effect/landmark/start/assistant,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
+/area/hallway/primary/port)
 "hMy" = (
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/bar)
@@ -20059,11 +20374,13 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "hNt" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
+/obj/structure/railing{
+	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/turf/open/floor/plasteel/stairs/right{
+	dir = 4
+	},
+/area/hallway/primary/aft)
 "hNv" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -20154,10 +20471,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard)
 "hPA" = (
 /turf/open/floor/plating,
-/area/chapel/main)
+/area/chapel/dock)
 "hPC" = (
 /obj/machinery/door/airlock/atmos{
 	name = "Atmospherics";
@@ -20189,7 +20506,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/fore)
 "hQb" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -20231,6 +20548,13 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
+"hQO" = (
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -22
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
 "hRe" = (
 /obj/structure/chair/office/dark{
 	dir = 8
@@ -20242,7 +20566,7 @@
 /area/quartermaster/qm)
 "hRG" = (
 /turf/open/floor/plating,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "hRH" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -20297,6 +20621,12 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "hSD" = (
@@ -20326,7 +20656,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "hSZ" = (
 /obj/structure/table/wood/fancy/green,
 /obj/item/reagent_containers/food/drinks/bottle/holywater{
@@ -20340,7 +20670,7 @@
 /obj/machinery/disposal/bin,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
+/area/hallway/primary/port)
 "hTy" = (
 /obj/machinery/light{
 	dir = 4
@@ -20387,7 +20717,7 @@
 /obj/effect/spawner/lootdrop/organ_spawner,
 /obj/machinery/light/small,
 /turf/open/floor/plating,
-/area/hallway/primary/fore)
+/area/maintenance/starboard/aft)
 "hUc" = (
 /obj/structure/railing/corner{
 	dir = 4
@@ -20435,11 +20765,11 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "hVg" = (
 /obj/effect/landmark/xmastree,
 /turf/open/floor/plasteel/grimy,
-/area/chapel/main)
+/area/chapel/main/monastery)
 "hVh" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -20515,7 +20845,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "hVO" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/security/wooden_tv,
@@ -20578,7 +20908,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/fore)
 "hXb" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -20642,7 +20972,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard/fore)
 "hZa" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -20693,7 +21023,7 @@
 	name = "west facing firelock"
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "hZU" = (
 /obj/structure/table/wood,
 /obj/item/radio/intercom{
@@ -20785,7 +21115,7 @@
 	icon_state = "cobweb2"
 	},
 /turf/open/floor/plating,
-/area/hallway/primary/port)
+/area/maintenance/port/central)
 "iaL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -20826,7 +21156,7 @@
 /area/lawoffice)
 "ibi" = (
 /turf/open/floor/plasteel/median/darktogrime,
-/area/chapel/main)
+/area/chapel/main/monastery)
 "icb" = (
 /obj/structure/closet/secure_closet/captains,
 /turf/open/floor/carpet,
@@ -20845,7 +21175,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "icU" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "32"
@@ -20866,6 +21196,7 @@
 	dir = 4
 	},
 /obj/machinery/light,
+/obj/machinery/portable_atmospherics/pump,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "idh" = (
@@ -20953,6 +21284,12 @@
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
+"ifE" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "ifQ" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8;
@@ -20982,7 +21319,7 @@
 "igi" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "igK" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -21059,7 +21396,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "ihX" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -21087,16 +21424,15 @@
 	},
 /obj/machinery/vending/cigarette,
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "iiY" = (
 /turf/closed/wall/r_wall,
 /area/crew_quarters/heads/chief)
 "ijl" = (
-/obj/structure/table/wood,
-/turf/open/floor/wood{
-	icon_state = "wood-broken6"
-	},
-/area/maintenance/aft/secondary)
+/obj/structure/chair/stool,
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
 "ijz" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -21106,7 +21442,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/maintenance/starboard)
+/area/quartermaster/sorting)
 "ijL" = (
 /obj/structure/reflector/double,
 /turf/open/floor/plating,
@@ -21121,12 +21457,11 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "ikh" = (
-/obj/effect/turf_decal/tile/blue{
+/obj/machinery/light{
 	dir = 1
 	},
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = 24
+/obj/structure/railing/corner{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
@@ -21177,7 +21512,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "ilM" = (
 /obj/item/reagent_containers/spray/plantbgone,
 /obj/item/reagent_containers/spray/pestspray{
@@ -21311,7 +21646,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/hallway/primary/fore)
+/area/maintenance/starboard/aft)
 "ioG" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/tile/purple{
@@ -21327,7 +21662,7 @@
 "iph" = (
 /obj/structure/closet/firecloset/full,
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard/fore)
 "ipi" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction{
 	dir = 1
@@ -21362,14 +21697,14 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard/fore)
 "iqH" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "iqJ" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Security Office";
@@ -21396,7 +21731,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "iqZ" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -21418,7 +21753,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "ire" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -21496,7 +21831,7 @@
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
-/area/hallway/primary/port)
+/area/maintenance/port/central)
 "itn" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
@@ -21538,14 +21873,14 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "itN" = (
 /obj/machinery/vending/coffee,
 /obj/item/radio/intercom{
 	pixel_x = 25
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "itU" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -21573,7 +21908,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
-/area/maintenance/central)
+/area/maintenance/department/security)
 "iux" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -21588,7 +21923,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard)
 "iuC" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -21659,7 +21994,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "iwk" = (
 /obj/structure/closet/crate,
 /obj/item/radio/intercom{
@@ -21668,6 +22003,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"iws" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "ixd" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
@@ -21822,6 +22164,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
+"iAI" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "iAO" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /turf/open/floor/plating,
@@ -21896,7 +22242,7 @@
 "iBW" = (
 /obj/machinery/light/small,
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard)
 "iCq" = (
 /obj/machinery/door/airlock/engineering/glass/critical{
 	heat_proof = 1;
@@ -21920,10 +22266,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"iDe" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/chapel/dock)
 "iDh" = (
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/carpet/eighties,
-/area/crew_quarters/fitness)
+/area/crew_quarters/fitness/recreation{
+	name = "Arcade Room"
+	})
 "iDi" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -21997,7 +22349,7 @@
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "iET" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -22048,7 +22400,7 @@
 	name = "west facing firelock"
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "iFl" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -22067,7 +22419,7 @@
 /turf/open/floor/plasteel/white/corner{
 	dir = 8
 	},
-/area/hallway/secondary/entry)
+/area/hallway/primary/port)
 "iFq" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -22090,7 +22442,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard)
 "iFK" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -22241,7 +22593,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "iIg" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -22253,7 +22605,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/chapel/main)
+/area/chapel/main/monastery)
 "iIz" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -22327,21 +22679,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
-"iJS" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "iJX" = (
 /obj/structure/bookcase/random/fiction,
 /turf/open/floor/wood,
@@ -22370,7 +22707,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "iLw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
@@ -22379,7 +22716,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/maintenance/aft/secondary)
+/area/maintenance/aft)
 "iLA" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -22389,7 +22726,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/stairs/left,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard)
 "iMc" = (
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
@@ -22401,7 +22738,7 @@
 /obj/effect/turf_decal/bot,
 /obj/machinery/light,
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "iMX" = (
 /obj/structure/cable,
 /obj/machinery/power/terminal,
@@ -22457,6 +22794,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"iNY" = (
+/turf/closed/wall,
+/area/chapel/dock)
 "iOd" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -22466,9 +22806,21 @@
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "iOe" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/carpet,
+/area/crew_quarters/dorms)
 "iOp" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -22513,7 +22865,7 @@
 	pixel_y = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/chapel/main)
+/area/chapel/main/monastery)
 "iOR" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
@@ -22562,11 +22914,10 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "iPX" = (
-/obj/machinery/light,
-/obj/machinery/quantumpad{
-	map_pad_id = "2";
-	map_pad_link_id = "1"
+/obj/machinery/light/small{
+	dir = 8
 	},
+/obj/machinery/space_heater,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "iQv" = (
@@ -22623,7 +22974,7 @@
 	},
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard)
 "iRO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 9
@@ -22703,20 +23054,25 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
-/area/hallway/primary/port)
+/area/hallway/primary/port/fore)
 "iUp" = (
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 10
+	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "iUV" = (
 /obj/machinery/hydroponics/soil,
 /obj/item/seeds/harebell,
 /turf/open/floor/grass,
-/area/chapel/main)
+/area/hydroponics/garden/monastery)
 "iVY" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
@@ -22736,7 +23092,7 @@
 /area/storage/primary)
 "iWf" = (
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard/fore)
 "iWu" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -22772,7 +23128,7 @@
 	dir = 2
 	},
 /turf/open/floor/plasteel/white,
-/area/hallway/primary/port)
+/area/hallway/primary/port/fore)
 "iXG" = (
 /obj/structure/fans/tiny,
 /obj/machinery/door/airlock/external,
@@ -22891,7 +23247,7 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "jae" = (
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
@@ -22935,7 +23291,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/maintenance/central)
+/area/maintenance/department/security)
 "jbp" = (
 /obj/machinery/space_heater,
 /obj/effect/turf_decal/tile/brown{
@@ -22992,7 +23348,7 @@
 /turf/open/floor/plasteel/median/darktogrime/corner{
 	dir = 1
 	},
-/area/chapel/main)
+/area/chapel/main/monastery)
 "jcR" = (
 /obj/structure/table/wood,
 /obj/item/taperecorder,
@@ -23024,7 +23380,7 @@
 	pixel_x = -32
 	},
 /turf/open/floor/plasteel/median/darktogrime/corner,
-/area/chapel/main)
+/area/chapel/main/monastery)
 "jdr" = (
 /obj/structure/chair,
 /obj/effect/decal/cleanable/blood/old,
@@ -23045,7 +23401,12 @@
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
 "jdS" = (
-/obj/effect/turf_decal/vg_decals/atmos/mix,
+/obj/effect/turf_decal/vg_decals/atmos/mix{
+	pixel_x = -16
+	},
+/obj/effect/turf_decal/vg_decals/numbers/one{
+	pixel_x = 16
+	},
 /turf/open/floor/engine/airless,
 /area/engine/atmos)
 "jdY" = (
@@ -23075,7 +23436,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "jen" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
@@ -23088,7 +23449,7 @@
 	name = "north facing firelock"
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard)
 "jeo" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
@@ -23102,7 +23463,7 @@
 	name = "west facing firelock"
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "jeJ" = (
 /obj/machinery/door/poddoor{
 	id = "tegvent";
@@ -23150,7 +23511,7 @@
 	pixel_x = -28
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard/fore)
 "jgD" = (
 /obj/structure/table,
 /obj/item/storage/box/bodybags,
@@ -23172,7 +23533,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "jhF" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating/airless,
@@ -23184,14 +23545,23 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 5
 	},
-/turf/open/floor/plating,
-/area/maintenance/aft/secondary)
-"jie" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft/secondary)
+"jie" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/freezer,
+/area/crew_quarters/toilet)
 "jih" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -23241,8 +23611,11 @@
 "jji" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard/fore)
 "jjn" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -23303,14 +23676,14 @@
 	pixel_y = 32
 	},
 /turf/open/floor/plating,
-/area/maintenance/aft/secondary)
+/area/maintenance/aft)
 "jkw" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "jkJ" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/disposalpipe/segment{
@@ -23359,7 +23732,9 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/plasteel/stairs/right,
 /area/maintenance/disposal)
 "jmd" = (
 /obj/effect/turf_decal/stripes/line{
@@ -23382,6 +23757,12 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "jmU" = (
@@ -23399,9 +23780,17 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "jnm" = (
-/obj/structure/bed/roller/bodypillow/kevin,
-/turf/open/floor/plating/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/freezer,
+/area/crew_quarters/toilet)
 "job" = (
 /obj/structure/chair/comfy/black,
 /turf/open/floor/plasteel/dark,
@@ -23434,7 +23823,7 @@
 	},
 /obj/machinery/door/airlock/external,
 /turf/open/floor/plating,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "joT" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -23528,7 +23917,7 @@
 	},
 /obj/effect/turf_decal/stripes/box,
 /turf/open/floor/plating,
-/area/hallway/secondary/entry)
+/area/maintenance/port/aft)
 "jqJ" = (
 /obj/structure/closet,
 /obj/item/storage/book/bible,
@@ -23588,7 +23977,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
-/area/hallway/primary/port)
+/area/hallway/primary/port/fore)
 "jrR" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -23602,7 +23991,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard/aft)
 "jso" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -23666,7 +24055,7 @@
 "juv" = (
 /obj/machinery/vending/games,
 /turf/open/floor/plasteel/median/darktogrime,
-/area/chapel/main)
+/area/chapel/main/monastery)
 "juI" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -23678,7 +24067,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "jvb" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -23702,7 +24091,7 @@
 /obj/structure/table/wood,
 /obj/item/book/random,
 /turf/open/floor/carpet,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard)
 "jvy" = (
 /obj/structure/barricade/wooden/snowed{
 	max_integrity = 10;
@@ -23714,9 +24103,12 @@
 /turf/open/floor/wood,
 /area/maintenance/bar)
 "jvV" = (
-/obj/machinery/light/small,
+/obj/machinery/power/apc/auto_name/west,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
 /turf/open/floor/plasteel,
-/area/maintenance/disposal)
+/area/hallway/secondary/service)
 "jwc" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -23748,7 +24140,13 @@
 "jwD" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard/fore)
+"jwE" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "jwW" = (
 /obj/structure/sign/poster/random{
 	pixel_x = 32
@@ -23756,7 +24154,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard/fore)
 "jxr" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -23853,7 +24251,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "jAb" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -23948,7 +24346,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "jBr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -23990,7 +24388,7 @@
 	pixel_y = 25
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "jCL" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -24066,10 +24464,10 @@
 /area/crew_quarters/heads/hor)
 "jDJ" = (
 /obj/structure/cable{
-	icon_state = "0-8"
+	icon_state = "4-8"
 	},
-/turf/open/floor/plating,
-/area/maintenance/aft/secondary)
+/turf/open/floor/plasteel/freezer,
+/area/crew_quarters/toilet)
 "jDK" = (
 /obj/structure/chair/sofa/right{
 	dir = 4
@@ -24092,6 +24490,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"jEG" = (
+/obj/structure/tank_dispenser/oxygen,
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
 "jER" = (
 /obj/machinery/vending/kink,
 /turf/open/floor/plating,
@@ -24103,7 +24505,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "jFv" = (
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall/r_wall,
@@ -24200,7 +24602,7 @@
 /obj/item/reagent_containers/food/snacks/meat/slab/chicken,
 /obj/item/reagent_containers/food/snacks/meat/slab/chicken,
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard/fore)
 "jHC" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -24244,7 +24646,7 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/ausbushes/stalkybush,
 /turf/open/floor/grass,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "jIc" = (
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible,
 /turf/open/floor/plasteel,
@@ -24257,7 +24659,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "jIk" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/open/floor/plating,
@@ -24289,24 +24691,20 @@
 /area/crew_quarters/heads/chief)
 "jJd" = (
 /turf/open/floor/pod/dark,
-/area/maintenance/starboard)
-"jJt" = (
-/obj/structure/table_frame,
-/turf/open/floor/plating,
-/area/maintenance/aft/secondary)
+/area/quartermaster/sorting)
 "jJu" = (
 /turf/closed/wall/r_wall,
 /area/medical/medbay/zone3)
 "jJG" = (
 /obj/machinery/seed_extractor,
 /turf/open/floor/plasteel/dark,
-/area/chapel/main)
+/area/hydroponics/garden/monastery)
 "jKb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "jKx" = (
 /obj/structure/sign/poster/random{
 	pixel_x = 32
@@ -24315,7 +24713,9 @@
 	dir = 8
 	},
 /turf/open/floor/carpet/eighties,
-/area/crew_quarters/fitness)
+/area/crew_quarters/fitness/recreation{
+	name = "Arcade Room"
+	})
 "jKC" = (
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
@@ -24360,7 +24760,7 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "jLG" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -24373,7 +24773,7 @@
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard/fore)
 "jNd" = (
 /obj/structure/closet/secure_closet/genpop,
 /obj/item/radio/headset{
@@ -24421,7 +24821,7 @@
 /turf/open/floor/plasteel/median/darktogrime{
 	dir = 1
 	},
-/area/chapel/main)
+/area/chapel/main/monastery)
 "jNw" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -24438,8 +24838,9 @@
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "jNK" = (
+/obj/machinery/light/small,
 /turf/open/floor/plating,
-/area/janitor)
+/area/maintenance/starboard/central)
 "jOj" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -24449,7 +24850,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
+/area/hallway/primary/port)
 "jOo" = (
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall/mineral/wood,
@@ -24564,7 +24965,7 @@
 	dir = 8
 	},
 /turf/open/floor/carpet,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard)
 "jQj" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -24588,7 +24989,7 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "jQB" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/dark,
@@ -24600,13 +25001,12 @@
 /turf/open/floor/engine/o2,
 /area/engine/atmos)
 "jRn" = (
-/obj/structure/chair{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "0-8"
 	},
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
-/area/maintenance/aft/secondary)
+/obj/machinery/power/apc/auto_name/east,
+/turf/open/floor/plasteel/freezer,
+/area/crew_quarters/toilet)
 "jRB" = (
 /obj/structure/table,
 /obj/item/storage/belt/utility,
@@ -24660,7 +25060,7 @@
 "jRX" = (
 /obj/machinery/vending/snack/random,
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "jSq" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -24715,7 +25115,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "jTv" = (
 /turf/closed/indestructible/rock/glacierrock/blue,
 /area/chapel/office)
@@ -24749,7 +25149,7 @@
 "jUd" = (
 /obj/structure/bookcase/random/religion,
 /turf/open/floor/plasteel/median/darktogrime/corner,
-/area/chapel/main)
+/area/chapel/main/monastery)
 "jUf" = (
 /obj/machinery/atmospherics/pipe/manifold4w/yellow/visible,
 /obj/machinery/computer/atmos_control/tank/nitrogen_tank{
@@ -24778,7 +25178,7 @@
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
-/area/hallway/primary/aft)
+/area/maintenance/starboard/fore)
 "jVc" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1;
@@ -24869,7 +25269,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard/aft)
 "jXh" = (
 /obj/machinery/door/firedoor/border_only{
 	name = "south facing firelock"
@@ -24937,7 +25337,7 @@
 "jYW" = (
 /obj/item/cultivator,
 /turf/open/floor/grass,
-/area/chapel/main)
+/area/hydroponics/garden/monastery)
 "jZb" = (
 /obj/machinery/atmospherics/pipe/simple/multiz,
 /obj/structure/railing{
@@ -24945,7 +25345,7 @@
 	},
 /obj/effect/turf_decal/stripes/box,
 /turf/open/floor/plating,
-/area/maintenance/central)
+/area/maintenance/department/security)
 "jZg" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
@@ -24957,7 +25357,7 @@
 	dir = 4
 	},
 /turf/open/floor/carpet,
-/area/hallway/primary/aft)
+/area/hallway/primary/fore)
 "jZW" = (
 /turf/open/floor/plasteel,
 /area/engine/atmospherics_engine)
@@ -25007,7 +25407,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard)
 "kcw" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -25089,7 +25489,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
-/area/chapel/main)
+/area/chapel/dock)
 "kdM" = (
 /obj/effect/turf_decal/stripes,
 /obj/machinery/conveyor{
@@ -25118,7 +25518,7 @@
 	icon_state = "plant-22"
 	},
 /turf/open/floor/wood,
-/area/chapel/main)
+/area/chapel/dock)
 "keq" = (
 /obj/machinery/airalarm{
 	dir = 1;
@@ -25180,7 +25580,7 @@
 /obj/structure/table/wood,
 /obj/item/reagent_containers/glass/beaker/waterbottle/wataur,
 /turf/open/floor/plasteel/grimy,
-/area/chapel/main)
+/area/chapel/main/monastery)
 "kfl" = (
 /obj/machinery/atmospherics/pipe/simple/multiz{
 	dir = 8;
@@ -25214,7 +25614,12 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
+"kgg" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "kgo" = (
 /obj/machinery/door/poddoor{
 	id = "chapelgun";
@@ -25267,7 +25672,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "khy" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -25283,7 +25688,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "kii" = (
 /obj/machinery/cryopod,
 /obj/machinery/light/small{
@@ -25346,7 +25751,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "kkn" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -25420,7 +25825,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/maintenance/starboard)
+/area/quartermaster/sorting)
 "klh" = (
 /obj/structure/reagent_dispensers/virusfood{
 	pixel_x = 30
@@ -25450,7 +25855,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "klQ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -25511,6 +25916,15 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
+"knk" = (
+/obj/structure/table/reinforced,
+/obj/item/stack/sheet/metal{
+	amount = 30
+	},
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/cable_coil/white,
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "knn" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Security Lobby"
@@ -25525,7 +25939,7 @@
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
-/area/hallway/primary/aft)
+/area/maintenance/starboard/fore)
 "knx" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -25549,7 +25963,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "knR" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -25660,14 +26074,17 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "kqo" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
@@ -25785,7 +26202,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
 	},
-/obj/structure/closet/secure_closet/atmospherics,
 /obj/machinery/power/apc{
 	areastring = "/area/engine/atmos";
 	name = "Atmospherics APC";
@@ -25857,7 +26273,7 @@
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/grass,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "ktW" = (
 /obj/machinery/vending/wallmed{
 	pixel_y = 28
@@ -25947,18 +26363,18 @@
 	pixel_x = 26
 	},
 /turf/open/floor/plasteel/grimy,
-/area/chapel/main)
+/area/chapel/main/monastery)
 "kwl" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard)
 "kwC" = (
 /obj/machinery/door/airlock/external{
 	name = "Escape Pod Three"
 	},
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard/fore)
 "kwL" = (
 /turf/open/floor/plating,
 /area/security/brig)
@@ -26008,6 +26424,10 @@
 "kxD" = (
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
 	},
 /turf/open/floor/wood,
 /area/security/vacantoffice/b)
@@ -26098,10 +26518,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/zone2)
-"kAX" = (
-/obj/machinery/door/airlock/maintenance/abandoned,
-/turf/open/floor/plating,
-/area/maintenance/aft/secondary)
 "kBb" = (
 /obj/machinery/door/airlock/external{
 	name = "Engineering External Access";
@@ -26115,7 +26531,7 @@
 "kBe" = (
 /obj/structure/chair,
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard/fore)
 "kBK" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -26183,7 +26599,7 @@
 "kDE" = (
 /obj/structure/closet/cardboard,
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard/fore)
 "kDT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -26238,11 +26654,15 @@
 /turf/open/floor/plasteel,
 /area/engine/atmospherics_engine)
 "kGt" = (
-/obj/machinery/door/airlock{
-	name = "Garden"
+/obj/machinery/door/firedoor/border_only{
+	dir = 1;
+	name = "north facing firelock"
+	},
+/obj/machinery/door/airlock/glass{
+	name = "Chapel Garden"
 	},
 /turf/open/floor/plasteel/dark,
-/area/chapel/main)
+/area/chapel/main/monastery)
 "kGu" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -26252,12 +26672,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"kGD" = (
+/obj/effect/spawner/blocker,
+/turf/open/floor/plating,
+/area/maintenance/port/central)
 "kGX" = (
 /obj/structure/transit_tube/curved{
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/chapel/main)
+/area/chapel/dock)
 "kHd" = (
 /obj/structure/window/reinforced{
 	dir = 8;
@@ -26311,6 +26735,15 @@
 	},
 /turf/open/floor/wood,
 /area/medical/psych)
+"kIb" = (
+/obj/machinery/airalarm{
+	pixel_y = 26
+	},
+/obj/structure/railing/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "kIl" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -26509,7 +26942,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/hallway/primary/port)
+/area/hallway/primary/port/fore)
 "kMy" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -26618,7 +27051,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "kPu" = (
 /obj/structure/window/plasma/reinforced{
 	dir = 4
@@ -26635,18 +27068,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
-"kPA" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/disposal)
 "kPQ" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -26672,8 +27093,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
 /turf/open/floor/plating,
-/area/hallway/secondary/entry)
+/area/maintenance/port/aft)
 "kQn" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/techstorage/tcomms,
@@ -26711,7 +27135,7 @@
 	name = "south facing firelock"
 	},
 /turf/open/floor/plasteel/dark,
-/area/chapel/main)
+/area/chapel/main/monastery)
 "kRk" = (
 /turf/open/floor/plasteel/yellowsiding{
 	dir = 4
@@ -26736,6 +27160,10 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/wood,
 /area/hallway/primary/port)
+"kRR" = (
+/obj/item/lighter/gold,
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors)
 "kRX" = (
 /obj/structure/closet/secure_closet/hydroponics,
 /turf/open/floor/plasteel,
@@ -26744,15 +27172,18 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
 /obj/structure/fans/tiny,
+/obj/machinery/door/airlock/external{
+	req_access_txt = "13"
+	},
 /turf/open/floor/plating,
 /area/hallway/primary/port)
 "kSv" = (
-/turf/open/floor/wood,
+/obj/structure/closet/emcloset,
+/turf/open/floor/plating,
 /area/maintenance/aft/secondary)
 "kSP" = (
 /obj/structure/cable{
@@ -26767,7 +27198,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "kSQ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -26776,7 +27207,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/wood,
-/area/chapel/main)
+/area/chapel/dock)
 "kSR" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
@@ -26810,7 +27241,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard)
 "kUo" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -26875,16 +27306,11 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/supermatter)
 "kVF" = (
-/obj/item/shard{
-	icon_state = "small"
-	},
-/turf/open/floor/wood{
-	icon_state = "wood-broken6"
-	},
-/area/hallway/primary/port)
+/turf/closed/wall,
+/area/maintenance/starboard/central)
 "kVO" = (
 /turf/closed/wall,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard/fore)
 "kWl" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
@@ -26893,7 +27319,7 @@
 	dir = 8
 	},
 /turf/open/floor/wood,
-/area/chapel/main)
+/area/chapel/dock)
 "kWC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -26937,7 +27363,13 @@
 /turf/open/floor/plasteel/white/corner{
 	dir = 8
 	},
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
+"kYp" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft/secondary)
 "kYs" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -26945,7 +27377,9 @@
 	name = "Arcade Shutters"
 	},
 /turf/open/floor/plating,
-/area/crew_quarters/fitness)
+/area/crew_quarters/fitness/recreation{
+	name = "Arcade Room"
+	})
 "kYE" = (
 /obj/machinery/limbgrower,
 /turf/open/floor/plasteel/freezer,
@@ -27025,7 +27459,7 @@
 /turf/open/floor/plasteel/chapel{
 	dir = 1
 	},
-/area/chapel/main)
+/area/chapel/main/monastery)
 "laE" = (
 /obj/machinery/door/airlock/virology{
 	name = "Break Room";
@@ -27070,11 +27504,14 @@
 	},
 /turf/open/floor/plating/asteroid/snow/ice/icemoon/solarpanel,
 /area/icemoon/surface/outdoors)
+"lbD" = (
+/turf/open/floor/mech_bay_recharge_floor,
+/area/maintenance/aft)
 "lck" = (
 /turf/open/floor/plasteel/chapel{
 	dir = 1
 	},
-/area/chapel/main)
+/area/chapel/main/monastery)
 "ldt" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -27094,10 +27531,13 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/white/corner{
 	dir = 8
 	},
-/area/hallway/secondary/entry)
+/area/hallway/primary/port)
 "led" = (
 /obj/machinery/power/compressor{
 	comp_id = "incineratorturbine";
@@ -27146,9 +27586,13 @@
 /turf/open/floor/plating,
 /area/security/prison)
 "leO" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plating,
-/area/maintenance/aft/secondary)
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/railing/corner,
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "leT" = (
 /turf/open/floor/engine,
 /area/engine/supermatter)
@@ -27180,7 +27624,7 @@
 /turf/open/floor/plasteel/median/darktogrime{
 	dir = 1
 	},
-/area/chapel/main)
+/area/chapel/main/monastery)
 "lfl" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/floor/engine,
@@ -27255,7 +27699,7 @@
 /obj/effect/turf_decal/delivery,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "lgq" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -27280,14 +27724,16 @@
 "lgJ" = (
 /obj/machinery/prize_counter/upgraded,
 /turf/open/floor/carpet/eighties,
-/area/crew_quarters/fitness)
+/area/crew_quarters/fitness/recreation{
+	name = "Arcade Room"
+	})
 "lgN" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/railing{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/chapel/main)
+/area/chapel/main/monastery)
 "lgX" = (
 /obj/machinery/camera{
 	c_tag = "Fore Starboard Solars";
@@ -27319,10 +27765,6 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
 "lhB" = (
-/obj/machinery/camera{
-	c_tag = "Northwestern Hall 7";
-	dir = 8
-	},
 /obj/effect/turf_decal/arrows/red{
 	dir = 4
 	},
@@ -27357,7 +27799,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "liL" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -27390,11 +27832,13 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/hallway/primary/port)
+/area/hallway/primary/port/fore)
 "lkI" = (
 /obj/structure/chair/stool,
 /turf/open/floor/carpet/eighties,
-/area/crew_quarters/fitness)
+/area/crew_quarters/fitness/recreation{
+	name = "Arcade Room"
+	})
 "lkP" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/red,
@@ -27416,11 +27860,11 @@
 	},
 /obj/structure/loot_pile/maint,
 /turf/open/floor/plating,
-/area/hallway/secondary/entry)
+/area/maintenance/port/aft)
 "llu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard/fore)
 "llz" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -27473,13 +27917,14 @@
 /turf/closed/wall,
 /area/medical/storage)
 "lmU" = (
-/obj/structure/table,
-/obj/structure/light_construct{
+/obj/structure/chair/comfy/black{
+	dir = 4
+	},
+/obj/structure/railing/corner{
 	dir = 8
 	},
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/aft/secondary)
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "lng" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -27506,7 +27951,7 @@
 /turf/open/floor/plasteel/white/corner{
 	dir = 8
 	},
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "lnH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -27529,6 +27974,14 @@
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
+"lnU" = (
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 2;
+	name = "2maintenance loot spawner"
+	},
+/obj/structure/closet,
+/turf/open/floor/plating,
+/area/maintenance/aft/secondary)
 "lnV" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 8
@@ -27554,6 +28007,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -27627,7 +28083,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "lpR" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -27693,7 +28149,7 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/barricade/wooden/crude,
 /turf/open/floor/plating,
-/area/hallway/primary/fore)
+/area/maintenance/starboard/aft)
 "lrK" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /obj/effect/spawner/structure/window/plasma/reinforced,
@@ -27791,7 +28247,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "ltY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/airlock/public/glass{
@@ -27849,7 +28305,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "luO" = (
 /obj/structure/closet/crate/medical,
 /obj/item/stack/medical/bruise_pack,
@@ -27984,7 +28440,7 @@
 	dir = 5
 	},
 /turf/closed/wall,
-/area/hallway/secondary/entry)
+/area/maintenance/port/aft)
 "lzw" = (
 /obj/machinery/firealarm{
 	pixel_y = 25
@@ -28014,7 +28470,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/dark,
-/area/chapel/main)
+/area/chapel/main/monastery)
 "lzW" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -28156,7 +28612,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "lDj" = (
 /obj/item/storage/firstaid/regular{
 	pixel_x = -5;
@@ -28185,7 +28641,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 9
 	},
 /turf/open/floor/plating,
@@ -28214,7 +28673,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
-/area/janitor)
+/area/maintenance/starboard/central)
 "lFc" = (
 /obj/structure/transit_tube/horizontal{
 	dir = 1
@@ -28287,7 +28746,7 @@
 /area/engine/engineering)
 "lGc" = (
 /turf/open/floor/carpet,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard)
 "lGp" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -28347,8 +28806,15 @@
 /area/crew_quarters/fitness/pool)
 "lHl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/visible,
-/obj/machinery/portable_atmospherics/pump,
-/turf/open/floor/plasteel,
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/machinery/power/deck_relay,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/effect/turf_decal/stripes/box,
+/turf/open/floor/plasteel/elevatorshaft,
 /area/engine/atmos)
 "lHn" = (
 /obj/structure/chair{
@@ -28362,6 +28828,12 @@
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
+"lHz" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "lHZ" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -28383,7 +28855,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
+/area/hallway/primary/port)
 "lIm" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 4
@@ -28400,11 +28872,10 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "lJe" = (
-/obj/structure/girder,
-/turf/open/floor/plating,
-/area/maintenance/aft/secondary)
+/turf/open/floor/circuit,
+/area/maintenance/aft)
 "lJi" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -28425,7 +28896,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
-/area/maintenance/aft/secondary)
+/area/maintenance/aft)
 "lKf" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/simple/dark/visible{
@@ -28482,7 +28953,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "lMF" = (
 /obj/machinery/camera{
 	c_tag = "Virology Module";
@@ -28501,7 +28972,7 @@
 	},
 /obj/machinery/door/airlock/external,
 /turf/open/floor/plating,
-/area/chapel/main)
+/area/chapel/dock)
 "lNK" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -28514,7 +28985,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard)
 "lNN" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -28527,7 +28998,7 @@
 "lOs" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard/fore)
 "lOF" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -28550,6 +29021,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
+"lPe" = (
+/obj/structure/chair/stool,
+/turf/open/floor/plating,
+/area/maintenance/aft/secondary)
 "lPB" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/floor/plasteel,
@@ -28571,12 +29046,12 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "lQc" = (
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
-/area/hallway/primary/fore)
+/area/maintenance/starboard/aft)
 "lQp" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -28594,7 +29069,13 @@
 	dir = 1
 	},
 /turf/open/floor/carpet,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
+"lQA" = (
+/obj/structure/table/reinforced,
+/obj/item/clothing/gloves/color/black,
+/obj/item/multitool,
+/turf/open/floor/plasteel,
+/area/maintenance/aft)
 "lQJ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
@@ -28628,7 +29109,7 @@
 /turf/open/floor/plasteel/median/darktogrime/fullcorner{
 	dir = 8
 	},
-/area/chapel/main)
+/area/chapel/main/monastery)
 "lSt" = (
 /obj/structure/janitorialcart{
 	dir = 4
@@ -28659,6 +29140,16 @@
 /obj/machinery/rnd/production/techfab/department/medical,
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
+"lSS" = (
+/obj/machinery/door/airlock/command{
+	name = "Auxiliary E.V.A. Storage";
+	req_access_txt = "18"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "lTp" = (
 /obj/structure/closet,
 /turf/open/floor/plating,
@@ -28667,12 +29158,13 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/firedoor/border_only{
 	name = "south facing firelock"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/maintenance,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "lTB" = (
@@ -28716,6 +29208,12 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
+"lTV" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/plasteel/stairs/medium,
+/area/hallway/primary/port)
 "lUb" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -28774,9 +29272,11 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "lVi" = (
-/obj/structure/sign/poster/ripped,
-/turf/closed/wall,
-/area/maintenance/aft/secondary)
+/obj/structure/chair/comfy/black{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "lVK" = (
 /obj/machinery/blackbox_recorder,
 /turf/open/floor/plasteel/dark/telecomms,
@@ -28793,7 +29293,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "lWb" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -28914,9 +29414,14 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "lYJ" = (
-/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plating,
-/area/maintenance/aft/secondary)
+/area/maintenance/aft)
 "lYM" = (
 /obj/machinery/light{
 	dir = 8
@@ -29044,10 +29549,13 @@
 /area/engine/atmos)
 "maq" = (
 /obj/effect/decal/cleanable/oil,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
-/area/hallway/primary/fore)
+/area/maintenance/starboard/aft)
 "mau" = (
 /obj/machinery/vending/coffee,
 /obj/machinery/light{
@@ -29058,7 +29566,7 @@
 "mav" = (
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plating,
-/area/hallway/secondary/entry)
+/area/maintenance/port/aft)
 "maG" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -29070,7 +29578,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard)
 "maK" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	volume_rate = 200
@@ -29109,7 +29617,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "mbE" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -29147,7 +29655,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "mde" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -29184,7 +29692,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "meL" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -29228,10 +29736,14 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "mfD" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/disposal)
+/obj/structure/table,
+/obj/item/hand_labeler,
+/obj/item/stack/packageWrap,
+/obj/structure/sign/poster/official/random{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/service)
 "mfF" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -29305,7 +29817,7 @@
 "mhF" = (
 /obj/structure/loot_pile,
 /turf/open/floor/plating,
-/area/hallway/primary/fore)
+/area/maintenance/starboard/aft)
 "mhG" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 9
@@ -29323,7 +29835,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "mia" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -29343,7 +29855,9 @@
 	pixel_x = 3
 	},
 /turf/open/floor/carpet/eighties,
-/area/crew_quarters/fitness)
+/area/crew_quarters/fitness/recreation{
+	name = "Arcade Room"
+	})
 "mip" = (
 /obj/effect/landmark/blobstart,
 /obj/structure/loot_pile/maint,
@@ -29353,6 +29867,17 @@
 /obj/machinery/gibber,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
+"mjw" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel/stairs/medium{
+	dir = 4
+	},
+/area/hallway/primary/aft)
 "mjH" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -29368,7 +29893,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "mjX" = (
 /obj/machinery/light{
 	dir = 8
@@ -29410,7 +29935,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "mkr" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -29439,13 +29964,13 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "mkU" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/maintenance/central)
+/area/maintenance/department/security)
 "mlM" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -29481,6 +30006,9 @@
 /area/ai_monitored/turret_protected/ai_upload_foyer)
 "mmK" = (
 /obj/effect/landmark/event_spawn,
+/obj/structure/railing/corner{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "mmM" = (
@@ -29556,7 +30084,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard/fore)
 "moD" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -29580,7 +30108,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard)
 "mpj" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -29614,7 +30142,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard)
 "mql" = (
 /obj/machinery/light{
 	dir = 1
@@ -29635,7 +30163,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "mqm" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -29655,7 +30183,7 @@
 /obj/structure/flora/grass/jungle,
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/floor/grass,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "mqC" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -29680,7 +30208,7 @@
 	},
 /obj/structure/fans/tiny,
 /turf/open/floor/plasteel/dark,
-/area/hallway/primary/port)
+/area/hallway/primary/port/fore)
 "mrM" = (
 /obj/machinery/newscaster,
 /turf/closed/wall/r_wall,
@@ -29689,7 +30217,7 @@
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/grass,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard)
 "mse" = (
 /obj/machinery/light{
 	dir = 8
@@ -29731,7 +30259,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/stairs/left,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "msA" = (
 /obj/machinery/holopad,
 /turf/open/floor/wood,
@@ -29769,8 +30297,11 @@
 "msR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/grille/broken,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard/fore)
 "mtv" = (
 /obj/structure/sink{
 	dir = 8;
@@ -29794,7 +30325,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
-/area/chapel/main)
+/area/chapel/main/monastery)
 "mtP" = (
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
@@ -29909,7 +30440,7 @@
 "mxV" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
-/area/hallway/primary/fore)
+/area/maintenance/starboard/aft)
 "myh" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -29955,8 +30486,9 @@
 /turf/open/floor/plating,
 /area/engine/storage)
 "mzv" = (
-/turf/open/floor/plating/asteroid/snow/icemoon,
-/area/maintenance/aft/secondary)
+/obj/machinery/door/airlock/maintenance/abandoned,
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "mzx" = (
 /obj/machinery/telecomms/processor/preset_four,
 /turf/open/floor/plasteel/dark/telecomms,
@@ -29970,12 +30502,14 @@
 	pixel_x = -6
 	},
 /turf/open/floor/carpet/eighties,
-/area/crew_quarters/fitness)
+/area/crew_quarters/fitness/recreation{
+	name = "Arcade Room"
+	})
 "mzQ" = (
 /turf/open/floor/plasteel/median/darktogrime/fullcorner{
 	dir = 1
 	},
-/area/chapel/main)
+/area/chapel/main/monastery)
 "mAh" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor/border_only{
@@ -30049,17 +30583,31 @@
 /turf/open/floor/plasteel/chapel{
 	dir = 8
 	},
-/area/chapel/main)
+/area/chapel/main/monastery)
+"mBe" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "evashutters2";
+	name = "E.V.A. Storage Shutters"
+	},
+/obj/machinery/button/door{
+	id = "evashutters2";
+	name = "E.V.A. Shutters";
+	pixel_x = 1;
+	pixel_y = 26;
+	req_access_txt = "19"
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "mBv" = (
 /turf/open/openspace/icemoon,
-/area/hallway/primary/aft)
+/area/maintenance/starboard/fore)
 "mBK" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/wood,
 /area/security/courtroom)
 "mCK" = (
 /turf/open/floor/plasteel/median/darktogrime/fullcorner,
-/area/chapel/main)
+/area/chapel/main/monastery)
 "mDm" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -30198,15 +30746,15 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "mGa" = (
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/structure/rack,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/maintenance/aft/secondary)
+/obj/machinery/recharge_station,
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "mGb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -30289,7 +30837,7 @@
 	dir = 4
 	},
 /turf/open/floor/wood,
-/area/chapel/main)
+/area/chapel/dock)
 "mIe" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -30311,7 +30859,7 @@
 	},
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
-/area/hallway/primary/port)
+/area/hallway/primary/port/fore)
 "mIl" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/green/visible{
@@ -30367,7 +30915,7 @@
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
+/area/hallway/primary/port)
 "mJr" = (
 /obj/structure/chair/sofa{
 	dir = 4
@@ -30409,11 +30957,11 @@
 /obj/structure/flora/grass/jungle,
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/grass,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "mKD" = (
 /obj/structure/chair/sofa/right,
 /turf/open/floor/carpet,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard)
 "mKO" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -30528,7 +31076,7 @@
 /obj/machinery/atmospherics/pipe/simple/multiz,
 /obj/effect/turf_decal/stripes/box,
 /turf/open/floor/plating,
-/area/maintenance/aft/secondary)
+/area/maintenance/aft)
 "mMs" = (
 /turf/closed/wall/r_wall,
 /area/engine/break_room)
@@ -30627,12 +31175,21 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"mOV" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/aft)
 "mPA" = (
 /obj/machinery/atmospherics/components/unary/tank/air{
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/chapel/main)
+/area/chapel/dock)
 "mPM" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -30647,7 +31204,7 @@
 	name = "Bathroom"
 	},
 /turf/open/floor/plasteel/freezer,
-/area/crew_quarters/dorms)
+/area/crew_quarters/toilet)
 "mQo" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -30665,13 +31222,16 @@
 /turf/open/floor/plasteel/dark,
 /area/hydroponics)
 "mQC" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 5
 	},
 /turf/open/floor/plating,
@@ -30744,6 +31304,16 @@
 /obj/structure/closet/crate/bin,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
+"mRE" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/railing/corner,
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "mRZ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -30761,7 +31331,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "mSs" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -30829,10 +31399,6 @@
 	},
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/medical/virology)
-"mUz" = (
-/obj/machinery/space_heater,
-/turf/open/floor/plating,
-/area/maintenance/aft/secondary)
 "mVb" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -30920,7 +31486,7 @@
 	pixel_y = 33
 	},
 /turf/open/floor/plasteel,
-/area/maintenance/starboard)
+/area/quartermaster/sorting)
 "mVr" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -30950,7 +31516,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard)
 "mWm" = (
 /obj/machinery/light{
 	dir = 4
@@ -30982,7 +31548,7 @@
 	},
 /obj/effect/turf_decal/tile/brown,
 /turf/open/floor/plasteel,
-/area/maintenance/starboard)
+/area/quartermaster/sorting)
 "mWJ" = (
 /turf/open/floor/plasteel,
 /area/storage/primary)
@@ -31001,7 +31567,7 @@
 	charge = 5e+006
 	},
 /turf/open/floor/plating,
-/area/chapel/main)
+/area/chapel/dock)
 "mXC" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -31012,6 +31578,9 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"mXE" = (
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/cryopod)
 "mXT" = (
 /obj/machinery/computer/communications{
 	dir = 4
@@ -31034,8 +31603,11 @@
 /area/medical/morgue)
 "mYg" = (
 /obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
 /turf/open/floor/plating,
-/area/hallway/primary/fore)
+/area/maintenance/starboard/aft)
 "mYx" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -31062,7 +31634,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard)
 "mYE" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/manifold{
 	dir = 8
@@ -31097,7 +31669,9 @@
 /area/medical/chemistry)
 "mZh" = (
 /turf/open/floor/carpet/eighties,
-/area/crew_quarters/fitness)
+/area/crew_quarters/fitness/recreation{
+	name = "Arcade Room"
+	})
 "mZk" = (
 /obj/effect/landmark/start/janitor,
 /obj/structure/cable{
@@ -31272,7 +31846,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/stairs/right,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "ndX" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -31293,7 +31867,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard/fore)
 "net" = (
 /obj/machinery/atmospherics/pipe/simple/dark/visible{
 	dir = 4
@@ -31323,7 +31897,7 @@
 /obj/structure/table,
 /obj/item/reagent_containers/glass/beaker/waterbottle/wataur,
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard/fore)
 "nft" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 5
@@ -31361,13 +31935,13 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "ngj" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
-/area/janitor)
+/area/maintenance/starboard/central)
 "ngp" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -31380,14 +31954,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/medical/chemistry)
-"nhb" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table_frame,
-/turf/open/floor/plating,
-/area/maintenance/aft/secondary)
 "nhd" = (
 /turf/open/floor/plating,
-/area/hallway/secondary/entry)
+/area/maintenance/port/aft)
 "nhe" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -31475,7 +32044,7 @@
 	pixel_y = -29
 	},
 /turf/open/floor/pod/dark,
-/area/maintenance/starboard)
+/area/quartermaster/sorting)
 "njn" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -31552,7 +32121,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "nmM" = (
 /obj/machinery/airalarm{
 	pixel_y = 26
@@ -31611,7 +32180,7 @@
 /area/medical/virology)
 "nog" = (
 /turf/open/openspace,
-/area/hallway/primary/port)
+/area/maintenance/port/central)
 "nok" = (
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/bridge)
@@ -31630,7 +32199,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/janitor)
+/area/quartermaster/sorting)
 "noB" = (
 /obj/effect/turf_decal/bot,
 /mob/living/simple_animal/sloth/paperwork,
@@ -31640,10 +32209,12 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "noG" = (
-/obj/structure/closet/crate,
-/obj/effect/spawner/lootdrop/maintenance,
+/obj/machinery/mecha_part_fabricator{
+	name = "counterfeit exosuit fabricator";
+	req_access = null
+	},
 /turf/open/floor/plating,
-/area/maintenance/aft/secondary)
+/area/maintenance/aft)
 "noQ" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating,
@@ -31651,7 +32222,7 @@
 "noU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/openspace,
-/area/hallway/secondary/entry)
+/area/maintenance/port/aft)
 "npl" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -31722,10 +32293,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"nqx" = (
-/obj/machinery/space_heater,
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "nrd" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/disposalpipe/segment{
@@ -31754,7 +32321,7 @@
 	req_access_txt = "31"
 	},
 /turf/open/floor/plating,
-/area/janitor)
+/area/maintenance/starboard/central)
 "nrJ" = (
 /obj/structure/table,
 /obj/item/stack/sheet/metal/fifty,
@@ -31800,7 +32367,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/obj/structure/railing,
+/turf/open/floor/plasteel/stairs/left{
+	dir = 4
+	},
 /area/quartermaster/storage)
 "nsv" = (
 /obj/machinery/requests_console{
@@ -31847,7 +32417,7 @@
 /turf/open/floor/plasteel/chapel{
 	dir = 1
 	},
-/area/chapel/main)
+/area/chapel/main/monastery)
 "nsK" = (
 /obj/structure/bed,
 /turf/open/floor/plasteel,
@@ -31917,7 +32487,7 @@
 /turf/open/floor/plasteel/white/corner{
 	dir = 8
 	},
-/area/hallway/secondary/entry)
+/area/hallway/primary/port)
 "nvW" = (
 /obj/structure/bed,
 /obj/item/bedsheet/mime,
@@ -31938,10 +32508,12 @@
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "nwe" = (
-/turf/open/floor/wood{
-	icon_state = "wood-broken5"
+/obj/structure/disposalpipe/segment,
+/obj/structure/railing{
+	dir = 8
 	},
-/area/maintenance/aft/secondary)
+/turf/open/floor/plasteel/stairs/left,
+/area/hallway/primary/starboard)
 "nwq" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -31986,7 +32558,7 @@
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel,
-/area/janitor)
+/area/quartermaster/sorting)
 "nxt" = (
 /obj/machinery/door/airlock/research{
 	name = "Nanites Lab";
@@ -32053,7 +32625,7 @@
 "nzn" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
-/area/maintenance/central)
+/area/maintenance/department/security)
 "nzD" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -32229,8 +32801,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/carpet/eighties,
-/area/crew_quarters/fitness)
+/area/crew_quarters/fitness/recreation{
+	name = "Arcade Room"
+	})
 "nCL" = (
 /obj/machinery/vending/cola/random,
 /turf/open/floor/plasteel/cafeteria,
@@ -32245,7 +32822,7 @@
 	dir = 4
 	},
 /turf/open/floor/grass,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "nDa" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -32313,7 +32890,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard/aft)
 "nEs" = (
 /obj/docking_port/stationary{
 	dir = 4;
@@ -32355,7 +32932,7 @@
 	},
 /obj/structure/chair/sofa/left,
 /turf/open/floor/carpet,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard)
 "nEJ" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -32402,13 +32979,16 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "nFS" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -32437,7 +33017,7 @@
 	pixel_x = 26
 	},
 /turf/open/floor/pod/dark,
-/area/maintenance/starboard)
+/area/quartermaster/sorting)
 "nGf" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/tile/red,
@@ -32460,7 +33040,6 @@
 /area/quartermaster/storage)
 "nGi" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "nGp" = (
@@ -32480,7 +33059,9 @@
 	dir = 6
 	},
 /turf/open/floor/carpet/eighties,
-/area/crew_quarters/fitness)
+/area/crew_quarters/fitness/recreation{
+	name = "Arcade Room"
+	})
 "nHe" = (
 /obj/structure/chair/stool,
 /turf/open/floor/wood,
@@ -32501,17 +33082,15 @@
 	pixel_x = 32
 	},
 /turf/open/floor/carpet/eighties,
-/area/crew_quarters/fitness)
+/area/crew_quarters/fitness/recreation{
+	name = "Arcade Room"
+	})
 "nHQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/wood,
 /area/library)
-"nHX" = (
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "nIu" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -32586,6 +33165,14 @@
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
+"nJv" = (
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/deck_relay,
+/obj/effect/turf_decal/stripes/box,
+/turf/open/floor/plating,
+/area/maintenance/aft/secondary)
 "nJI" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4;
@@ -32616,11 +33203,11 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/stairs/left,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard/fore)
 "nKf" = (
 /obj/structure/chair/sofa/left,
 /turf/open/floor/plasteel/grimy,
-/area/chapel/main)
+/area/chapel/main/monastery)
 "nKO" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -32674,11 +33261,14 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 5
 	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
 /turf/open/floor/plating,
-/area/maintenance/aft/secondary)
+/area/maintenance/aft)
 "nLv" = (
 /turf/open/openspace/icemoon,
-/area/maintenance/central)
+/area/maintenance/department/security)
 "nLF" = (
 /obj/machinery/atmospherics/pipe/manifold/orange/visible{
 	dir = 1
@@ -32689,9 +33279,8 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
 "nLS" = (
-/obj/machinery/door/airlock/maintenance,
-/turf/open/floor/plating,
-/area/hallway/primary/port)
+/turf/closed/wall,
+/area/maintenance/port/central)
 "nMt" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
@@ -32699,12 +33288,8 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
 "nMz" = (
-/obj/structure/chair/wood,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft/secondary)
+/turf/open/floor/plasteel/stairs/medium,
+/area/hallway/primary/starboard)
 "nMJ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
@@ -32715,7 +33300,7 @@
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
-/area/chapel/main)
+/area/chapel/main/monastery)
 "nNj" = (
 /obj/machinery/chem_master/condimaster{
 	name = "HoochMaster 2000"
@@ -32732,7 +33317,7 @@
 /turf/open/floor/plasteel/median/darktogrime{
 	dir = 4
 	},
-/area/chapel/main)
+/area/chapel/main/monastery)
 "nNV" = (
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/carpet/orange,
@@ -32784,7 +33369,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard)
 "nOE" = (
 /obj/structure/grille,
 /obj/structure/sign/warning/securearea{
@@ -32876,10 +33461,15 @@
 /turf/open/floor/wood,
 /area/maintenance/bar)
 "nPF" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plating,
-/area/engine/break_room)
+/obj/structure/disposalpipe/segment,
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "nQd" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 6
@@ -32901,7 +33491,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "nQp" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -32953,7 +33543,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "nQW" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-22"
@@ -32962,7 +33552,7 @@
 	pixel_y = -24
 	},
 /turf/open/floor/plasteel/dark,
-/area/chapel/main)
+/area/chapel/main/monastery)
 "nRn" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Evidence Storage";
@@ -33001,7 +33591,10 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/plasteel/stairs/right,
 /area/hallway/primary/port)
 "nRI" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -33019,7 +33612,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard)
 "nRR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -33095,8 +33688,12 @@
 /obj/machinery/cryopod{
 	dir = 1
 	},
+/obj/machinery/light_switch{
+	pixel_x = -7;
+	pixel_y = -26
+	},
 /turf/open/floor/circuit/green,
-/area/hallway/secondary/exit/departure_lounge)
+/area/crew_quarters/cryopod)
 "nUm" = (
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall,
@@ -33132,12 +33729,12 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "nUT" = (
-/obj/machinery/door/airlock{
-	id_tag = "bardorm3";
-	name = "Room Three"
+/obj/structure/disposalpipe/segment,
+/obj/structure/railing/corner{
+	dir = 1
 	},
-/turf/open/floor/plating,
-/area/maintenance/aft/secondary)
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "nVp" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -33152,7 +33749,7 @@
 /area/storage/auxiliary)
 "nVs" = (
 /turf/open/floor/plasteel/dark,
-/area/chapel/main)
+/area/chapel/main/monastery)
 "nVv" = (
 /obj/structure/table/glass,
 /obj/machinery/light{
@@ -33204,6 +33801,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/structure/railing/corner,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "nWM" = (
@@ -33328,7 +33926,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/stairs/right,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard)
 "nZR" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -33353,20 +33951,20 @@
 /turf/open/floor/plasteel/white/corner{
 	dir = 8
 	},
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "oaG" = (
 /obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/maintenance/central)
+/area/maintenance/department/security)
 "oaS" = (
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
 "oaY" = (
 /obj/structure/chair/sofa/right,
 /turf/open/floor/plasteel/grimy,
-/area/chapel/main)
+/area/chapel/main/monastery)
 "oba" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -33429,7 +34027,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard)
 "ocy" = (
 /obj/machinery/button/door{
 	id = "hos";
@@ -33460,7 +34058,7 @@
 "ocY" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
-/area/maintenance/starboard)
+/area/quartermaster/sorting)
 "odg" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4
@@ -33511,7 +34109,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/hallway/secondary/entry)
+/area/hallway/primary/port/aft)
 "oeh" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/research{
@@ -33536,7 +34134,7 @@
 "oeC" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "oeS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -33567,10 +34165,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"ofH" = (
-/obj/structure/grille/broken,
-/turf/open/floor/plating,
-/area/maintenance/aft/secondary)
 "ofP" = (
 /obj/machinery/airalarm{
 	pixel_y = 26
@@ -33670,7 +34264,7 @@
 	pixel_y = 25
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard)
 "ohF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -33678,8 +34272,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 5
 	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard/fore)
 "ohK" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -33694,7 +34291,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "oib" = (
 /obj/machinery/door/airlock/external{
 	name = "Engineering External Access";
@@ -33745,7 +34342,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "oje" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -33768,7 +34365,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "ojp" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -33845,12 +34442,9 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "okh" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/spawner/lootdrop/grille_or_trash,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/maintenance/disposal)
+/area/storage/eva)
 "okm" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -33873,7 +34467,7 @@
 	location = "HOP2"
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard)
 "okY" = (
 /turf/open/floor/wood,
 /area/medical/psych)
@@ -33991,7 +34585,7 @@
 "omQ" = (
 /obj/effect/landmark/start/cargo_technician,
 /turf/open/floor/pod/dark,
-/area/maintenance/starboard)
+/area/quartermaster/sorting)
 "ond" = (
 /obj/effect/landmark/start/assistant,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -34051,13 +34645,13 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/public/glass{
-	name = "Snow Airlock"
-	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
 /obj/structure/fans/tiny,
+/obj/machinery/door/airlock/external{
+	req_access_txt = "13"
+	},
 /turf/open/floor/plating,
 /area/hallway/primary/port)
 "ooR" = (
@@ -34239,7 +34833,7 @@
 /obj/structure/closet/firecloset,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
-/area/maintenance/central)
+/area/maintenance/department/security)
 "osc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -34282,7 +34876,7 @@
 	dir = 1
 	},
 /turf/closed/wall,
-/area/hallway/secondary/entry)
+/area/hallway/primary/port)
 "otZ" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -34298,7 +34892,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "oui" = (
 /turf/open/floor/plasteel/yellowsiding,
 /area/crew_quarters/fitness/pool)
@@ -34387,7 +34981,7 @@
 /obj/item/pickaxe,
 /obj/item/pickaxe,
 /turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
+/area/hallway/primary/port)
 "ovr" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -34490,7 +35084,7 @@
 	pixel_x = 24
 	},
 /turf/open/floor/pod/dark,
-/area/maintenance/starboard)
+/area/quartermaster/sorting)
 "oym" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
@@ -34512,6 +35106,12 @@
 "oyW" = (
 /obj/structure/cable{
 	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
@@ -34571,8 +35171,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard/fore)
 "oBD" = (
 /obj/machinery/camera{
 	c_tag = "Dorms South";
@@ -34617,7 +35220,7 @@
 	dir = 9
 	},
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard/fore)
 "oCj" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -34650,8 +35253,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plating,
-/area/maintenance/aft/secondary)
+/area/maintenance/aft)
 "oDw" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -34725,7 +35331,7 @@
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/grass,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "oER" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /turf/open/floor/plasteel,
@@ -34737,7 +35343,7 @@
 /turf/open/floor/plasteel/chapel{
 	dir = 8
 	},
-/area/chapel/main)
+/area/chapel/main/monastery)
 "oGU" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-10"
@@ -34751,7 +35357,7 @@
 	},
 /obj/effect/turf_decal/stripes/box,
 /turf/open/floor/plating,
-/area/maintenance/aft/secondary)
+/area/maintenance/aft)
 "oHl" = (
 /obj/structure/closet/crate/secure/engineering{
 	name = "TEG crate"
@@ -34778,7 +35384,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "oIq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall,
@@ -34797,8 +35403,11 @@
 /area/hallway/secondary/exit/departure_lounge)
 "oIT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating,
-/area/hallway/secondary/entry)
+/area/maintenance/port/aft)
 "oJa" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -34821,7 +35430,7 @@
 	dir = 5
 	},
 /turf/closed/wall,
-/area/hallway/secondary/entry)
+/area/maintenance/port/aft)
 "oJD" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4;
@@ -34853,7 +35462,7 @@
 /turf/open/floor/plasteel/median/darktogrime{
 	dir = 8
 	},
-/area/chapel/main)
+/area/chapel/main/monastery)
 "oJX" = (
 /obj/structure/closet/secure_closet/quartermaster,
 /obj/effect/turf_decal/tile/brown{
@@ -34929,7 +35538,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard)
 "oLy" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -34954,7 +35563,7 @@
 	icon_state = "2-4"
 	},
 /turf/open/floor/wood,
-/area/chapel/main)
+/area/chapel/dock)
 "oLT" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -34972,6 +35581,21 @@
 	dir = 4
 	},
 /area/hallway/secondary/exit/departure_lounge)
+"oMe" = (
+/obj/item/kirbyplants/random,
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"oMD" = (
+/obj/structure/chair/pew/left{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/chapel{
+	dir = 8
+	},
+/area/chapel/main/monastery)
 "oME" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -35026,7 +35650,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "oOe" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/tile/red{
@@ -35042,6 +35666,13 @@
 /obj/machinery/holopad,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
+"oOq" = (
+/obj/effect/decal/cleanable/oil,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/aft)
 "oOu" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -35055,7 +35686,7 @@
 "oOR" = (
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "oPB" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -35148,7 +35779,7 @@
 "oRc" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "oSt" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 10
@@ -35160,10 +35791,13 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/chapel,
-/area/chapel/main)
+/area/chapel/main/monastery)
 "oTb" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating,
-/area/hallway/primary/fore)
+/area/maintenance/starboard/aft)
 "oTv" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -35287,7 +35921,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard)
 "oWT" = (
 /obj/machinery/vending/cigarette,
 /obj/structure/disposalpipe/segment,
@@ -35304,6 +35938,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"oXh" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/hallway/primary/aft)
 "oXi" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -35325,6 +35963,19 @@
 /obj/machinery/hydroponics/constructable,
 /turf/open/floor/plasteel/dark,
 /area/hydroponics)
+"oXu" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1;
+	name = "north facing firelock"
+	},
+/obj/machinery/door/airlock/glass{
+	name = "Chapel Garden"
+	},
+/turf/open/floor/plasteel/dark,
+/area/chapel/main/monastery)
 "oXI" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -35334,7 +35985,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/dark,
-/area/chapel/main)
+/area/chapel/main/monastery)
 "oXZ" = (
 /obj/structure/chair/comfy/brown{
 	dir = 1
@@ -35350,7 +36001,7 @@
 "oYU" = (
 /obj/structure/chair,
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "oZe" = (
 /obj/machinery/camera{
 	c_tag = "Escape Arm Airlocks";
@@ -35469,7 +36120,7 @@
 	dir = 6
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "pbg" = (
 /obj/machinery/vending/cola/random,
 /obj/effect/turf_decal/tile/green{
@@ -35482,7 +36133,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "pbs" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -35715,6 +36366,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"pfU" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "pfY" = (
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
@@ -35756,10 +36413,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
-/area/maintenance/aft/secondary)
+/area/maintenance/aft)
 "phf" = (
 /obj/structure/railing/corner{
 	dir = 8
@@ -35784,7 +36444,7 @@
 /turf/open/floor/plasteel/white/corner{
 	dir = 8
 	},
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "phs" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -35919,7 +36579,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "pjA" = (
 /obj/structure/table/wood,
 /obj/item/paicard,
@@ -36069,6 +36729,27 @@
 /obj/structure/railing/corner,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
+"pop" = (
+/obj/item/tank/internals/emergency_oxygen/double{
+	pixel_x = 3
+	},
+/obj/item/tank/internals/emergency_oxygen/double{
+	pixel_x = 3
+	},
+/obj/item/clothing/mask/breath{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/clothing/mask/breath{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/structure/closet/crate/internals,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "por" = (
 /obj/machinery/computer/crew{
 	dir = 1
@@ -36146,7 +36827,7 @@
 /area/hallway/secondary/exit/departure_lounge)
 "pqj" = (
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "pqs" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -36217,7 +36898,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard)
 "psD" = (
 /obj/machinery/button/door{
 	id = "armouryaccess";
@@ -36309,6 +36990,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
+"pud" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/hydroponics/garden/monastery)
 "puf" = (
 /obj/machinery/pipedispenser/disposal,
 /obj/structure/fireaxecabinet{
@@ -36434,7 +37121,7 @@
 /turf/open/floor/plasteel/white/corner{
 	dir = 8
 	},
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "pvw" = (
 /obj/machinery/telecomms/processor/preset_three,
 /turf/open/floor/plasteel/dark/telecomms,
@@ -36469,8 +37156,11 @@
 	name = "Engineering Maintenance";
 	req_access_txt = "10"
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating,
-/area/hallway/primary/fore)
+/area/maintenance/starboard/aft)
 "pwB" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plasteel/dark,
@@ -36557,7 +37247,7 @@
 	name = "south facing firelock"
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "pxS" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -36613,7 +37303,7 @@
 	pixel_x = -32
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard/fore)
 "pyI" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -36682,7 +37372,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard/fore)
 "pAz" = (
 /obj/machinery/light{
 	dir = 8
@@ -36705,7 +37395,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/chapel/main)
+/area/chapel/main/monastery)
 "pAN" = (
 /obj/machinery/airalarm{
 	pixel_y = 28
@@ -36734,7 +37424,7 @@
 	name = "Bathroom"
 	},
 /turf/open/floor/plasteel/freezer,
-/area/crew_quarters/dorms)
+/area/crew_quarters/toilet)
 "pBx" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -36746,7 +37436,7 @@
 /turf/open/floor/plasteel/white/corner{
 	dir = 8
 	},
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "pBU" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -36786,7 +37476,7 @@
 	name = "west facing firelock"
 	},
 /turf/open/floor/plasteel/dark,
-/area/chapel/main)
+/area/chapel/main/monastery)
 "pCj" = (
 /obj/structure/sink{
 	dir = 8;
@@ -36800,7 +37490,7 @@
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/freezer,
-/area/crew_quarters/dorms)
+/area/crew_quarters/toilet)
 "pCo" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 9
@@ -36824,7 +37514,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/stairs/left,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard)
 "pCY" = (
 /obj/machinery/computer/communications,
 /obj/machinery/newscaster/security_unit{
@@ -36833,10 +37523,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "pDh" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark/side,
 /area/engine/atmos)
 "pDu" = (
 /obj/structure/cable{
@@ -36855,7 +37542,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard)
 "pDF" = (
 /obj/structure/table/reinforced,
 /obj/item/grenade/barrier{
@@ -36956,7 +37643,7 @@
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "pFf" = (
-/obj/machinery/pipedispenser/disposal/transit_tube,
+/obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "pFo" = (
@@ -36983,7 +37670,7 @@
 /area/medical/medbay/central)
 "pFR" = (
 /turf/closed/wall,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "pGe" = (
 /obj/machinery/vending/assist,
 /obj/effect/turf_decal/tile/yellow{
@@ -37053,7 +37740,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "pIf" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -37152,10 +37839,10 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "pKF" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
@@ -37189,7 +37876,7 @@
 	},
 /obj/machinery/light,
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "pLg" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 5
@@ -37201,7 +37888,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "pLo" = (
 /obj/structure/fence/post,
 /turf/open/floor/plating/asteroid/snow/icemoon,
@@ -37260,7 +37947,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "pMp" = (
 /obj/machinery/plate_press,
 /obj/item/stack/license_plates/empty/fifty,
@@ -37305,10 +37992,8 @@
 /turf/open/floor/plasteel/dark,
 /area/security/warden)
 "pNh" = (
-/obj/structure/bed,
-/obj/item/bedsheet/orange,
-/turf/open/floor/plating,
-/area/maintenance/aft/secondary)
+/turf/closed/wall,
+/area/hallway/primary/port/fore)
 "pNo" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -37385,10 +38070,14 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "pOO" = (
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc/auto_name/north,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
-/area/hallway/primary/aft)
+/area/maintenance/starboard/fore)
 "pOU" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -37446,7 +38135,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/port)
+/area/hallway/primary/port/fore)
 "pQg" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 6
@@ -37511,16 +38200,23 @@
 	},
 /turf/open/floor/plating,
 /area/security/detectives_office)
-"pSs" = (
-/obj/structure/chair/wood,
-/turf/open/floor/plating,
-/area/maintenance/aft/secondary)
+"pSo" = (
+/obj/structure/chair/pew/right{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/chapel{
+	dir = 1
+	},
+/area/chapel/main/monastery)
 "pSC" = (
 /obj/structure/rack,
 /obj/item/stack/cable_coil,
 /obj/item/stack/cable_coil,
 /turf/open/floor/plating,
-/area/hallway/primary/fore)
+/area/maintenance/starboard/aft)
 "pSO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
@@ -37592,7 +38288,7 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
-/area/chapel/main)
+/area/chapel/main/monastery)
 "pUf" = (
 /obj/effect/turf_decal/stripes,
 /obj/machinery/conveyor{
@@ -37605,7 +38301,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "pVz" = (
 /obj/structure/railing/corner{
 	dir = 4
@@ -37616,20 +38312,10 @@
 	},
 /obj/structure/flora/rock/jungle,
 /turf/open/floor/grass,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "pVM" = (
-/obj/effect/decal/cleanable/cobweb{
-	icon_state = "cobweb2"
-	},
-/obj/machinery/button/door{
-	id = "bardorm1";
-	name = "Dorm Bolt Control";
-	normaldoorcontrol = 1;
-	pixel_x = 25;
-	specialfunctions = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft/secondary)
+/turf/closed/wall/r_wall,
+/area/maintenance/starboard/aft)
 "pVU" = (
 /obj/structure/table/wood/fancy/green,
 /obj/item/nullrod,
@@ -37646,7 +38332,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard/aft)
 "pVZ" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/head/that,
@@ -37679,13 +38365,18 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
+"pWF" = (
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/aft)
 "pWS" = (
 /turf/closed/wall/r_wall,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "pWT" = (
 /obj/machinery/hydroponics/soil,
 /turf/open/floor/grass,
-/area/chapel/main)
+/area/hydroponics/garden/monastery)
 "pXb" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -37759,7 +38450,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "pYM" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -37785,7 +38476,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/hallway/primary/port)
+/area/hallway/primary/port/fore)
 "pZl" = (
 /obj/machinery/light,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
@@ -37805,11 +38496,11 @@
 	pixel_x = -27
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "qaO" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard/fore)
 "qaX" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/disposalpipe/segment,
@@ -37820,7 +38511,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "qbg" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -37903,19 +38594,17 @@
 /turf/closed/wall,
 /area/maintenance/disposal/incinerator)
 "qdi" = (
-/obj/machinery/light,
-/obj/machinery/camera{
-	c_tag = "Toxins Launch Hall 2";
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/obj/structure/railing,
+/turf/open/floor/plasteel/stairs/left{
+	dir = 4
+	},
+/area/hallway/primary/aft)
 "qdK" = (
 /obj/effect/spawner/structure/window/ice,
 /turf/open/floor/plating,
@@ -37935,7 +38624,7 @@
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
-/area/hallway/primary/port)
+/area/maintenance/port/central)
 "qeo" = (
 /obj/machinery/holopad,
 /obj/effect/landmark/start/security_officer,
@@ -38018,6 +38707,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
+"qfw" = (
+/obj/structure/railing/corner,
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
 "qfB" = (
 /obj/machinery/door/airlock/public/glass/incinerator/atmos_exterior,
 /obj/effect/mapping_helpers/airlock/locked,
@@ -38047,7 +38740,7 @@
 /area/hallway/primary/central)
 "qgm" = (
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard/fore)
 "qgC" = (
 /obj/structure/light_construct/small{
 	dir = 1
@@ -38060,7 +38753,7 @@
 	pixel_y = -22
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "qha" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 5
@@ -38094,7 +38787,7 @@
 /turf/open/floor/plasteel/median/darktogrime/corner{
 	dir = 8
 	},
-/area/chapel/main)
+/area/chapel/main/monastery)
 "qhU" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -38144,7 +38837,7 @@
 	light_color = "#d8b1b1"
 	},
 /turf/open/floor/plating,
-/area/maintenance/aft/secondary)
+/area/maintenance/aft)
 "qjc" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/food/snacks/pie/cream,
@@ -38192,7 +38885,7 @@
 "qjQ" = (
 /obj/item/hatchet,
 /turf/open/floor/grass,
-/area/chapel/main)
+/area/hydroponics/garden/monastery)
 "qjX" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
@@ -38209,7 +38902,7 @@
 	pixel_x = 28
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "qle" = (
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
@@ -38218,7 +38911,9 @@
 /obj/machinery/atmospherics/pipe/simple/dark/visible{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark/corner{
+	dir = 1
+	},
 /area/engine/atmos)
 "qlj" = (
 /obj/machinery/button/door{
@@ -38253,7 +38948,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard/fore)
 "qlY" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -38284,7 +38979,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/dark,
-/area/chapel/main)
+/area/chapel/main/monastery)
 "qmD" = (
 /obj/structure/chair/comfy/brown{
 	dir = 4
@@ -38462,7 +39157,7 @@
 /turf/open/floor/plasteel/chapel{
 	dir = 1
 	},
-/area/chapel/main)
+/area/chapel/main/monastery)
 "qqR" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -38493,7 +39188,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "qrq" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -38637,7 +39332,7 @@
 /obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "qve" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
@@ -38645,8 +39340,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 10
 	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard/fore)
 "qvG" = (
 /obj/item/radio/intercom{
 	pixel_y = -26
@@ -38713,7 +39411,9 @@
 	dir = 4
 	},
 /turf/open/floor/carpet/eighties,
-/area/crew_quarters/fitness)
+/area/crew_quarters/fitness/recreation{
+	name = "Arcade Room"
+	})
 "qxM" = (
 /obj/machinery/door/airlock/public/glass{
 	id_tag = null;
@@ -38744,6 +39444,9 @@
 "qxT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
+	},
+/obj/structure/railing/corner{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
@@ -38824,11 +39527,7 @@
 "qAo" = (
 /obj/structure/table/wood,
 /turf/open/floor/plasteel/grimy,
-/area/chapel/main)
-"qAq" = (
-/obj/structure/closet/emcloset/anchored,
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/chapel/main/monastery)
 "qAx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -38857,7 +39556,9 @@
 "qAY" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/carpet/eighties,
-/area/crew_quarters/fitness)
+/area/crew_quarters/fitness/recreation{
+	name = "Arcade Room"
+	})
 "qBb" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -38923,7 +39624,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "qCo" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -38973,7 +39674,7 @@
 	pixel_x = 26
 	},
 /turf/open/floor/plasteel/grimy,
-/area/chapel/main)
+/area/chapel/main/monastery)
 "qDg" = (
 /obj/structure/chair/comfy/brown,
 /obj/structure/barricade/wooden/snowed{
@@ -38983,11 +39684,8 @@
 /turf/open/floor/wood,
 /area/maintenance/bar)
 "qDt" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /turf/closed/wall,
-/area/maintenance/disposal)
+/area/maintenance/starboard/aft)
 "qDY" = (
 /obj/structure/fence/post,
 /obj/structure/cable{
@@ -39033,10 +39731,13 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
-/area/maintenance/aft/secondary)
+/area/maintenance/aft)
 "qFf" = (
 /obj/structure/closet/secure_closet/personal/patient,
 /obj/effect/turf_decal/tile/green{
@@ -39074,7 +39775,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
-/area/hallway/primary/port)
+/area/maintenance/port/central)
 "qGn" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -39097,7 +39798,7 @@
 "qGM" = (
 /obj/machinery/door/airlock/maintenance,
 /turf/open/floor/plating,
-/area/maintenance/central)
+/area/maintenance/department/security)
 "qHc" = (
 /obj/effect/landmark/start/paramedic,
 /turf/open/floor/plasteel/white,
@@ -39125,14 +39826,18 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/lumos/loading_area/white,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard/fore)
 "qHq" = (
 /obj/structure/closet/emcloset/anchored,
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "qHC" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
@@ -39220,7 +39925,7 @@
 	pixel_x = -22
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard/fore)
 "qJL" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 10
@@ -39259,6 +39964,11 @@
 /obj/item/clothing/shoes/winterboots/ice_boots,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
+"qKg" = (
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/closet,
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "qKq" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -39274,7 +39984,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard/fore)
 "qKA" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -39284,17 +39994,20 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "qKJ" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
-/area/hallway/primary/aft)
+/area/maintenance/starboard/fore)
 "qKM" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
-/area/hallway/primary/fore)
+/area/maintenance/starboard/aft)
 "qKP" = (
 /obj/machinery/computer/security{
 	dir = 8
@@ -39354,6 +40067,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
+"qLP" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "qMn" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -39398,12 +40115,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/wood,
 /area/security/vacantoffice/a)
-"qOr" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plating/asteroid/snow/icemoon,
-/area/maintenance/aft/secondary)
 "qOs" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -39446,7 +40157,7 @@
 /obj/item/reagent_containers/food/snacks/grown/harebell,
 /obj/item/reagent_containers/food/snacks/grown/harebell,
 /turf/open/floor/plasteel/dark,
-/area/chapel/main)
+/area/chapel/main/monastery)
 "qQb" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
@@ -39482,7 +40193,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "qQC" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/wood,
@@ -39555,13 +40266,16 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "qSi" = (
 /obj/structure/disposalpipe/junction/yjunction{
 	dir = 8
 	},
+/obj/structure/railing/corner{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "qSy" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -39574,6 +40288,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/railing/corner{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "qSP" = (
@@ -39615,7 +40332,7 @@
 	map_pad_link_id = "6"
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard)
 "qTG" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -39657,7 +40374,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
+/area/hallway/primary/port)
 "qUe" = (
 /obj/structure/window/plasma/reinforced,
 /obj/machinery/atmospherics/pipe/simple/dark/visible/layer1,
@@ -39691,8 +40408,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating,
-/area/hallway/primary/port)
+/area/maintenance/port/central)
 "qUF" = (
 /obj/structure/table,
 /obj/item/aicard,
@@ -39715,7 +40435,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "qVf" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -39728,7 +40448,7 @@
 	dir = 8
 	},
 /turf/open/floor/wood,
-/area/chapel/main)
+/area/chapel/dock)
 "qVD" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -39746,7 +40466,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/grimy,
-/area/chapel/main)
+/area/chapel/main/monastery)
 "qWg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -39772,6 +40492,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -39882,7 +40605,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "qZP" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -39914,11 +40637,11 @@
 "rad" = (
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
-/area/hallway/primary/port)
+/area/maintenance/port/central)
 "rai" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard)
 "ral" = (
 /obj/machinery/door/airlock/external{
 	name = "Engineering External Access";
@@ -40028,7 +40751,7 @@
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
-/area/maintenance/aft/secondary)
+/area/maintenance/aft)
 "rck" = (
 /obj/machinery/door/airlock{
 	name = "Kitchen cold room";
@@ -40185,13 +40908,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard/fore)
 "rgG" = (
 /obj/structure/chair/sofa/left{
 	dir = 4
 	},
 /turf/open/floor/plasteel/grimy,
-/area/chapel/main)
+/area/chapel/main/monastery)
 "rgH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/components/binary/pump/on/layer3{
@@ -40217,7 +40940,7 @@
 /obj/effect/turf_decal/tile/neutral,
 /obj/item/kirbyplants/random,
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "rhX" = (
 /turf/closed/wall,
 /area/medical/paramedic)
@@ -40226,6 +40949,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/storage/auxiliary)
 "rio" = (
@@ -40252,7 +40976,7 @@
 "riR" = (
 /obj/structure/chair,
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "rjx" = (
 /obj/structure/chair{
 	dir = 8
@@ -40286,7 +41010,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard/fore)
 "rjQ" = (
 /obj/structure/light_construct/small{
 	dir = 1
@@ -40307,7 +41031,7 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/biolumi/mine/weaklight,
 /turf/open/floor/grass,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "rkd" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -40323,7 +41047,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "rke" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -40335,7 +41059,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
-/area/hallway/primary/port)
+/area/hallway/primary/port/fore)
 "rkp" = (
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/computer)
@@ -40344,7 +41068,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/grimy,
-/area/chapel/main)
+/area/chapel/main/monastery)
 "rkL" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
@@ -40378,7 +41102,7 @@
 "rlo" = (
 /obj/structure/table,
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "rlp" = (
 /obj/structure/table/optable,
 /obj/machinery/camera{
@@ -40414,7 +41138,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard/fore)
 "rlW" = (
 /obj/structure/table,
 /obj/machinery/computer/security/telescreen/rd,
@@ -40437,7 +41161,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "rmL" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -40481,7 +41205,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "rnk" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -40524,7 +41248,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard)
 "rom" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -40553,7 +41277,7 @@
 /obj/structure/closet/emcloset,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
-/area/maintenance/aft/secondary)
+/area/maintenance/aft)
 "roF" = (
 /obj/structure/table/wood,
 /obj/item/folder,
@@ -40596,7 +41320,7 @@
 /obj/item/pickaxe,
 /obj/item/pickaxe,
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "rpT" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -40605,14 +41329,13 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"rqf" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 2;
-	name = "2maintenance loot spawner"
+/obj/structure/railing/corner{
+	dir = 4
 	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"rqf" = (
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/aft/secondary)
 "rqw" = (
@@ -40704,11 +41427,11 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/chapel,
-/area/chapel/main)
+/area/chapel/main/monastery)
 "rrC" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard/fore)
 "rrD" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -40723,7 +41446,7 @@
 	pixel_x = -27
 	},
 /turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
+/area/hallway/primary/port)
 "rsD" = (
 /obj/structure/table/wood,
 /obj/structure/bedsheetbin/towel,
@@ -40749,9 +41472,9 @@
 	},
 /area/crew_quarters/fitness/pool)
 "rte" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/open/floor/plating,
-/area/maintenance/aft/secondary)
+/obj/structure/bed/roller/bodypillow/kevin,
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors)
 "rtm" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -40799,6 +41522,9 @@
 	dir = 1
 	},
 /obj/machinery/meter,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "rtT" = (
@@ -40810,7 +41536,7 @@
 "ruk" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
-/area/chapel/main)
+/area/chapel/dock)
 "rum" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/engine,
@@ -40886,7 +41612,7 @@
 "rwz" = (
 /obj/structure/chair/sofa/corner,
 /turf/open/floor/plasteel/grimy,
-/area/chapel/main)
+/area/chapel/main/monastery)
 "rwR" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -40895,7 +41621,7 @@
 /obj/structure/flora/grass/jungle,
 /obj/structure/flora/rock/jungle,
 /turf/open/floor/grass,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "rwW" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 5
@@ -40912,12 +41638,16 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "rxf" = (
-/obj/structure/reagent_dispensers/fueltank,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
 	dir = 8
 	},
+/obj/structure/reagent_dispensers/watertank/high,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"rxk" = (
+/obj/structure/girder,
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "rxu" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -40992,9 +41722,8 @@
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "rAf" = (
-/obj/effect/decal/cleanable/blood,
-/turf/open/floor/plating,
-/area/maintenance/aft/secondary)
+/turf/open/floor/plasteel,
+/area/hallway/primary/port/fore)
 "rAj" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -41079,18 +41808,21 @@
 	pixel_y = -25;
 	req_access_txt = "12"
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "rDl" = (
 /obj/structure/rack,
 /turf/open/floor/plating,
-/area/hallway/primary/fore)
+/area/maintenance/starboard/aft)
 "rDv" = (
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/disposal/bin,
@@ -41098,7 +41830,7 @@
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/fore)
 "rDG" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/open/floor/plasteel,
@@ -41126,6 +41858,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
+"rEX" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/railing/corner,
+/turf/open/floor/plasteel/white/side,
+/area/hallway/primary/port)
 "rFk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -41190,7 +41929,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "rGP" = (
 /obj/machinery/turnstile{
 	dir = 8;
@@ -41228,10 +41967,9 @@
 /turf/open/floor/wood,
 /area/library)
 "rHo" = (
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
-	},
-/area/maintenance/aft/secondary)
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "rHS" = (
 /obj/machinery/door/airlock/medical{
 	name = "Morgue";
@@ -41298,14 +42036,13 @@
 /obj/structure/chair{
 	dir = 8
 	},
-/obj/effect/landmark/start/assistant,
 /obj/effect/turf_decal/tile/purple,
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_x = 29
 	},
 /turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
+/area/hallway/primary/port)
 "rJl" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
@@ -41349,6 +42086,13 @@
 	},
 /turf/open/floor/circuit/off,
 /area/ai_monitored/turret_protected/ai)
+"rKz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "rKG" = (
 /obj/structure/table/wood,
 /obj/item/clothing/under/misc/burial,
@@ -41397,9 +42141,16 @@
 /turf/open/floor/carpet,
 /area/bridge)
 "rLU" = (
-/obj/effect/spawner/blocker,
-/turf/open/floor/plating,
-/area/maintenance/aft/secondary)
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/corner{
+	dir = 4
+	},
+/area/hallway/primary/port/fore)
 "rMb" = (
 /obj/machinery/rnd/production/circuit_imprinter/department/science,
 /obj/item/reagent_containers/glass/beaker/large,
@@ -41459,8 +42210,9 @@
 /obj/structure/chair/comfy/black{
 	dir = 8
 	},
+/obj/structure/railing/corner,
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "rOd" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -41515,7 +42267,7 @@
 "rQs" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "rQu" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -41530,14 +42282,14 @@
 /obj/effect/decal/cleanable/blood,
 /obj/effect/spawner/lootdrop/organ_spawner,
 /turf/open/floor/plating,
-/area/hallway/primary/fore)
+/area/maintenance/starboard/aft)
 "rQH" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard/fore)
 "rQJ" = (
 /turf/closed/wall,
 /area/science/robotics/lab)
@@ -41588,17 +42340,26 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/dorms)
 "rRH" = (
-/obj/structure/chair/wood{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/open/floor/plating,
-/area/maintenance/aft/secondary)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/port/fore)
 "rRU" = (
 /obj/structure/closet/crate,
 /obj/item/soap/nanotrasen,
 /obj/item/toy/lumosplush/vadim,
 /turf/open/floor/plating,
-/area/hallway/primary/port)
+/area/maintenance/port/central)
 "rRV" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
@@ -41624,7 +42385,10 @@
 	dir = 8
 	},
 /obj/machinery/meter,
-/obj/structure/closet/crate/bin,
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/pump,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "rSN" = (
@@ -41664,6 +42428,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
+"rTB" = (
+/obj/structure/loot_pile/maint,
+/turf/open/floor/plating,
+/area/maintenance/port/central)
 "rTG" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -41680,7 +42448,7 @@
 	dir = 6
 	},
 /turf/open/floor/plating,
-/area/maintenance/aft/secondary)
+/area/maintenance/aft)
 "rTW" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/turf_decal/tile/yellow{
@@ -41692,15 +42460,20 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "rUa" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/open/floor/plating,
-/area/maintenance/disposal)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/port/fore)
 "rUk" = (
-/obj/item/clothing/glasses/sunglasses/big,
-/turf/open/floor/wood,
-/area/hallway/primary/port)
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "rUq" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -41732,7 +42505,7 @@
 "rVg" = (
 /obj/item/reagent_containers/glass/bucket,
 /turf/open/floor/grass,
-/area/chapel/main)
+/area/hydroponics/garden/monastery)
 "rVy" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
@@ -41752,7 +42525,7 @@
 /obj/structure/closet/cardboard,
 /obj/item/clothing/head/foilhat,
 /turf/open/floor/plating,
-/area/hallway/primary/fore)
+/area/maintenance/starboard/aft)
 "rWi" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -41808,7 +42581,7 @@
 /turf/open/floor/plasteel/chapel{
 	dir = 8
 	},
-/area/chapel/main)
+/area/chapel/main/monastery)
 "rYN" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -41825,9 +42598,8 @@
 /turf/open/floor/wood,
 /area/maintenance/bar)
 "rZe" = (
-/obj/effect/spawner/lootdrop/maintenance,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/stairs,
 /area/maintenance/disposal)
 "rZJ" = (
 /obj/structure/chair/stool{
@@ -41855,7 +42627,7 @@
 /turf/open/floor/plasteel/chapel{
 	dir = 8
 	},
-/area/chapel/main)
+/area/chapel/main/monastery)
 "sax" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -41876,6 +42648,9 @@
 /area/security/vacantoffice/b)
 "sbo" = (
 /obj/machinery/portable_atmospherics/scrubber,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "sbB" = (
@@ -41887,10 +42662,10 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "sbD" = (
-/obj/item/shard,
-/obj/item/chair,
-/turf/open/floor/wood,
-/area/hallway/primary/port)
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/maintenance/starboard/aft)
 "sbN" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -41997,13 +42772,17 @@
 /area/library)
 "sdN" = (
 /turf/open/floor/plating,
-/area/maintenance/central)
+/area/maintenance/department/security)
 "sdR" = (
 /obj/structure/table/wood,
 /obj/item/folder/blue,
 /obj/item/hand_labeler,
 /turf/open/floor/wood,
 /area/security/vacantoffice/b)
+"sec" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/crew_quarters/cryopod)
 "seo" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -42019,7 +42798,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/maintenance/starboard)
+/area/quartermaster/sorting)
 "seG" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -42032,7 +42811,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "seR" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/carpet/purple,
@@ -42176,7 +42955,7 @@
 "siY" = (
 /obj/structure/chair/sofa,
 /turf/open/floor/plasteel/grimy,
-/area/chapel/main)
+/area/chapel/main/monastery)
 "sjk" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -42216,7 +42995,7 @@
 	dir = 6
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "sjW" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -42296,7 +43075,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard/fore)
 "skZ" = (
 /obj/vehicle/ridden/janicart,
 /obj/structure/sink{
@@ -42343,6 +43122,12 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
@@ -42392,6 +43177,11 @@
 /obj/item/pickaxe,
 /turf/open/floor/carpet,
 /area/hallway/secondary/exit/departure_lounge)
+"smo" = (
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/port/central)
 "smp" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -42406,7 +43196,14 @@
 "smB" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
-/area/hallway/primary/fore)
+/area/maintenance/starboard/aft)
+"smK" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "smP" = (
 /turf/closed/wall/r_wall,
 /area/security/detectives_office)
@@ -42425,7 +43222,7 @@
 	name = "north facing firelock"
 	},
 /turf/open/floor/plasteel/dark,
-/area/chapel/main)
+/area/chapel/main/monastery)
 "snb" = (
 /obj/machinery/computer/card,
 /turf/open/floor/wood,
@@ -42442,6 +43239,12 @@
 /obj/effect/landmark/blobstart,
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
@@ -42489,14 +43292,9 @@
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "spV" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -14
-	},
-/turf/open/floor/wood{
-	icon_state = "wood-broken5"
-	},
-/area/maintenance/aft/secondary)
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "sqg" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -42514,7 +43312,7 @@
 "sqs" = (
 /obj/machinery/vending/cola/random,
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "sqv" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 8;
@@ -42534,7 +43332,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/maintenance/central)
+/area/maintenance/department/security)
 "sqH" = (
 /turf/closed/wall,
 /area/hydroponics/garden)
@@ -42614,7 +43412,7 @@
 /obj/item/pickaxe,
 /obj/item/pickaxe,
 /turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
+/area/hallway/primary/port)
 "ssF" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -42731,7 +43529,7 @@
 "svv" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "svY" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 4
@@ -42789,7 +43587,7 @@
 	dir = 1
 	},
 /turf/closed/wall,
-/area/hallway/secondary/entry)
+/area/hallway/primary/port)
 "sxB" = (
 /obj/machinery/light{
 	dir = 8
@@ -42861,7 +43659,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "szD" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -42932,7 +43730,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "sAC" = (
 /obj/structure/table/glass,
 /obj/item/plant_analyzer,
@@ -42982,7 +43780,7 @@
 "sBs" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard/aft)
 "sBy" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -42999,7 +43797,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "sBN" = (
 /obj/machinery/hydroponics/soil,
 /obj/machinery/light{
@@ -43106,7 +43904,19 @@
 	pixel_x = -32
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
+"sFJ" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "sGC" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/effect/turf_decal/stripes/line,
@@ -43117,8 +43927,16 @@
 	name = "Service Hall";
 	req_one_access_txt = "25;26;35;28"
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/door/firedoor/border_only{
+	name = "south facing firelock"
+	},
 /turf/open/floor/plasteel,
-/area/maintenance/disposal)
+/area/hallway/secondary/service)
 "sGL" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4;
@@ -43160,7 +43978,7 @@
 	name = "south facing firelock"
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "sHl" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -43197,7 +44015,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard/aft)
 "sHK" = (
 /obj/machinery/door/airlock{
 	name = "Bar Storage";
@@ -43223,7 +44041,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/chapel/main)
+/area/chapel/dock)
 "sIo" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Chapel"
@@ -43239,7 +44057,7 @@
 	name = "east facing firelock"
 	},
 /turf/open/floor/plasteel/dark,
-/area/chapel/main)
+/area/chapel/main/monastery)
 "sIT" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -43290,7 +44108,7 @@
 /obj/structure/fans/tiny,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
-/area/hallway/secondary/entry)
+/area/hallway/primary/port/aft)
 "sKN" = (
 /obj/structure/window/plasma/reinforced{
 	dir = 8
@@ -43466,7 +44284,7 @@
 	},
 /obj/structure/chair/comfy/brown,
 /turf/open/floor/carpet,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "sOz" = (
 /obj/structure/disposalpipe/junction/flip{
 	dir = 8
@@ -43484,13 +44302,16 @@
 	name = "east facing firelock"
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "sOH" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating,
-/area/maintenance/aft/secondary)
+/area/maintenance/aft)
 "sPq" = (
 /obj/machinery/light{
 	dir = 4
@@ -43512,7 +44333,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
-/area/hallway/secondary/entry)
+/area/hallway/primary/port/aft)
 "sPF" = (
 /obj/machinery/airalarm{
 	pixel_y = 26
@@ -43535,14 +44356,13 @@
 	icon_state = "lantern-on"
 	},
 /turf/open/floor/wood,
-/area/chapel/main)
+/area/chapel/dock)
 "sQJ" = (
-/obj/structure/table_frame/wood,
-/obj/item/trash/can,
-/turf/open/floor/wood{
-	icon_state = "wood-broken"
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/area/hallway/primary/port)
+/turf/open/floor/plasteel,
+/area/hallway/primary/port/fore)
 "sRh" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -43706,7 +44526,7 @@
 	pixel_x = -27
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "sVh" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
@@ -43846,7 +44666,7 @@
 /area/icemoon/surface/outdoors)
 "sYT" = (
 /turf/open/floor/plasteel/chapel,
-/area/chapel/main)
+/area/chapel/main/monastery)
 "sYW" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/blood/gibs/human/body,
@@ -43903,13 +44723,15 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engine/atmospherics_engine)
-"tad" = (
-/obj/structure/closet/emcloset,
-/obj/machinery/light/small{
+"sZX" = (
+/obj/structure/railing/corner{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/maintenance/aft/secondary)
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
+"tad" = (
+/turf/closed/wall/r_wall,
+/area/maintenance/aft)
 "tag" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 9
@@ -43972,10 +44794,7 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "tcu" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/chair/stool/bar,
+/obj/machinery/door/airlock/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/aft/secondary)
 "tcD" = (
@@ -43994,9 +44813,14 @@
 /turf/open/floor/plating,
 /area/construction/storage)
 "tcH" = (
-/obj/machinery/portable_atmospherics/canister/air,
+/obj/machinery/power/deck_relay,
+/obj/effect/turf_decal/stripes/box,
+/obj/structure/cable{
+	icon_state = "0-2";
+	pixel_y = 1
+	},
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard/fore)
 "tcN" = (
 /obj/structure/table/wood,
 /obj/item/storage/box/donkpockets,
@@ -44085,7 +44909,7 @@
 	dir = 1
 	},
 /turf/open/floor/wood,
-/area/chapel/main)
+/area/chapel/dock)
 "teC" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
@@ -44114,12 +44938,12 @@
 	dir = 9
 	},
 /turf/closed/wall,
-/area/hallway/secondary/entry)
+/area/maintenance/port/aft)
 "tfa" = (
 /obj/structure/table,
 /obj/item/storage/box/lights/mixed,
 /turf/open/floor/plating,
-/area/hallway/primary/fore)
+/area/maintenance/starboard/aft)
 "tfq" = (
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=2";
@@ -44137,7 +44961,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard/fore)
 "tfx" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -44151,9 +44975,12 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "tfM" = (
-/obj/item/chair,
-/turf/open/floor/wood,
-/area/hallway/primary/port)
+/obj/machinery/power/apc/auto_name/south,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "tfP" = (
 /obj/machinery/light,
 /obj/machinery/airalarm{
@@ -44240,7 +45067,7 @@
 	},
 /obj/machinery/door/airlock/external,
 /turf/open/floor/plating,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "tjh" = (
 /obj/structure/table/wood,
 /obj/item/book/granter/spell/smoke/lesser,
@@ -44259,7 +45086,7 @@
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
 /turf/open/floor/plasteel/dark,
-/area/chapel/main)
+/area/hydroponics/garden/monastery)
 "tkm" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
@@ -44369,7 +45196,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "tmx" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
@@ -44384,7 +45211,7 @@
 	name = "west facing firelock"
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "tmy" = (
 /obj/machinery/sleeper{
 	dir = 8
@@ -44403,7 +45230,7 @@
 "tnd" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/closed/wall,
-/area/maintenance/aft/secondary)
+/area/maintenance/aft)
 "tnq" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -44431,7 +45258,7 @@
 	name = "north facing firelock"
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "tnX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -44459,7 +45286,7 @@
 /area/icemoon/surface/outdoors)
 "tod" = (
 /turf/closed/wall,
-/area/maintenance/central)
+/area/maintenance/department/security)
 "tos" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -44520,7 +45347,7 @@
 	pixel_x = -32
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "tpf" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -44629,7 +45456,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
+"trk" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft/secondary)
 "trn" = (
 /obj/machinery/telecomms/broadcaster/preset_right,
 /turf/open/floor/plasteel/dark/telecomms,
@@ -44653,7 +45486,7 @@
 /obj/item/reagent_containers/food/snacks/grown/poppy,
 /obj/item/reagent_containers/food/snacks/grown/poppy,
 /turf/open/floor/plasteel/dark,
-/area/chapel/main)
+/area/chapel/main/monastery)
 "trO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -44674,7 +45507,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "tsi" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -44716,7 +45549,7 @@
 "ttl" = (
 /obj/machinery/door/airlock/maintenance,
 /turf/open/floor/plating,
-/area/hallway/primary/fore)
+/area/maintenance/starboard/aft)
 "tty" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -44770,7 +45603,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/grimy,
-/area/chapel/main)
+/area/chapel/main/monastery)
 "ttU" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -44873,7 +45706,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard)
 "tys" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -44998,7 +45831,7 @@
 	icon_state = "plant-22"
 	},
 /turf/open/floor/plasteel/dark,
-/area/chapel/main)
+/area/chapel/main/monastery)
 "tBL" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-22"
@@ -45008,7 +45841,7 @@
 	light_color = "#ffc1c1"
 	},
 /turf/open/floor/plasteel/median/darktogrime,
-/area/chapel/main)
+/area/chapel/main/monastery)
 "tBW" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -45078,13 +45911,18 @@
 /turf/open/floor/plating,
 /area/blueshield)
 "tDC" = (
-/obj/structure/table_frame/wood,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plating,
-/area/hallway/primary/port)
+/area/maintenance/starboard/aft)
 "tDO" = (
-/obj/structure/reagent_dispensers/beerkeg,
-/turf/open/floor/wood,
-/area/hallway/primary/port)
+/obj/structure/grille/broken,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "tEb" = (
 /obj/structure/window/reinforced,
 /obj/effect/turf_decal/tile/neutral{
@@ -45160,15 +45998,21 @@
 /turf/open/floor/plasteel,
 /area/storage/auxiliary)
 "tGq" = (
-/obj/structure/table/wood,
-/obj/machinery/light/small{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plating,
-/area/maintenance/aft/secondary)
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/port/fore)
 "tGJ" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -45203,7 +46047,17 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "tHs" = (
-/obj/structure/trash_pile,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/door/airlock/public/glass{
+	name = "Fore Primary Hallway"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/port/fore)
+"tHw" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/spawner/lootdrop/gloves,
 /turf/open/floor/plating,
 /area/maintenance/aft/secondary)
 "tHU" = (
@@ -45255,11 +46109,14 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
 /turf/open/floor/carpet,
 /area/hallway/secondary/exit/departure_lounge)
 "tJJ" = (
 /turf/open/openspace,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "tJL" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -45274,7 +46131,7 @@
 	dir = 6
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard)
 "tKa" = (
 /obj/machinery/door/airlock/security/glass{
 	id_tag = "innerbrig";
@@ -45436,7 +46293,17 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
+"tNi" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/external{
+	req_access_txt = "13"
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft/secondary)
 "tNp" = (
 /obj/machinery/airalarm{
 	pixel_y = 23
@@ -45512,7 +46379,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "tPF" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -45562,7 +46429,7 @@
 "tQv" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
-/area/janitor)
+/area/maintenance/starboard/central)
 "tQy" = (
 /obj/structure/closet,
 /turf/open/floor/plasteel/dark,
@@ -45604,8 +46471,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard/fore)
 "tRe" = (
 /obj/structure/closet/secure_closet/miner,
 /obj/item/clothing/shoes/winterboots/ice_boots,
@@ -45642,7 +46512,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "tSd" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -45659,9 +46529,15 @@
 /turf/open/floor/plasteel/dark,
 /area/science/server)
 "tTt" = (
-/obj/effect/decal/cleanable/femcum,
-/turf/open/floor/plating,
-/area/maintenance/aft/secondary)
+/obj/docking_port/stationary{
+	dwidth = 3;
+	height = 4;
+	id = "snaxi_nw";
+	name = "Northwest Taxi Port";
+	width = 6
+	},
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/surface/outdoors)
 "tTO" = (
 /obj/effect/landmark/xeno_spawn,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
@@ -45677,7 +46553,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "tTS" = (
 /obj/structure/pool/ladder,
 /turf/open/pool,
@@ -45707,7 +46583,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/grimy,
-/area/chapel/main)
+/area/chapel/main/monastery)
 "tUF" = (
 /obj/machinery/light{
 	dir = 1
@@ -45719,6 +46595,14 @@
 	dir = 4
 	},
 /area/hallway/primary/port)
+"tUP" = (
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/structure/closet/secure_closet/blueshield,
+/turf/open/floor/plasteel/dark,
+/area/blueshield)
 "tVh" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -45745,7 +46629,7 @@
 "tVD" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard/fore)
 "tVS" = (
 /obj/item/radio/intercom{
 	frequency = 1485;
@@ -45834,7 +46718,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "tXN" = (
 /turf/closed/wall/r_wall,
 /area/science/robotics/lab)
@@ -45884,7 +46768,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "tZe" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -45895,7 +46779,13 @@
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "tZf" = (
-/obj/machinery/door/airlock/maintenance,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc/auto_name/north,
 /turf/open/floor/plating,
 /area/maintenance/aft/secondary)
 "tZu" = (
@@ -46028,8 +46918,11 @@
 "ubH" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard/fore)
 "ubL" = (
 /obj/item/radio/intercom{
 	pixel_y = 25
@@ -46044,10 +46937,16 @@
 	},
 /turf/open/floor/plating,
 /area/engine/storage)
+"ubS" = (
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white/side,
+/area/hallway/primary/port)
 "uca" = (
 /obj/structure/mopbucket,
 /turf/open/floor/plating,
-/area/hallway/primary/port)
+/area/maintenance/port/central)
 "ucC" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating,
@@ -46082,11 +46981,17 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/hallway/primary/fore)
+/area/maintenance/starboard/aft)
 "udh" = (
-/obj/structure/table/wood,
-/turf/open/floor/wood,
-/area/maintenance/aft/secondary)
+/obj/machinery/camera{
+	c_tag = "Northwestern Hall 7"
+	},
+/obj/machinery/quantumpad{
+	map_pad_id = "2";
+	map_pad_link_id = "1"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
 "udB" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Brig Control";
@@ -46246,7 +47151,7 @@
 	},
 /obj/effect/spawner/lootdrop/soap/seventyfive_percent,
 /turf/open/floor/plasteel/freezer,
-/area/crew_quarters/dorms)
+/area/crew_quarters/toilet)
 "uha" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -46267,12 +47172,12 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "uhD" = (
-/obj/item/radio/intercom{
-	pixel_y = 25
-	},
 /obj/vehicle/ridden/atv/snowmobile,
 /obj/item/key,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "uhN" = (
@@ -46300,6 +47205,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"ujj" = (
+/obj/structure/rack,
+/obj/item/radio,
+/obj/item/clothing/suit/hooded/wintercoat,
+/obj/item/pickaxe,
+/obj/item/clothing/shoes/winterboots/ice_boots,
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "ujD" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -46312,14 +47225,15 @@
 /turf/open/floor/plasteel,
 /area/medical/genetics)
 "ujE" = (
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/structure/reagent_dispensers/watertank,
 /obj/machinery/newscaster{
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/bot,
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_x = 29
+	},
 /turf/open/floor/plasteel,
 /area/storage/auxiliary)
 "ujF" = (
@@ -46357,6 +47271,13 @@
 /obj/structure/closet/secure_closet/freezer/fridge,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
+"ukK" = (
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc/auto_name/north,
+/turf/open/floor/plasteel/dark,
+/area/hydroponics/garden/monastery)
 "ukV" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/airlock/external{
@@ -46403,7 +47324,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "umD" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 5
@@ -46450,18 +47371,12 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "unU" = (
-/obj/effect/decal/cleanable/cobweb{
-	icon_state = "cobweb2"
+/obj/machinery/quantumpad{
+	map_pad_id = "3";
+	map_pad_link_id = "4"
 	},
-/obj/machinery/button/door{
-	id = "bardorm3";
-	name = "Dorm Bolt Control";
-	normaldoorcontrol = 1;
-	pixel_x = 25;
-	specialfunctions = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft/secondary)
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
 "unX" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -46488,7 +47403,7 @@
 "uon" = (
 /obj/structure/flora/tree/jungle/small,
 /turf/open/floor/grass,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "uot" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -46503,6 +47418,11 @@
 /obj/structure/closet/secure_closet/engineering_personal,
 /turf/open/floor/plasteel/dark,
 /area/engine/secure_construction)
+"upt" = (
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/rack,
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "upH" = (
 /obj/structure/bedsheetbin,
 /obj/structure/table,
@@ -46541,7 +47461,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "uqV" = (
 /obj/structure/closet/secure_closet/brig_phys,
 /turf/open/floor/plasteel/white,
@@ -46551,9 +47471,7 @@
 /turf/open/floor/plating,
 /area/hydroponics)
 "urO" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
+/obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "urV" = (
@@ -46586,9 +47504,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard/aft)
 "usE" = (
-/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/airlock/external,
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/hallway/primary/port)
 "usN" = (
@@ -46598,7 +47520,7 @@
 "utd" = (
 /obj/structure/table/optable,
 /turf/open/floor/plating,
-/area/hallway/primary/fore)
+/area/maintenance/starboard/aft)
 "utj" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -46675,7 +47597,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "uvO" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -46750,9 +47672,8 @@
 /turf/open/floor/carpet,
 /area/hallway/secondary/exit/departure_lounge)
 "uxx" = (
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = 28
+/obj/machinery/atm{
+	pixel_x = 28
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
@@ -46787,7 +47708,7 @@
 	dir = 4
 	},
 /turf/open/floor/wood,
-/area/chapel/main)
+/area/chapel/dock)
 "uze" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/green/visible{
@@ -46803,7 +47724,7 @@
 /obj/machinery/light,
 /obj/machinery/vending/cola/random,
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "uzT" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -46848,6 +47769,9 @@
 /area/bridge/meeting_room)
 "uAu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/visible,
+/obj/structure/railing/corner{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "uAI" = (
@@ -46892,19 +47816,22 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "uBy" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
 	},
-/obj/structure/disposalpipe/segment,
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = 24
+	},
 /turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
+/area/hallway/primary/port)
 "uBG" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
-/area/hallway/secondary/entry)
+/area/hallway/primary/port)
 "uBW" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -46913,7 +47840,7 @@
 	pixel_y = -24
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "uCi" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plasteel/white,
@@ -46943,13 +47870,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/teleporter)
+"uEc" = (
+/turf/closed/wall/r_wall,
+/area/crew_quarters/cryopod)
 "uEd" = (
 /obj/effect/turf_decal/tile/red,
 /obj/machinery/space_heater,
 /turf/open/floor/plasteel/white/corner{
 	dir = 8
 	},
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "uEz" = (
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
@@ -47006,7 +47936,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/wood,
-/area/chapel/main)
+/area/chapel/dock)
 "uGl" = (
 /obj/structure/closet/secure_closet/engineering_personal,
 /obj/structure/disposalpipe/segment{
@@ -47022,7 +47952,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
-/area/chapel/main)
+/area/chapel/dock)
 "uGY" = (
 /obj/structure/chair/comfy/brown,
 /obj/structure/disposalpipe/segment{
@@ -47196,7 +48126,7 @@
 	pixel_y = 28
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard)
 "uKG" = (
 /obj/effect/landmark/start/cyborg,
 /obj/machinery/airalarm{
@@ -47272,11 +48202,14 @@
 	dir = 6
 	},
 /turf/closed/wall,
-/area/hallway/primary/aft)
+/area/maintenance/starboard/fore)
 "uLL" = (
 /obj/structure/grille,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating,
-/area/hallway/primary/fore)
+/area/maintenance/starboard/aft)
 "uLV" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -47305,7 +48238,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard/aft)
 "uNq" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-22"
@@ -47313,7 +48246,7 @@
 /turf/open/floor/plasteel/median/darktogrime/corner{
 	dir = 4
 	},
-/area/chapel/main)
+/area/chapel/main/monastery)
 "uOy" = (
 /obj/machinery/atmospherics/pipe/simple,
 /obj/machinery/door/airlock/command/glass{
@@ -47329,7 +48262,7 @@
 /turf/open/floor/plasteel/chapel{
 	dir = 4
 	},
-/area/chapel/main)
+/area/chapel/main/monastery)
 "uOT" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -47362,7 +48295,7 @@
 "uPx" = (
 /obj/structure/sink/puddle,
 /turf/open/floor/grass,
-/area/chapel/main)
+/area/hydroponics/garden/monastery)
 "uPJ" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin{
@@ -47405,7 +48338,7 @@
 /area/icemoon/surface/outdoors)
 "uRg" = (
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "1-4"
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft/secondary)
@@ -47434,7 +48367,7 @@
 	name = "east facing firelock"
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "uSv" = (
 /obj/machinery/deepfryer,
 /turf/open/floor/plasteel/cafeteria,
@@ -47442,7 +48375,7 @@
 "uSH" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
-/area/maintenance/aft/secondary)
+/area/maintenance/aft)
 "uSJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
@@ -47474,8 +48407,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/turf/open/floor/plasteel/stairs/medium,
+/area/hallway/primary/starboard)
 "uTm" = (
 /obj/machinery/airalarm{
 	pixel_y = 28
@@ -47546,11 +48479,7 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "uUZ" = (
-/obj/machinery/quantumpad{
-	map_pad_id = "3";
-	map_pad_link_id = "4"
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/carpet,
 /area/hallway/primary/port)
 "uVe" = (
 /obj/structure/table/wood,
@@ -47565,13 +48494,13 @@
 "uVi" = (
 /obj/structure/loot_pile/maint,
 /turf/open/floor/plating,
-/area/hallway/primary/fore)
+/area/maintenance/starboard/aft)
 "uVo" = (
 /obj/structure/chair{
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/hallway/primary/fore)
+/area/maintenance/starboard/aft)
 "uVt" = (
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
@@ -47616,7 +48545,7 @@
 	req_access_txt = "6;5"
 	},
 /turf/open/floor/plating,
-/area/hallway/primary/port)
+/area/hallway/primary/port/fore)
 "uWC" = (
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
@@ -47693,7 +48622,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/chapel,
-/area/chapel/main)
+/area/chapel/main/monastery)
 "uXs" = (
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Supermatter Engine Room";
@@ -47755,7 +48684,7 @@
 /turf/open/floor/plasteel/white/corner{
 	dir = 8
 	},
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "uXO" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -47817,7 +48746,7 @@
 /turf/open/floor/plasteel/chapel{
 	dir = 1
 	},
-/area/chapel/main)
+/area/chapel/main/monastery)
 "uYQ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -47838,7 +48767,7 @@
 	sortType = 30
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "uZz" = (
 /turf/closed/wall,
 /area/quartermaster/sorting)
@@ -47869,7 +48798,7 @@
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
-/area/hallway/primary/aft)
+/area/maintenance/starboard/fore)
 "vaj" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -47887,7 +48816,7 @@
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "vam" = (
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/disposal/bin,
@@ -47928,6 +48857,15 @@
 /obj/machinery/vending/cigarette,
 /turf/open/floor/plating,
 /area/maintenance/bar)
+"vaS" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "vbe" = (
 /obj/machinery/firealarm{
 	pixel_y = 29
@@ -48010,7 +48948,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/chapel/main)
+/area/chapel/main/monastery)
 "vdw" = (
 /turf/open/floor/circuit,
 /area/science/robotics/mechbay)
@@ -48102,12 +49040,15 @@
 "vfp" = (
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/pod/dark,
-/area/maintenance/starboard)
+/area/quartermaster/sorting)
 "vfr" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/floor/plasteel/stairs/left,
 /area/hallway/primary/port)
 "vfx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -48124,7 +49065,7 @@
 	name = "south facing firelock"
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard/fore)
 "vfZ" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -48230,7 +49171,7 @@
 /obj/structure/table,
 /obj/item/trash/candle,
 /turf/open/floor/plating,
-/area/hallway/primary/fore)
+/area/maintenance/starboard/aft)
 "vir" = (
 /obj/structure/disposalpipe/sorting/mail{
 	dir = 8;
@@ -48244,6 +49185,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
+"viZ" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/plating,
+/area/maintenance/department/security)
 "vju" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -48252,7 +49201,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "vjQ" = (
 /obj/structure/closet/secure_closet/exile,
 /obj/machinery/light{
@@ -48310,8 +49259,11 @@
 /area/security/execution/education)
 "vkk" = (
 /obj/structure/disposalpipe/segment,
+/obj/structure/railing/corner{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "vkw" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -48378,7 +49330,7 @@
 	pixel_x = 30
 	},
 /turf/open/floor/plasteel/freezer,
-/area/crew_quarters/dorms)
+/area/crew_quarters/toilet)
 "vlN" = (
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plasteel,
@@ -48435,7 +49387,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 10
 	},
-/obj/structure/closet/firecloset,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "vmO" = (
@@ -48549,11 +49500,11 @@
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
 "vqD" = (
-/obj/structure/table,
-/obj/effect/decal/cleanable/cobweb,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/aft/secondary)
+/obj/structure/chair/sofa/right{
+	dir = 8
+	},
+/turf/open/floor/carpet,
+/area/hallway/primary/port)
 "vqF" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -48616,13 +49567,16 @@
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/engine/atmospherics_engine)
 "vra" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plating{
@@ -48644,7 +49598,9 @@
 	dir = 4
 	},
 /turf/open/floor/carpet/eighties,
-/area/crew_quarters/fitness)
+/area/crew_quarters/fitness/recreation{
+	name = "Arcade Room"
+	})
 "vrI" = (
 /obj/machinery/button/door{
 	id = "tegheat";
@@ -48677,7 +49633,7 @@
 	dir = 4
 	},
 /turf/open/floor/carpet,
-/area/chapel/main)
+/area/chapel/main/monastery)
 "vse" = (
 /obj/machinery/light{
 	dir = 8
@@ -48700,7 +49656,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
-/area/hallway/secondary/entry)
+/area/hallway/primary/port/aft)
 "vsM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
@@ -48727,7 +49683,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/maintenance/central)
+/area/maintenance/department/security)
 "vuJ" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -26
@@ -48743,7 +49699,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "vvH" = (
 /obj/effect/landmark/start/medical_doctor,
 /obj/structure/disposalpipe/segment,
@@ -48760,6 +49716,12 @@
 "vvW" = (
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg2"
@@ -48925,8 +49887,14 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/plasteel/stairs/right,
+/area/hallway/primary/starboard)
+"vyQ" = (
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/aft)
 "vyV" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -49097,7 +50065,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "vCv" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -49115,6 +50083,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"vCA" = (
+/obj/structure/table,
+/obj/item/reagent_containers/glass/beaker/waterbottle/wataur,
+/turf/open/floor/plating,
+/area/maintenance/aft/secondary)
 "vCE" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -49162,7 +50135,7 @@
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/grass,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "vEe" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -49295,7 +50268,7 @@
 "vGj" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
-/area/hallway/primary/port)
+/area/maintenance/port/central)
 "vGn" = (
 /obj/structure/closet/secure_closet/medical3,
 /obj/item/gun/syringe/dart,
@@ -49307,17 +50280,27 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "vHd" = (
-/obj/machinery/light/small{
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/chair/wood,
-/turf/open/floor/plating,
-/area/maintenance/aft/secondary)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel/stairs/medium{
+	dir = 4
+	},
+/area/hallway/primary/port)
 "vHU" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
+/area/hallway/primary/port)
 "vIf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
@@ -49356,10 +50339,16 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
 	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
-/area/hallway/primary/aft)
+/area/maintenance/starboard/fore)
 "vJG" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -49371,7 +50360,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
-/area/hallway/primary/port)
+/area/hallway/primary/port/fore)
 "vKa" = (
 /turf/closed/wall,
 /area/crew_quarters/kitchen)
@@ -49403,7 +50392,7 @@
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "vKO" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -49426,7 +50415,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "vKT" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -49469,17 +50458,17 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/door/airlock/public/glass{
+	name = "Fore Primary Hallway"
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/port)
+/area/hallway/primary/port/fore)
 "vLt" = (
 /obj/effect/turf_decal/arrows/red{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard)
 "vLE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 5
@@ -49526,10 +50515,13 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
 /turf/open/floor/plasteel/white/corner{
 	dir = 8
 	},
-/area/hallway/secondary/entry)
+/area/hallway/primary/port)
 "vMh" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -49550,7 +50542,7 @@
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/grass,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "vMB" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -49589,6 +50581,15 @@
 	},
 /turf/open/floor/wood,
 /area/security/vacantoffice/a)
+"vOn" = (
+/obj/machinery/cryopod,
+/obj/structure/cable{
+	icon_state = "0-2";
+	pixel_y = 1
+	},
+/obj/machinery/power/apc/auto_name/north,
+/turf/open/floor/circuit/green,
+/area/crew_quarters/cryopod)
 "vOo" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -49613,7 +50614,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "vOS" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Snow Airlock"
@@ -49626,7 +50627,7 @@
 	name = "east facing firelock"
 	},
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard)
 "vOU" = (
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -49643,7 +50644,7 @@
 "vPD" = (
 /obj/structure/ladder,
 /turf/open/floor/plating,
-/area/hallway/secondary/entry)
+/area/maintenance/port/aft)
 "vPQ" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -49655,12 +50656,15 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating,
-/area/hallway/secondary/entry)
+/area/maintenance/port/aft)
 "vQd" = (
 /obj/structure/frame/machine,
 /turf/open/floor/plating,
-/area/hallway/primary/fore)
+/area/maintenance/starboard/aft)
 "vQk" = (
 /turf/open/pool,
 /area/crew_quarters/fitness/pool)
@@ -49668,7 +50672,7 @@
 /obj/structure/closet/firecloset,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
-/area/maintenance/aft/secondary)
+/area/maintenance/aft)
 "vQo" = (
 /turf/closed/wall/r_wall,
 /area/engine/supermatter)
@@ -49750,7 +50754,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "vSg" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -49829,11 +50833,9 @@
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "vTF" = (
-/obj/item/radio/intercom{
-	pixel_y = -26
-	},
+/obj/structure/closet/emcloset/anchored,
 /turf/open/floor/plasteel,
-/area/quartermaster/miningdock)
+/area/hallway/primary/port)
 "vTL" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -49877,7 +50879,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "vUs" = (
 /obj/structure/railing,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
@@ -49966,7 +50968,7 @@
 "vWg" = (
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "vWt" = (
 /obj/structure/table,
 /obj/item/stack/sheet/mineral/plasma,
@@ -50027,7 +51029,7 @@
 /obj/effect/landmark/blobstart,
 /obj/item/pickaxe,
 /turf/open/floor/plating,
-/area/hallway/secondary/entry)
+/area/maintenance/port/aft)
 "vYL" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4;
@@ -50063,7 +51065,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard/aft)
 "vZl" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 9
@@ -50171,7 +51173,7 @@
 	dir = 1
 	},
 /turf/open/floor/grass,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard)
 "waP" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -50280,7 +51282,7 @@
 /area/hallway/secondary/exit/departure_lounge)
 "wcK" = (
 /turf/closed/wall,
-/area/chapel/main)
+/area/chapel/main/monastery)
 "wcS" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/ausbushes/ppflowers,
@@ -50288,7 +51290,7 @@
 	dir = 1
 	},
 /turf/open/floor/grass,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard)
 "wdb" = (
 /turf/closed/wall/r_wall,
 /area/science/explab)
@@ -50346,7 +51348,7 @@
 	charge = 5e+006
 	},
 /turf/open/floor/plating,
-/area/chapel/main)
+/area/chapel/dock)
 "wen" = (
 /obj/structure/table/reinforced,
 /obj/machinery/cell_charger,
@@ -50359,6 +51361,20 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"weD" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"weI" = (
+/obj/structure/closet/crate{
+	icon_state = "crateopen"
+	},
+/obj/item/reagent_containers/glass/beaker/waterbottle/wataur,
+/obj/item/bonesetter,
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "weS" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -50366,7 +51382,7 @@
 	},
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard)
 "wfK" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-08"
@@ -50387,7 +51403,7 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/transit_tube/horizontal,
 /turf/open/floor/plating,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "wgu" = (
 /obj/machinery/light/floor,
 /obj/structure/disposalpipe/segment{
@@ -50409,14 +51425,14 @@
 /area/crew_quarters/bar)
 "wgO" = (
 /turf/open/openspace,
-/area/chapel/main)
+/area/chapel/main/monastery)
 "wgP" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard/fore)
 "wha" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/n2o{
 	dir = 1
@@ -50428,15 +51444,15 @@
 	icon_state = "plant-22"
 	},
 /turf/open/floor/plasteel/dark,
-/area/chapel/main)
+/area/chapel/main/monastery)
 "whB" = (
 /obj/machinery/light/small,
 /turf/open/floor/plating,
-/area/maintenance/central)
+/area/maintenance/department/security)
 "whR" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
-/area/chapel/main)
+/area/chapel/dock)
 "whW" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -50469,7 +51485,7 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "wje" = (
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
@@ -50480,7 +51496,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "wjn" = (
 /obj/machinery/firealarm{
 	pixel_y = 24
@@ -50532,7 +51548,7 @@
 "wjP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/carpet,
-/area/chapel/main)
+/area/chapel/main/monastery)
 "wkg" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -50565,7 +51581,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "wkS" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -50614,17 +51630,17 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
+	},
+/obj/machinery/door/airlock/external{
+	req_access_txt = "13"
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "wlV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plating,
-/area/maintenance/aft/secondary)
+/area/maintenance/aft)
 "wlZ" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
@@ -50791,7 +51807,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "wqe" = (
 /obj/structure/chair/sofa/left{
 	dir = 1
@@ -50807,13 +51823,17 @@
 /area/security/brig)
 "wrh" = (
 /obj/machinery/cryopod,
+/obj/machinery/firealarm{
+	pixel_y = 29
+	},
 /turf/open/floor/circuit/green,
-/area/hallway/secondary/exit/departure_lounge)
+/area/crew_quarters/cryopod)
 "wrI" = (
-/obj/machinery/light/small,
-/obj/structure/loot_pile/maint,
-/turf/open/floor/plating,
-/area/maintenance/aft/secondary)
+/obj/structure/chair/sofa/left{
+	dir = 8
+	},
+/turf/open/floor/carpet,
+/area/hallway/primary/port)
 "wrN" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -50823,7 +51843,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/maintenance/starboard)
+/area/quartermaster/sorting)
 "wsc" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/plasma{
 	dir = 1
@@ -50852,7 +51872,7 @@
 "wsK" = (
 /obj/structure/flora/tree/jungle/small,
 /turf/open/floor/grass,
-/area/chapel/main)
+/area/hydroponics/garden/monastery)
 "wsY" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -50865,16 +51885,18 @@
 	name = "north facing firelock"
 	},
 /turf/open/floor/plasteel/dark,
-/area/chapel/main)
+/area/chapel/main/monastery)
 "wtf" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
 /obj/structure/fans/tiny,
+/obj/machinery/door/airlock/external{
+	req_access_txt = "13"
+	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "wtp" = (
@@ -50883,7 +51905,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "wtt" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green{
@@ -50994,16 +52016,18 @@
 /turf/open/floor/plasteel/white,
 /area/security/brig)
 "wuZ" = (
-/obj/machinery/door/airlock{
-	id_tag = "bardorm1";
-	name = "Room One"
+/obj/structure/railing,
+/turf/open/floor/plasteel/stairs/left{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/maintenance/aft/secondary)
+/area/hallway/primary/port)
 "wvg" = (
 /obj/machinery/bookbinder,
 /turf/open/floor/carpet,
 /area/library)
+"wvh" = (
+/turf/closed/wall,
+/area/hallway/primary/aft)
 "wvj" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -51023,14 +52047,14 @@
 	},
 /obj/machinery/light,
 /turf/open/floor/circuit/green,
-/area/hallway/secondary/exit/departure_lounge)
+/area/crew_quarters/cryopod)
 "wvW" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/open/floor/carpet,
-/area/chapel/main)
+/area/chapel/main/monastery)
 "wwh" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -51046,7 +52070,7 @@
 "wwi" = (
 /obj/structure/punji_sticks,
 /turf/open/floor/plating,
-/area/hallway/primary/fore)
+/area/maintenance/starboard/aft)
 "wwx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/closed/wall/mineral/wood,
@@ -51118,13 +52142,13 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "wzl" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
 /turf/closed/wall,
-/area/hallway/primary/aft)
+/area/maintenance/starboard/fore)
 "wzv" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -51144,6 +52168,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
+"wzT" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/external{
+	req_access_txt = "13"
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft/secondary)
 "wAx" = (
 /turf/closed/wall,
 /area/hydroponics)
@@ -51203,7 +52235,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/maintenance/starboard)
+/area/quartermaster/sorting)
 "wDJ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -51250,8 +52282,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/machinery/camera{
+	c_tag = "Toxins Launch Hall 2";
+	dir = 1
+	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "wEP" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/eastright{
@@ -51312,7 +52348,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard/fore)
 "wFB" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -51337,7 +52373,7 @@
 "wFD" = (
 /obj/machinery/vending/cola/random,
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard/fore)
 "wFO" = (
 /obj/machinery/shieldgen,
 /turf/open/floor/plating,
@@ -51357,7 +52393,7 @@
 	dir = 4
 	},
 /turf/open/floor/carpet,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "wFY" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -51423,7 +52459,7 @@
 /obj/structure/table/wood,
 /obj/item/taperecorder,
 /turf/open/floor/carpet,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "wHM" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -51439,7 +52475,7 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/item/statuebust,
 /turf/open/floor/grass,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard)
 "wHX" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -51449,15 +52485,18 @@
 "wIu" = (
 /obj/structure/transit_tube/horizontal,
 /turf/open/floor/plating,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "wIx" = (
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/fitness)
 "wIz" = (
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/wood{
-	icon_state = "wood-broken3"
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
 	},
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "wIA" = (
 /turf/open/floor/plasteel,
@@ -51479,7 +52518,7 @@
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/grass,
-/area/maintenance/aft/secondary)
+/area/maintenance/aft)
 "wJf" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -51493,7 +52532,7 @@
 	dir = 5
 	},
 /turf/open/floor/wood,
-/area/chapel/main)
+/area/chapel/dock)
 "wJw" = (
 /obj/machinery/computer/arcade{
 	dir = 8
@@ -51535,8 +52574,7 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
 "wKL" = (
-/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
-/turf/open/floor/plasteel,
+/turf/open/openspace,
 /area/engine/atmos)
 "wKN" = (
 /obj/structure/sink{
@@ -51557,7 +52595,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard)
 "wLh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
@@ -51566,7 +52604,7 @@
 /turf/open/floor/plasteel/chapel{
 	dir = 4
 	},
-/area/chapel/main)
+/area/chapel/main/monastery)
 "wLG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/closed/wall/mineral/wood,
@@ -51585,14 +52623,17 @@
 	},
 /obj/structure/table/wood,
 /turf/open/floor/carpet,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "wMp" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plating,
-/area/hallway/secondary/entry)
+/area/maintenance/port/aft)
 "wMr" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -51638,7 +52679,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
-/area/chapel/main)
+/area/chapel/dock)
 "wOn" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -51792,7 +52833,7 @@
 	},
 /obj/structure/flora/ausbushes/grassybush,
 /turf/open/floor/grass,
-/area/maintenance/aft/secondary)
+/area/maintenance/aft)
 "wRY" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/solars/starboard/aft)
@@ -51834,7 +52875,7 @@
 /obj/structure/grille/broken,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard/fore)
 "wSI" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -51872,7 +52913,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/chapel/main)
+/area/chapel/main/monastery)
 "wUc" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -51913,7 +52954,7 @@
 	pixel_y = -26
 	},
 /turf/open/floor/circuit/green,
-/area/hallway/secondary/exit/departure_lounge)
+/area/crew_quarters/cryopod)
 "wVO" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/closed/wall/r_wall,
@@ -51956,7 +52997,9 @@
 	dir = 1
 	},
 /turf/open/floor/carpet/eighties,
-/area/crew_quarters/fitness)
+/area/crew_quarters/fitness/recreation{
+	name = "Arcade Room"
+	})
 "wWF" = (
 /obj/machinery/atmospherics/components/trinary/filter/critical{
 	filter_type = "n2"
@@ -52013,7 +53056,12 @@
 	name = "Confession Booth"
 	},
 /turf/open/floor/plasteel/dark,
-/area/chapel/main)
+/area/chapel/main/monastery)
+"wXE" = (
+/obj/structure/reagent_dispensers/watertank,
+/obj/machinery/light/small,
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "wXR" = (
 /obj/structure/transit_tube/curved/flipped{
 	dir = 1
@@ -52023,7 +53071,7 @@
 "wYk" = (
 /obj/machinery/vending/snack/random,
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "wYl" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/light{
@@ -52120,7 +53168,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "xaK" = (
 /obj/machinery/door/airlock/external{
 	name = "Security External Access";
@@ -52166,19 +53214,25 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plating,
-/area/maintenance/aft/secondary)
+/area/maintenance/aft)
 "xcd" = (
 /obj/effect/turf_decal/bot_white,
 /turf/open/floor/plasteel/dark,
 /area/teleporter)
+"xci" = (
+/turf/open/floor/plasteel,
+/area/maintenance/aft)
 "xcA" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
 /obj/machinery/disposal/bin,
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "xcL" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop{
@@ -52267,6 +53321,11 @@
 /obj/structure/reagent_dispensers/foamtank,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"xfj" = (
+/turf/open/floor/plasteel/stairs/left{
+	dir = 4
+	},
+/area/maintenance/aft)
 "xfs" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -52303,7 +53362,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "xfE" = (
 /obj/structure/rack,
 /obj/item/gun/energy/e_gun{
@@ -52466,7 +53525,7 @@
 	dir = 10
 	},
 /turf/closed/wall,
-/area/chapel/main)
+/area/chapel/main/monastery)
 "xjF" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -52489,7 +53548,7 @@
 "xka" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard)
 "xkR" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/effect/turf_decal/tile/green{
@@ -52507,8 +53566,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plating,
-/area/maintenance/central)
+/turf/open/floor/plasteel/stairs,
+/area/maintenance/department/security)
 "xkW" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 4
@@ -52519,7 +53578,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "xlg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -52543,9 +53602,11 @@
 /area/maintenance/bar)
 "xlX" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/visible{
-	dir = 1
+	dir = 8
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark/corner{
+	dir = 8
+	},
 /area/engine/atmos)
 "xmo" = (
 /obj/structure/table,
@@ -52645,7 +53706,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard)
 "xop" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -52738,6 +53799,10 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
+"xrv" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plating,
+/area/maintenance/port/central)
 "xrL" = (
 /obj/machinery/light{
 	dir = 1
@@ -52761,7 +53826,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/port)
+/area/hallway/primary/port/fore)
 "xrW" = (
 /obj/structure/sign/warning/vacuum/external{
 	pixel_y = -32
@@ -52786,7 +53851,7 @@
 "xtb" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard/fore)
 "xto" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
@@ -52796,12 +53861,12 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/chapel/main)
+/area/chapel/main/monastery)
 "xtq" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "xty" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-22"
@@ -52809,7 +53874,7 @@
 /turf/open/floor/plasteel/median/darktogrime/corner{
 	dir = 1
 	},
-/area/chapel/main)
+/area/chapel/main/monastery)
 "xtP" = (
 /obj/machinery/computer/rdconsole/robotics,
 /turf/open/floor/plasteel/dark,
@@ -52872,7 +53937,7 @@
 /obj/effect/turf_decal/tile/bar,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard)
 "xvj" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -52884,7 +53949,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "xvo" = (
 /obj/machinery/atmospherics/pipe/simple/multiz,
 /obj/structure/railing{
@@ -52892,7 +53957,7 @@
 	},
 /obj/effect/turf_decal/stripes/box,
 /turf/open/floor/plating,
-/area/hallway/secondary/entry)
+/area/maintenance/port/aft)
 "xvC" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -52969,7 +54034,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard/fore)
 "xzn" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/navbeacon{
@@ -52999,7 +54064,7 @@
 "xzM" = (
 /obj/effect/turf_decal/arrows/red,
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard)
 "xAa" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -53049,7 +54114,7 @@
 "xAT" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard/fore)
 "xBi" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -53172,10 +54237,14 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "xDu" = (
 /turf/open/floor/plasteel/grimy,
-/area/chapel/main)
+/area/chapel/main/monastery)
+"xDz" = (
+/obj/machinery/mech_bay_recharge_port,
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "xDQ" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Port Quarter Solar Access";
@@ -53364,7 +54433,11 @@
 "xHp" = (
 /obj/structure/grille/broken,
 /turf/open/floor/plating,
-/area/hallway/primary/fore)
+/area/maintenance/starboard/aft)
+"xHB" = (
+/obj/effect/spawner/structure/window/ice,
+/turf/open/floor/plating,
+/area/hydroponics/garden/monastery)
 "xHE" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -53464,16 +54537,22 @@
 "xJU" = (
 /obj/effect/spawner/blocker,
 /turf/open/floor/plating,
-/area/hallway/primary/fore)
+/area/maintenance/starboard/aft)
 "xKa" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
+"xKb" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "xKn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/obj/structure/reagent_dispensers/watertank/high,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
 	},
@@ -53481,6 +54560,7 @@
 	c_tag = "Atmospherics Central";
 	dir = 4
 	},
+/obj/structure/closet/crate/bin,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "xKu" = (
@@ -53519,11 +54599,9 @@
 /turf/open/floor/plating,
 /area/crew_quarters/heads/chief)
 "xKO" = (
-/obj/structure/bed,
-/obj/item/bedsheet/purple,
-/obj/effect/decal/cleanable/femcum,
-/turf/open/floor/plating,
-/area/maintenance/aft/secondary)
+/obj/machinery/vending/pdavendor,
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
 "xLF" = (
 /obj/structure/closet/secure_closet/bar{
 	pixel_x = -3;
@@ -53549,7 +54627,7 @@
 "xMo" = (
 /obj/machinery/vending/hydronutrients,
 /turf/open/floor/plasteel/dark,
-/area/chapel/main)
+/area/hydroponics/garden/monastery)
 "xMG" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -53600,7 +54678,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "xOR" = (
 /obj/machinery/camera{
 	c_tag = "Auxiliary Bridge";
@@ -53676,7 +54754,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/chapel,
-/area/chapel/main)
+/area/chapel/main/monastery)
 "xQv" = (
 /obj/machinery/light_switch{
 	pixel_x = 25
@@ -53684,12 +54762,10 @@
 /turf/open/openspace,
 /area/security/execution/education)
 "xQA" = (
-/obj/machinery/door/airlock{
-	id_tag = "bardorm2";
-	name = "Room Two"
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft/secondary)
+/obj/structure/table/wood/fancy,
+/obj/item/flashlight/lamp,
+/turf/open/floor/carpet,
+/area/hallway/primary/port)
 "xQF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -53722,7 +54798,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/dark,
-/area/chapel/main)
+/area/chapel/main/monastery)
 "xRq" = (
 /turf/closed/wall/r_wall,
 /area/blueshield)
@@ -53773,7 +54849,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
-/area/hallway/primary/port)
+/area/hallway/primary/port/fore)
 "xSP" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -53845,11 +54921,14 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "xUI" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
@@ -53893,7 +54972,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard)
 "xVn" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -53947,7 +55026,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "xXX" = (
 /turf/closed/wall,
 /area/security/vacantoffice/a)
@@ -54011,7 +55090,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "xZX" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -54038,13 +55117,13 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
-/area/chapel/main)
+/area/chapel/dock)
 "ybr" = (
 /obj/structure/chair{
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/hallway/primary/fore)
+/area/maintenance/starboard/aft)
 "ybQ" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -54081,7 +55160,7 @@
 	},
 /obj/structure/fans/tiny,
 /turf/open/floor/pod/dark,
-/area/maintenance/starboard)
+/area/quartermaster/sorting)
 "ycQ" = (
 /obj/machinery/light,
 /obj/structure/extinguisher_cabinet{
@@ -54099,13 +55178,11 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/chapel/main)
+/area/chapel/dock)
 "ydl" = (
-/obj/structure/bed,
-/obj/item/bedsheet/green,
-/obj/effect/decal/cleanable/flour,
+/obj/machinery/door/airlock/maintenance,
 /turf/open/floor/plating,
-/area/maintenance/aft/secondary)
+/area/maintenance/port/central)
 "ydo" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
@@ -54114,13 +55191,19 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "ydp" = (
 /turf/closed/mineral/random/snow/no_caves,
 /area/icemoon/surface/outdoors)
 "yds" = (
 /turf/open/floor/plasteel,
 /area/medical/chemistry)
+"ydO" = (
+/obj/machinery/computer/mech_bay_power_console{
+	dir = 1
+	},
+/turf/open/floor/circuit,
+/area/maintenance/aft)
 "ydQ" = (
 /obj/machinery/power/apc{
 	areastring = "/area/maintenance/solars/starboard/aft";
@@ -54156,7 +55239,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/starboard)
 "yeA" = (
 /obj/machinery/holopad,
 /obj/structure/disposalpipe/segment{
@@ -54171,7 +55254,7 @@
 "yeS" = (
 /obj/machinery/door/airlock/maintenance,
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard/fore)
 "yfp" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -54184,7 +55267,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/maintenance/starboard)
+/area/quartermaster/sorting)
 "yfA" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -54240,7 +55323,7 @@
 	name = "west facing firelock"
 	},
 /turf/open/floor/plasteel/dark,
-/area/chapel/main)
+/area/chapel/main/monastery)
 "ygB" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -54250,7 +55333,7 @@
 "ygL" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
-/area/hallway/primary/aft)
+/area/maintenance/starboard/fore)
 "yhj" = (
 /obj/structure/chair/comfy/black{
 	dir = 4
@@ -54295,7 +55378,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/hallway/primary/port)
+/area/hallway/primary/port/fore)
 "yij" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -54308,7 +55391,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
-/area/hallway/primary/port)
+/area/hallway/primary/port/fore)
 "yiy" = (
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall,
@@ -54363,6 +55446,9 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "yjq" = (
@@ -54378,7 +55464,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plating,
-/area/maintenance/aft/secondary)
+/area/maintenance/aft)
 "yjJ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -54423,7 +55509,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "yky" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
@@ -54478,7 +55564,7 @@
 /turf/open/floor/plasteel/chapel{
 	dir = 4
 	},
-/area/chapel/main)
+/area/chapel/main/monastery)
 "ylW" = (
 /obj/structure/chair/stool,
 /turf/open/floor/plasteel,
@@ -66664,8 +67750,8 @@ cTE
 axc
 gLH
 atb
-xSH
-jwo
+vHd
+wuZ
 clB
 dKQ
 azC
@@ -66678,7 +67764,7 @@ opq
 aHu
 llj
 nhd
-nhd
+dyM
 aIP
 avT
 avT
@@ -66922,7 +68008,7 @@ lat
 ldt
 qSy
 wGB
-jwo
+wIz
 axG
 gTc
 aym
@@ -66935,7 +68021,7 @@ puk
 puk
 puk
 puk
-nhd
+jwE
 aIP
 avT
 avT
@@ -67192,7 +68278,7 @@ kex
 sCz
 fWC
 puk
-nhd
+jwE
 aIP
 avT
 avT
@@ -67434,7 +68520,7 @@ ixu
 vjQ
 xCf
 gLH
-aCX
+uBy
 xSH
 pYh
 aFI
@@ -67449,8 +68535,8 @@ twZ
 jar
 erx
 lpR
-nhd
-bxk
+jwE
+iAI
 avT
 avT
 ydp
@@ -67706,8 +68792,8 @@ itn
 cSJ
 cSJ
 lpR
-nhd
-bxk
+jwE
+iAI
 avT
 avT
 avT
@@ -67963,8 +69049,8 @@ loD
 fXs
 cZu
 lpR
-nhd
-bxk
+jwE
+iAI
 avT
 avT
 avT
@@ -68220,8 +69306,8 @@ aGF
 cSJ
 cSJ
 lpR
-nhd
-bxk
+jwE
+iAI
 avT
 avT
 avT
@@ -68477,8 +69563,8 @@ rJQ
 hoe
 erx
 lpR
-nhd
-bxk
+jwE
+iAI
 avT
 avT
 avT
@@ -69754,7 +70840,7 @@ azq
 azq
 azq
 aAK
-aIP
+tmO
 aDa
 gfQ
 rsp
@@ -70011,7 +71097,7 @@ wje
 wje
 wje
 aAx
-aIP
+tmO
 aAQ
 eZi
 aFU
@@ -70527,7 +71613,7 @@ kkG
 vsN
 bxk
 ovq
-aFO
+wje
 aEC
 bsL
 rJM
@@ -71038,7 +72124,7 @@ avX
 pdo
 wnO
 jil
-vsN
+rEX
 otz
 bxk
 bxk
@@ -71295,11 +72381,11 @@ axi
 kTI
 wje
 rBc
-aDd
+gpc
 vfr
+xok
 wje
-aFO
-aSE
+rBc
 ldE
 aPA
 nlk
@@ -71553,9 +72639,9 @@ kTI
 wje
 etM
 oNR
+lTV
 mNo
 mNo
-aFQ
 mJq
 aHe
 aIN
@@ -71810,9 +72896,9 @@ qAx
 wje
 ouH
 ndX
+dui
 gKt
 gKt
-uBy
 aFR
 vMg
 vsK
@@ -72066,11 +73152,11 @@ axi
 axi
 wje
 xSH
-wje
+qfw
 nRA
+sZX
 wje
-aFO
-hIH
+rbo
 nuS
 aPE
 wDR
@@ -72323,7 +73409,7 @@ avX
 axj
 wnO
 lgq
-aAY
+ubS
 sxt
 bxk
 bxk
@@ -72840,7 +73926,7 @@ eDr
 aAY
 bxk
 srU
-aFO
+wje
 aEC
 aHD
 aPC
@@ -73352,7 +74438,7 @@ xJr
 xJr
 uCE
 sco
-aIP
+tmO
 aDp
 eZi
 aFU
@@ -73609,7 +74695,7 @@ xSZ
 xSZ
 xSZ
 aAO
-aIP
+tmO
 aDe
 rJk
 aFT
@@ -75642,14 +76728,14 @@ iJl
 nyI
 iJl
 uWA
-wje
+rAf
 hBQ
-qmO
+sQJ
 xrU
 yij
 iWY
 iTY
-yij
+tGq
 vLr
 rPD
 srq
@@ -75898,7 +76984,7 @@ qIm
 qIm
 mbm
 mbm
-tmO
+pNh
 hvX
 aYf
 xSN
@@ -75907,7 +76993,7 @@ jrH
 rke
 vJG
 jrH
-kCE
+tHs
 kCE
 nDl
 wbO
@@ -76155,9 +77241,9 @@ xUL
 xUL
 xUL
 cNd
-tmO
+pNh
 fYx
-pIm
+rRH
 rhX
 rhX
 rhX
@@ -76413,7 +77499,7 @@ xUL
 xUL
 tKV
 mIh
-fYx
+rLU
 bTh
 rhX
 ndM
@@ -76443,8 +77529,8 @@ eKy
 rfw
 cKe
 dhg
-tmO
-tmO
+nLS
+nLS
 avT
 avT
 avT
@@ -76669,9 +77755,9 @@ xUL
 xUL
 xUL
 xUL
-tmO
-fYx
-pIm
+pNh
+rLU
+rUa
 xVn
 vFd
 por
@@ -76700,8 +77786,8 @@ vor
 fEQ
 cKe
 dhg
-sCC
-tmO
+rTB
+nLS
 avT
 avT
 avT
@@ -76923,12 +78009,12 @@ avT
 avT
 avT
 avT
-tmO
-tmO
-tmO
-tmO
+pNh
+pNh
+pNh
+pNh
 bhZ
-pIm
+rUa
 xVn
 uUC
 iop
@@ -76958,7 +78044,7 @@ jAc
 opF
 dhg
 buj
-tmO
+nLS
 avT
 avT
 avT
@@ -77183,9 +78269,9 @@ xUL
 xUL
 xUL
 cNd
-tmO
-fYx
-pIm
+pNh
+rLU
+rUa
 xVn
 vTP
 vTP
@@ -77215,7 +78301,7 @@ jLI
 dhg
 dhg
 gdQ
-usE
+cxe
 avT
 avT
 avT
@@ -77441,8 +78527,8 @@ xUL
 xUL
 tKV
 aFB
-fYx
-pIm
+rLU
+rUa
 rhX
 oDH
 sHd
@@ -77451,28 +78537,28 @@ aQs
 vfZ
 rhX
 xWq
-xWq
+ebM
 xWq
 xWq
 tmO
 ahk
 eed
 qFZ
-eex
-eex
+gER
+gER
 gER
 eKw
-eex
-eex
-eex
+gER
+gER
+gER
 qUr
 aBG
 bff
 gdQ
-sCC
-tmO
+rTB
+nLS
 gdQ
-usE
+cxe
 avT
 avT
 avT
@@ -77697,9 +78783,9 @@ xUL
 xUL
 xUL
 xUL
-tmO
-fYx
-pIm
+pNh
+rLU
+rUa
 rhX
 quh
 kHd
@@ -77707,29 +78793,29 @@ jkO
 qeH
 ubd
 xVn
-xUL
-xUL
-xUL
-xUL
-tmO
-uxx
+avT
+avT
+avT
+avT
+bxk
+wje
 fOA
-tmO
-tmO
-tmO
-tmO
-tmO
-tmO
-cEW
-tmO
-tmO
-tmO
-qel
+nLS
+nLS
+nLS
+nLS
+nLS
+nLS
+kGD
+nLS
+nLS
+nLS
+dQF
 vGj
 gdQ
-cEW
+hgw
 gdQ
-tmO
+nLS
 avT
 avT
 avT
@@ -77951,10 +79037,10 @@ avT
 avT
 avT
 avT
-tmO
-tmO
-tmO
-tmO
+pNh
+pNh
+pNh
+pNh
 lki
 kMt
 rhX
@@ -77968,25 +79054,25 @@ xUL
 xUL
 xUL
 xUL
-tmO
-wje
+bxk
+udh
 cpC
 iPX
-tmO
-ydp
-tmO
-sCC
-tmO
+vTF
+xKO
+nLS
+rTB
+nLS
 iaJ
 rad
-mNL
-cEW
+smo
+gdQ
 gdQ
 gdQ
 iti
-tmO
+nLS
 gdQ
-tmO
+nLS
 avT
 avT
 avT
@@ -78211,7 +79297,7 @@ avT
 avT
 avT
 avT
-tmO
+pNh
 euY
 yhF
 rhX
@@ -78225,25 +79311,25 @@ xUL
 xUL
 xUL
 xUL
-usE
+tmO
 buO
 wje
 wje
-tmO
-ydp
-tmO
+wje
+wje
+ydl
 gdQ
-tmO
-tmO
-cEW
-tmO
-tmO
+nLS
+nLS
+gdQ
+nLS
+nLS
 gdq
 gdQ
 gdQ
-tmO
-cEW
-tmO
+nLS
+gdQ
+nLS
 avT
 avT
 avT
@@ -78468,7 +79554,7 @@ avT
 avT
 avT
 avT
-tmO
+pNh
 mqU
 pZg
 rhX
@@ -78481,26 +79567,26 @@ rhX
 xUL
 xUL
 xUL
-eNu
-arl
-wje
+xUL
+bxk
+unU
 lhB
 uUZ
-tmO
-ydp
-tmO
-mNL
+uUZ
+uUZ
+nLS
+smo
 uca
-tmO
+nLS
 gdQ
-kIz
-tmO
+xrv
+nLS
 nog
 nog
 nog
-tmO
-gdQ
-tmO
+nLS
+rTB
+nLS
 avT
 avT
 avT
@@ -78738,26 +79824,26 @@ xVn
 xUL
 xUL
 xUL
-xUL
+tTt
 usE
-usE
-usE
-tmO
-tmO
-ydp
-tmO
+wje
+uxx
+vqD
+wrI
+xQA
+nLS
 gdQ
 gdQ
 buj
 qel
 rRU
-tmO
-tmO
-tmO
-tmO
-tmO
 nLS
-tmO
+nLS
+nLS
+nLS
+nLS
+nLS
+nLS
 avT
 avT
 avT
@@ -78996,25 +80082,25 @@ xUL
 xUL
 xUL
 xUL
-wdv
+bxk
+bxk
+tmO
+bxk
+bxk
+tmO
+nLS
+nLS
+nLS
+nLS
+nLS
+nLS
+nLS
 avT
 avT
-ydp
-ydp
-ydp
-tmO
-tmO
-tmO
-tmO
-tmO
-tmO
-tmO
-tDO
-sQJ
-sbD
-gdQ
-gdQ
-tmO
+avT
+avT
+avT
+avT
 avT
 avT
 avT
@@ -79249,13 +80335,15 @@ jzb
 qCo
 wOn
 xVn
-avT
-avT
-avT
-avT
+xUL
+xUL
+xUL
+xUL
 wdv
 avT
 avT
+avT
+avT
 ydp
 ydp
 ydp
@@ -79263,16 +80351,14 @@ ydp
 ydp
 ydp
 ydp
-ydp
-ydp
-tmO
-gnS
-tDC
-rUk
-axi
-gdQ
-tmO
-ydp
+avT
+avT
+avT
+avT
+avT
+avT
+avT
+avT
 avT
 avT
 vcG
@@ -79510,7 +80596,7 @@ avT
 avT
 avT
 avT
-ydp
+wdv
 avT
 avT
 avT
@@ -79522,13 +80608,13 @@ ydp
 ydp
 ydp
 ydp
-tmO
-axi
-axi
-axi
-axi
-hgu
-tmO
+avT
+avT
+avT
+avT
+avT
+avT
+avT
 avT
 avT
 avT
@@ -79770,22 +80856,22 @@ ydp
 ydp
 ydp
 avT
+avT
+avT
+avT
 ydp
 ydp
 ydp
 ydp
 ydp
 ydp
-ydp
-ydp
-ydp
-tmO
-kVF
-bcl
-wIz
-cjt
-tfM
-tmO
+avT
+avT
+avT
+avT
+avT
+avT
+avT
 avT
 avT
 avT
@@ -80028,7 +81114,7 @@ ydp
 ydp
 avT
 avT
-ydp
+avT
 ydp
 ydp
 ydp
@@ -80036,13 +81122,13 @@ ydp
 ydp
 ydp
 avT
-tmO
-tmO
-tmO
-tmO
-tmO
-tmO
-tmO
+avT
+avT
+avT
+avT
+avT
+avT
+avT
 avT
 avT
 avT
@@ -80285,8 +81371,8 @@ ydp
 ydp
 ydp
 ydp
-ydp
-ydp
+avT
+avT
 ydp
 ydp
 ydp
@@ -82176,11 +83262,11 @@ ydp
 ydp
 ydp
 ydp
-ydp
-ydp
-ydp
-ydp
-ydp
+qrR
+qrR
+qrR
+qrR
+qrR
 yhx
 yhx
 yhx
@@ -82433,11 +83519,11 @@ ydp
 ydp
 ydp
 ydp
-ydp
-ydp
-ydp
-ydp
-ydp
+qrR
+qrR
+qrR
+qrR
+qrR
 yhx
 yhx
 yhx
@@ -82690,11 +83776,11 @@ ydp
 ydp
 ydp
 ydp
-ydp
-ydp
-ydp
-ydp
-ydp
+qrR
+qrR
+qrR
+qrR
+qrR
 yhx
 yhx
 yhx
@@ -82947,11 +84033,11 @@ ydp
 ydp
 ydp
 ydp
-ydp
-ydp
-ydp
-ydp
-ydp
+qrR
+qrR
+qrR
+qrR
+qrR
 yhx
 yhx
 yhx
@@ -84940,12 +86026,12 @@ bok
 sLq
 wcB
 wcB
-bok
-unA
-unA
-unA
-unA
-bwt
+uEc
+sec
+sec
+sec
+sec
+uEc
 sPF
 buZ
 dWF
@@ -85197,12 +86283,12 @@ bok
 cwo
 wcB
 wcB
-bok
+uEc
 wrh
 cFO
 eWp
 wvL
-bwt
+uEc
 ewK
 fPN
 msA
@@ -85454,12 +86540,12 @@ bok
 uxF
 wcB
 wcB
-bok
-wrh
+uEc
+vOn
 dno
 fcu
 wVg
-bwt
+uEc
 aNw
 hRe
 buZ
@@ -85483,7 +86569,7 @@ uWQ
 fKC
 giT
 xkT
-xkT
+viZ
 dYl
 rYN
 qOb
@@ -85711,12 +86797,12 @@ bok
 sLq
 wcB
 wcB
-bok
-wrh
+uEc
+grO
 drK
-tif
+mXE
 nUk
-bwt
+uEc
 cTD
 cTD
 iQv
@@ -85968,12 +87054,12 @@ bok
 unA
 uFq
 uFq
-bok
-unA
+uEc
+sec
 dTo
 bmA
-unA
-grV
+sec
+dhs
 xTL
 lHn
 bsk
@@ -86516,11 +87602,11 @@ osa
 bKO
 bPq
 nzn
-jcT
+tod
 cii
-lhQ
-lhQ
-lhQ
+vyQ
+smK
+vyQ
 bsy
 dMj
 cex
@@ -86668,7 +87754,7 @@ lkI
 lkI
 mZh
 haU
-iDh
+hps
 ajP
 pgp
 xAv
@@ -86773,11 +87859,11 @@ sdN
 sdN
 sdN
 sdN
-jcT
+tod
 wFU
-lhQ
+vyQ
 sAw
-lhQ
+vyQ
 rka
 dMj
 riE
@@ -86919,12 +88005,12 @@ xUL
 fTM
 xUL
 xUL
-blD
+fHK
 gum
 nHI
 jKx
 byI
-haU
+hmP
 nGR
 wWt
 pgp
@@ -87030,11 +88116,11 @@ tod
 tod
 tod
 tod
-jcT
+tod
 wHB
-lhQ
-cZq
-lhQ
+vyQ
+dBC
+vyQ
 jIb
 dMj
 dMj
@@ -87176,14 +88262,14 @@ xUL
 fTM
 xUL
 eLl
-blD
-blD
-blD
-blD
-blD
+fHK
+fHK
+fHK
+fHK
+fHK
 nCE
 fRh
-blD
+fHK
 pgp
 pgp
 axL
@@ -87271,14 +88357,14 @@ mbh
 bBB
 lhQ
 lhQ
-vPQ
+oXh
 cGQ
-vPQ
-vPQ
+gTx
+gTx
 bNn
-vPQ
+gTx
 qQt
-vPQ
+gTx
 bJF
 bVX
 mqq
@@ -87289,10 +88375,10 @@ sUX
 toP
 pjn
 tNf
-lhQ
+vyQ
 haj
-vPQ
-vPQ
+gTx
+gTx
 iwd
 ykt
 jIj
@@ -87528,33 +88614,33 @@ bAj
 ezY
 wZl
 wZl
-wZl
-wZl
-wZl
-wZl
-wZl
-wZl
+btd
+xKb
+xKb
+xKb
+xKb
+xKb
 uZd
-wZl
+xKb
 bPa
 fZV
 bCT
 msm
 qCa
-wZl
-wZl
-wZl
-wZl
+xKb
+xKb
+xKb
+xKb
 xXV
-wZl
+xKb
 fZV
 ilF
-wZl
-wZl
-wZl
+xKb
+xKb
+xKb
 hvr
-wZl
-wZl
+xKb
+xKb
 iau
 hKc
 olx
@@ -87785,33 +88871,33 @@ nRt
 xmB
 tys
 tys
-tys
-tys
-tys
-tys
-tys
-tys
-tys
-tys
+faF
+kgg
+kgg
+kgg
+kgg
+kgg
+kgg
+kgg
 tXn
 mhH
 bCW
 ndS
 qUY
-tys
-tys
-tys
-tys
-tys
-tys
+kgg
+kgg
+kgg
+kgg
+kgg
+kgg
 xtq
 bPd
-tys
-tys
-tys
+kgg
+kgg
+kgg
 jhe
-tys
-tys
+kgg
+kgg
 civ
 fJW
 ina
@@ -88042,28 +89128,28 @@ pBU
 reS
 lhQ
 czY
-ceA
-ceA
-ceA
-ceA
-ceA
-ceA
+oXh
+pfU
+pfU
+pfU
+pfU
+pfU
 sOv
 wLU
 lQs
-ceA
+pfU
 bDI
 nCU
 rwR
-lhQ
-lhQ
-ceA
-ceA
+vyQ
+vyQ
+pfU
+pfU
 fsF
-ceA
+pfU
 gkX
 bPc
-ceA
+pfU
 bUL
 rmB
 tNf
@@ -88576,8 +89662,8 @@ njU
 cfm
 srk
 gtG
-mbh
-lhQ
+vaS
+vyQ
 chb
 vam
 gsr
@@ -88833,7 +89919,7 @@ njU
 agy
 xjF
 xZL
-mbh
+vaS
 bwr
 chb
 eZA
@@ -89091,7 +90177,7 @@ sRh
 eDu
 gpp
 bXU
-hxf
+weD
 vBo
 gMD
 pIz
@@ -89347,8 +90433,8 @@ agy
 agy
 xjF
 cZk
-mbh
-fad
+vaS
+oMe
 chb
 pXW
 hZU
@@ -89371,7 +90457,7 @@ avT
 avT
 avT
 avT
-avT
+ydp
 avT
 ydp
 ydp
@@ -89604,8 +90690,8 @@ agy
 cfm
 srk
 mql
-mbh
-lhQ
+vaS
+vyQ
 chb
 qbv
 ayP
@@ -89754,7 +90840,7 @@ dGc
 lZO
 ylW
 xcL
-ylW
+ijl
 yjJ
 tOz
 cBZ
@@ -89861,8 +90947,8 @@ jTc
 srk
 srk
 qZs
-mbh
-lhQ
+vaS
+vyQ
 cdD
 eyS
 vfd
@@ -89870,13 +90956,13 @@ dVJ
 eyS
 chb
 rte
-wGq
-cbQ
-wTK
-wGq
-wGq
-wGq
-wTK
+avT
+avT
+avT
+avT
+avT
+avT
+avT
 avT
 avT
 avT
@@ -89886,7 +90972,7 @@ avT
 avT
 ydp
 ydp
-avT
+ydp
 avT
 ydp
 ydp
@@ -90116,24 +91202,20 @@ iJX
 iJX
 iJX
 srk
-lhQ
-xPP
-mbh
-lhQ
+vyQ
+gsq
+vaS
+vyQ
 cdD
 uQR
 bDB
 edH
 mAK
 chb
-leO
-wGq
-wGq
-rLU
-wGq
-wTK
-wGq
-wTK
+avT
+kRR
+avT
+avT
 avT
 avT
 avT
@@ -90148,8 +91230,12 @@ avT
 ydp
 ydp
 ydp
+avT
 ydp
 ydp
+qrR
+qrR
+qrR
 yhx
 yhx
 yhx
@@ -90373,42 +91459,42 @@ agy
 agy
 agy
 xjF
-lhQ
-xPP
-mbh
-lhQ
+vyQ
+gsq
+vaS
+vyQ
 cdD
 ebq
 fZn
 hTy
 oQy
 chb
-uSH
-wGq
-wrI
-wTK
-wGq
-wTK
-wGq
-wTK
-wTK
-wTK
-wTK
-wTK
+avT
+avT
+avT
+avT
+avT
+avT
+avT
 avT
 avT
 avT
 avT
 ydp
 ydp
+ydp
+ydp
+ydp
+ydp
+ydp
 avT
 ydp
 ydp
-ydp
-ydp
-ydp
-ydp
-ydp
+qrR
+qrR
+qrR
+qrR
+qrR
 yhx
 yhx
 yhx
@@ -90630,9 +91716,9 @@ wVP
 bVZ
 vKc
 xjF
-lhQ
-xPP
-mbh
+vyQ
+gsq
+vaS
 xRq
 chb
 chb
@@ -90640,23 +91726,13 @@ chb
 chb
 chb
 chb
-wTK
-wTK
-wTK
-wTK
-wGq
-wTK
-wGq
-vqD
-lmU
-tHs
-uSH
+rqf
+rqf
 wTK
 avT
 avT
 avT
 avT
-ydp
 avT
 avT
 ydp
@@ -90666,6 +91742,16 @@ ydp
 ydp
 ydp
 ydp
+ydp
+avT
+avT
+ydp
+ydp
+qrR
+qrR
+qrR
+qrR
+qrR
 yhx
 yhx
 yhx
@@ -90872,10 +91958,10 @@ bvw
 bFT
 iza
 biW
-wTK
-wTK
-wTK
-wTK
+doP
+doP
+doP
+doP
 srk
 hzs
 xTI
@@ -90887,9 +91973,9 @@ agy
 nHQ
 agy
 xjF
-lhQ
-xPP
-mbh
+vyQ
+gsq
+vaS
 xRq
 djx
 gEi
@@ -90898,31 +91984,31 @@ kuU
 djw
 xRq
 wGq
-wGq
-wGq
-wGq
-wGq
-rLU
-wGq
-wGq
-wGq
-wGq
-wGq
-wTK
-avT
-avT
+lPe
+rqf
 avT
 avT
 ydp
+ydp
+ydp
+ydp
+ydp
+ydp
+ydp
+ydp
+ydp
+ydp
+ydp
+ydp
 avT
 ydp
 ydp
 ydp
-ydp
-ydp
-ydp
-ydp
-ydp
+qrR
+qrR
+qrR
+qrR
+qrR
 yhx
 yhx
 yhx
@@ -91039,7 +92125,7 @@ naE
 lap
 tAY
 hcc
-wXe
+iOe
 wXe
 nOY
 wXe
@@ -91129,7 +92215,7 @@ bvw
 bFT
 czg
 lhQ
-wTK
+doP
 rTQ
 yjq
 amc
@@ -91144,9 +92230,9 @@ xfW
 plP
 gVL
 xjF
-lhQ
-xPP
-mbh
+vyQ
+gsq
+vaS
 rdu
 fsT
 pfk
@@ -91155,22 +92241,9 @@ smp
 qXm
 xRq
 wGq
-wTK
+wGq
 rqf
-wTK
-wTK
-wTK
-wGq
-wGq
-wGq
-wGq
-wGq
-lYJ
-lYJ
-lYJ
 avT
-ydp
-ydp
 avT
 ydp
 ydp
@@ -91180,6 +92253,19 @@ ydp
 ydp
 ydp
 ydp
+ydp
+ydp
+ydp
+ydp
+avT
+ydp
+ydp
+ydp
+qrR
+qrR
+qrR
+qrR
+qrR
 yhx
 yhx
 yhx
@@ -91294,8 +92380,8 @@ dQd
 flh
 iOG
 iOG
-pgp
-pgp
+hEm
+hEm
 fPM
 pgp
 pgp
@@ -91401,7 +92487,7 @@ agy
 nHQ
 agy
 xjF
-lhQ
+vyQ
 ydo
 kSP
 oBj
@@ -91411,23 +92497,9 @@ pbs
 gEi
 szD
 xRq
+vCA
 wGq
 wTK
-wTK
-wTK
-rqf
-wTK
-wGq
-wGq
-cbQ
-wGq
-wGq
-bkz
-wGq
-bif
-avT
-ydp
-ydp
 avT
 ydp
 ydp
@@ -91437,6 +92509,20 @@ ydp
 ydp
 ydp
 ydp
+ydp
+ydp
+ydp
+ydp
+ydp
+avT
+ydp
+ydp
+ydp
+qrR
+qrR
+qrR
+qrR
+qrR
 yhx
 yhx
 yhx
@@ -91553,7 +92639,7 @@ xNX
 iOG
 pCj
 dZV
-gLk
+jie
 pgp
 qFH
 nBd
@@ -91643,9 +92729,9 @@ aWO
 bPm
 dyb
 fad
-wTK
-wTK
-wTK
+doP
+doP
+doP
 xbC
 lqG
 agy
@@ -91658,9 +92744,9 @@ chp
 cLD
 chp
 srk
-lhQ
-xPP
-mbh
+kIb
+gsq
+mRE
 tDn
 gEi
 hQl
@@ -91668,20 +92754,20 @@ gEi
 gEi
 uZI
 xRq
-wGq
-wGq
-jie
-rLU
-wGq
-wGq
+lnU
 wGq
 wTK
-wTK
-wTK
-wTK
-wTK
-wTK
-wTK
+avT
+avT
+ydp
+ydp
+ydp
+ydp
+ydp
+ydp
+ydp
+ydp
+ydp
 ydp
 ydp
 ydp
@@ -91689,11 +92775,11 @@ bmX
 ydp
 ydp
 ydp
-ydp
-ydp
-ydp
-ydp
-ydp
+qrR
+qrR
+qrR
+qrR
+qrR
 yhx
 yhx
 yhx
@@ -91810,7 +92896,7 @@ kLo
 iOG
 hGM
 gLk
-gLk
+jnm
 pgp
 vVZ
 mWy
@@ -91898,9 +92984,9 @@ thV
 bLT
 bLT
 bLT
-wTK
-wTK
-wTK
+doP
+doP
+doP
 uSH
 rcj
 xbC
@@ -91916,29 +93002,23 @@ nEy
 sMR
 srk
 hNt
-xPP
-mbh
+mjw
+qdi
 xRq
 ryA
 mqC
+tUP
 uxn
 uxn
-hps
-xRq
-tZf
-wTK
-wTK
-wTK
-wTK
-wTK
-wTK
-wTK
+cwU
 wGq
-wGq
-nUT
-wGq
-wGq
+kYp
 wTK
+avT
+avT
+avT
+avT
+avT
 ydp
 ydp
 ydp
@@ -91951,6 +93031,12 @@ ydp
 ydp
 ydp
 ydp
+ydp
+qrR
+qrR
+qrR
+qrR
+qrR
 yhx
 yhx
 yhx
@@ -92066,7 +93152,7 @@ nok
 nok
 iOG
 vlz
-gLk
+hIH
 fBs
 pgp
 pgp
@@ -92080,14 +93166,14 @@ mSt
 mSt
 mSt
 mSt
-dSQ
-iOe
-iOe
+uZz
+xYJ
+xYJ
 ycl
 ycl
-iOe
-iOe
-dSQ
+xYJ
+xYJ
+uZz
 avT
 ydp
 ydp
@@ -92156,9 +93242,9 @@ bEi
 qJV
 bLT
 cbQ
-wGq
-wTK
-wTK
+wlV
+doP
+doP
 jjE
 oDt
 srk
@@ -92172,8 +93258,8 @@ xTI
 vwq
 pSX
 srk
-dNo
-xPP
+hNt
+mjw
 qdi
 xRq
 xRq
@@ -92182,21 +93268,15 @@ ire
 vyW
 xRq
 xRq
-eXT
-udh
-udh
-spV
-tZf
-jie
-cbQ
-wTK
-epJ
 wGq
 wTK
-unU
-xKO
 wTK
-jnm
+wTK
+wTK
+avT
+avT
+avT
+avT
 ydp
 ydp
 ydp
@@ -92208,6 +93288,12 @@ ydp
 ydp
 ydp
 ydp
+ydp
+qrR
+qrR
+qrR
+qrR
+qrR
 yhx
 yhx
 yhx
@@ -92322,9 +93408,9 @@ aEW
 gga
 xOR
 iOG
-pgp
-pgp
-gLk
+hEm
+hEm
+jDJ
 pgp
 qFH
 tYo
@@ -92344,7 +93430,7 @@ jJd
 jJd
 jJd
 jJd
-dSQ
+uZz
 avT
 ydp
 ydp
@@ -92414,9 +93500,9 @@ tRe
 bLT
 dDe
 giD
-wGq
+ifE
 sOH
-wGq
+ifE
 phd
 vQm
 vQm
@@ -92429,9 +93515,9 @@ are
 qoT
 sdM
 srk
-lhQ
-xPP
-mbh
+cQo
+gsq
+sFJ
 xTw
 jSV
 ilM
@@ -92439,22 +93525,16 @@ sAC
 iBd
 jpS
 wTK
-kSv
-nwe
-kSv
-kSv
-fHK
-wGq
-exE
-wTK
-lJe
 wGq
 wTK
+kSv
+kSv
 wTK
 wTK
 wTK
 avT
-fjW
+avT
+avT
 ydp
 ydp
 ydp
@@ -92465,6 +93545,12 @@ ydp
 ydp
 ydp
 ydp
+ydp
+qrR
+qrR
+qrR
+qrR
+qrR
 yhx
 yhx
 yhx
@@ -92581,7 +93667,7 @@ iuG
 iOG
 ugr
 pBh
-gLk
+jDJ
 pgp
 vVZ
 mWy
@@ -92601,7 +93687,7 @@ jJd
 omQ
 jJd
 njd
-dSQ
+uZz
 avT
 ydp
 ydp
@@ -92659,7 +93745,7 @@ avT
 avT
 avT
 bLT
-bEi
+jEG
 suL
 bEi
 jkL
@@ -92669,13 +93755,13 @@ cZN
 bEi
 afp
 bLT
-wTK
-wGq
+doP
+lHz
 mLS
 aIf
 bhC
 iLw
-wGq
+wlV
 bIq
 srk
 wqf
@@ -92687,8 +93773,8 @@ xTI
 pSX
 srk
 hIC
-xPP
-mbh
+gsq
+vaS
 xTw
 uid
 uid
@@ -92696,23 +93782,16 @@ nby
 uid
 bWP
 wTK
-kSv
-udh
-udh
-ijl
-wTK
-wTK
-wTK
-wTK
-blR
-wGq
-xQA
-tTt
 wGq
 wTK
-etQ
-etQ
-wTK
+wGq
+wGq
+wzT
+wGq
+tNi
+avT
+avT
+avT
 ydp
 ydp
 ydp
@@ -92722,6 +93801,13 @@ ydp
 ydp
 ydp
 ydp
+ydp
+ydp
+qrR
+qrR
+qrR
+qrR
+qrR
 yhx
 yhx
 yhx
@@ -92836,8 +93922,8 @@ ufQ
 qBH
 peH
 iOG
-pgp
-pgp
+hEm
+hEm
 eEa
 pgp
 pgp
@@ -92852,13 +93938,13 @@ pyW
 dwS
 mSt
 mVo
-exi
+vFM
 yfp
 vfp
 vfp
 vfp
 vfp
-dSQ
+uZz
 avT
 ydp
 ydp
@@ -92923,11 +94009,11 @@ bra
 xRH
 xRH
 bri
-bEi
+ahY
 aDM
 bLT
 dFp
-wGq
+lHz
 oHa
 tnd
 fDk
@@ -92955,25 +94041,25 @@ cvZ
 tdy
 uRg
 tcu
-tcu
-tcu
-nMz
-tGq
-asn
-wTK
-fQz
+wGq
 wGq
 wTK
-eLp
-pNh
 wTK
-rHo
-noG
 wTK
+avT
+avT
+avT
 ydp
 ydp
 ydp
 ydp
+qrR
+qrR
+qrR
+qrR
+qrR
+qrR
+qrR
 yhx
 yhx
 yhx
@@ -93095,7 +94181,7 @@ rCE
 iOG
 fCQ
 mPR
-gLk
+jRn
 pgp
 qFH
 vqY
@@ -93115,7 +94201,7 @@ nGa
 fpW
 oyf
 dzS
-dSQ
+uZz
 avT
 ydp
 ydp
@@ -93180,17 +94266,17 @@ xpl
 xRH
 xRH
 cqt
-bvq
-aGl
+bEi
 bLT
-wGq
-wGq
-wGq
-wTK
-wTK
-wTK
-wTK
-wTK
+bLT
+tad
+erl
+xfj
+doP
+doP
+doP
+doP
+doP
 srk
 srk
 srk
@@ -93201,7 +94287,7 @@ srk
 srk
 srk
 jCF
-xPP
+gsq
 tNf
 xTw
 uid
@@ -93210,27 +94296,27 @@ jTE
 uid
 azs
 wTK
-wGq
-wGq
-wGq
-wGq
-wGq
-wGq
-jDJ
-tZf
-wGq
-wGq
+gYK
 wTK
-wTK
-wTK
-wTK
+trk
 wGq
-blR
-wTK
+rqf
+avT
+avT
+avT
+avT
+avT
 ydp
 ydp
 ydp
 ydp
+qrR
+qrR
+qrR
+qrR
+qrR
+qrR
+qrR
 yhx
 yhx
 yhx
@@ -93365,14 +94451,14 @@ sdq
 iux
 aFA
 mSt
-mSt
-dSQ
+uZz
+uZz
 seo
-dSQ
-dSQ
-dSQ
-dSQ
-dSQ
+uZz
+uZz
+uZz
+uZz
+uZz
 avT
 ydp
 ydp
@@ -93439,26 +94525,26 @@ bLT
 bBJ
 wmG
 bLT
-bLT
-wGq
+rxk
+bSR
 gKR
 hAb
-hAb
-ofH
-wGq
-wGq
-kAX
-wGq
-wGq
-wGq
-wGq
-giD
-wGq
-wGq
-wTK
-wTK
-lhQ
-xPP
+rKz
+wlV
+mzv
+wlV
+wlV
+drq
+wlV
+wlV
+wlV
+grm
+wlV
+wlV
+doP
+doP
+vyQ
+gsq
 tNf
 xTw
 jpS
@@ -93468,26 +94554,26 @@ jpS
 sBN
 wTK
 epJ
-vHd
+wTK
 hzL
-rRH
-pSs
-hzL
-rRH
-wTK
 wGq
-wGq
-wuZ
-wGq
-wGq
-wTK
-rAf
-eri
-wTK
+rqf
+avT
+avT
+avT
+avT
 ydp
 ydp
 ydp
 ydp
+ydp
+qrR
+qrR
+qrR
+qrR
+qrR
+qrR
+qrR
 yhx
 yhx
 yhx
@@ -93697,25 +94783,25 @@ bzd
 hGr
 bLT
 bPn
-wGq
+lHz
 hyd
-nhb
 wlV
-wTK
-wTK
-wTK
-wTK
-wTK
-wTK
+wlV
+upt
+doP
+wlV
+wlV
+doP
+doP
 blR
-wTK
-wTK
-wTK
-wGq
-wTK
+doP
+doP
+doP
+wlV
+doP
 wJb
-lhQ
-xPP
+vyQ
+gsq
 uBW
 sqH
 sqH
@@ -93726,25 +94812,25 @@ sqH
 wTK
 tZf
 wTK
-lYJ
-lYJ
 wTK
 wTK
 wTK
-wTK
-hEm
-wGq
-wTK
-pVM
-ydl
-lVi
-wGq
-blR
-wTK
+avT
+avT
+avT
+avT
 ydp
 ydp
 ydp
 ydp
+ydp
+qrR
+qrR
+qrR
+qrR
+qrR
+qrR
+qrR
 yhx
 yhx
 yhx
@@ -93951,57 +95037,57 @@ avT
 avT
 xnP
 bBN
-vTF
+bEi
 bLT
-mUz
-wGq
-jJt
-gKp
-wGq
-bkz
-wGq
+tad
+lSS
+tad
+tad
+mBe
+tad
+tad
 doP
 mzv
-wTK
+doP
 mGa
-wGq
-wGq
-ofH
-wGq
-rHo
-wTK
+wlV
+qKg
+xDz
+doP
+pWF
+doP
 wRX
-lhQ
+vyQ
 hSV
 tNf
-lbp
+oXh
 wkv
 ehW
 tJJ
 tJJ
 tnV
 wTK
-wGq
+gYK
+lnU
 wTK
 avT
 avT
 avT
-wTK
-cgB
-wTK
-wTK
-tZf
-wTK
-wTK
-wTK
-wTK
-dgi
-wTK
-wTK
+avT
 ydp
 ydp
 ydp
 ydp
+ydp
+ydp
+ydp
+qrR
+qrR
+qrR
+qrR
+qrR
+qrR
+qrR
 yhx
 yhx
 yhx
@@ -94132,11 +95218,11 @@ pWS
 trU
 xvj
 eha
-mSt
+kVF
 ngj
 jNK
-mSt
-mSt
+kVF
+kVF
 ads
 qoh
 aeG
@@ -94210,25 +95296,25 @@ bLT
 hrN
 vER
 bLT
-mUz
-wGq
-wGq
+lQA
+lHz
 aMs
-wGq
-wTK
+aMs
+xci
+knk
 tad
-wTK
-qOr
-wTK
-wTK
-wTK
+weI
+wlV
+doP
+axd
+daG
 lJe
-wTK
-wTK
-wGq
-wTK
-wTK
-lhQ
+lbD
+doP
+dYb
+doP
+doP
+vyQ
 ydo
 pYH
 oud
@@ -94238,27 +95324,27 @@ tJJ
 tJJ
 ciA
 wTK
-wGq
+gYK
+tHw
 wTK
 avT
 avT
 avT
-wTK
-wGq
-wGq
-ofH
-wGq
-blR
-fRK
-cnB
-wTK
-wGq
-wTK
 ydp
 ydp
 ydp
 ydp
 ydp
+ydp
+ydp
+ydp
+qrR
+qrR
+qrR
+qrR
+qrR
+qrR
+qrR
 yhx
 yhx
 yhx
@@ -94367,8 +95453,8 @@ ydp
 ydp
 ydp
 ydp
-kVO
-kVO
+pFR
+pFR
 weS
 weS
 iOG
@@ -94465,30 +95551,30 @@ avT
 bLT
 kEz
 bBN
-bEi
+hQO
 bLT
-wTK
+azY
 lYJ
-lYJ
-lYJ
-wTK
-wTK
-wTK
-wTK
-avT
-wTK
+aVw
+aVw
+oOq
+wXE
+tad
+gZV
+wlV
+doP
 noG
 rHo
-wGq
-cbQ
-wTK
-wGq
-wGq
-kAX
-lhQ
+lJe
+ydO
+doP
+wlV
+wlV
+doP
+vyQ
 hDf
 tNf
-lbp
+oXh
 szC
 sHj
 tJJ
@@ -94496,26 +95582,26 @@ tJJ
 cTQ
 hOa
 jhU
+uRg
 wTK
 avT
 avT
 avT
-wTK
-tHs
-wGq
-wTK
-wTK
-wTK
-avR
-wGq
-blR
-fRK
-wTK
 ydp
 ydp
 ydp
 ydp
 ydp
+ydp
+ydp
+ydp
+qrR
+qrR
+qrR
+qrR
+qrR
+qrR
+qrR
 yhx
 yhx
 yhx
@@ -94624,9 +95710,9 @@ ydp
 ydp
 ydp
 ydp
-kVO
+pFR
 xka
-iWf
+evO
 iBW
 iOG
 gyk
@@ -94646,11 +95732,11 @@ pWS
 trU
 itw
 kPn
-mSt
-mSt
-mSt
-mSt
-mSt
+kVF
+kVF
+kVF
+kVF
+kVF
 kdm
 ecN
 vBa
@@ -94724,28 +95810,28 @@ uhD
 aFa
 bCY
 bLT
-avT
-avT
-avT
-avT
-avT
-avT
-avT
-avT
-avT
-wTK
-wTK
-wTK
-wTK
-wTK
-wTK
-wTK
-wTK
-wTK
+pop
+mOV
+ujj
+fIs
+lYJ
+eGY
+tad
+doP
+doP
+doP
+doP
+doP
+doP
+doP
+doP
+doP
+mzv
+doP
 bdm
 ehp
 tNf
-jcT
+wvh
 pLg
 wiD
 iFj
@@ -94753,26 +95839,26 @@ tmx
 lPR
 wTK
 ekJ
+nJv
 wTK
 avT
 avT
 avT
-wTK
-avR
-goj
-blR
-tHs
-wTK
-tHs
-jRn
-wTK
-wTK
-wTK
 ydp
 ydp
 ydp
 ydp
 ydp
+ydp
+ydp
+ydp
+qrR
+qrR
+qrR
+qrR
+qrR
+qrR
+qrR
 yhx
 yhx
 yhx
@@ -94881,8 +95967,8 @@ xUL
 xUL
 xUL
 xUL
-kVO
-kVO
+pFR
+pFR
 vOS
 vOS
 iOG
@@ -94981,48 +96067,40 @@ mcy
 bBP
 ojY
 bLT
+iws
+iws
+tad
+tad
+iws
+iws
+tad
 avT
 avT
 avT
 avT
-avT
-avT
-avT
-avT
-avT
-avT
-avT
-lbp
+oXh
 uon
 eBo
 vKN
-fmw
-fmw
-fmw
-fmw
-fmw
+qLP
+qLP
+qLP
+qLP
+qLP
 wEn
-jcT
-jcT
-lbp
-jcT
-lbp
-jcT
+wvh
+wvh
+oXh
+wvh
+oXh
+wvh
 wTK
 kfl
 wTK
+wTK
 avT
 avT
 avT
-wTK
-wTK
-wTK
-wTK
-wTK
-wTK
-lYJ
-lYJ
-wTK
 ydp
 ydp
 ydp
@@ -95030,6 +96108,14 @@ ydp
 ydp
 ydp
 ydp
+ydp
+qrR
+qrR
+qrR
+qrR
+qrR
+qrR
+qrR
 yhx
 yhx
 yhx
@@ -95138,16 +96224,16 @@ xUL
 xUL
 xUL
 xUL
-kVO
+pFR
 bQf
 vLt
-qgm
+pqj
 nRQ
 iLA
 bXI
 rai
-qgm
-qgm
+pqj
+pqj
 jen
 vOB
 vOB
@@ -95249,17 +96335,17 @@ avT
 avT
 avT
 avT
-lbp
+oXh
 hpA
-lhQ
-lhQ
-lhQ
-lhQ
-lhQ
-lhQ
-lhQ
+vyQ
+vyQ
+vyQ
+vyQ
+vyQ
+vyQ
+vyQ
 aet
-jcT
+wvh
 avT
 avT
 avT
@@ -95272,13 +96358,6 @@ avT
 avT
 avT
 avT
-avT
-avT
-avT
-avT
-avT
-avT
-avT
 ydp
 ydp
 ydp
@@ -95287,6 +96366,13 @@ ydp
 ydp
 ydp
 ydp
+qrR
+qrR
+qrR
+qrR
+qrR
+qrR
+qrR
 yhx
 yhx
 yhx
@@ -95395,16 +96481,16 @@ xUL
 xUL
 xUL
 xUL
-qaO
+rQs
 gct
-qgm
+pqj
 tJL
 cuL
 nZQ
 giv
 erL
-rjP
-rjP
+iqH
+iqH
 pss
 iqH
 xCU
@@ -95506,26 +96592,17 @@ avT
 avT
 avT
 avT
-lbp
+oXh
 riR
-lhQ
-lhQ
-lhQ
+vyQ
+vyQ
+vyQ
 cgQ
 bRm
 bRm
 bRm
 dzq
-jcT
-avT
-avT
-avT
-avT
-avT
-avT
-avT
-avT
-avT
+wvh
 avT
 avT
 avT
@@ -95544,6 +96621,15 @@ ydp
 ydp
 ydp
 ydp
+ydp
+ydp
+qrR
+qrR
+qrR
+qrR
+qrR
+qrR
+qrR
 yhx
 yhx
 yhx
@@ -95652,7 +96738,7 @@ xUL
 xUL
 xUL
 xUL
-qaO
+rQs
 qTo
 xzM
 txL
@@ -95672,7 +96758,7 @@ wAx
 wAx
 wzf
 pqj
-iJS
+txL
 pqj
 pJS
 pJS
@@ -95761,28 +96847,19 @@ avT
 avT
 avT
 avT
-jcT
-lbp
-jcT
+wvh
+oXh
+wvh
 deU
-lhQ
-lhQ
-lhQ
-jcT
-lbp
+vyQ
+vyQ
+vyQ
+wvh
+oXh
 tiV
 gTH
-lbp
-jcT
-avT
-avT
-avT
-avT
-avT
-avT
-avT
-avT
-avT
+oXh
+wvh
 avT
 avT
 avT
@@ -95801,6 +96878,15 @@ ydp
 ydp
 ydp
 ydp
+ydp
+ydp
+qrR
+qrR
+qrR
+qrR
+qrR
+qrR
+qrR
 yhx
 yhx
 yhx
@@ -95910,8 +96996,8 @@ xUL
 xUL
 dns
 iRF
-qgm
-qgm
+pqj
+pqj
 mqc
 wAx
 vwV
@@ -96018,26 +97104,18 @@ avT
 avT
 avT
 avT
-lbp
+oXh
 jee
 jBo
-lhQ
-lhQ
-lhQ
+vyQ
+vyQ
+vyQ
 svv
-jcT
-lbp
+wvh
+oXh
 hRG
 hfk
-lbp
-avT
-avT
-avT
-avT
-avT
-avT
-avT
-avT
+oXh
 avT
 avT
 avT
@@ -96058,6 +97136,14 @@ ydp
 ydp
 ydp
 ydp
+ydp
+qrR
+qrR
+qrR
+qrR
+qrR
+qrR
+qrR
 yhx
 yhx
 yhx
@@ -96166,9 +97252,9 @@ xUL
 xUL
 xUL
 xUL
-qaO
-nqx
-qgm
+rQs
+oeC
+pqj
 axg
 wAx
 lzW
@@ -96275,18 +97361,18 @@ avT
 avT
 avT
 avT
-lbp
+oXh
 wIu
 jBo
-lhQ
-lhQ
-lhQ
+vyQ
+vyQ
+vyQ
 sqs
-jcT
-lbp
+wvh
+oXh
 joE
 dgo
-lbp
+oXh
 avT
 avT
 avT
@@ -96298,14 +97384,6 @@ avT
 avT
 avT
 avT
-avT
-avT
-avT
-avT
-avT
-avT
-avT
-avT
 ydp
 ydp
 ydp
@@ -96315,6 +97393,14 @@ ydp
 ydp
 ydp
 ydp
+ydp
+qrR
+qrR
+qrR
+qrR
+qrR
+qrR
+qrR
 yhx
 yhx
 yhx
@@ -96423,9 +97509,9 @@ xUL
 xUL
 xUL
 xUL
-qaO
-qAq
-qgm
+rQs
+qHq
+pqj
 fJc
 lfy
 fWB
@@ -96532,14 +97618,14 @@ avT
 avT
 avT
 avT
-lbp
+oXh
 wIu
 nQT
 icA
 icA
-lhQ
+vyQ
 jRX
-jcT
+wvh
 avT
 xUL
 xUL
@@ -96555,14 +97641,6 @@ avT
 avT
 avT
 avT
-avT
-avT
-avT
-avT
-avT
-avT
-avT
-avT
 ydp
 ydp
 ydp
@@ -96572,6 +97650,14 @@ ydp
 ydp
 ydp
 ydp
+ydp
+qrR
+qrR
+qrR
+qrR
+qrR
+qrR
+qrR
 yhx
 yhx
 yhx
@@ -96669,20 +97755,20 @@ ydp
 ydp
 avT
 avT
-kVO
-kVO
-kVO
+asn
+asn
+asn
 cfp
 xac
 wzv
 xac
-cfp
-cfp
-cfp
-xac
-cfp
-cfp
-qgm
+bif
+bvq
+bvq
+bvq
+bif
+bif
+exi
 txL
 wAx
 nij
@@ -96789,14 +97875,14 @@ avT
 avT
 avT
 avT
-jcT
+wvh
 wgj
-jcT
-lbp
-lbp
-lbp
-jcT
-jcT
+wvh
+oXh
+oXh
+oXh
+wvh
+wvh
 avT
 xUL
 xUL
@@ -96812,14 +97898,6 @@ avT
 avT
 avT
 avT
-avT
-avT
-avT
-avT
-avT
-avT
-avT
-avT
 ydp
 ydp
 ydp
@@ -96829,6 +97907,14 @@ ydp
 ydp
 ydp
 ydp
+ydp
+qrR
+qrR
+qrR
+qrR
+qrR
+qrR
+qrR
 yhx
 yhx
 yhx
@@ -96926,20 +98012,20 @@ avT
 avT
 avT
 avT
-kVO
+asn
 kDE
-kVO
+asn
 pva
 wFY
 sjD
 lTp
-cfp
+bif
 mfD
-cfp
+cjt
 dpp
 jvV
-cfp
-eue
+bif
+pqj
 erb
 wAx
 wuQ
@@ -97072,10 +98158,6 @@ avT
 avT
 avT
 avT
-avT
-avT
-avT
-avT
 ydp
 ydp
 ydp
@@ -97083,9 +98165,13 @@ ydp
 ydp
 ydp
 ydp
-ydp
-ydp
-ydp
+qrR
+qrR
+qrR
+qrR
+qrR
+qrR
+qrR
 yhx
 yhx
 yhx
@@ -97180,24 +98266,24 @@ ydp
 ydp
 ydp
 avT
-kVO
+asn
 qaO
 qaO
-kVO
-iWf
+asn
+aFQ
 yeS
 cjO
 iPk
 mWB
-pWc
-cfp
-pWc
-cfp
+bcl
+bif
+cgB
+cnB
 aHU
-aHU
+dgi
 sGE
-qgm
-txL
+exE
+eNu
 wAx
 wxZ
 vPB
@@ -97330,19 +98416,19 @@ ydp
 ydp
 avT
 avT
-avT
 ydp
 ydp
 ydp
 ydp
-ydp
-ydp
-ydp
-ydp
-ydp
-ydp
-ydp
-ydp
+qrR
+qrR
+qrR
+qrR
+qrR
+qrR
+qrR
+qrR
+qrR
 yhx
 yhx
 yhx
@@ -97441,18 +98527,18 @@ qaO
 mBv
 mBv
 mnO
-iWf
-kVO
+aFQ
+asn
 cjO
 iPk
 bwf
 oyW
-cfp
-pWc
-cfp
-cfp
+bif
+bif
+bif
+bif
 gxY
-cfp
+bif
 gNI
 moX
 etV
@@ -97591,15 +98677,15 @@ avT
 ydp
 ydp
 ydp
-ydp
-ydp
-ydp
-ydp
-ydp
-ydp
-ydp
-ydp
-ydp
+qrR
+qrR
+qrR
+qrR
+qrR
+qrR
+qrR
+qrR
+qrR
 yhx
 yhx
 yhx
@@ -97698,8 +98784,8 @@ qaO
 mBv
 mBv
 mnO
-iWf
-kVO
+aFQ
+asn
 kDT
 iPk
 fvp
@@ -97707,10 +98793,10 @@ vvW
 cfp
 cCv
 jLG
-eai
-rUa
+pWc
+pWc
 cfp
-qgm
+pqj
 mqc
 vKa
 vKa
@@ -97848,15 +98934,15 @@ ydp
 ydp
 ydp
 ydp
-ydp
-ydp
-ydp
-ydp
-ydp
-ydp
-ydp
-ydp
-ydp
+qrR
+qrR
+qrR
+qrR
+qrR
+qrR
+qrR
+qrR
+qrR
 yhx
 yhx
 yhx
@@ -97948,26 +99034,26 @@ ydp
 avT
 avT
 avT
-kVO
-kVO
-kVO
-kVO
-iWf
-iWf
-kVO
+asn
+asn
+asn
+asn
+aFQ
+aFQ
+asn
 knv
-kVO
+asn
 cjO
 iPk
 osC
 bOO
 cfp
-okh
+piu
 piu
 pWc
 nGi
 cfp
-lOs
+igi
 lNK
 eua
 lVd
@@ -98105,15 +99191,15 @@ ydp
 ydp
 ydp
 ydp
-ydp
-ydp
-ydp
-ydp
-ydp
-ydp
-ydp
-ydp
-ydp
+qrR
+qrR
+qrR
+qrR
+qrR
+qrR
+qrR
+qrR
+qrR
 yhx
 yhx
 yhx
@@ -98208,18 +99294,18 @@ xUL
 xUL
 xUL
 xUL
-kVO
+asn
 jUW
-iWf
-kVO
-iWf
-kVO
+aFQ
+asn
+aFQ
+asn
 cjO
 iPk
 psY
 rDc
 cfp
-qDt
+cfp
 cfp
 mQV
 cfp
@@ -98362,12 +99448,12 @@ ydp
 ydp
 ydp
 ydp
-ydp
-ydp
-ydp
-ydp
-ydp
-ydp
+qrR
+qrR
+qrR
+qrR
+qrR
+qrR
 yhx
 yhx
 yhx
@@ -98466,22 +99552,22 @@ xUL
 xUL
 tKV
 kwC
-iWf
-iWf
+aFQ
+aFQ
 yeS
-iWf
-kVO
+aFQ
+asn
 cjO
 ceL
 nYb
 xUI
-aKf
-aDn
-eYe
-hmP
+xac
+pWc
+pWc
+pWc
 cfp
 jZl
-qgm
+pqj
 xol
 cYj
 lBT
@@ -98603,7 +99689,7 @@ ydp
 wdv
 ydp
 xUL
-xUL
+vBe
 ydp
 ydp
 ydp
@@ -98619,12 +99705,12 @@ ydp
 ydp
 ydp
 ydp
-ydp
-ydp
-ydp
-ydp
-ydp
-ydp
+qrR
+qrR
+qrR
+qrR
+qrR
+qrR
 yhx
 yhx
 yhx
@@ -98722,24 +99808,24 @@ xUL
 xUL
 xUL
 xUL
-kVO
+asn
 ygL
 tVD
-kVO
-iWf
-kVO
+asn
+aFQ
+asn
 cjO
 iPk
 skI
 jmE
 xac
-urO
+pWc
 gph
-evO
+pWc
 cfp
 aMR
-qgm
-erG
+pqj
+klo
 vKa
 ukJ
 puA
@@ -98860,7 +99946,7 @@ ydp
 ydp
 ydp
 xUL
-vBe
+xUL
 ydp
 ydp
 ydp
@@ -98876,12 +99962,12 @@ ydp
 ydp
 ydp
 ydp
-ydp
-ydp
-ydp
-ydp
-ydp
-ydp
+qrR
+qrR
+qrR
+qrR
+qrR
+qrR
 yhx
 yhx
 yhx
@@ -98976,15 +100062,15 @@ ydp
 avT
 avT
 avT
-kVO
-kVO
-kVO
-kVO
-kVO
-kVO
-kVO
+asn
+asn
+asn
+asn
+asn
+asn
+asn
 pOO
-kVO
+asn
 cjO
 iPk
 skI
@@ -98992,11 +100078,11 @@ snB
 xac
 urO
 gph
-evO
+pWc
 cfp
 gmH
 okq
-erG
+klo
 vKa
 lLD
 fHG
@@ -99133,12 +100219,12 @@ ydp
 ydp
 ydp
 ydp
-ydp
-ydp
-ydp
-ydp
-ydp
-ydp
+qrR
+qrR
+qrR
+qrR
+qrR
+qrR
 yhx
 yhx
 yhx
@@ -99233,15 +100319,15 @@ ydp
 avT
 avT
 avT
-kVO
+asn
 jHo
-iWf
-kVO
+aDn
+asn
 gEq
 ygL
 xtb
-iWf
-kVO
+aKf
+asn
 cjO
 iPk
 xhx
@@ -99249,11 +100335,11 @@ slA
 cfp
 gfE
 huF
-cCA
+nGi
 cfp
 hPO
-qgm
-erG
+pqj
+klo
 vKa
 fjw
 vgH
@@ -99390,12 +100476,12 @@ ydp
 ydp
 ydp
 ydp
-ydp
-ydp
-ydp
-ydp
-ydp
-ydp
+qrR
+qrR
+qrR
+qrR
+qrR
+qrR
 yhx
 yhx
 yhx
@@ -99490,15 +100576,15 @@ avT
 avT
 avT
 avT
-kVO
+asn
 clf
 ego
 hYN
 llu
 crg
 hLE
-hLE
-kVO
+aSE
+asn
 cjO
 kIl
 pBZ
@@ -99647,12 +100733,12 @@ ydp
 ydp
 ydp
 ydp
-ydp
-ydp
-ydp
-ydp
-ydp
-ydp
+qrR
+qrR
+qrR
+qrR
+qrR
+qrR
 yhx
 yhx
 yhx
@@ -99747,27 +100833,27 @@ avT
 avT
 avT
 avT
-kVO
+asn
 cqM
 ftV
 jji
-ftV
+aGl
 ohF
-kVO
+asn
 msR
-kVO
+asn
 kDT
 oQY
 fFo
 jmE
 cfp
-kPA
+nFS
 cfp
 nFS
 cfp
 hWW
-qgm
-erG
+pqj
+klo
 vKa
 vKa
 vKa
@@ -99886,10 +100972,10 @@ ydp
 ydp
 ydp
 ydp
-gSE
+iDe
 hLC
 gmZ
-gSE
+iDe
 avT
 ydp
 ydp
@@ -99904,12 +100990,12 @@ ydp
 ydp
 ydp
 ydp
-ydp
-ydp
-ydp
-ydp
-ydp
-ydp
+qrR
+qrR
+qrR
+qrR
+qrR
+qrR
 yhx
 yhx
 yhx
@@ -100004,11 +101090,11 @@ avT
 avT
 avT
 avT
-kVO
+asn
 tcH
-iWf
-kVO
-iWf
+aFO
+asn
+aFQ
 qve
 ubH
 vJt
@@ -100018,15 +101104,15 @@ mQM
 mnL
 hSv
 cfp
-kPA
+nFS
 cfp
 vra
 cfp
-jwD
-qgm
-erG
-jZl
-qaO
+eri
+pqj
+klo
+eYe
+rQs
 abQ
 lGc
 waC
@@ -100143,10 +101229,10 @@ ydp
 ydp
 ydp
 ydp
-gSE
+iDe
 dRM
 hPA
-gSE
+iDe
 avT
 ydp
 ydp
@@ -100161,12 +101247,12 @@ ydp
 ydp
 ydp
 ydp
-ydp
-ydp
-ydp
-ydp
-ydp
-ydp
+qrR
+qrR
+qrR
+qrR
+qrR
+qrR
 yhx
 yhx
 yhx
@@ -100259,15 +101345,15 @@ xUL
 xUL
 xUL
 kVO
-qaO
-qaO
-kVO
-kVO
-kVO
-kVO
-kVO
+avR
+avR
+asn
+asn
+asn
+asn
+asn
 gEq
-iWf
+aFQ
 oBs
 wzl
 yaE
@@ -100283,7 +101369,7 @@ ffv
 kwl
 oWy
 jvr
-qaO
+rQs
 mKD
 lGc
 wcS
@@ -100301,12 +101387,12 @@ iSv
 kge
 dhX
 vkk
-vkk
-vkk
-vkk
+nwe
+nPF
+nUT
 qSi
-vkk
-vkk
+nUT
+kwl
 pUz
 ohS
 pqj
@@ -100397,20 +101483,20 @@ nbC
 gUW
 ydp
 ydp
-wcK
-gSE
-wcK
-gSE
+iNY
+iDe
+iNY
+iDe
 lNj
 hHZ
-gSE
-wcK
-wcK
-wcK
-wcK
-wcK
-wcK
-wcK
+iDe
+iNY
+iNY
+iNY
+iNY
+iNY
+iNY
+iNY
 ydp
 ydp
 ydp
@@ -100418,12 +101504,12 @@ ydp
 ydp
 ydp
 ydp
-ydp
-ydp
-ydp
-ydp
-ydp
-ydp
+qrR
+qrR
+qrR
+qrR
+qrR
+qrR
 yhx
 yhx
 yhx
@@ -100522,11 +101608,11 @@ pyF
 rrC
 wFD
 xAT
-kVO
-kVO
-kVO
+asn
+asn
+asn
 amJ
-kVO
+asn
 cfp
 cfp
 cfp
@@ -100536,11 +101622,11 @@ cfp
 cfp
 bkI
 cfp
-kVO
-qgm
-erG
+etQ
+pqj
+klo
 jPI
-qaO
+rQs
 nEI
 lGc
 aQr
@@ -100558,7 +101644,7 @@ fzG
 khy
 trU
 pqj
-pqj
+nMz
 pqj
 pqj
 pqj
@@ -100662,12 +101748,12 @@ dNf
 dNf
 kef
 sQi
-wcK
+iNY
 mPA
 fCK
 mWW
 wdY
-wcK
+iNY
 ydp
 ydp
 ydp
@@ -100675,12 +101761,12 @@ ydp
 ydp
 ydp
 ydp
-ydp
-ydp
-ydp
-ydp
-ydp
-ydp
+qrR
+qrR
+qrR
+qrR
+qrR
+qrR
 yhx
 yhx
 yhx
@@ -100799,7 +101885,7 @@ mWc
 iFF
 pCU
 kcn
-rjP
+iqH
 xve
 gJP
 eGi
@@ -100911,7 +101997,7 @@ avT
 vBe
 avT
 avT
-gSE
+iDe
 kGX
 teB
 uza
@@ -100924,7 +102010,7 @@ uGE
 crr
 sIl
 sIl
-wcK
+iNY
 ydp
 ydp
 ydp
@@ -101056,8 +102142,8 @@ czA
 nOu
 fqj
 hwd
-bcA
-bcA
+rGy
+rGy
 cKl
 npv
 uJV
@@ -101071,7 +102157,7 @@ fPD
 jHT
 eeE
 mky
-iqH
+leO
 vyO
 rpT
 uqy
@@ -101181,7 +102267,7 @@ hDU
 bXQ
 huU
 ruk
-wcK
+iNY
 ydp
 ydp
 ydp
@@ -101285,8 +102371,8 @@ avT
 avT
 kVO
 boK
-kVO
-kVO
+asn
+asn
 hqx
 saN
 saN
@@ -101314,7 +102400,7 @@ xFZ
 xFZ
 xFZ
 xFZ
-qgm
+pqj
 obR
 cKk
 uIv
@@ -101328,7 +102414,7 @@ fPD
 iSv
 vUq
 eMl
-jTs
+lmU
 jtb
 nwF
 tVh
@@ -101434,11 +102520,11 @@ pCd
 gSE
 wcK
 wcK
-wcK
-wcK
-wcK
-wcK
-wcK
+iNY
+iNY
+iNY
+iNY
+iNY
 ydp
 ydp
 ydp
@@ -101542,7 +102628,7 @@ xUL
 avT
 kVO
 kVO
-kVO
+asn
 iph
 edo
 saN
@@ -101555,10 +102641,10 @@ saN
 qgm
 qgm
 cUP
-qaO
-qaO
-qaO
-qaO
+avR
+avR
+avR
+avR
 cUP
 bxL
 dri
@@ -101571,7 +102657,7 @@ hYi
 qzO
 cCg
 tfq
-qgm
+pqj
 txL
 cKk
 dFa
@@ -101597,7 +102683,7 @@ pqj
 oYU
 oYU
 pqj
-nHX
+rai
 pvs
 xuB
 kFF
@@ -101799,7 +102885,7 @@ xUL
 avT
 avT
 ydp
-kVO
+asn
 fGS
 uZK
 saN
@@ -101828,7 +102914,7 @@ bZI
 bZI
 msi
 xFZ
-qgm
+pqj
 xVl
 gcY
 xop
@@ -101842,7 +102928,7 @@ oNv
 hbb
 khy
 trU
-rNS
+lVi
 jtb
 cDW
 pOU
@@ -101954,7 +103040,7 @@ ydp
 ydp
 ydp
 ydp
-qrR
+ydp
 qrR
 qrR
 qrR
@@ -102110,7 +103196,7 @@ wtp
 eOd
 hwG
 azJ
-czu
+iuy
 pqj
 pvs
 xuB
@@ -102208,7 +103294,7 @@ lSs
 xty
 eNc
 ydp
-qrR
+ydp
 qrR
 qrR
 qrR
@@ -102342,7 +103428,7 @@ bZI
 bZI
 msi
 xFZ
-qgm
+pqj
 mYB
 cKk
 kCI
@@ -102363,11 +103449,11 @@ fzg
 kyc
 tfP
 dQz
-pFR
-rQs
-rQs
-rQs
-pFR
+dQz
+okh
+okh
+okh
+dQz
 oRc
 pvs
 hHy
@@ -102465,7 +103551,7 @@ xDu
 jNv
 eNc
 ydp
-qrR
+ydp
 qrR
 qrR
 qrR
@@ -102570,7 +103656,7 @@ bum
 dwT
 ydp
 ydp
-kVO
+asn
 qKJ
 edo
 saN
@@ -102633,8 +103719,8 @@ sFc
 sFc
 sFc
 sFc
-pFR
-pFR
+qDt
+qDt
 avT
 avT
 avT
@@ -102722,7 +103808,7 @@ xDu
 aET
 wcK
 ydp
-qrR
+ydp
 qrR
 qrR
 qrR
@@ -102827,7 +103913,7 @@ cBe
 wmb
 gFv
 ydp
-kVO
+asn
 gCT
 qKq
 fTx
@@ -102856,8 +103942,8 @@ hNv
 qsm
 olW
 xFZ
-qgm
-erG
+pqj
+klo
 cKk
 cKk
 cKk
@@ -102866,8 +103952,8 @@ cKk
 cKk
 cKk
 cKk
-pFR
-pFR
+cKk
+cKk
 ihJ
 hVN
 rQs
@@ -102886,17 +103972,17 @@ itN
 oaF
 ttl
 udd
-qKM
+sbD
 xJU
-oTb
-oTb
+rUk
+rUk
 ybr
-pFR
-pFR
-pFR
-pFR
-pFR
-pFR
+qDt
+qDt
+qDt
+qDt
+qDt
+qDt
 avT
 avT
 avT
@@ -102979,7 +104065,7 @@ xDu
 jNv
 eNc
 ydp
-qrR
+ydp
 qrR
 qrR
 qrR
@@ -103093,7 +104179,7 @@ qcX
 qcX
 aWr
 jLV
-kVO
+asn
 xUL
 xUL
 vUs
@@ -103139,21 +104225,21 @@ pcs
 iBl
 vBS
 dQz
-pFR
-pFR
-pFR
-oTb
-pFR
-pFR
-oTb
-qKM
+dQz
+dQz
+dQz
+rUk
+qDt
+qDt
+rUk
+sbD
 viq
-pFR
+qDt
 vQd
 vQd
 vQd
 vQd
-pFR
+qDt
 avT
 avT
 avT
@@ -103236,7 +104322,7 @@ mCK
 uNq
 eNc
 ydp
-qrR
+ydp
 qrR
 qrR
 qrR
@@ -103365,20 +104451,20 @@ cQu
 dXa
 bei
 hIl
-njH
+eXT
 cQp
 wKL
-hjw
+wKL
 bKI
 hpg
-qgm
-fyz
-qgm
-qgm
+pqj
+ohS
+pqj
+pqj
 iuy
-qgm
+pqj
 maG
-qgm
+pqj
 hcu
 vju
 eYu
@@ -103399,18 +104485,18 @@ jDD
 qzz
 uqa
 dQz
-oTb
+rUk
 pSC
-pFR
+qDt
 euz
 uVi
 uVo
-pFR
+qDt
 rQG
-oTb
-oTb
-oTb
-pFR
+rUk
+rUk
+rUk
+qDt
 avT
 avT
 avT
@@ -103493,7 +104579,7 @@ lff
 eNc
 eNc
 ydp
-qrR
+ydp
 qrR
 qrR
 qrR
@@ -103619,13 +104705,13 @@ aRr
 vBe
 fen
 mao
-sdr
+dSQ
 pDh
-sdr
-njH
-cQp
+eLp
+eXT
+fjW
 wKL
-hjw
+wKL
 bKI
 bKI
 bKI
@@ -103656,18 +104742,18 @@ jDD
 jDD
 jDD
 dQz
-oTb
+rUk
 smB
-pFR
-pFR
-pFR
-pFR
-pFR
-oTb
-oTb
+qDt
+qDt
+qDt
+qDt
+qDt
+rUk
+rUk
 lQc
 hTY
-pFR
+qDt
 avT
 avT
 avT
@@ -103753,7 +104839,7 @@ ydp
 ydp
 ydp
 ydp
-qrR
+ydp
 qrR
 qrR
 qrR
@@ -103876,13 +104962,13 @@ xUL
 xUL
 fen
 cYq
-sdr
+eai
 xlX
 gOW
 qlh
 uAu
 lHl
-lHl
+fQz
 rSF
 oIq
 tBl
@@ -103914,17 +105000,17 @@ jDD
 jDD
 dQz
 xHp
-pFR
-pFR
+qDt
+qDt
 uVi
 wwi
-oTb
+rUk
 xJU
-oTb
-oTb
+rUk
+rUk
 gWx
 utd
-pFR
+qDt
 avT
 avT
 avT
@@ -104138,14 +105224,14 @@ maL
 ufJ
 njH
 sdr
-sbo
+sdr
 sbo
 idb
 egk
 puf
 sdr
 vhT
-nPF
+iBL
 mzj
 giZ
 oQg
@@ -104170,18 +105256,18 @@ gar
 waa
 uqa
 dQz
-qKM
+sbD
 mxV
-pFR
+qDt
 wwi
 rDl
 rDl
-pFR
+qDt
 mhF
 fQt
 fhG
 ioB
-pFR
+qDt
 avT
 avT
 avT
@@ -104262,11 +105348,11 @@ pAF
 nVs
 nQW
 wcK
-eNc
-eNc
-eNc
-eNc
-eNc
+xHB
+xHB
+xHB
+xHB
+xHB
 ydp
 ydp
 qrR
@@ -104396,7 +105482,7 @@ idl
 lKf
 sdr
 sdr
-sdr
+fRK
 hXO
 egk
 pFf
@@ -104427,18 +105513,18 @@ mZp
 mZp
 mZp
 mZp
-oTb
+rUk
 hJm
-pFR
+qDt
 gWx
 wwi
-oTb
-pFR
-pFR
-pFR
-pFR
-pFR
-pFR
+rUk
+qDt
+qDt
+qDt
+qDt
+qDt
+qDt
 avT
 avT
 avT
@@ -104519,12 +105605,12 @@ qqE
 saj
 nVs
 gSE
-nVs
-nVs
-nVs
+hGv
+hGv
+hGv
 epT
-nVs
-eNc
+hGv
+xHB
 ydp
 ydp
 qrR
@@ -104653,7 +105739,7 @@ pnS
 nsR
 sLN
 sLN
-sLN
+gnS
 xdD
 xKn
 rxf
@@ -104685,12 +105771,12 @@ oHl
 gPF
 mZp
 ttl
-pFR
-pFR
-pFR
-pFR
+qDt
+qDt
+qDt
+qDt
 xJU
-pFR
+qDt
 ydp
 ydp
 ydp
@@ -104776,12 +105862,12 @@ fiE
 sYT
 nVs
 gSE
-nVs
+hGv
 eXS
 dzF
 pWT
-nVs
-eNc
+hGv
+xHB
 ydp
 ydp
 ydp
@@ -104910,12 +105996,12 @@ gyE
 njH
 sdr
 sdr
-sdr
-sdr
-sdr
+goj
+hgu
+hgu
 mFg
-sdr
-sdr
+hgu
+hgu
 rtJ
 hMD
 lAv
@@ -104941,13 +106027,13 @@ tTO
 ijL
 ijL
 mZp
-qKM
-oTb
+sbD
+rUk
 dDB
 xHp
 gWx
-oTb
-pFR
+rUk
+qDt
 ydp
 ydp
 ydp
@@ -105032,14 +106118,14 @@ ajk
 qqE
 saj
 nVs
-gSE
-nVs
+wcK
+hGv
 ggg
 ggg
 ggg
-nVs
+hGv
 jJG
-eNc
+xHB
 ydp
 ydp
 qrR
@@ -105198,13 +106284,13 @@ diD
 cEq
 cEq
 mZp
-oTb
-oTb
-pFR
-pFR
-pFR
-pFR
-pFR
+rUk
+rUk
+qDt
+qDt
+qDt
+qDt
+qDt
 ydp
 ydp
 ydp
@@ -105290,13 +106376,13 @@ fiE
 sYT
 nVs
 kGt
-nVs
+hGv
 pWT
 iUV
 fPO
-nVs
+hGv
 aSk
-eNc
+xHB
 ydp
 ydp
 qrR
@@ -105429,7 +106515,7 @@ sdr
 sdr
 sdr
 sxJ
-wGe
+sdr
 aDJ
 mMs
 wRv
@@ -105455,9 +106541,9 @@ diD
 cEq
 cEq
 mZp
-oTb
+rUk
 tfa
-pFR
+qDt
 avT
 avT
 avT
@@ -105543,17 +106629,17 @@ uYE
 hEC
 hFZ
 cPC
-qqE
-saj
-nVs
-kGt
-nVs
+pSo
+oMD
+gfL
+oXu
+eJg
 jYW
 rVg
 qjQ
-nVs
+hGv
 xMo
-eNc
+xHB
 ydp
 qrR
 qrR
@@ -105712,9 +106798,9 @@ vaB
 fBS
 uPa
 mZp
-oTb
-uLL
-pFR
+rUk
+spV
+qDt
 avT
 avT
 avT
@@ -105803,14 +106889,14 @@ vrV
 fiE
 sYT
 nVs
-gSE
-nVs
+wcK
+ukK
 ggg
 uPx
 ggg
-nVs
+hGv
 tjC
-eNc
+xHB
 ydp
 ydp
 qrR
@@ -105969,9 +107055,9 @@ jAy
 fBS
 wFO
 mZp
-oTb
+rUk
 uVi
-pFR
+qDt
 avT
 avT
 avT
@@ -106061,12 +107147,12 @@ lck
 rYK
 nVs
 gSE
-nVs
+hGv
 wsK
 ggg
 wsK
-nVs
-eNc
+hGv
+xHB
 ydp
 ydp
 qrR
@@ -106226,9 +107312,9 @@ pwC
 fBS
 wFO
 mZp
-oTb
-oTb
-pFR
+rUk
+tfM
+qDt
 avT
 avT
 bmX
@@ -106318,12 +107404,12 @@ fiE
 sYT
 whw
 gSE
-nVs
-nVs
-nVs
-wUb
-nVs
-eNc
+hGv
+hGv
+hGv
+pud
+hGv
+xHB
 ydp
 ydp
 ydp
@@ -106484,8 +107570,8 @@ fBS
 fBS
 mZp
 vQd
-oTb
-pFR
+tDC
+qDt
 avT
 avT
 avT
@@ -106575,11 +107661,11 @@ nVs
 wUb
 bWk
 wcK
-eNc
-eNc
-eNc
-eNc
-eNc
+xHB
+xHB
+xHB
+xHB
+xHB
 ydp
 ydp
 ydp
@@ -106740,9 +107826,9 @@ rXo
 mzs
 xiL
 mZp
-uLL
+spV
 maq
-pFR
+qDt
 avT
 avT
 avT
@@ -106997,9 +108083,9 @@ gkJ
 mzs
 lHZ
 mZp
-uLL
-xHp
-pFR
+spV
+tDO
+qDt
 avT
 avT
 ydp
@@ -107254,9 +108340,9 @@ mZp
 mZp
 mZp
 mZp
-oTb
+rUk
 fBg
-pFR
+qDt
 avT
 ydp
 ydp
@@ -107513,7 +108599,7 @@ uLL
 oTb
 oTb
 mYg
-pFR
+qDt
 ydp
 ydp
 ydp
@@ -107763,14 +108849,14 @@ eMi
 dkQ
 lnW
 eWg
-pWS
+pVM
 rVB
 uVi
-pFR
+qDt
 lrl
 lrl
-pFR
-pFR
+qDt
+qDt
 ydp
 ydp
 ydp


### PR DESCRIPTION
## About The Pull Request
This pr contains changes for literally the entirety of snaxi in the form of area fixes, maint refurbishings, multiz power cable adapters, and more. Obviously some cosmetic changes as well, thanks to @MrFagetti 's #250 pr and ideas that came up.
Atmos was given a second floor to their pipe playground, with adapters galore to connect them both.

## Why It's Good For The Game
I'll pretty much be done with snaxi after this, as most issues were fixed and ideas implemented. Once again, engineering players will have more to enjoy, and so will the entire crew because now the area names make sense for once. Also, more maint/trimmed maint, especially below the garden where I completely removed the maint bar.

## Changelog
:cl:
add: Added second floor to atmospherics
add: Extensions to many rooms and maints across the station to make the place interesting and bearable
del: Removed the second maint bar below the garden
fix: Fixed areas for halls and maints not being directionally correct
/:cl: