### PR TITLE
Xenoarcheology Remap

### DIFF
--- a/_maps/map_files/Mining/Lavaland_Lumos.dmm
+++ b/_maps/map_files/Mining/Lavaland_Lumos.dmm
@@ -39,12 +39,11 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/sec)
 "ae" = (
-/obj/machinery/door/airlock/research{
-	name = "Research Division Access";
-	req_access_txt = "47"
+/obj/effect/turf_decal/lumos/tile/purple/half{
+	dir = 1
 	},
 /obj/machinery/door/firedoor,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "af" = (
 /obj/structure/rack,
@@ -55,43 +54,11 @@
 /obj/item/storage/bag/strangerock,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
-"ag" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/turf_decal/lumos/tile/purple/half{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
-"ah" = (
-/obj/machinery/suit_storage_unit/mining,
-/obj/effect/turf_decal/lumos/tile/purple/fullcorner{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
-"ai" = (
-/obj/effect/turf_decal/lumos/tile/blue/checker{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/arch)
 "ak" = (
 /obj/machinery/door/airlock/maintenance{
 	req_one_access_txt = "48"
 	},
 /turf/open/floor/plating,
-/area/xenoarch/arch)
-"am" = (
-/obj/effect/turf_decal/lumos/tile/purple/half{
-	dir = 8
-	},
-/obj/structure/table,
-/turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "an" = (
 /obj/effect/turf_decal/stripes/line{
@@ -99,22 +66,6 @@
 	},
 /turf/open/floor/plasteel/elevatorshaft,
 /area/mining_level_access/lower)
-"ao" = (
-/obj/structure/chair/office/dark{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
-"ap" = (
-/obj/structure/sign/poster/official/random{
-	pixel_x = 32
-	},
-/obj/machinery/suit_storage_unit/mining,
-/obj/effect/turf_decal/lumos/tile/purple/half{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "aq" = (
 /obj/machinery/requests_console{
 	department = "Xenoarchaeology";
@@ -141,13 +92,17 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "as" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 8
+/obj/machinery/firealarm{
+	pixel_y = 24
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/effect/turf_decal/lumos/tile/purple/half{
+	dir = 1
 	},
-/turf/open/floor/plasteel/white,
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "garbageL"
+	},
+/turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "at" = (
 /obj/machinery/firealarm{
@@ -187,15 +142,6 @@
 	},
 /turf/open/floor/plating,
 /area/xenoarch/arch)
-"ax" = (
-/obj/effect/turf_decal/lumos/tile/purple/half{
-	dir = 8
-	},
-/obj/machinery/computer/rdconsole/core{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "ay" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/yellow,
@@ -212,18 +158,6 @@
 /area/lavaland/surface/outdoors)
 "aA" = (
 /turf/closed/mineral/random/volcanic,
-/area/xenoarch/arch)
-"aB" = (
-/obj/item/radio/intercom{
-	dir = 8;
-	name = "Station Intercom (General)";
-	pixel_x = 28
-	},
-/obj/effect/turf_decal/lumos/tile/purple/half{
-	dir = 4
-	},
-/obj/structure/tank_dispenser/oxygen,
-/turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "aC" = (
 /obj/structure/stone_tile/slab,
@@ -371,14 +305,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/bot)
-"aR" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "aT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/yellow{
@@ -439,11 +365,13 @@
 	layer = 4;
 	pixel_y = 32
 	},
-/obj/machinery/conveyor{
-	dir = 6;
-	id = "garbageL"
+/obj/effect/turf_decal/lumos/tile/purple/half{
+	dir = 1
 	},
-/turf/open/floor/plating,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "bc" = (
 /obj/structure/closet/cardboard,
@@ -489,15 +417,6 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/xenoarch/arch)
-"bk" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/lumos/tile/purple/half,
-/obj/structure/disposalpipe/segment{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "bl" = (
 /obj/structure/rack,
 /obj/structure/sign/poster/official/random{
@@ -525,16 +444,17 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "bp" = (
-/obj/machinery/door/airlock/research{
-	name = "Research Division Access";
-	req_access_txt = "47"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/lumos/tile/purple/fulltile,
-/obj/structure/disposalpipe/segment{
+/obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 1
+	},
+/obj/machinery/mineral/stacking_unit_console{
+	machinedir = 8;
+	pixel_x = 28
+	},
+/obj/machinery/conveyor_switch/oneway{
+	dir = 8;
+	id = "garbageL";
+	name = "disposal conveyor"
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
@@ -584,15 +504,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
-"bt" = (
-/obj/effect/turf_decal/lumos/tile/purple/half{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "bu" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -638,22 +549,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
-"bB" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
-"bC" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "bD" = (
 /obj/structure/stone_tile/cracked{
 	dir = 4
@@ -678,13 +573,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
-"bG" = (
-/obj/effect/turf_decal/lumos/tile/purple/half{
-	dir = 4
-	},
-/obj/structure/table,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "bH" = (
@@ -752,12 +640,6 @@
 /mob/living/simple_animal/hostile/asteroid/gutlunch/gubbuck,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
-"bP" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "bQ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
@@ -872,17 +754,24 @@
 /turf/open/floor/grass,
 /area/xenoarch/arch)
 "cA" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/table/reinforced,
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/lumos/tile/red/fulltile,
+/turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
 "cB" = (
-/obj/machinery/status_display/evac{
-	layer = 4;
-	pixel_x = -32
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "cC" = (
 /obj/structure/stone_tile/slab,
@@ -983,12 +872,6 @@
 /obj/structure/stone_tile,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"dn" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/arch)
 "do" = (
 /obj/machinery/door/airlock/research/glass,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -1174,10 +1057,23 @@
 /turf/open/floor/plating,
 /area/xenoarch/eng)
 "eo" = (
-/obj/machinery/airalarm{
-	pixel_y = 23
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "garbageL"
+	},
+/turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "eu" = (
 /obj/structure/table,
@@ -1252,16 +1148,6 @@
 /obj/structure/stone_tile/cracked,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"fd" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/effect/turf_decal/lumos/tile/purple/checker,
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/arch)
 "fg" = (
 /obj/structure/stone_tile/surrounding_tile/cracked,
 /obj/structure/stone_tile/surrounding_tile/cracked{
@@ -1326,12 +1212,12 @@
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
-"fy" = (
-/obj/structure/chair/office/dark,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+"fC" = (
+/obj/structure/chair{
+	dir = 1
+	},
 /turf/open/floor/plasteel/white,
-/area/xenoarch/arch)
+/area/lavaland/surface/outdoors)
 "fE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 1
@@ -1342,7 +1228,7 @@
 	},
 /obj/machinery/door/airlock/maintenance,
 /obj/machinery/door/firedoor/heavy,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "fF" = (
 /obj/structure/stone_tile/slab,
@@ -1356,14 +1242,11 @@
 /turf/open/floor/engine/air,
 /area/xenoarch/eng)
 "fH" = (
-/obj/machinery/conveyor{
-	dir = 6;
-	id = "garbageL"
+/obj/machinery/suit_storage_unit/mining,
+/obj/effect/turf_decal/lumos/tile/purple/fullcorner{
+	dir = 8
 	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "fI" = (
 /obj/effect/turf_decal/tile/green{
@@ -1397,10 +1280,8 @@
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/gen)
 "fX" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/turf/open/floor/plasteel/white,
+/obj/machinery/light,
+/turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "ga" = (
 /turf/closed/mineral/volcanic/lava_land_surface,
@@ -1510,6 +1391,12 @@
 "gO" = (
 /turf/open/lava/smooth/lava_land_surface,
 /area/summoning_altar)
+"gP" = (
+/obj/structure/bed,
+/obj/machinery/iv_drip,
+/obj/item/bedsheet/medical,
+/turf/open/floor/plasteel/white,
+/area/lavaland/surface/outdoors)
 "gQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -1643,15 +1530,10 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "hy" = (
-/obj/machinery/door/airlock/medical/glass{
-	id_tag = null;
-	name = "Medbay";
-	req_access_txt = "5"
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
 "hE" = (
 /obj/structure/flora/ausbushes/lavendergrass,
@@ -1661,14 +1543,30 @@
 /turf/open/floor/grass,
 /area/lavaland/surface/outdoors)
 "hH" = (
-/obj/structure/disposalpipe/trunk{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/disposal/bin,
-/obj/machinery/light{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/conveyor{
+	dir = 10;
+	id = "garbageL"
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
+"hJ" = (
+/obj/structure/table,
+/obj/effect/turf_decal/lumos/tile/purple/fullcorner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "hK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -1718,6 +1616,12 @@
 /obj/machinery/light/small,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/xenoarch/arch)
+"hZ" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/lavaland/surface/outdoors)
 "ia" = (
 /obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 4
@@ -1809,6 +1713,12 @@
 /obj/machinery/power/apc/auto_name/east,
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/gen)
+"iq" = (
+/obj/machinery/computer/operating{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/xenoarch/arch)
 "is" = (
 /obj/structure/stone_tile/cracked,
 /obj/structure/stone_tile/cracked{
@@ -1838,7 +1748,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "iz" = (
 /obj/structure/sign/poster/official/random{
@@ -1846,26 +1756,43 @@
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
+"iB" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/lavaland/surface/outdoors)
 "iC" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 30
+	},
+/obj/effect/turf_decal/lumos/tile/purple/half{
+	dir = 1
+	},
+/obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "garbageL"
-	},
-/turf/open/floor/plating,
+/obj/machinery/disposal/bin,
+/turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "iD" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/arch)
-"iG" = (
-/obj/structure/bed,
-/obj/machinery/iv_drip,
-/obj/item/bedsheet/medical,
-/turf/open/floor/plasteel/white,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/mineral/stacking_machine{
+	input_dir = 1;
+	stack_amt = 10
+	},
+/turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "iI" = (
 /turf/closed/indestructible/riveted/boss,
@@ -1966,6 +1893,18 @@
 	},
 /turf/open/floor/plasteel/stairs,
 /area/xenoarch/gen)
+"jl" = (
+/obj/machinery/atmospherics/pipe/simple/supply/visible/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/eng)
 "jm" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
@@ -1986,14 +1925,8 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plating,
-/area/xenoarch/eng)
-"ju" = (
-/obj/effect/turf_decal/delivery,
-/obj/structure/closet/wardrobe/xenoarch,
-/obj/item/clothing/glasses/meson,
 /turf/open/floor/plasteel,
-/area/xenoarch/arch)
+/area/xenoarch/eng)
 "jv" = (
 /obj/structure/flora/grass/jungle,
 /obj/machinery/light/small{
@@ -2035,7 +1968,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/turf/closed/wall,
+/turf/open/floor/plating,
 /area/xenoarch/arch)
 "jU" = (
 /obj/structure/stone_tile/block/cracked{
@@ -2050,10 +1983,10 @@
 /turf/open/indestructible/boss,
 /area/lavaland/surface/outdoors)
 "jV" = (
-/obj/machinery/conveyor{
-	id = "garbageL"
+/obj/structure/chair/office/dark{
+	dir = 1
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "jY" = (
 /obj/structure/stone_tile/block/cracked,
@@ -2082,10 +2015,11 @@
 /turf/open/floor/plating,
 /area/xenoarch/arch)
 "ki" = (
-/obj/structure/chair/office/dark{
-	dir = 1
+/obj/effect/turf_decal/lumos/tile/blue/checker,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
 "kk" = (
 /obj/structure/stone_tile,
@@ -2097,12 +2031,6 @@
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"km" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "kr" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -2163,10 +2091,6 @@
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
-"kC" = (
-/obj/structure/chair/office/dark,
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "kD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
@@ -2192,14 +2116,13 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/bot)
 "kI" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/lumos/tile/blue/checker{
 	dir = 4
 	},
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "garbageL"
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
 "kK" = (
 /obj/machinery/hydroponics/constructable,
@@ -2221,11 +2144,8 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "kT" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
-/turf/open/floor/plasteel/white,
+/obj/structure/window/reinforced,
+/turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
 "kU" = (
 /obj/structure/stone_tile/surrounding_tile,
@@ -2258,13 +2178,6 @@
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"la" = (
-/obj/machinery/conveyor{
-	dir = 10;
-	id = "garbageL"
-	},
-/turf/open/floor/plating,
-/area/xenoarch/arch)
 "le" = (
 /turf/closed/indestructible/riveted/boss,
 /area/summoning_altar)
@@ -2285,16 +2198,19 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/sec)
 "lm" = (
-/obj/machinery/mineral/stacking_machine{
-	input_dir = 1;
-	stack_amt = 10
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "lo" = (
 /obj/machinery/computer/shuttle/elevator/mining,
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/gen)
+"lp" = (
+/obj/structure/table/optable,
+/turf/open/floor/plasteel/white,
+/area/lavaland/surface/outdoors)
 "lt" = (
 /obj/effect/landmark/stationroom/lavaland/station,
 /turf/open/lava/smooth/lava_land_surface,
@@ -2407,6 +2323,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
+"lR" = (
+/obj/machinery/door/airlock/medical/glass{
+	id_tag = null;
+	name = "Medbay";
+	req_access_txt = "5"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/white,
+/area/lavaland/surface/outdoors)
 "lT" = (
 /turf/open/floor/plasteel/stairs,
 /area/xenoarch/arch)
@@ -2438,11 +2365,6 @@
 /obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
-"mc" = (
-/obj/effect/turf_decal/lumos/tile/purple/fullcorner,
-/obj/structure/table,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "mf" = (
@@ -2553,6 +2475,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/gen)
+"mR" = (
+/obj/structure/table,
+/obj/machinery/light,
+/obj/effect/turf_decal/lumos/tile/purple/half,
+/obj/item/clipboard,
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "mU" = (
 /obj/structure/stone_tile/block{
 	dir = 8
@@ -2583,10 +2512,8 @@
 /turf/open/floor/plating,
 /area/xenoarch/arch)
 "nd" = (
+/obj/effect/turf_decal/lumos/tile/purple/half,
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/lumos/tile/purple/half{
-	dir = 1
-	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "nf" = (
@@ -2653,7 +2580,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "nz" = (
 /obj/structure/stone_tile/block{
@@ -2662,11 +2589,10 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "nC" = (
-/obj/structure/closet/secure_closet/medical2,
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "nE" = (
 /obj/structure/stone_tile{
@@ -2735,13 +2661,6 @@
 	},
 /turf/open/indestructible/boss,
 /area/lavaland/surface/outdoors)
-"nW" = (
-/obj/structure/table,
-/obj/machinery/light,
-/obj/effect/turf_decal/lumos/tile/purple/half,
-/obj/item/clipboard,
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "nY" = (
 /obj/structure/stone_tile/block/cracked,
 /obj/structure/stone_tile{
@@ -2784,12 +2703,18 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "ok" = (
 /obj/effect/turf_decal/vg_decals/atmos/plasma,
 /turf/open/floor/engine/plasma,
 /area/xenoarch/eng)
+"ol" = (
+/obj/machinery/atm{
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel/white,
+/area/lavaland/surface/outdoors)
 "ox" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/lumos/tile/purple/half{
@@ -2826,13 +2751,9 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "oR" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/medical/glass{
-	id_tag = null;
-	name = "Medbay";
-	req_access_txt = "5"
-	},
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/lumos/tile/purple/half,
+/obj/machinery/light,
+/turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "oT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/visible{
@@ -2849,6 +2770,24 @@
 "oX" = (
 /turf/closed/wall,
 /area/lavaland/surface/outdoors)
+"pa" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/door/airlock/medical/glass{
+	id_tag = "xemed";
+	name = "Medbay";
+	req_access_txt = "5"
+	},
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/lavaland/surface/outdoors)
 "pc" = (
 /obj/structure/table,
 /obj/machinery/plantgenes,
@@ -2861,18 +2800,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/bot)
-"pe" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 1
+"pf" = (
+/obj/effect/turf_decal/caution{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/xenoarch/arch)
-"pf" = (
-/obj/machinery/conveyor{
-	id = "garbageL"
-	},
-/obj/structure/fans/tiny,
-/turf/open/floor/plating,
 /area/xenoarch/arch)
 "pg" = (
 /obj/structure/stone_tile/surrounding_tile,
@@ -2924,6 +2856,25 @@
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
+"pw" = (
+/obj/machinery/computer/crew{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/machinery/airalarm{
+	pixel_y = 23
+	},
+/turf/open/floor/plasteel/white,
+/area/lavaland/surface/outdoors)
+"px" = (
+/obj/machinery/computer/shuttle/elevator/mining{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/mining_level_access)
 "pB" = (
 /obj/structure/stone_tile{
 	dir = 4
@@ -2932,13 +2883,12 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "pC" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
+/obj/machinery/door/airlock/research{
+	name = "Research Division Access";
+	req_access_txt = "47"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
 /area/xenoarch/arch)
 "pD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -3201,7 +3151,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
-/turf/closed/wall,
+/turf/open/floor/plating,
 /area/xenoarch/arch)
 "qJ" = (
 /obj/structure/stone_tile,
@@ -3209,6 +3159,12 @@
 	dir = 8
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"qK" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/white,
 /area/lavaland/surface/outdoors)
 "qN" = (
 /obj/structure/rack,
@@ -3221,7 +3177,7 @@
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "qO" = (
 /obj/machinery/airalarm{
@@ -3251,7 +3207,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "re" = (
 /obj/structure/stone_tile/cracked{
@@ -3309,7 +3265,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "rt" = (
 /obj/effect/turf_decal/lumos/tile/yellow/fullcorner{
@@ -3323,12 +3279,20 @@
 /turf/open/floor/grass,
 /area/lavaland/surface/outdoors)
 "rw" = (
-/obj/structure/sign/warning/securearea{
-	name = "\improper STAY CLEAR HEAVY MACHINERY";
-	pixel_y = 32
+/obj/machinery/light{
+	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/lumos/tile/purple/half{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
 /area/xenoarch/arch)
+"rA" = (
+/obj/structure/chair/office/dark,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/white,
+/area/lavaland/surface/outdoors)
 "rB" = (
 /obj/structure/flora/grass/jungle,
 /obj/structure/flora/ausbushes/grassybush,
@@ -3404,10 +3368,6 @@
 /obj/machinery/portable_atmospherics/scrubber/huge/movable,
 /turf/open/floor/plasteel,
 /area/xenoarch/gen)
-"rT" = (
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "rU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
@@ -3436,26 +3396,19 @@
 	},
 /turf/open/floor/engine,
 /area/xenoarch/eng)
-"sa" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 1
-	},
-/obj/structure/table,
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "sc" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/o2,
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "sf" = (
-/obj/machinery/conveyor{
-	id = "garbageL"
+/obj/structure/disposalpipe/segment{
+	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "sg" = (
 /obj/structure/stone_tile{
@@ -3551,6 +3504,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
+"sN" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating,
+/area/lavaland/surface/outdoors)
 "sP" = (
 /obj/machinery/firealarm{
 	pixel_y = 24
@@ -3561,16 +3521,16 @@
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/sec)
 "sS" = (
-/obj/machinery/computer/med_data{
-	dir = 8
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/obj/machinery/requests_console{
-	department = "Medbay";
-	departmentType = 1;
-	name = "Medbay RC";
-	pixel_x = 30
+/obj/effect/turf_decal/lumos/tile/red/checker{
+	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
 "sT" = (
 /obj/machinery/airalarm{
@@ -3745,11 +3705,8 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "tT" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/smartfridge/chemistry/preloaded,
-/turf/closed/wall,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "tU" = (
 /obj/structure/stone_tile/slab,
@@ -3855,6 +3812,12 @@
 	},
 /obj/structure/stone_tile/cracked,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"uF" = (
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel/white,
 /area/lavaland/surface/outdoors)
 "uH" = (
 /obj/structure/stone_tile{
@@ -3993,7 +3956,13 @@
 /turf/open/indestructible/boss,
 /area/lavaland/surface/outdoors)
 "vz" = (
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/lumos/tile/purple/half{
+	dir = 1
+	},
+/obj/effect/turf_decal/delivery,
+/obj/structure/closet/wardrobe/xenoarch,
+/obj/item/clothing/glasses/meson,
+/turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "vF" = (
 /obj/structure/summoning_altar,
@@ -4105,10 +4074,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/sec)
-"wp" = (
-/obj/item/kirbyplants/random,
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "ws" = (
 /obj/structure/fluff/drake_statue,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
@@ -4211,9 +4176,12 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "xk" = (
-/obj/machinery/cell_charger,
-/obj/structure/table/reinforced,
-/turf/open/floor/plasteel/white,
+/obj/structure/window/reinforced,
+/obj/effect/turf_decal/lumos/tile/purple/checker,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
 "xl" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
@@ -4242,17 +4210,7 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "xz" = (
-/obj/machinery/computer/crew{
-	dir = 8
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/machinery/airalarm{
-	pixel_y = 23
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
 "xA" = (
 /obj/structure/stone_tile/block/cracked{
@@ -4323,11 +4281,12 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "xT" = (
-/obj/structure/chair/stool,
-/obj/item/radio/intercom{
-	dir = 8;
-	name = "Station Intercom (General)";
-	pixel_x = -28
+/obj/structure/window/reinforced,
+/obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
 	},
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
@@ -4358,13 +4317,6 @@
 /obj/item/stack/sheet/cloth/ten,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
-"yk" = (
-/obj/effect/turf_decal/lumos/tile/blue/checker,
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/arch)
 "yl" = (
 /obj/structure/stone_tile/cracked{
 	dir = 1
@@ -4405,17 +4357,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/sec)
-"yu" = (
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
-	},
-/obj/machinery/camera{
-	c_tag = "Xenoarchaeology Nine";
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/arch)
 "yv" = (
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 4
@@ -4481,19 +4422,15 @@
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"yK" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 30
-	},
-/obj/structure/reagent_dispensers/water_cooler,
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "yL" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+/obj/structure/window/reinforced{
 	dir = 1
 	},
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/lumos/tile/purple/checker,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
 "yN" = (
 /obj/structure/stone_tile/surrounding_tile{
@@ -4511,6 +4448,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
+"yT" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/disposal/bin,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/lavaland/surface/outdoors)
 "yV" = (
 /obj/structure/stone_tile/block{
 	dir = 8
@@ -4521,16 +4468,6 @@
 	},
 /turf/open/indestructible/boss,
 /area/lavaland/surface/outdoors)
-"yW" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "yX" = (
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 8
@@ -4558,31 +4495,23 @@
 /turf/open/indestructible/boss,
 /area/lavaland/surface/outdoors)
 "zc" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/structure/disposaloutlet{
+/obj/structure/table,
+/obj/effect/turf_decal/lumos/tile/purple/fullcorner{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "zd" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 8
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/effect/turf_decal/lumos/tile/purple/checker{
 	dir = 4
 	},
-/obj/machinery/door/airlock/medical/glass{
-	id_tag = "xemed";
-	name = "Medbay";
-	req_access_txt = "5"
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
 	},
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
 "zg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/visible{
@@ -4597,16 +4526,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
-/area/xenoarch/arch)
-"zl" = (
-/obj/structure/window/reinforced,
-/obj/effect/turf_decal/lumos/tile/blue/checker{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
 "zn" = (
 /obj/structure/tank_dispenser/oxygen,
@@ -4633,6 +4552,11 @@
 /obj/machinery/portable_atmospherics/scrubber/huge/movable,
 /turf/open/floor/plasteel,
 /area/xenoarch/gen)
+"zz" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow,
+/turf/open/floor/plating,
+/area/lavaland/surface/outdoors)
 "zB" = (
 /obj/structure/stone_tile{
 	dir = 1
@@ -4642,6 +4566,15 @@
 "zC" = (
 /turf/closed/wall/r_wall,
 /area/xenoarch/gen)
+"zD" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel/white,
+/area/xenoarch/arch)
 "zH" = (
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 1
@@ -4751,6 +4684,15 @@
 /obj/structure/stone_tile/block,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
+"Aq" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/medical/glass{
+	id_tag = null;
+	name = "Medbay";
+	req_access_txt = "5"
+	},
+/turf/open/floor/plasteel/white,
+/area/xenoarch/arch)
 "Av" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
@@ -4767,20 +4709,13 @@
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"AC" = (
-/obj/effect/turf_decal/lumos/tile/purple/half{
-	dir = 1
-	},
-/obj/effect/turf_decal/delivery,
-/obj/structure/closet/wardrobe/xenoarch,
-/obj/item/clothing/glasses/meson,
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "AD" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
+/obj/structure/window/reinforced,
+/obj/effect/turf_decal/lumos/tile/blue/checker,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
 "AF" = (
 /obj/structure/stone_tile/block/cracked{
@@ -4790,20 +4725,6 @@
 	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
 /area/ruin/unpowered/ash_walkers)
-"AG" = (
-/obj/structure/window/reinforced,
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/arch)
-"AH" = (
-/obj/effect/turf_decal/lumos/tile/blue/fulltile,
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/arch)
-"AK" = (
-/obj/effect/turf_decal/caution{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "AN" = (
 /obj/structure/stone_tile/cracked,
 /turf/open/lava/smooth/lava_land_surface,
@@ -4858,9 +4779,10 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "Be" = (
-/obj/machinery/light,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/lumos/tile/purple/half,
+/obj/effect/turf_decal/lumos/tile/purple/half{
+	dir = 8
+	},
+/obj/structure/table,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "Bf" = (
@@ -4876,11 +4798,18 @@
 /turf/closed/mineral/random/high_chance/volcanic,
 /area/lavaland/surface/outdoors/unexplored/danger)
 "Bh" = (
-/obj/machinery/conveyor{
-	id = "garbageL"
+/obj/machinery/door/airlock/research{
+	name = "Research Division Access";
+	req_access_txt = "47"
 	},
-/obj/structure/fans/tiny,
-/turf/open/floor/plasteel/dark,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/lumos/tile/purple/fulltile,
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "Bk" = (
 /obj/structure/stone_tile/block{
@@ -4918,12 +4847,13 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/bot)
 "Bx" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
 	},
-/obj/machinery/mineral/stacking_unit_console{
-	machinedir = 8;
-	pixel_x = 28
+/obj/machinery/camera{
+	c_tag = "Xenoarchaeology Nine";
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
@@ -5019,14 +4949,6 @@
 /obj/structure/stone_tile/center/cracked,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"Cj" = (
-/obj/structure/window/reinforced,
-/obj/effect/turf_decal/lumos/tile/blue/checker,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/arch)
 "Ct" = (
 /obj/machinery/door/poddoor/incinerator_atmos_main{
 	id = "atmos_incinerator_mainventL"
@@ -5104,18 +5026,6 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
-"CR" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/effect/turf_decal/lumos/tile/purple/checker{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/arch)
 "CS" = (
 /obj/structure/well_foundation,
 /obj/item/reagent_containers/glass/bucket/wood,
@@ -5169,14 +5079,6 @@
 "Db" = (
 /turf/open/floor/engine,
 /area/xenoarch/eng)
-"Dc" = (
-/obj/machinery/quantumpad{
-	map_pad_id = "tostation";
-	map_pad_link_id = "toxenoarch"
-	},
-/obj/effect/turf_decal/lumos/tile/purple/fulltile,
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/arch)
 "Df" = (
 /obj/machinery/atmospherics/pipe/manifold/purple/visible/layer3,
 /turf/open/floor/plasteel,
@@ -5200,6 +5102,7 @@
 /obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 1
 	},
+/obj/machinery/recycler,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "Do" = (
@@ -5281,28 +5184,10 @@
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating,
 /area/xenoarch/eng)
-"DM" = (
-/obj/structure/window/reinforced,
-/obj/effect/turf_decal/lumos/tile/purple/checker{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/arch)
 "DN" = (
 /obj/structure/ore_box,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"DP" = (
-/obj/structure/window/reinforced,
-/obj/effect/turf_decal/lumos/tile/purple/checker,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/arch)
 "DR" = (
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 1
@@ -5335,28 +5220,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
-"DW" = (
-/obj/item/radio/intercom{
-	dir = 8;
-	name = "Station Intercom (General)";
-	pixel_x = -28
-	},
-/obj/effect/turf_decal/lumos/tile/purple/half{
-	dir = 8
-	},
-/obj/machinery/rnd/production/protolathe/department/science,
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
-"DX" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/effect/turf_decal/lumos/tile/red/checker,
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/arch)
 "Eb" = (
 /obj/structure/stone_tile/block{
 	dir = 4
@@ -5366,18 +5229,6 @@
 	},
 /turf/open/indestructible/boss,
 /area/lavaland/surface/outdoors)
-"Ec" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/effect/turf_decal/lumos/tile/red/checker{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/arch)
 "Ef" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/yellow{
@@ -5412,10 +5263,6 @@
 /obj/machinery/hydroponics/constructable,
 /turf/open/floor/plasteel,
 /area/xenoarch/bot)
-"Eq" = (
-/obj/effect/turf_decal/lumos/tile/red/fulltile,
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/arch)
 "EC" = (
 /obj/structure/stone_tile/block/cracked,
 /turf/open/lava/smooth{
@@ -5432,6 +5279,15 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/xenoarch/sec)
+"EL" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/lavaland/surface/outdoors)
 "EM" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -5471,13 +5327,6 @@
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"ET" = (
-/obj/structure/table,
-/obj/effect/turf_decal/lumos/tile/purple/fullcorner{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "EW" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/structure/table,
@@ -5485,13 +5334,6 @@
 /obj/item/inducer,
 /turf/open/floor/plasteel,
 /area/xenoarch/gen)
-"EX" = (
-/obj/effect/turf_decal/lumos/tile/red/checker,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/arch)
 "EY" = (
 /obj/structure/stone_tile,
 /obj/structure/stone_tile{
@@ -5521,32 +5363,9 @@
 /obj/item/stack/sheet/metal/fifty,
 /turf/open/floor/plasteel,
 /area/xenoarch/gen)
-"Fw" = (
-/obj/machinery/light,
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/effect/turf_decal/lumos/tile/purple/half,
-/obj/structure/table,
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
-"Fy" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "FB" = (
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
-"FD" = (
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "garbageL"
-	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/arch)
 "FG" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
@@ -5565,7 +5384,6 @@
 /turf/closed/indestructible/riveted/boss/see_through,
 /area/lavaland/surface/outdoors)
 "FK" = (
-/obj/machinery/light,
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
@@ -5573,15 +5391,11 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "FO" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable/yellow,
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
+/obj/structure/disposalpipe/segment{
+	dir = 8
 	},
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "FQ" = (
 /obj/structure/stone_tile/surrounding_tile/cracked{
@@ -5650,13 +5464,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/bot)
-"Gq" = (
-/obj/structure/table,
-/obj/effect/turf_decal/lumos/tile/purple/fullcorner{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "Gs" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
@@ -5691,6 +5498,10 @@
 	},
 /obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 1
+	},
+/obj/machinery/conveyor{
+	dir = 6;
+	id = "garbageL"
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
@@ -5790,12 +5601,11 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "GW" = (
-/obj/machinery/conveyor_switch/oneway{
-	dir = 8;
-	id = "garbageL";
-	name = "disposal conveyor"
+/obj/structure/disposalpipe/segment{
+	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/lumos/tile/purple/half,
+/turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "GY" = (
 /obj/machinery/door/airlock/maintenance,
@@ -5813,15 +5623,13 @@
 /obj/structure/stone_tile/block/cracked,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"He" = (
-/obj/effect/turf_decal/lumos/tile/red/checker{
-	dir = 4
+"Hh" = (
+/obj/structure/closet/secure_closet/medical2,
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/arch)
+/turf/open/floor/plasteel/white,
+/area/lavaland/surface/outdoors)
 "Hl" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -5833,9 +5641,9 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 5
+	dir = 6
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "Hq" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
@@ -5908,12 +5716,6 @@
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
-"HK" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/xenoarch/arch)
 "HL" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 9
@@ -5937,10 +5739,6 @@
 /obj/item/stack/sheet/glass/fifty,
 /turf/open/floor/plasteel,
 /area/xenoarch/gen)
-"HS" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "Ia" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
@@ -5976,29 +5774,24 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/gen)
 "Ig" = (
+/obj/effect/turf_decal/delivery,
+/obj/structure/closet/wardrobe/xenoarch,
+/obj/item/clothing/glasses/meson,
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
+"Ih" = (
 /obj/structure/disposalpipe/trunk{
-	dir = 2
-	},
-/obj/machinery/disposal/deliveryChute{
 	dir = 4
 	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
+/obj/structure/disposaloutlet{
 	dir = 1
 	},
-/obj/machinery/door/window{
-	base_state = "right";
-	dir = 4;
-	icon_state = "right";
-	layer = 3
+/obj/machinery/camera{
+	c_tag = "Xenoarchaeology Twelve";
+	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plating,
+/obj/effect/turf_decal/lumos/tile/purple/half,
+/turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "Ii" = (
 /obj/structure/stone_tile{
@@ -6035,6 +5828,11 @@
 /obj/effect/landmark/start/depsec/science,
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/sec)
+"Il" = (
+/obj/machinery/cell_charger,
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/white,
+/area/lavaland/surface/outdoors)
 "Im" = (
 /obj/machinery/hydroponics/constructable,
 /obj/effect/turf_decal/tile/green,
@@ -6090,9 +5888,21 @@
 /turf/open/floor/plating,
 /area/xenoarch/arch)
 "Iz" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/lumos/tile/purple/fullcorner,
+/obj/structure/table,
+/turf/open/floor/plasteel,
 /area/xenoarch/arch)
+"IA" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/lavaland/surface/outdoors)
 "IB" = (
 /turf/closed/mineral/random/high_chance/volcanic,
 /area/lavaland/surface/outdoors/unexplored)
@@ -6161,10 +5971,20 @@
 /obj/item/spear/bonespear,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
+"IZ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/obj/structure/table,
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "Jb" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/white,
+/obj/machinery/quantumpad{
+	map_pad_id = "tostation";
+	map_pad_link_id = "toxenoarch"
+	},
+/obj/effect/turf_decal/lumos/tile/purple/fulltile,
+/turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
 "Je" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -6194,6 +6014,17 @@
 	dir = 8
 	},
 /turf/open/indestructible/boss,
+/area/lavaland/surface/outdoors)
+"Jp" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/lavaland/surface/outdoors)
+"Jy" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
 /area/lavaland/surface/outdoors)
 "JG" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -6225,19 +6056,18 @@
 "JM" = (
 /turf/closed/mineral/random/volcanic,
 /area/lavaland/surface/outdoors/unexplored/danger)
-"JR" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1
+"JV" = (
+/obj/machinery/computer/med_data{
+	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
-"JX" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 1
+/obj/machinery/requests_console{
+	department = "Medbay";
+	departmentType = 1;
+	name = "Medbay RC";
+	pixel_x = 30
 	},
-/obj/machinery/disposal/bin,
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
+/turf/open/floor/plasteel/white,
+/area/lavaland/surface/outdoors)
 "Ka" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 10
@@ -6277,6 +6107,13 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
+/area/xenoarch/arch)
+"Km" = (
+/obj/effect/turf_decal/lumos/tile/red/checker,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
 "Ko" = (
 /obj/structure/stone_tile/cracked,
@@ -6320,7 +6157,8 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "KE" = (
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/lumos/tile/blue/fulltile,
+/turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
 "KF" = (
 /obj/structure/stone_tile{
@@ -6336,19 +6174,6 @@
 /obj/item/stack/marker_beacon/ten,
 /turf/open/indestructible/boss,
 /area/ruin/unpowered/ash_walkers)
-"KG" = (
-/obj/machinery/status_display/evac{
-	layer = 4;
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/lumos/tile/purple/half{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "KJ" = (
 /obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 4
@@ -6366,10 +6191,14 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "KO" = (
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "KR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -6444,6 +6273,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/gen)
+"Lq" = (
+/obj/machinery/airalarm{
+	pixel_y = 23
+	},
+/turf/open/floor/plasteel/white,
+/area/lavaland/surface/outdoors)
 "Lr" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -6484,11 +6319,21 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "LB" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1
+/obj/effect/turf_decal/lumos/tile/purple/half{
+	dir = 8
 	},
-/turf/closed/wall,
+/obj/machinery/computer/rdconsole/core{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/xenoarch/arch)
+"LD" = (
+/obj/machinery/status_display/evac{
+	layer = 4;
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel/white,
+/area/lavaland/surface/outdoors)
 "LE" = (
 /obj/structure/stone_tile/block/cracked{
 	dir = 4
@@ -6529,9 +6374,17 @@
 /turf/open/floor/plating,
 /area/xenoarch/arch)
 "LK" = (
-/obj/machinery/computer/shuttle/elevator/mining,
-/turf/open/floor/plating,
-/area/mining_level_access)
+/obj/item/radio/intercom{
+	dir = 8;
+	name = "Station Intercom (General)";
+	pixel_x = 28
+	},
+/obj/effect/turf_decal/lumos/tile/purple/half{
+	dir = 4
+	},
+/obj/structure/tank_dispenser/oxygen,
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "LM" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -6574,6 +6427,9 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/gen)
+"Ma" = (
+/turf/open/floor/plasteel/white,
+/area/xenoarch/arch)
 "Md" = (
 /obj/structure/stone_tile/block{
 	dir = 4
@@ -6630,10 +6486,11 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "Mv" = (
-/obj/machinery/atm{
-	pixel_y = 30
+/obj/structure/disposalpipe/trunk{
+	dir = 1
 	},
-/turf/open/floor/plasteel/white,
+/obj/machinery/disposal/bin,
+/turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "My" = (
 /obj/effect/turf_decal/lumos/tile/purple/half{
@@ -6653,8 +6510,22 @@
 /turf/open/floor/plasteel,
 /area/space)
 "ML" = (
-/turf/open/floor/plating,
-/area/xenoarch/eng)
+/obj/structure/window/reinforced,
+/obj/effect/turf_decal/lumos/tile/purple/checker{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/xenoarch/arch)
+"MR" = (
+/obj/effect/turf_decal/lumos/tile/purple/half{
+	dir = 4
+	},
+/obj/structure/table,
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "MU" = (
 /obj/structure/stone_tile/block{
 	dir = 8
@@ -6672,6 +6543,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/bot)
+"MX" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/turf/closed/wall,
+/area/xenoarch/arch)
 "Nb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2
@@ -6723,13 +6600,6 @@
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating,
 /area/xenoarch/eng)
-"Nq" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1
-	},
-/obj/structure/table,
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "Nr" = (
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 8
@@ -6773,10 +6643,6 @@
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"ND" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel/white,
-/area/xenoarch/arch)
 "NF" = (
 /obj/structure/fluff/drake_statue/falling,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
@@ -6810,6 +6676,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
+"NN" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/obj/machinery/airalarm{
+	pixel_y = 23
+	},
+/turf/open/floor/plasteel/white,
+/area/lavaland/surface/outdoors)
 "NQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -6819,10 +6692,10 @@
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/gen)
 "NT" = (
-/obj/machinery/light{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "NY" = (
 /obj/machinery/vending/wardrobe/sec_wardrobe,
@@ -6951,18 +6824,8 @@
 /turf/open/floor/engine/air,
 /area/xenoarch/eng)
 "OH" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
@@ -6984,16 +6847,14 @@
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"OM" = (
-/obj/structure/table,
-/obj/item/storage/firstaid/regular,
-/turf/open/floor/plasteel/white,
-/area/xenoarch/arch)
 "OQ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/machinery/light,
+/obj/structure/disposalpipe/segment{
+	dir = 10
 	},
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/lumos/tile/purple/half,
+/obj/structure/table,
+/turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "OR" = (
 /obj/structure/stone_tile/cracked{
@@ -7066,6 +6927,12 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/xenoarch/arch)
+"PB" = (
+/obj/structure/chair/office/dark{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/lavaland/surface/outdoors)
 "PJ" = (
 /obj/machinery/door/airlock/research/glass,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
@@ -7088,17 +6955,18 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "PO" = (
-/obj/machinery/computer/operating{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/obj/item/kirbyplants/random,
+/turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "PQ" = (
-/obj/machinery/conveyor{
-	dir = 10;
-	id = "garbageL"
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
 	},
-/turf/open/floor/plasteel/dark,
+/obj/machinery/suit_storage_unit/mining,
+/obj/effect/turf_decal/lumos/tile/purple/half{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "PR" = (
 /obj/structure/cable/yellow{
@@ -7164,6 +7032,10 @@
 	},
 /turf/open/floor/plating,
 /area/xenoarch/eng)
+"Qd" = (
+/obj/structure/chair/office/dark,
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "Qe" = (
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_y = 30
@@ -7178,10 +7050,16 @@
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/sec)
 "Qf" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/item/radio/intercom{
+	dir = 8;
+	name = "Station Intercom (General)";
+	pixel_x = -28
 	},
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/lumos/tile/purple/half{
+	dir = 8
+	},
+/obj/machinery/rnd/production/protolathe/department/science,
+/turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "Qi" = (
 /turf/closed/wall/r_wall,
@@ -7473,13 +7351,10 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "SB" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "SC" = (
 /obj/machinery/air_sensor/atmos/oxygen_tank,
@@ -7580,27 +7455,8 @@
 /obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
-"Ta" = (
-/obj/structure/table,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/turf_decal/lumos/tile/purple/half{
-	dir = 1
-	},
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
-"Td" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
+/obj/structure/disposaloutlet{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
@@ -7638,6 +7494,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
+"Tv" = (
+/obj/structure/table,
+/obj/item/storage/firstaid/regular,
+/turf/open/floor/plasteel/white,
+/area/lavaland/surface/outdoors)
 "TB" = (
 /turf/open/floor/engine/n2,
 /area/xenoarch/eng)
@@ -7687,6 +7548,15 @@
 /obj/structure/closet/emcloset/anchored,
 /turf/open/floor/plasteel,
 /area/xenoarch/gen)
+"TS" = (
+/obj/effect/turf_decal/lumos/tile/red/checker{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/xenoarch/arch)
 "TT" = (
 /obj/structure/stone_tile/block/cracked{
 	dir = 8
@@ -7704,45 +7574,29 @@
 /turf/closed/indestructible/riveted/boss/see_through,
 /area/lavaland/surface/outdoors)
 "Ub" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/backpack/duffelbag/med/surgery,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/lumos/tile/red/checker,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
 "Ue" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/plasma,
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
-"Ug" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/obj/effect/turf_decal/lumos/tile/purple/half,
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "Uh" = (
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "garbageL"
+/obj/structure/disposalpipe/segment{
+	dir = 1
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "Uj" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/xenoarch/bot)
-"Uk" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/xenoarch/arch)
 "Um" = (
 /obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 1
@@ -7866,15 +7720,13 @@
 /turf/open/indestructible/boss,
 /area/lavaland/surface/outdoors)
 "Va" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/effect/turf_decal/lumos/tile/purple/half{
+	dir = 1
 	},
-/obj/machinery/recycler,
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "garbageL"
+/obj/structure/disposalpipe/segment{
+	dir = 10
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "Vd" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
@@ -7914,12 +7766,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
-"Vs" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "VA" = (
 /obj/structure/flora/grass/jungle,
 /turf/open/floor/grass,
@@ -7933,6 +7779,15 @@
 "VN" = (
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors/unexplored/danger)
+"VQ" = (
+/obj/machinery/light,
+/turf/open/floor/plasteel/white,
+/area/lavaland/surface/outdoors)
+"VX" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/white,
+/area/lavaland/surface/outdoors)
 "Wa" = (
 /obj/machinery/power/turbine{
 	dir = 8;
@@ -7944,11 +7799,15 @@
 /turf/open/floor/engine,
 /area/xenoarch/eng)
 "Wc" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/obj/machinery/airalarm{
-	pixel_y = 23
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
 	},
-/turf/open/floor/plasteel/white,
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/obj/structure/table,
+/turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "Wt" = (
 /obj/structure/stone_tile/block{
@@ -7972,8 +7831,11 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "WD" = (
-/obj/structure/table/optable,
-/turf/open/floor/plasteel/white,
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 30
+	},
+/obj/structure/reagent_dispensers/water_cooler,
+/turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "WI" = (
 /obj/machinery/door/airlock/security{
@@ -8097,6 +7959,15 @@
 	},
 /turf/open/lava/smooth/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"XG" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/turf/open/floor/plasteel/white,
+/area/lavaland/surface/outdoors)
 "XH" = (
 /obj/structure/stone_tile/surrounding_tile,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
@@ -8114,13 +7985,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/gen)
-"XT" = (
-/obj/structure/table,
-/obj/structure/sign/poster/official/random{
-	pixel_x = -32
-	},
-/obj/effect/turf_decal/lumos/tile/purple/half{
-	dir = 8
+"XX" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/lumos/tile/purple/half,
+/obj/structure/disposalpipe/segment{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
@@ -8133,14 +8003,17 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "Yh" = (
+/obj/structure/table,
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "garbageL"
+/obj/effect/turf_decal/lumos/tile/purple/half{
+	dir = 1
 	},
-/turf/open/floor/plating,
+/obj/machinery/newscaster{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "Yj" = (
 /obj/machinery/firealarm{
@@ -8167,6 +8040,14 @@
 	},
 /turf/open/indestructible/boss,
 /area/ruin/unpowered/ash_walkers)
+"YA" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "YB" = (
 /obj/structure/stone_tile/surrounding_tile/cracked{
 	dir = 8
@@ -8183,9 +8064,14 @@
 	},
 /area/ruin/unpowered/ash_walkers)
 "YC" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/structure/barricade/wooden,
-/turf/open/floor/plating,
+/obj/structure/table,
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
+/obj/effect/turf_decal/lumos/tile/purple/half{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "YE" = (
 /obj/effect/turf_decal/stripes/line{
@@ -8236,19 +8122,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/gen)
-"YX" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 30
-	},
-/obj/effect/turf_decal/lumos/tile/purple/half{
-	dir = 1
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/machinery/disposal/bin,
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "YY" = (
 /obj/effect/turf_decal/lumos/tile/yellow/fullcorner,
 /turf/open/floor/plasteel,
@@ -8256,6 +8129,15 @@
 "Za" = (
 /turf/closed/wall,
 /area/xenoarch/gen)
+"Ze" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/lavaland/surface/outdoors)
 "Zg" = (
 /obj/structure/stone_tile/cracked,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
@@ -8277,6 +8159,13 @@
 	},
 /turf/open/floor/plating,
 /area/xenoarch/sec)
+"Zz" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/smartfridge/chemistry/preloaded,
+/turf/closed/wall,
+/area/lavaland/surface/outdoors)
 "ZC" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 6
@@ -8294,19 +8183,11 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "ZF" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/structure/disposaloutlet{
-	dir = 1
-	},
-/obj/machinery/camera{
-	c_tag = "Xenoarchaeology Twelve";
-	dir = 1
-	},
-/obj/effect/turf_decal/lumos/tile/purple/half,
-/turf/open/floor/plasteel,
+/turf/open/space/basic,
 /area/xenoarch/arch)
+"ZG" = (
+/turf/open/floor/plasteel/white,
+/area/lavaland/surface/outdoors)
 "ZP" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/toxin_output,
 /turf/open/floor/engine/plasma,
@@ -8333,6 +8214,13 @@
 	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
 /area/ruin/unpowered/ash_walkers)
+"ZZ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/turf/open/floor/plasteel/white,
+/area/lavaland/surface/outdoors)
 
 (1,1,1) = {"
 tN
@@ -15239,18 +15127,18 @@ tN
 tN
 tN
 tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
+oX
+oX
+oX
+oX
+oX
+oX
+oX
+oX
+oX
+oX
+oX
+oX
 tN
 tN
 tN
@@ -15496,18 +15384,18 @@ tN
 tN
 tN
 tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
+oX
+gP
+ZG
+ZZ
+lR
+VX
+VX
+rA
+qK
+VX
+XG
+VQ
 tN
 tN
 yE
@@ -15753,18 +15641,18 @@ tN
 tN
 tN
 tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
+oX
+gP
+ZG
+iB
+oX
+pw
+Il
+JV
+oX
+ZG
+Ze
+ZG
 tN
 tN
 tN
@@ -16010,18 +15898,18 @@ tN
 tN
 tN
 tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
+oX
+Hh
+ZG
+ZG
+oX
+oX
+oX
+oX
+oX
+uF
+Ze
+Tv
 tN
 tN
 tN
@@ -16267,18 +16155,18 @@ tN
 tN
 tN
 tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
+oX
+Lq
+ZG
+ZG
+LD
+ZG
+ZG
+ZG
+oX
+NN
+Jy
+EL
 tN
 tN
 tN
@@ -16524,18 +16412,18 @@ tN
 tN
 tN
 tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
+oX
+lp
+PB
+ZG
+ZG
+ZG
+ZG
+ZG
+oX
+hZ
+Ze
+fC
 tN
 tN
 tN
@@ -16781,18 +16669,18 @@ aA
 aA
 aA
 aA
-aA
-aA
-aA
-aA
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
+BS
+iq
+zD
+Ma
+yT
+ZG
+ZG
+ZG
+oX
+ol
+Ze
+Tv
 tN
 tN
 tN
@@ -17038,18 +16926,18 @@ aA
 aA
 aA
 aA
-aA
-aA
-aA
-aA
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
+BS
+BS
+BS
+Aq
+Zz
+sN
+IA
+zz
+oX
+Jp
+pa
+Jp
 tN
 tN
 tN
@@ -18314,18 +18202,6 @@ aA
 aA
 aA
 aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
 BS
 BS
 BS
@@ -18337,6 +18213,18 @@ BS
 BS
 BS
 BS
+aA
+ZF
+ZF
+ZF
+ZF
+ZF
+ZF
+ZF
+ZF
+ZF
+ZF
+ZF
 QV
 QV
 QV
@@ -18572,28 +18460,28 @@ BS
 BS
 BS
 BS
+ki
+xz
+xT
+yL
+Bx
+ML
+Ub
+xz
+TS
 BS
-BS
-BS
-BS
-BS
-BS
-BS
-BS
-BS
-BS
-BS
-BS
-yk
-vz
-zl
-fd
-yu
-DM
-DX
-vz
-He
-BS
+ZF
+ZF
+ZF
+ZF
+ZF
+ZF
+ZF
+ZF
+ZF
+ZF
+ZF
+ZF
 QV
 QV
 QV
@@ -18829,28 +18717,28 @@ sV
 jn
 jn
 BS
-iG
+xz
 KE
 kT
 hy
 Jb
-Jb
-fy
+kT
+hy
 cA
-Jb
-Ho
-ND
+xz
 BS
-vz
-AH
-AG
-dn
-Dc
-AG
-dn
-Eq
-vz
-BS
+ZF
+ZF
+ZF
+ZF
+ZF
+ZF
+ZF
+ZF
+ZF
+ZF
+ZF
+ZF
 QV
 QV
 QV
@@ -19086,28 +18974,28 @@ CT
 CT
 jn
 BS
-iG
-KE
+kI
+xz
 AD
-BS
+zd
 xz
 xk
 sS
+xz
+Km
 BS
-KE
-as
-KE
-BS
-ai
-vz
-Cj
-CR
-vz
-DP
-Ec
-vz
-EX
-BS
+ZF
+ZF
+ZF
+ZF
+ZF
+ZF
+ZF
+ZF
+ZF
+ZF
+ZF
+ZF
 QV
 QV
 QV
@@ -19344,27 +19232,27 @@ CT
 jn
 BS
 nC
-KE
-KE
-BS
-BS
-BS
-BS
-BS
+pf
+AU
+AU
+pf
+AU
+AU
+pf
 fX
-as
-OM
 BS
-Vs
-AK
-AU
-AU
-AK
-AU
-AU
-AK
-HS
-BS
+ZF
+ZF
+ZF
+ZF
+ZF
+ZF
+ZF
+ZF
+ZF
+ZF
+ZF
+ZF
 QV
 QV
 QV
@@ -19600,18 +19488,6 @@ Id
 CT
 jn
 BS
-eo
-KE
-KE
-cB
-KE
-KE
-KE
-BS
-Wc
-yL
-Uk
-BS
 AU
 AU
 AU
@@ -19622,6 +19498,18 @@ AU
 AU
 AU
 BS
+ZF
+ZF
+ZF
+ZF
+ZF
+ZF
+ZF
+ZF
+ZF
+ZF
+ZF
+ZF
 QV
 QV
 QV
@@ -19858,27 +19746,27 @@ CT
 jn
 BS
 WD
-ki
-KE
-KE
-KE
-KE
-KE
-BS
-NT
-as
-HK
-BS
-yK
 AU
 AU
 wW
-Td
-pe
+Ho
+NT
 AU
 AU
 AU
 BS
+ZF
+ZF
+ZF
+ZF
+ZF
+ZF
+ZF
+ZF
+ZF
+ZF
+ZF
+ZF
 QV
 QV
 QV
@@ -20115,27 +20003,27 @@ CT
 jn
 BS
 PO
-Ub
-KE
-hH
-KE
-KE
-KE
-BS
-Mv
-as
-OM
-BS
-wp
 AU
 AU
 AU
 Bf
-km
-sa
-Nq
-JX
+OH
+Wc
+IZ
+Mv
 BS
+ZF
+ZF
+ZF
+ZF
+ZF
+ZF
+ZF
+ZF
+ZF
+ZF
+ZF
+ZF
 QV
 QV
 QV
@@ -20373,26 +20261,26 @@ GY
 BS
 BS
 BS
-oR
+BS
 tT
-aw
+KO
 FO
-ay
-BS
-pU
-zd
-pU
 BS
 BS
 BS
 BS
-rT
-yW
-Fy
-BS
-BS
-BS
-BS
+ZF
+ZF
+ZF
+ZF
+ZF
+ZF
+ZF
+ZF
+ZF
+ZF
+ZF
+ZF
 QV
 QV
 QV
@@ -21397,9 +21285,9 @@ kr
 Og
 ku
 CT
-Ng
-UN
-HP
+ae
+cB
+nd
 BS
 BS
 BS
@@ -21657,13 +21545,13 @@ CT
 SZ
 dF
 fa
-qI
+BS
 zc
-vz
-vz
-vz
-vz
-vz
+Be
+LB
+Qf
+YC
+hJ
 BS
 tN
 Pd
@@ -21917,11 +21805,11 @@ HP
 BS
 Yh
 jV
-jV
-jV
-jV
-jV
-pf
+AU
+AU
+Qd
+mR
+BS
 Pd
 Pd
 Pd
@@ -22168,17 +22056,17 @@ CT
 CT
 CT
 CT
-Yj
-UN
+as
+eo
 HP
 BS
 iC
-kI
-Qf
-Qf
-Qf
-Qf
-vz
+AU
+AU
+AU
+AU
+HP
+BS
 Pd
 Pd
 Pd
@@ -22418,23 +22306,23 @@ KZ
 BS
 jn
 BS
-ET
-am
-ax
-DW
-XT
-Gq
+ZF
+ZF
+ZF
+ZF
+ZF
+ZF
 BS
-nd
-OH
-Be
-BS
+Ng
+UN
+di
+pC
 Va
 Uh
 Uh
 sf
-sf
-sf
+YA
+XX
 Bh
 Pd
 Pd
@@ -22675,23 +22563,23 @@ BS
 BS
 jn
 BS
-Ta
-ao
-AU
-AU
-kC
-nW
+ZF
+ZF
+ZF
+ZF
+ZF
+ZF
 BS
 Gy
-UN
+hH
 vg
 BS
 bb
-la
 lm
-pU
-BS
-pU
+lm
+SB
+AU
+Ih
 BS
 Pd
 Pd
@@ -22932,22 +22820,22 @@ BS
 QW
 jn
 BS
-YX
-AU
-AU
-AU
-AU
-HP
+ZF
+ZF
+ZF
+ZF
+ZF
+ZF
 BS
-Ng
-gQ
+bp
+iD
 HP
 BS
 vz
-FD
 Ig
-pC
-xT
+Ig
+AU
+AU
 GW
 BS
 Pd
@@ -23188,25 +23076,25 @@ aA
 BS
 aK
 jn
-ae
-bt
-JR
-JR
-bB
-aR
-bk
-bp
+BS
+ZF
+ZF
+ZF
+ZF
+ZF
+ZF
+BS
 bs
 bv
 HP
 BS
 rw
-FD
-Uh
-SB
-vz
+AU
+AU
+AU
+Qd
 OQ
-BS
+MX
 tN
 tN
 tN
@@ -23446,11 +23334,11 @@ BS
 jn
 jn
 BS
-KG
-bP
-bP
-bC
-AU
+ZF
+ZF
+ZF
+ZF
+ZF
 ZF
 BS
 Ng
@@ -23459,9 +23347,9 @@ XI
 BS
 fH
 PQ
-jn
-SB
-vz
+LK
+ia
+MR
 Iz
 BS
 tN
@@ -23703,23 +23591,23 @@ BS
 aW
 jn
 BS
-AC
-ju
-ju
-AU
-AU
-Ug
+ZF
+ZF
+ZF
+ZF
+ZF
+ZF
 BS
 Yj
 UN
-HP
-YC
-OQ
-OQ
-Bx
-KO
-vz
-iD
+oR
+BS
+BS
+BS
+BS
+BS
+BS
+BS
 BS
 tN
 tN
@@ -23960,13 +23848,13 @@ BS
 BS
 dt
 BS
-ag
-AU
-AU
-AU
-kC
-Fw
-LB
+ZF
+ZF
+ZF
+ZF
+ZF
+ZF
+BS
 hw
 cd
 FK
@@ -23975,7 +23863,7 @@ qI
 qI
 qI
 jS
-BS
+jn
 tN
 tN
 tN
@@ -24217,12 +24105,12 @@ aA
 BS
 jn
 BS
-ah
-ap
-aB
-ia
-bG
-mc
+ZF
+ZF
+ZF
+ZF
+ZF
+ZF
 BS
 Xr
 KR
@@ -27825,14 +27713,14 @@ ac
 MC
 MC
 MC
-Pn
-ML
-ML
-ML
-ML
-ML
-ML
-Pn
+FB
+FB
+FB
+FB
+FB
+FB
+FB
+FB
 qN
 qX
 Ge
@@ -28082,16 +27970,16 @@ ac
 MC
 MC
 MC
-Ym
-Ym
-Ym
-Ym
-Ym
-Ym
-Ym
-Ym
-Pn
-en
+MC
+MC
+MC
+MC
+MC
+MC
+MC
+MC
+FB
+jl
 Ge
 Qo
 Ox
@@ -93377,8 +93265,8 @@ Pd
 tN
 tN
 tN
-tN
-tN
+Yp
+Yp
 Yp
 hu
 bN
@@ -93626,25 +93514,25 @@ Yp
 Yp
 Yp
 Yp
+Pd
+Pd
+Pd
+Yp
 tN
 tN
 tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-jd
-bN
-bN
-bN
-bN
-bN
+Yp
+Yp
+Yp
 jd
 jd
+bN
+bN
+bN
+bN
+bN
+jd
+Yp
 Yp
 Yp
 Yp
@@ -93885,23 +93773,23 @@ Yp
 Yp
 Yp
 Yp
-tN
-tN
-tN
-tN
-Pd
-Pd
-Pd
+Yp
+Yp
+Yp
+Yp
+Yp
+Yp
 Yp
 Yp
 jd
+px
 bN
 bN
 bN
 bN
 bN
-LK
 jd
+Yp
 Yp
 Yp
 Yp
@@ -94145,20 +94033,20 @@ Yp
 Yp
 Yp
 Yp
-Pd
-Pd
-Pd
-Pd
 Yp
 Yp
-jd
-bN
-bN
-bN
-bN
-bN
+Yp
+Yp
+Yp
 jd
 jd
+bN
+bN
+bN
+bN
+bN
+jd
+Yp
 Yp
 Yp
 Yp
@@ -94403,10 +94291,10 @@ Pd
 Pd
 Pd
 Pd
-Pd
-Pd
-Pd
-Pd
+Yp
+Yp
+Yp
+Yp
 Yp
 XB
 bN
@@ -94662,8 +94550,8 @@ Pd
 Pd
 Pd
 Pd
-Pd
-Pd
+Yp
+Yp
 Yp
 RM
 US
@@ -94921,7 +94809,7 @@ Pd
 Pd
 Pd
 Pd
-Pd
+Yp
 Yp
 Yp
 Yp

--- a/_maps/map_files/Mining/Lavaland_Lumos.dmm
+++ b/_maps/map_files/Mining/Lavaland_Lumos.dmm
@@ -1,37 +1,24 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "aa" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/structure/table,
 /turf/open/floor/plating,
 /area/xenoarch/arch)
 "ac" = (
 /turf/closed/wall,
-/area/space)
+/area/xenoarch/eng)
 "ad" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 30
+/obj/structure/chair/office/dark{
+	dir = 8
 	},
-/obj/machinery/newscaster/security_unit{
-	pixel_x = -32
-	},
-/obj/effect/turf_decal/lumos/tile/red/fullcorner{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/sec)
+/obj/item/cardboard_cutout,
+/turf/open/floor/plating,
+/area/xenoarch/arch)
 "ae" = (
-/obj/machinery/computer/card{
+/obj/structure/frame/computer{
 	dir = 4
 	},
-/obj/effect/turf_decal/lumos/tile/red/half{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/sec)
+/turf/open/floor/plating,
+/area/xenoarch/arch)
 "ak" = (
 /obj/machinery/door/airlock/maintenance{
 	req_one_access_txt = "48"
@@ -58,24 +45,18 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "ar" = (
-/obj/machinery/airalarm{
-	pixel_y = 23
-	},
 /obj/machinery/camera{
-	c_tag = "Xenoarchaeology Sixteen"
+	c_tag = "Xenoarchaeology Foreman Office"
 	},
 /obj/effect/turf_decal/lumos/tile/brown/half{
 	dir = 1
 	},
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "as" = (
 /obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 1
-	},
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "garbageL"
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
@@ -128,7 +109,10 @@
 /turf/open/lava/smooth/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "aA" = (
-/turf/closed/mineral/random/volcanic,
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/turf/open/floor/plating,
 /area/xenoarch/arch)
 "aC" = (
 /obj/structure/stone_tile/slab,
@@ -155,8 +139,8 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/effect/turf_decal/stripes/corner,
 /obj/structure/reagent_dispensers/fueltank,
+/obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "aF" = (
@@ -172,7 +156,7 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "aH" = (
-/obj/structure/closet/cardboard,
+/obj/item/caution,
 /turf/open/floor/plating,
 /area/xenoarch/arch)
 "aI" = (
@@ -198,6 +182,7 @@
 /area/xenoarch/arch)
 "aK" = (
 /obj/structure/table,
+/obj/item/poster/random_contraband,
 /turf/open/floor/plating,
 /area/xenoarch/arch)
 "aL" = (
@@ -219,8 +204,12 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "aM" = (
-/turf/closed/mineral/random/volcanic,
-/area/space)
+/obj/structure/closet/crate{
+	icon_state = "crateopen"
+	},
+/obj/item/poster/random_official,
+/turf/open/floor/plating,
+/area/xenoarch/arch)
 "aN" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
@@ -272,12 +261,13 @@
 /turf/open/floor/plasteel/elevatorshaft,
 /area/mining_level_access/lower)
 "aU" = (
-/obj/structure/closet/crate{
-	icon_state = "crateopen"
+/obj/machinery/door/airlock/medical/glass{
+	id_tag = null;
+	name = "Medbay";
+	req_access_txt = "5"
 	},
-/obj/item/poster/random_official,
 /turf/open/floor/plating,
-/area/xenoarch/sec)
+/area/xenoarch/arch)
 "aV" = (
 /obj/structure/stone_tile/block{
 	dir = 4
@@ -329,16 +319,16 @@
 	dir = 4
 	},
 /obj/machinery/camera{
-	c_tag = "Xenoarchaeology Twelve"
+	c_tag = "Xenoarchaeology Research Room"
 	},
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "bc" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/seeds,
+/obj/structure/table,
+/obj/item/newspaper,
 /turf/open/floor/plating,
-/area/xenoarch/sec)
+/area/xenoarch/arch)
 "bd" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -359,23 +349,29 @@
 /turf/open/floor/plating,
 /area/xenoarch/arch)
 "bh" = (
-/obj/effect/turf_decal/lumos/tile/red/fullcorner{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/sec)
-"bi" = (
-/obj/machinery/door/airlock/medical/glass{
-	id_tag = null;
-	name = "Medbay";
-	req_access_txt = "5"
+/obj/structure/chair/office/dark{
+	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/machinery/newscaster{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/white,
+/area/xenoarch/arch)
+"bi" = (
+/obj/structure/closet/cardboard,
 /turf/open/floor/plating,
 /area/xenoarch/arch)
 "bj" = (
-/obj/structure/grille/broken,
+/obj/structure/table,
+/obj/item/clipboard,
 /turf/open/floor/plating,
-/area/xenoarch/sec)
+/area/xenoarch/arch)
 "bl" = (
 /obj/structure/rack,
 /obj/structure/sign/poster/official/random{
@@ -403,18 +399,12 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "bp" = (
-/obj/machinery/mineral/stacking_unit_console{
-	machinedir = 8;
-	pixel_x = 28
-	},
-/obj/machinery/conveyor_switch/oneway{
-	dir = 8;
-	id = "garbageL";
-	name = "disposal conveyor"
-	},
 /obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "bq" = (
@@ -452,17 +442,6 @@
 /obj/item/hatchet,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"bs" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/disposalpipe/segment{
-	dir = 1
-	},
-/obj/effect/turf_decal/lumos/tile/blue/half{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "bu" = (
 /obj/structure/table,
 /obj/machinery/smartfridge/disks,
@@ -485,10 +464,14 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/structure/disposalpipe/junction{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
@@ -499,13 +482,14 @@
 "bx" = (
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plating,
-/area/xenoarch/sec)
+/area/xenoarch/arch)
 "by" = (
-/obj/structure/chair/sofa/corp/right{
-	dir = 8
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 12
 	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/gen)
+/turf/open/floor/plasteel/white,
+/area/xenoarch/arch)
 "bA" = (
 /obj/machinery/power/smes/engineering,
 /obj/structure/cable{
@@ -530,21 +514,26 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "bG" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+/obj/structure/closet/crate/freezer/blood,
+/obj/machinery/iv_drip,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/obj/machinery/camera{
+	c_tag = "Xenoarchaeology Medbay Backroom";
 	dir = 4
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/gen)
+/turf/open/floor/plasteel/white,
+/area/xenoarch/arch)
 "bH" = (
 /obj/structure/flora/tree/jungle/small,
 /turf/open/floor/grass,
 /area/lavaland/surface/outdoors)
 "bI" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
 /turf/open/floor/plating,
 /area/xenoarch/sec)
 "bJ" = (
@@ -569,7 +558,7 @@
 "bN" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
-/area/xenoarch/sec)
+/area/xenoarch/arch)
 "bO" = (
 /obj/item/seeds/glowshroom{
 	potency = 50;
@@ -592,6 +581,7 @@
 /obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 8
 	},
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "bT" = (
@@ -614,24 +604,13 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
-/area/xenoarch/sec)
+/area/xenoarch/arch)
 "cd" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/white,
 /area/xenoarch/arch)
 "ci" = (
 /obj/structure/stone_tile{
@@ -650,7 +629,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/research/glass,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
@@ -658,6 +636,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/lumos/tile/purple/fulltile,
+/obj/machinery/door/airlock/external/glass{
+	name = "Xenoarcheology External Access"
+	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "cp" = (
@@ -676,25 +657,23 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "ct" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
 /obj/effect/turf_decal/lumos/tile/yellow/half,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "cv" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/floor/grass,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/turf/open/floor/plasteel/white,
 /area/xenoarch/arch)
 "cA" = (
 /obj/effect/turf_decal/lumos/tile/red/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
 "cB" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -703,7 +682,11 @@
 	name = "Security Checkpoint";
 	req_access_txt = "1"
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/lumos/tile/red/fulltile,
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel/dark,
 /area/xenoarch/sec)
 "cC" = (
 /obj/structure/stone_tile/slab,
@@ -725,13 +708,9 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "cH" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 8
-	},
-/obj/effect/turf_decal/lumos/tile/purple/half{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
 /area/xenoarch/arch)
 "cL" = (
 /obj/item/flashlight/lantern,
@@ -761,7 +740,12 @@
 /area/lavaland/surface/outdoors)
 "cY" = (
 /obj/machinery/airalarm/directional/north,
-/obj/machinery/computer/crew,
+/obj/machinery/vending/medical{
+	pixel_x = -2
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
 /turf/open/floor/plasteel/white,
 /area/xenoarch/arch)
 "cZ" = (
@@ -786,7 +770,12 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "dh" = (
-/obj/machinery/computer/med_data,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/xenoarch/arch)
 "di" = (
@@ -826,9 +815,10 @@
 /turf/open/lava/smooth/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "ds" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/lumos/tile/blue/half{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
 /area/xenoarch/arch)
 "dt" = (
 /obj/machinery/light/small,
@@ -850,14 +840,12 @@
 /turf/open/floor/plating,
 /area/xenoarch/sec)
 "dx" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/lumos/tile/purple/half,
 /obj/machinery/camera{
-	c_tag = "Xenoarchaeology Seven";
+	c_tag = "Xenobotany Hallway";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -872,6 +860,9 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "dF" = (
@@ -884,7 +875,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/junction/yjunction,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "dL" = (
@@ -914,15 +907,22 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "dQ" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/xenoarch/sec)
+/obj/effect/turf_decal/lumos/tile/blue/fullcorner{
+	dir = 4
+	},
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk,
+/turf/open/floor/plasteel/white,
+/area/xenoarch/arch)
 "dV" = (
 /obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/lumos/shower,
+/obj/machinery/shower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -940,8 +940,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/machinery/light/small,
 /turf/open/floor/plating,
-/area/xenoarch/sec)
+/area/xenoarch/arch)
 "ec" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -971,28 +972,21 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "garbageL"
-	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "eu" = (
-/obj/structure/table,
-/obj/item/newspaper,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/lumos/tile/blue/half{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/white,
 /area/xenoarch/arch)
 "ey" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/gen)
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/xenoarch/arch)
 "eA" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -1025,12 +1019,14 @@
 /turf/closed/indestructible/riveted/boss,
 /area/lavaland/surface/outdoors)
 "fa" = (
-/obj/effect/turf_decal/lumos/tile/purple/half,
-/obj/structure/disposalpipe/segment{
-	dir = 2
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/xenoarch/sec)
 "fb" = (
 /obj/structure/stone_tile{
 	dir = 1
@@ -1079,9 +1075,6 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "fl" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
 /obj/effect/turf_decal/lumos/tile/yellow/half,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/machinery/computer/atmos_control/tank/nitrogen_tank{
@@ -1113,21 +1106,17 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "fw" = (
-/obj/machinery/light{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
+/turf/open/floor/plasteel/dark,
+/area/xenoarch/sec)
+"fC" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/xenoarch/gen)
-"fC" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/lavaland/surface/outdoors)
+/area/xenoarch/sec)
 "fE" = (
 /obj/machinery/door/firedoor/heavy,
 /obj/effect/turf_decal/lumos/tile/yellow/fulltile,
@@ -1167,7 +1156,7 @@
 "fP" = (
 /obj/structure/reagent_dispensers/foamtank,
 /turf/open/floor/plating,
-/area/xenoarch/sec)
+/area/xenoarch/arch)
 "fX" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/lumos/loading_area{
@@ -1221,12 +1210,14 @@
 /turf/open/indestructible/boss,
 /area/ruin/unpowered/ash_walkers)
 "go" = (
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
-/obj/machinery/power/apc/auto_name/east,
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/gen)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/xenoarch/arch)
 "gq" = (
 /obj/structure/stone_tile/surrounding,
 /obj/structure/stone_tile/center/cracked,
@@ -1236,7 +1227,7 @@
 "gu" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
-/area/xenoarch/sec)
+/area/xenoarch/arch)
 "gw" = (
 /obj/structure/stone_tile{
 	dir = 4
@@ -1252,7 +1243,7 @@
 "gC" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
-/area/xenoarch/sec)
+/area/xenoarch/arch)
 "gE" = (
 /obj/structure/stone_tile/cracked{
 	dir = 8
@@ -1276,15 +1267,18 @@
 /turf/open/lava/smooth/lava_land_surface,
 /area/summoning_altar)
 "gP" = (
-/obj/structure/bed,
-/obj/machinery/iv_drip,
-/obj/item/bedsheet/medical,
-/turf/open/floor/plasteel/white,
-/area/lavaland/surface/outdoors)
-"gQ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/xenoarch/arch)
+"gQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
@@ -1293,6 +1287,9 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
@@ -1331,31 +1328,51 @@
 /turf/open/floor/engine,
 /area/xenoarch/eng)
 "gZ" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+/obj/effect/turf_decal/lumos/tile/blue/half{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/gen)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/xenoarch/arch)
 "ha" = (
-/obj/machinery/door/airlock/medical/glass{
-	id_tag = null;
-	name = "Medbay";
-	req_access_txt = "5"
+/obj/effect/turf_decal/lumos/tile/blue/fulltile,
+/obj/machinery/door/airlock/public/glass{
+	name = "Medbay"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/xenoarch/arch)
 "hi" = (
-/obj/structure/chair/sofa/corp/left{
+/obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 8
 	},
-/obj/structure/sign/poster/official/random{
-	pixel_x = 32
+/obj/structure/disposalpipe/segment{
+	dir = 9
 	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/gen)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/xenoarch/arch)
 "hk" = (
 /obj/structure/stone_tile/slab/cracked,
 /obj/effect/decal/cleanable/blood,
@@ -1400,15 +1417,6 @@
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"hw" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1
-	},
-/obj/effect/turf_decal/lumos/tile/purple/half{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "hx" = (
 /obj/structure/closet/secure_closet/medical2,
 /turf/open/floor/plasteel/white/side,
@@ -1424,23 +1432,13 @@
 /turf/open/floor/plasteel/white,
 /area/xenoarch/arch)
 "hH" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
+	dir = 9
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/conveyor{
-	dir = 10;
-	id = "garbageL"
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/white,
 /area/xenoarch/arch)
 "hJ" = (
 /obj/structure/table,
@@ -1466,6 +1464,10 @@
 /obj/item/kirbyplants{
 	icon_state = "plant-10"
 	},
+/obj/effect/turf_decal/lumos/tile/blue/fullcorner{
+	dir = 8
+	},
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/plasteel/white,
 /area/xenoarch/arch)
 "hV" = (
@@ -1478,13 +1480,16 @@
 /turf/closed/indestructible/riveted/boss,
 /area/ruin/unpowered/ash_walkers)
 "hW" = (
-/turf/open/floor/grass,
+/obj/effect/turf_decal/lumos/tile/blue/half{
+	dir = 4
+	},
+/obj/structure/bed,
+/obj/item/bedsheet/medical,
+/turf/open/floor/plasteel/white,
 /area/xenoarch/arch)
 "hZ" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
+/obj/structure/flora/tree/jungle,
+/turf/open/floor/grass,
 /area/lavaland/surface/outdoors)
 "ia" = (
 /obj/effect/turf_decal/lumos/tile/purple/half{
@@ -1493,9 +1498,6 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "ib" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
 /obj/effect/turf_decal/lumos/tile/yellow/half,
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/open/floor/plasteel,
@@ -1525,9 +1527,6 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
@@ -1560,13 +1559,16 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/xenoarch/sec)
-"iq" = (
-/obj/machinery/computer/operating{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
 /area/xenoarch/arch)
+"iq" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/lumos/tile/red/fullcorner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/xenoarch/sec)
 "is" = (
 /obj/structure/stone_tile/cracked,
 /obj/structure/stone_tile/cracked{
@@ -1583,26 +1585,22 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
-"ix" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/eng)
 "iz" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/grass,
-/area/space)
-"iB" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/blue/half,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/white,
-/area/lavaland/surface/outdoors)
+/area/xenoarch/arch)
+"iB" = (
+/obj/effect/turf_decal/lumos/tile/blue/fullcorner,
+/turf/open/floor/plasteel/white,
+/area/xenoarch/arch)
 "iC" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
@@ -1617,22 +1615,14 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "iD" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/disposalpipe/junction{
+	dir = 8
 	},
-/obj/machinery/mineral/stacking_machine{
-	input_dir = 1;
-	stack_amt = 10
-	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "iI" = (
@@ -1671,16 +1661,17 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "iS" = (
-/turf/open/water,
+/obj/effect/turf_decal/lumos/tile/blue/fullcorner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
 /area/xenoarch/arch)
 "iV" = (
 /obj/structure/stone_tile,
 /turf/open/lava/smooth/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "iX" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/structure/flora/biolumi/mine/weaklight,
 /turf/open/floor/grass,
 /area/lavaland/surface/outdoors)
 "ja" = (
@@ -1695,7 +1686,7 @@
 	dir = 1
 	},
 /turf/open/floor/grass,
-/area/lavaland/surface/outdoors)
+/area/xenoarch/arch)
 "je" = (
 /obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 1
@@ -1769,11 +1760,15 @@
 /obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 1
 	},
+/obj/machinery/status_display/evac{
+	layer = 4;
+	pixel_y = 32
+	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "jL" = (
-/obj/structure/table,
-/obj/item/clipboard,
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/xenoarch/arch)
 "jN" = (
@@ -1784,7 +1779,7 @@
 	pixel_x = 30
 	},
 /obj/machinery/camera{
-	c_tag = "Xenoarchaeology Eleven";
+	c_tag = "Xenoarchaeology Access Foyer";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -1824,12 +1819,9 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "ka" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4
-	},
-/obj/machinery/hydroponics/constructable,
-/turf/open/floor/plasteel,
-/area/xenoarch/bot)
+/obj/machinery/smartfridge/chemistry/preloaded,
+/turf/closed/wall,
+/area/xenoarch/arch)
 "kh" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
@@ -1855,11 +1847,10 @@
 /obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 1
 	},
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/plasteel,
-/area/space)
+/area/xenoarch/arch)
 "kr" = (
-/obj/structure/disposalpipe/trunk,
-/obj/machinery/disposal/bin,
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_y = 28
@@ -1867,16 +1858,16 @@
 /obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 1
 	},
+/obj/structure/closet/secure_closet/security_xenoarch,
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/sec)
 "kt" = (
-/obj/effect/turf_decal/lumos/tile/purple/half{
-	dir = 4
-	},
 /obj/machinery/status_display/evac{
 	layer = 4;
 	pixel_x = 32
 	},
+/obj/effect/turf_decal/lumos/tile/purple/fullcorner,
+/obj/item/kirbyplants/random,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "ku" = (
@@ -1903,9 +1894,6 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "kD" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/table,
 /obj/machinery/reagentgrinder{
 	desc = "Used to grind things up into raw materials and liquids.";
@@ -1921,8 +1909,8 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/space)
+/turf/open/floor/plasteel/dark,
+/area/xenoarch/eng)
 "kI" = (
 /obj/effect/turf_decal/lumos/tile/blue/checker{
 	dir = 4
@@ -2010,23 +1998,40 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "lo" = (
-/obj/machinery/computer/shuttle/elevator/mining,
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/gen)
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/window/northleft{
+	name = "Medbay Desk";
+	req_access_txt = "5"
+	},
+/turf/open/floor/plating,
+/area/xenoarch/arch)
 "lp" = (
-/obj/structure/table/optable,
-/turf/open/floor/plasteel/white,
-/area/lavaland/surface/outdoors)
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/lumos/tile/blue/half{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "lt" = (
 /obj/effect/landmark/stationroom/lavaland/station,
 /turf/open/lava/smooth/lava_land_surface,
 /area/template_noop)
 "lu" = (
-/obj/effect/turf_decal/lumos/tile/purple/half{
-	dir = 8
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/junction/flip{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
@@ -2119,10 +2124,6 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "lO" = (
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
@@ -2131,33 +2132,28 @@
 	dir = 8
 	},
 /obj/machinery/camera{
-	c_tag = "Xenoarchaeology Six";
+	c_tag = "Xenobotany";
 	dir = 1
 	},
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/plasteel,
 /area/xenoarch/bot)
 "lP" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/disposalpipe/segment{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "lR" = (
-/obj/machinery/door/airlock/medical/glass{
-	id_tag = null;
-	name = "Medbay";
-	req_access_txt = "5"
+/obj/effect/turf_decal/lumos/tile/purple/half,
+/obj/structure/disposalpipe/segment{
+	dir = 1
 	},
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/white,
-/area/lavaland/surface/outdoors)
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "lT" = (
 /turf/open/floor/plasteel/stairs,
 /area/xenoarch/arch)
@@ -2183,9 +2179,12 @@
 /turf/open/floor/plating,
 /area/xenoarch/sec)
 "mg" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/space)
+/obj/effect/turf_decal/lumos/tile/purple/half,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "mh" = (
 /obj/machinery/light/small,
 /turf/open/floor/plating,
@@ -2209,16 +2208,14 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/bot)
 "mm" = (
-/obj/machinery/status_display/evac{
-	layer = 4;
-	pixel_x = 32
+/obj/effect/turf_decal/lumos/tile/purple/half,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/obj/machinery/camera{
-	c_tag = "Xenoarchaeology Seventeen";
-	dir = 8
-	},
-/turf/open/floor/plasteel/stairs,
-/area/xenoarch/gen)
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "mp" = (
 /obj/machinery/suit_storage_unit/atmos,
 /obj/effect/turf_decal/lumos/tile/yellow/fullcorner{
@@ -2227,27 +2224,21 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "mu" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/gen)
+/obj/effect/turf_decal/lumos/tile/purple/half,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "my" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
+/obj/machinery/newscaster{
+	pixel_x = 32
 	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/gen)
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "mA" = (
-/obj/machinery/atmospherics/pipe/simple/supply/visible/layer1,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/visible,
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "mB" = (
@@ -2263,20 +2254,28 @@
 	dir = 1
 	},
 /turf/open/floor/grass,
-/area/space)
+/area/lavaland/surface/outdoors)
 "mJ" = (
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/space)
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "mQ" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 30
+/obj/effect/turf_decal/lumos/tile/purple/half{
+	dir = 8
 	},
-/obj/machinery/camera{
-	c_tag = "Xenoarchaeology Five";
-	dir = 9
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/gen)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "mR" = (
 /obj/structure/table,
 /obj/machinery/light,
@@ -2285,11 +2284,17 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "mT" = (
-/obj/structure/chair/sofa/corp/left{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
 	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/gen)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "mU" = (
 /obj/structure/stone_tile/block{
 	dir = 8
@@ -2308,11 +2313,17 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
-/area/space)
-"mY" = (
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/xenoarch/arch)
+"mY" = (
+/obj/effect/turf_decal/lumos/tile/yellow/half{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/eng)
 "mZ" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
@@ -2323,15 +2334,17 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/turf/open/floor/plasteel,
-/area/space)
-"nb" = (
-/obj/structure/table,
-/obj/machinery/newscaster{
-	pixel_y = 32
+/obj/structure/disposalpipe/segment{
+	dir = 10
 	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/gen)
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
+"nb" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/eng)
 "nf" = (
 /obj/machinery/atmospherics/pipe/simple/dark/visible,
 /obj/structure/cable/yellow{
@@ -2340,6 +2353,7 @@
 /obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 8
 	},
+/obj/machinery/meter,
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "nh" = (
@@ -2380,12 +2394,15 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/space)
+/area/xenoarch/arch)
 "nw" = (
 /obj/structure/flora/grass/jungle/b,
 /turf/open/floor/grass,
 /area/lavaland/surface/outdoors)
 "nx" = (
+/obj/effect/turf_decal/lumos/tile/yellow/half{
+	dir = 8
+	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
@@ -2496,9 +2513,6 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "of" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -2508,6 +2522,12 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/effect/turf_decal/lumos/tile/yellow/half{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "ok" = (
@@ -2515,21 +2535,29 @@
 /turf/open/floor/engine/plasma,
 /area/xenoarch/eng)
 "ol" = (
-/obj/machinery/atm{
-	pixel_y = 30
+/obj/effect/turf_decal/lumos/tile/yellow/half{
+	dir = 4
 	},
-/turf/open/floor/plasteel/white,
-/area/lavaland/surface/outdoors)
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/plasteel,
+/area/xenoarch/eng)
 "oo" = (
 /obj/effect/turf_decal/lumos/tile/blue/fullcorner,
+/obj/structure/bed,
+/obj/item/bedsheet/medical,
 /turf/open/floor/plasteel/white,
 /area/xenoarch/arch)
 "op" = (
-/obj/effect/turf_decal/lumos/tile/blue/half{
-	dir = 8
+/obj/effect/turf_decal/lumos/tile/blue/fullcorner{
+	dir = 4
 	},
-/obj/structure/closet/crate/freezer/blood,
-/obj/machinery/iv_drip,
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Xenoarchaeology Medbay Main";
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/xenoarch/arch)
 "ox" = (
@@ -2540,24 +2568,27 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "oy" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/structure/disposalpipe/segment{
+	dir = 1
 	},
-/obj/machinery/airalarm{
-	pixel_y = 23
-	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/gen)
-"oI" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/gen)
-"oJ" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/lumos/tile/purple/half,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
+"oI" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/eng)
+"oJ" = (
+/obj/effect/turf_decal/lumos/tile/yellow/half{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Xenoarchaeology Elevator Access";
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/eng)
 "oL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
@@ -2568,9 +2599,9 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "oM" = (
-/obj/structure/table,
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/gen)
+/obj/structure/disposalpipe/junction/flip,
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "oQ" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/structure/table,
@@ -2579,7 +2610,7 @@
 /obj/machinery/light,
 /obj/item/construction/rcd,
 /turf/open/floor/plasteel,
-/area/xenoarch/gen)
+/area/xenoarch/eng)
 "oR" = (
 /obj/effect/turf_decal/lumos/tile/purple/half,
 /obj/machinery/light,
@@ -2592,26 +2623,17 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "oX" = (
-/turf/closed/wall,
-/area/lavaland/surface/outdoors)
-"pa" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/airlock/medical/glass{
-	id_tag = "xemed";
-	name = "Medbay";
-	req_access_txt = "5"
-	},
-/obj/effect/mapping_helpers/airlock/unres{
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
+"pa" = (
+/obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
-/area/lavaland/surface/outdoors)
+/turf/open/floor/plasteel,
+/area/xenoarch/eng)
 "pf" = (
 /obj/effect/turf_decal/caution{
 	dir = 4;
@@ -2631,24 +2653,31 @@
 /turf/open/lava/smooth/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "ph" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/gen)
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/xenoarch/eng)
 "pi" = (
 /obj/structure/bonfire/dense,
 /obj/structure/stone_tile/center,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "pl" = (
-/obj/machinery/door/airlock/research/glass,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
 /obj/effect/turf_decal/lumos/tile/purple/fulltile,
+/obj/machinery/door/airlock/external/glass{
+	name = "Xenoarcheology External Access"
+	},
 /turf/open/floor/plasteel,
-/area/space)
+/area/xenoarch/arch)
 "pn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
@@ -2664,8 +2693,9 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "pq" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
+/obj/effect/turf_decal/lumos/tile/purple/half,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
@@ -2683,24 +2713,14 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "pw" = (
-/obj/machinery/computer/crew{
-	dir = 8
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/machinery/airalarm{
-	pixel_y = 23
-	},
-/turf/open/floor/plasteel/white,
-/area/lavaland/surface/outdoors)
+/turf/closed/wall/r_wall,
+/area/xenoarch/bot)
 "px" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/space)
+/area/lavaland/surface/outdoors)
 "pB" = (
 /obj/structure/stone_tile{
 	dir = 4
@@ -2716,12 +2736,23 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/lumos/tile/purple/fulltile,
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "pE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 8
+	},
+/obj/structure/sign/warning/nosmoking{
+	pixel_x = -28
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
@@ -2756,21 +2787,6 @@
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"pQ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "pU" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -2786,8 +2802,14 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "pZ" = (
-/obj/effect/turf_decal/lumos/tile/red/half{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/effect/turf_decal/lumos/tile/red/fullcorner{
+	dir = 4
+	},
+/obj/machinery/newscaster/security_unit{
+	pixel_x = -32
 	},
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/sec)
@@ -2795,7 +2817,7 @@
 /obj/effect/turf_decal/lumos/tile/purple/half,
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel,
-/area/space)
+/area/xenoarch/arch)
 "qd" = (
 /obj/structure/stone_tile/cracked{
 	dir = 4
@@ -2833,10 +2855,10 @@
 /turf/open/indestructible/boss,
 /area/ruin/unpowered/ash_walkers)
 "qg" = (
-/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/lumos/tile/yellow/half,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
-/area/space)
+/area/xenoarch/arch)
 "qn" = (
 /obj/structure/stone_tile,
 /obj/structure/stone_tile{
@@ -2852,9 +2874,6 @@
 /turf/open/indestructible/boss,
 /area/ruin/unpowered/ash_walkers)
 "qo" = (
-/obj/machinery/atmospherics/components/binary/volume_pump{
-	dir = 8
-	},
 /obj/machinery/light,
 /obj/effect/turf_decal/lumos/tile/yellow/half,
 /turf/open/floor/plasteel,
@@ -2866,11 +2885,12 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "qy" = (
-/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/n2{
+/obj/effect/turf_decal/lumos/tile/purple/fullcorner{
 	dir = 1
 	},
+/obj/machinery/vending/snack/random,
 /turf/open/floor/plasteel,
-/area/xenoarch/eng)
+/area/xenoarch/arch)
 "qC" = (
 /obj/structure/stone_tile/block/cracked{
 	dir = 8
@@ -2928,11 +2948,16 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "qK" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/table/reinforced,
-/turf/open/floor/plasteel/white,
-/area/lavaland/surface/outdoors)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/xenoarch/arch)
 "qN" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
@@ -2942,6 +2967,10 @@
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
@@ -2963,10 +2992,11 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/lumos/tile/yellow/half,
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
-/area/space)
+/area/xenoarch/arch)
 "re" = (
 /obj/structure/stone_tile/cracked{
 	dir = 4
@@ -3014,8 +3044,14 @@
 /turf/open/lava/smooth/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "rr" = (
+/obj/effect/turf_decal/lumos/tile/yellow/fullcorner{
+	dir = 1
+	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
+	},
+/obj/structure/sign/warning/securearea{
+	pixel_x = -32
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
@@ -3046,11 +3082,12 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "rA" = (
-/obj/structure/chair/office/dark,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/white,
-/area/lavaland/surface/outdoors)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/xenoarch/arch)
 "rB" = (
 /obj/structure/flora/grass/jungle,
 /obj/structure/flora/ausbushes/grassybush,
@@ -3098,11 +3135,14 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "rU" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 8
+/obj/machinery/door/airlock/maintenance{
+	name = "Disposal Access";
+	req_access_txt = "12"
 	},
-/turf/open/floor/plasteel,
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/turf/open/floor/plating,
 /area/xenoarch/arch)
 "rX" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
@@ -3126,17 +3166,21 @@
 /turf/open/floor/engine,
 /area/xenoarch/eng)
 "sc" = (
-/obj/machinery/atmospherics/components/trinary/filter/atmos/o2,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "sf" = (
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
+	dir = 5
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "sg" = (
@@ -3153,15 +3197,13 @@
 /turf/open/indestructible/boss,
 /area/ruin/unpowered/ash_walkers)
 "sl" = (
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/flora/ausbushes/grassybush,
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/effect/turf_decal/lumos/tile/yellow/half,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/obj/structure/window/reinforced,
-/turf/open/floor/grass,
-/area/xenoarch/gen)
+/turf/open/floor/plasteel,
+/area/xenoarch/eng)
 "sm" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/yellow{
@@ -3174,10 +3216,10 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "st" = (
-/obj/machinery/atmospherics/pipe/simple/supply/visible/layer1{
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/machinery/atmospherics/pipe/simple/supply/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "sw" = (
@@ -3191,8 +3233,12 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "sB" = (
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/gen)
+/obj/effect/turf_decal/lumos/tile/yellow/half,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/eng)
 "sE" = (
 /obj/effect/turf_decal/lumos/tile/purple/fullcorner,
 /obj/effect/turf_decal/stripes/corner{
@@ -3221,12 +3267,13 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "sN" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
+/obj/machinery/conveyor_switch/oneway{
+	dir = 8;
+	id = "garbageL";
+	name = "disposal conveyor"
 	},
 /turf/open/floor/plating,
-/area/lavaland/surface/outdoors)
+/area/xenoarch/arch)
 "sS" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -3252,13 +3299,12 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/bot)
 "sV" = (
-/obj/item/caution,
+/obj/effect/turf_decal/loading_area{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/xenoarch/arch)
 "sY" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
 /obj/effect/turf_decal/lumos/tile/yellow/half,
 /obj/machinery/atmospherics/pipe/simple/purple/visible/layer3,
 /obj/machinery/atmospherics/components/binary/volume_pump{
@@ -3338,23 +3384,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
-"tx" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/lumos/tile/yellow/half{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/eng)
 "ty" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
 /turf/open/floor/grass,
-/area/space)
+/area/lavaland/surface/outdoors)
 "tB" = (
 /turf/open/floor/circuit,
 /area/xenoarch/arch)
@@ -3408,8 +3444,11 @@
 /turf/closed/indestructible/riveted/boss,
 /area/lavaland/surface/outdoors)
 "tV" = (
-/obj/machinery/smartfridge/chemistry/preloaded,
-/turf/closed/wall,
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "garbageL"
+	},
+/turf/open/floor/plating,
 /area/xenoarch/arch)
 "uf" = (
 /obj/structure/flora/grass/jungle,
@@ -3433,7 +3472,6 @@
 /obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "uj" = (
@@ -3465,15 +3503,16 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "uv" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
+/obj/machinery/mineral/stacking_machine{
+	input_dir = 1;
+	stack_amt = 10
 	},
-/obj/machinery/camera{
-	c_tag = "Xenoarchaeology Three";
-	dir = 5
+/obj/machinery/mineral/stacking_unit_console{
+	machinedir = 8;
+	pixel_x = 28
 	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/gen)
+/turf/open/floor/plating,
+/area/xenoarch/arch)
 "ux" = (
 /obj/structure/stone_tile/block{
 	dir = 4
@@ -3515,11 +3554,14 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "uF" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
+/obj/structure/disposalpipe/segment,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
 	},
-/turf/open/floor/plasteel/white,
-/area/lavaland/surface/outdoors)
+/turf/open/floor/plating,
+/area/xenoarch/eng)
 "uH" = (
 /obj/structure/stone_tile{
 	dir = 4
@@ -3538,7 +3580,6 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "uT" = (
-/obj/machinery/atmospherics/pipe/simple/dark/visible,
 /obj/machinery/button/ignition{
 	id = "IncineratorL";
 	pixel_x = -24
@@ -3547,26 +3588,22 @@
 	dir = 4
 	},
 /obj/machinery/camera{
-	c_tag = "Xenoarchaeology Thirteen";
+	c_tag = "Xenoarchaeology Turbine Access";
 	dir = 5
 	},
 /obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 8
 	},
+/obj/machinery/atmospherics/components/binary/volume_pump,
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "uX" = (
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/flora/ausbushes/grassybush,
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
 	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/grass,
-/area/xenoarch/gen)
+/turf/open/floor/plating,
+/area/xenoarch/eng)
 "vf" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/research/glass,
@@ -3580,7 +3617,7 @@
 /area/xenoarch/arch)
 "vg" = (
 /obj/machinery/camera{
-	c_tag = "Xenoarchaeology Eight";
+	c_tag = "Xenoarchaeology Med-Sci Hallway";
 	dir = 1
 	},
 /obj/effect/turf_decal/lumos/tile/purple/half,
@@ -3610,31 +3647,19 @@
 /turf/closed/indestructible/riveted/boss,
 /area/ruin/unpowered/ash_walkers)
 "vq" = (
-/obj/item/stack/sheet/mineral/coal,
-/obj/item/stack/sheet/mineral/coal,
-/obj/item/stack/sheet/mineral/coal,
-/obj/item/stack/sheet/mineral/coal,
-/obj/item/stack/sheet/mineral/coal,
-/obj/item/stack/sheet/mineral/coal,
-/obj/item/stack/sheet/mineral/coal,
-/obj/item/stack/sheet/mineral/coal,
-/obj/item/stack/sheet/mineral/coal,
-/obj/item/stack/sheet/mineral/coal,
-/obj/item/stack/sheet/mineral/coal,
-/obj/item/stack/sheet/mineral/coal,
-/obj/item/stack/sheet/mineral/coal,
-/obj/item/stack/sheet/mineral/coal,
+/obj/item/stack/sheet/mineral/coal/ten,
+/obj/item/stack/sheet/mineral/coal/ten,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "vs" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 8
+/obj/structure/disposaloutlet{
+	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
+/obj/structure/disposalpipe/trunk{
+	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/gen)
+/turf/open/floor/plating,
+/area/xenoarch/arch)
 "vt" = (
 /obj/structure/stone_tile{
 	dir = 1
@@ -3704,22 +3729,28 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/lumos/tile/yellow/fulltile,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "vP" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "garbageL"
 	},
-/obj/effect/turf_decal/lumos/tile/purple/half{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/xenoarch/arch)
 "vQ" = (
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/gen)
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "garbageL"
+	},
+/obj/machinery/recycler,
+/obj/structure/sign/warning/securearea{
+	name = "\improper STAY CLEAR HEAVY MACHINERY";
+	pixel_y = -32
+	},
+/turf/open/floor/plating,
+/area/xenoarch/arch)
 "vT" = (
 /obj/structure/stone_tile/surrounding_tile/cracked{
 	dir = 4
@@ -3745,6 +3776,10 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Medbay"
 	},
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/white,
 /area/xenoarch/arch)
 "wh" = (
@@ -3759,8 +3794,12 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "wi" = (
-/obj/structure/flora/grass/jungle,
-/turf/open/floor/grass,
+/obj/structure/plasticflaps,
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "garbageL"
+	},
+/turf/open/floor/plating,
 /area/xenoarch/arch)
 "wj" = (
 /obj/effect/turf_decal/lumos/tile/brown/fullcorner,
@@ -3777,26 +3816,20 @@
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/sec)
 "wm" = (
-/obj/machinery/door/firedoor/heavy,
-/obj/effect/turf_decal/lumos/tile/yellow/fulltile,
-/turf/open/floor/plasteel,
-/area/space)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/xenoarch/eng)
 "ws" = (
 /obj/structure/fluff/drake_statue,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "wu" = (
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/purple/visible/layer3{
 	dir = 4
 	},
-/obj/effect/turf_decal/lumos/tile/purple/half{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/open/floor/plasteel,
-/area/xenoarch/arch)
+/area/xenoarch/eng)
 "wy" = (
 /obj/structure/stone_tile/cracked{
 	dir = 8
@@ -3821,6 +3854,9 @@
 	},
 /obj/effect/turf_decal/lumos/tile/yellow/fullcorner{
 	dir = 4
+	},
+/obj/structure/sign/warning/radiation/rad_area{
+	pixel_x = -32
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
@@ -3871,6 +3907,12 @@
 	name = "Medbay RC";
 	pixel_x = 30
 	},
+/obj/machinery/computer/crew{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
 /turf/open/floor/plasteel/white,
 /area/xenoarch/arch)
 "wW" = (
@@ -3878,9 +3920,11 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "xe" = (
-/obj/structure/flora/ausbushes/grassybush,
-/turf/open/floor/grass,
-/area/xenoarch/arch)
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/eng)
 "xf" = (
 /obj/structure/stone_tile/block/cracked{
 	dir = 1
@@ -3919,19 +3963,17 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "xv" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/gen)
+/turf/open/floor/plasteel,
+/area/xenoarch/eng)
 "xx" = (
 /obj/effect/turf_decal/lumos/tile/yellow/fulltile,
 /obj/machinery/vending/tool,
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/plasteel,
-/area/xenoarch/gen)
+/area/xenoarch/eng)
 "xy" = (
 /obj/effect/turf_decal/lumos/tile/brown/fullcorner{
 	dir = 8
@@ -3951,10 +3993,6 @@
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"xD" = (
-/obj/machinery/light/small,
-/turf/open/floor/grass,
-/area/space)
 "xE" = (
 /obj/machinery/atmospherics/components/binary/volume_pump{
 	dir = 8
@@ -3971,15 +4009,15 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "xI" = (
-/obj/structure/chair/sofa/corp/right{
-	dir = 4
+/obj/machinery/atmospherics/components/binary/volume_pump{
+	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/gen)
+/turf/open/floor/plasteel,
+/area/xenoarch/eng)
 "xL" = (
 /obj/machinery/light/small,
 /turf/open/floor/grass,
-/area/lavaland/surface/outdoors)
+/area/xenoarch/arch)
 "xM" = (
 /obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 8
@@ -4060,7 +4098,7 @@
 "yr" = (
 /obj/machinery/light/small,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/area/xenoarch/arch)
 "yv" = (
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 4
@@ -4129,7 +4167,7 @@
 "yK" = (
 /obj/machinery/light/small,
 /turf/open/water,
-/area/lavaland/surface/outdoors)
+/area/xenoarch/arch)
 "yL" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -4150,22 +4188,17 @@
 /turf/open/floor/engine/air,
 /area/xenoarch/eng)
 "yR" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
+/obj/machinery/atmospherics/components/trinary/filter/atmos/plasma{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "yT" = (
-/obj/structure/disposalpipe/trunk{
+/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/n2{
 	dir = 4
 	},
-/obj/machinery/disposal/bin,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/lavaland/surface/outdoors)
+/turf/open/floor/plasteel,
+/area/xenoarch/eng)
 "yV" = (
 /obj/structure/stone_tile/block{
 	dir = 8
@@ -4260,13 +4293,17 @@
 	pixel_y = 24
 	},
 /obj/structure/closet/secure_closet/engineering_electrical,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
-/area/xenoarch/gen)
+/area/xenoarch/eng)
 "zz" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable/yellow,
-/turf/open/floor/plating,
-/area/lavaland/surface/outdoors)
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/eng)
 "zB" = (
 /obj/structure/stone_tile{
 	dir = 1
@@ -4274,14 +4311,12 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "zD" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/backpack/duffelbag/med/surgery,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
 	},
-/turf/open/floor/plasteel/white,
-/area/xenoarch/arch)
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/xenoarch/eng)
 "zH" = (
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 1
@@ -4306,7 +4341,7 @@
 /obj/machinery/atmospherics/pipe/simple/purple/visible/layer3{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/visible/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/visible,
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "zO" = (
@@ -4411,23 +4446,21 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "Aq" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/medical/glass{
-	id_tag = null;
-	name = "Medbay";
-	req_access_txt = "5"
-	},
-/turf/open/floor/plasteel/white,
-/area/xenoarch/arch)
+/obj/machinery/atmospherics/pipe/simple/supply/visible,
+/turf/open/floor/plasteel,
+/area/xenoarch/eng)
 "Av" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/effect/turf_decal/lumos/tile/yellow/fullcorner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 10
 	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/space)
+/area/xenoarch/eng)
 "AB" = (
 /obj/structure/stone_tile/cracked{
 	dir = 4
@@ -4450,23 +4483,11 @@
 	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
 /area/ruin/unpowered/ash_walkers)
-"AI" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "AN" = (
 /obj/structure/stone_tile/cracked,
 /turf/open/lava/smooth/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "AP" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
 /obj/machinery/biogenerator,
 /obj/item/reagent_containers/glass/bucket,
 /turf/open/floor/plasteel,
@@ -4527,6 +4548,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "Bg" = (
@@ -4553,9 +4577,13 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/lumos/tile/yellow/half{
+	dir = 1
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "Br" = (
@@ -4588,13 +4616,12 @@
 	light_color = "#e8eaff"
 	},
 /obj/machinery/camera{
-	c_tag = "Xenoarchaeology Nine";
+	c_tag = "Xenoarchaeology Access Room";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
 "BC" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 4
 	},
@@ -4604,7 +4631,7 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "BD" = (
-/obj/machinery/atmospherics/pipe/simple/supply/visible/layer1{
+/obj/machinery/atmospherics/pipe/simple/supply/visible{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -4613,17 +4640,8 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/open/floor/plasteel,
-/area/xenoarch/eng)
-"BK" = (
-/obj/machinery/atmospherics/pipe/layer_manifold{
-	dir = 4;
-	layer = 2.47
-	},
-/turf/open/floor/plating,
 /area/xenoarch/eng)
 "BS" = (
 /turf/closed/wall,
@@ -4639,18 +4657,23 @@
 /turf/open/floor/plating,
 /area/xenoarch/arch)
 "BY" = (
+/obj/effect/turf_decal/lumos/tile/yellow/half{
+	dir = 1
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/space)
+/area/xenoarch/eng)
 "BZ" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/machinery/camera{
-	c_tag = "Xenoarchaeology Fourteen";
+	c_tag = "Xenoarchaeology Atmospherics Main";
 	dir = 9
 	},
 /obj/effect/turf_decal/lumos/tile/yellow/half{
+	dir = 4
+	},
+/obj/machinery/light{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -4665,11 +4688,14 @@
 /obj/machinery/atm{
 	pixel_x = 30
 	},
+/obj/effect/turf_decal/lumos/tile/yellow/fullcorner{
+	dir = 8
+	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/space)
+/area/xenoarch/eng)
 "Ce" = (
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 4
@@ -4689,7 +4715,7 @@
 	},
 /obj/machinery/autolathe,
 /turf/open/floor/plasteel,
-/area/xenoarch/gen)
+/area/xenoarch/eng)
 "Ct" = (
 /obj/machinery/door/poddoor/incinerator_atmos_main{
 	id = "atmos_incinerator_mainventL"
@@ -4702,7 +4728,7 @@
 /obj/item/pipe_dispenser,
 /obj/item/inducer,
 /turf/open/floor/plasteel,
-/area/xenoarch/gen)
+/area/xenoarch/eng)
 "Cx" = (
 /obj/structure/stone_tile/block/cracked{
 	dir = 8
@@ -4714,9 +4740,6 @@
 /turf/open/indestructible/boss,
 /area/lavaland/surface/outdoors)
 "CD" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/binary/volume_pump/layer3,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -4738,14 +4761,7 @@
 /obj/item/pickaxe,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
-"CI" = (
-/obj/machinery/vending/cola/random,
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/gen)
 "CJ" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
 /obj/machinery/power/terminal{
 	dir = 1
 	},
@@ -4802,17 +4818,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/xenoarch/gen)
-"CX" = (
-/obj/machinery/camera{
-	c_tag = "Xenoarchaeology Four";
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/gen)
+/area/xenoarch/eng)
 "Db" = (
 /turf/open/floor/engine,
 /area/xenoarch/eng)
@@ -4823,23 +4829,11 @@
 /obj/machinery/atmospherics/pipe/manifold/purple/visible/layer3,
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
-"Dk" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/disposalpipe/junction/flip{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "Dm" = (
 /obj/machinery/status_display/evac{
 	layer = 4;
 	pixel_y = 32
 	},
-/obj/machinery/recycler,
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
@@ -4861,17 +4855,6 @@
 /obj/effect/turf_decal/lumos/tile/purple/fullcorner,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
-"Dt" = (
-/obj/machinery/vending/snack/random,
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/gen)
-"Du" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/effect/turf_decal/lumos/tile/yellow/half{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/eng)
 "Dv" = (
 /obj/structure/stone_tile/block/cracked{
 	dir = 8
@@ -4887,7 +4870,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/xenoarch/gen)
+/area/xenoarch/eng)
 "Dy" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -4972,6 +4955,9 @@
 /area/lavaland/surface/outdoors)
 "Ef" = (
 /obj/structure/table/optable,
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
 /turf/open/floor/plasteel/white/side,
 /area/xenoarch/arch)
 "El" = (
@@ -4991,28 +4977,12 @@
 	},
 /turf/open/floor/plating,
 /area/xenoarch/arch)
-"Eo" = (
-/obj/machinery/hydroponics/constructable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/bot)
 "EC" = (
 /obj/structure/stone_tile/block/cracked,
 /turf/open/lava/smooth{
 	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
 /area/ruin/unpowered/ash_walkers)
-"EL" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/lavaland/surface/outdoors)
 "EN" = (
 /obj/structure/stone_tile{
 	dir = 4
@@ -5031,8 +5001,13 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "EQ" = (
-/obj/effect/turf_decal/lumos/tile/blue/half{
-	dir = 4
+/obj/effect/turf_decal/lumos/tile/blue/fullcorner{
+	dir = 8
+	},
+/obj/structure/bed,
+/obj/item/bedsheet/medical,
+/obj/machinery/firealarm{
+	pixel_y = 24
 	},
 /turf/open/floor/plasteel/white,
 /area/xenoarch/arch)
@@ -5052,7 +5027,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/xenoarch/bot)
 "EY" = (
@@ -5065,10 +5042,6 @@
 	},
 /turf/open/indestructible/boss,
 /area/lavaland/surface/outdoors)
-"Fq" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/gen)
 "Ft" = (
 /obj/structure/stone_tile/block/cracked{
 	dir = 8
@@ -5093,6 +5066,9 @@
 	dir = 8
 	},
 /obj/item/storage/firstaid/fire,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/xenoarch/arch)
 "FI" = (
@@ -5109,20 +5085,6 @@
 	},
 /turf/closed/indestructible/riveted/boss/see_through,
 /area/lavaland/surface/outdoors)
-"FK" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1
-	},
-/obj/effect/turf_decal/lumos/tile/purple/half,
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
-"FO" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "FQ" = (
 /obj/structure/stone_tile/surrounding_tile/cracked{
 	dir = 4
@@ -5145,10 +5107,13 @@
 /turf/open/floor/engine,
 /area/xenoarch/eng)
 "FY" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/machinery/meter,
+/obj/effect/turf_decal/lumos/tile/yellow/half{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible,
 /turf/open/floor/plasteel,
-/area/space)
+/area/xenoarch/eng)
 "FZ" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
@@ -5171,37 +5136,15 @@
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
-"Gn" = (
-/obj/machinery/atmospherics/pipe/simple/supply/visible/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/xenoarch/eng)
 "Go" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
 	},
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel/white/corner{
-	dir = 4
+/turf/open/floor/plasteel/median/whitetodark/fullcorner{
+	dir = 1
 	},
-/area/space)
-"Gs" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/lumos/tile/yellow/half,
-/turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "Gu" = (
 /obj/structure/table,
@@ -5219,10 +5162,6 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/bot)
 "Gy" = (
-/obj/machinery/conveyor{
-	dir = 6;
-	id = "garbageL"
-	},
 /obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 1
 	},
@@ -5249,6 +5188,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "GD" = (
@@ -5289,14 +5229,11 @@
 /turf/open/indestructible/boss,
 /area/ruin/unpowered/ash_walkers)
 "GM" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
 /obj/effect/turf_decal/lumos/tile/yellow/half,
-/obj/machinery/atmospherics/pipe/simple/supply/visible/layer1,
 /obj/machinery/computer/atmos_control/tank/air_tank{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/visible,
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "GN" = (
@@ -5316,8 +5253,9 @@
 "GS" = (
 /obj/effect/turf_decal/lumos/tile/yellow/fulltile,
 /obj/machinery/vending/engivend,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
-/area/xenoarch/gen)
+/area/xenoarch/eng)
 "GT" = (
 /obj/structure/stone_tile/block,
 /obj/structure/stone_tile/cracked{
@@ -5325,13 +5263,6 @@
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"GW" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/obj/effect/turf_decal/lumos/tile/purple/half,
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "GY" = (
 /obj/machinery/door/airlock/maintenance,
 /turf/open/floor/plating,
@@ -5344,20 +5275,7 @@
 /obj/structure/stone_tile/block/cracked,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"Hd" = (
-/turf/open/floor/plasteel/stairs,
-/area/xenoarch/gen)
-"Hh" = (
-/obj/structure/closet/secure_closet/medical2,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/lavaland/surface/outdoors)
 "Hl" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/machinery/chem_master,
 /turf/open/floor/plasteel,
 /area/xenoarch/bot)
@@ -5367,6 +5285,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
@@ -5380,8 +5301,6 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "Hr" = (
-/obj/machinery/atmospherics/pipe/simple/dark/visible,
-/obj/machinery/meter,
 /obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 8
 	},
@@ -5390,6 +5309,10 @@
 	name = "Station Intercom (General)";
 	pixel_x = -28
 	},
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 8
+	},
+/obj/machinery/meter,
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "Ht" = (
@@ -5399,16 +5322,25 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "Hu" = (
-/obj/machinery/atmospherics/pipe/simple/supply/visible/layer1,
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/visible,
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "Hw" = (
 /obj/machinery/atmospherics/components/binary/volume_pump/layer3{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
@@ -5440,23 +5372,6 @@
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
-"HL" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/eng)
-"HM" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/effect/turf_decal/lumos/tile/yellow/half{
-	dir = 4
-	},
-/obj/machinery/status_display/evac{
-	layer = 4;
-	pixel_x = 32
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/eng)
 "HP" = (
 /obj/effect/turf_decal/lumos/tile/purple/half,
 /turf/open/floor/plasteel,
@@ -5464,6 +5379,9 @@
 "HQ" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/bot)
@@ -5483,16 +5401,6 @@
 /obj/effect/turf_decal/delivery,
 /obj/structure/closet/wardrobe/xenoarch,
 /obj/item/clothing/glasses/meson,
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
-"Ih" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/structure/disposaloutlet{
-	dir = 1
-	},
-/obj/effect/turf_decal/lumos/tile/purple/half,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "Ii" = (
@@ -5523,11 +5431,6 @@
 /mob/living/simple_animal/hostile/asteroid/gutlunch/guthen,
 /turf/open/indestructible/boss,
 /area/ruin/unpowered/ash_walkers)
-"Il" = (
-/obj/machinery/cell_charger,
-/obj/structure/table/reinforced,
-/turf/open/floor/plasteel/white,
-/area/lavaland/surface/outdoors)
 "Im" = (
 /obj/machinery/hydroponics/constructable,
 /obj/effect/turf_decal/tile/green,
@@ -5561,22 +5464,25 @@
 /turf/open/indestructible/boss,
 /area/ruin/unpowered/ash_walkers)
 "Iu" = (
-/obj/machinery/atmospherics/components/binary/volume_pump,
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
 	},
 /obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/dark/visible,
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "Iw" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+/obj/machinery/meter,
+/obj/effect/turf_decal/lumos/tile/yellow/half{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/visible{
 	dir = 1
 	},
-/obj/machinery/meter,
 /turf/open/floor/plasteel,
-/area/space)
+/area/xenoarch/eng)
 "Ix" = (
 /obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
@@ -5586,28 +5492,12 @@
 "Iz" = (
 /obj/effect/turf_decal/lumos/tile/purple/fullcorner,
 /obj/structure/table,
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
-"IA" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable/yellow,
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating,
-/area/lavaland/surface/outdoors)
 "IB" = (
 /turf/closed/mineral/random/high_chance/volcanic,
 /area/lavaland/surface/outdoors/unexplored)
-"IE" = (
-/obj/machinery/door/airlock{
-	id_tag = "dorm2L"
-	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/gen)
 "IF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
@@ -5631,9 +5521,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "IN" = (
@@ -5650,13 +5537,12 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "IS" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "IX" = (
@@ -5671,9 +5557,6 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "IZ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1
-	},
 /obj/structure/table,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
@@ -5686,22 +5569,10 @@
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
 "Je" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/disposalpipe/segment{
-	dir = 1
-	},
+/obj/effect/turf_decal/lumos/tile/purple/half,
+/obj/machinery/vending/cola/random,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
-"Jf" = (
-/obj/machinery/button/door{
-	id = "dorm1L";
-	normaldoorcontrol = 1;
-	pixel_y = 28;
-	specialfunctions = 4
-	},
-/turf/open/floor/carpet,
-/area/xenoarch/gen)
 "Jj" = (
 /obj/structure/stone_tile/block{
 	dir = 4
@@ -5713,17 +5584,6 @@
 	dir = 8
 	},
 /turf/open/indestructible/boss,
-/area/lavaland/surface/outdoors)
-"Jp" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/lavaland/surface/outdoors)
-"Jy" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
 /area/lavaland/surface/outdoors)
 "JA" = (
 /obj/effect/turf_decal/lumos/tile/purple/half,
@@ -5745,27 +5605,12 @@
 "JM" = (
 /turf/closed/mineral/random/volcanic,
 /area/lavaland/surface/outdoors/unexplored/danger)
-"JV" = (
-/obj/machinery/computer/med_data{
-	dir = 8
-	},
-/obj/machinery/requests_console{
-	department = "Medbay";
-	departmentType = 1;
-	name = "Medbay RC";
-	pixel_x = 30
-	},
-/turf/open/floor/plasteel/white,
-/area/lavaland/surface/outdoors)
 "Ka" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
-"Kc" = (
-/turf/open/floor/carpet,
-/area/xenoarch/gen)
 "Kd" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible/layer3,
 /obj/machinery/atmospherics/components/trinary/mixer/flipped{
@@ -5774,8 +5619,14 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "Kf" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/medical/glass{
+	id_tag = null;
+	name = "Medbay";
+	req_access_txt = "5"
+	},
+/obj/effect/turf_decal/lumos/tile/blue/fulltile,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/white,
 /area/xenoarch/arch)
 "Kh" = (
@@ -5785,8 +5636,8 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "Ki" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 6
+/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/o2{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
@@ -5835,15 +5686,6 @@
 "Kp" = (
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors/unexplored)
-"Ks" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/gen)
 "Ku" = (
 /obj/machinery/atmospherics/components/binary/volume_pump/layer3{
 	dir = 8
@@ -5851,11 +5693,6 @@
 /obj/machinery/light,
 /turf/open/floor/engine,
 /area/xenoarch/eng)
-"Kz" = (
-/obj/structure/bed,
-/obj/item/bedsheet/brown,
-/turf/open/floor/carpet,
-/area/xenoarch/gen)
 "KC" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible/layer3{
 	dir = 4
@@ -5884,9 +5721,6 @@
 /obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 10
-	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
@@ -5894,7 +5728,7 @@
 /area/xenoarch/eng)
 "KL" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/visible/layer1{
+/obj/machinery/atmospherics/pipe/simple/supply/visible{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -5907,6 +5741,9 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "KR" = (
@@ -5938,13 +5775,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/bot)
-"KZ" = (
-/obj/structure/frame/computer{
-	dir = 8
-	},
-/obj/item/poster/random_contraband,
-/turf/open/floor/plating,
-/area/xenoarch/arch)
 "La" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -5960,32 +5790,20 @@
 /obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 9
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
-"Lg" = (
-/obj/machinery/button/door{
-	id = "dorm2L";
-	normaldoorcontrol = 1;
-	pixel_y = 28;
-	specialfunctions = 4
-	},
-/turf/open/floor/carpet,
-/area/xenoarch/gen)
-"Lq" = (
-/obj/machinery/airalarm{
-	pixel_y = 23
-	},
-/turf/open/floor/plasteel/white,
-/area/lavaland/surface/outdoors)
 "Lr" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/visible{
 	dir = 9
 	},
+/obj/effect/turf_decal/lumos/tile/yellow/fullcorner{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
-/area/space)
+/area/xenoarch/eng)
 "Ls" = (
 /obj/structure/rack,
 /obj/item/storage/bag/ore,
@@ -5994,11 +5812,12 @@
 	dir = 8;
 	pixel_x = 28
 	},
+/obj/effect/turf_decal/lumos/tile/yellow/half{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
-/area/space)
+/area/xenoarch/eng)
 "Lv" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
@@ -6008,16 +5827,18 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "Lw" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 8
-	},
-/obj/machinery/meter,
 /obj/effect/turf_decal/lumos/tile/yellow/fullcorner{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/dark/visible,
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "LB" = (
@@ -6029,13 +5850,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
-"LD" = (
-/obj/machinery/status_display/evac{
-	layer = 4;
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel/white,
-/area/lavaland/surface/outdoors)
 "LE" = (
 /obj/structure/stone_tile/block/cracked{
 	dir = 4
@@ -6072,9 +5886,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
-"LN" = (
-/turf/closed/wall,
-/area/xenoarch/eng)
 "LR" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -6097,6 +5908,9 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/effect/turf_decal/lumos/tile/yellow/half{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "Ma" = (
@@ -6116,9 +5930,6 @@
 /turf/open/indestructible/boss,
 /area/ruin/unpowered/ash_walkers)
 "Mf" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
 /obj/effect/turf_decal/lumos/tile/yellow/half,
 /obj/machinery/light,
 /turf/open/floor/plasteel,
@@ -6128,17 +5939,9 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "Mi" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 9
-	},
 /obj/effect/turf_decal/lumos/tile/yellow/half,
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
-"Mk" = (
-/obj/structure/fans/tiny,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plating,
-/area/xenoarch/gen)
 "Mn" = (
 /obj/structure/stone_tile/cracked{
 	dir = 8
@@ -6152,10 +5955,8 @@
 /turf/open/floor/plating,
 /area/mining_level_access)
 "Mv" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/machinery/disposal/bin,
+/obj/structure/table,
+/obj/machinery/cell_charger,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "My" = (
@@ -6165,34 +5966,32 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "MA" = (
-/obj/effect/turf_decal/stripes/corner,
 /obj/machinery/computer/shuttle/elevator/mining{
 	dir = 8
 	},
+/obj/effect/turf_decal/lumos/tile/yellow/half{
+	dir = 4
+	},
+/obj/structure/sign/warning/xeno_mining{
+	pixel_x = 32
+	},
+/obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel,
-/area/space)
+/area/xenoarch/eng)
 "MB" = (
-/obj/machinery/vending/medical{
-	pixel_x = -2
+/obj/machinery/computer/med_data{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
 	},
 /turf/open/floor/plasteel/white,
 /area/xenoarch/arch)
 "MC" = (
+/obj/effect/turf_decal/lumos/tile/yellow/half{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
-/area/space)
-"MH" = (
-/obj/machinery/atmospherics/pipe/simple/supply/visible/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/maintenance,
-/obj/machinery/door/firedoor/heavy,
-/turf/open/floor/plating,
 /area/xenoarch/eng)
 "ML" = (
 /obj/structure/window/reinforced,
@@ -6230,21 +6029,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/bot)
-"Nb" = (
-/turf/closed/wall/r_wall,
-/area/xenoarch/gen)
-"Nc" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/gen)
 "Ng" = (
 /obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 1
@@ -6293,27 +6077,13 @@
 /turf/open/lava/smooth/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "Nu" = (
-/obj/machinery/airalarm{
-	pixel_y = 23
-	},
 /obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 1
 	},
 /obj/structure/reagent_dispensers/foamtank,
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
-"Nx" = (
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/flora/ausbushes/grassybush,
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/grass,
-/area/xenoarch/gen)
 "NB" = (
 /obj/structure/stone_tile/block{
 	dir = 1
@@ -6340,10 +6110,6 @@
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
-"NK" = (
-/obj/structure/dresser,
-/turf/open/floor/carpet,
-/area/xenoarch/gen)
 "NM" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -6356,21 +6122,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
-"NN" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/obj/machinery/airalarm{
-	pixel_y = 23
-	},
-/turf/open/floor/plasteel/white,
-/area/lavaland/surface/outdoors)
-"NQ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atm{
-	pixel_x = 30
-	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/gen)
 "NT" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
@@ -6401,8 +6152,21 @@
 /obj/structure/fans/tiny,
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
-/area/space)
+/area/xenoarch/eng)
 "Og" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/lumos/tile/red/half{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/sec)
 "Oh" = (
@@ -6457,9 +6221,15 @@
 /obj/machinery/camera{
 	c_tag = "Xenoarchaeology Security Checkpoint"
 	},
-/obj/structure/closet/secure_closet/security_xenoarch,
 /obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 1
+	},
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 30
 	},
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/sec)
@@ -6477,8 +6247,9 @@
 /turf/open/indestructible/boss,
 /area/ruin/unpowered/ash_walkers)
 "Ox" = (
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
-/area/xenoarch/gen)
+/area/xenoarch/eng)
 "OB" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 1
@@ -6501,12 +6272,6 @@
 	},
 /turf/open/floor/engine/air,
 /area/xenoarch/eng)
-"OH" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "OI" = (
 /obj/structure/stone_tile{
 	dir = 4
@@ -6525,18 +6290,8 @@
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"OP" = (
-/obj/machinery/requests_console{
-	department = "Xenoarchaeology";
-	pixel_x = 32
-	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/gen)
 "OQ" = (
 /obj/machinery/light,
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
 /obj/effect/turf_decal/lumos/tile/purple/half,
 /obj/structure/table,
 /turf/open/floor/plasteel,
@@ -6585,30 +6340,15 @@
 /obj/structure/stone_tile/slab/cracked,
 /turf/open/indestructible/boss,
 /area/lavaland/surface/outdoors)
-"Pm" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/xenoarch/gen)
 "Pn" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/space)
-"Po" = (
-/obj/machinery/door/airlock/research/glass,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/floor/plasteel,
-/area/xenoarch/gen)
-"PA" = (
-/turf/open/lava/smooth/lava_land_surface,
-/area/xenoarch/arch)
-"PB" = (
-/obj/structure/chair/office/dark{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/lavaland/surface/outdoors)
+/area/xenoarch/eng)
 "PJ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -6652,18 +6392,13 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/disposalpipe/junction/yjunction{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
+/obj/structure/disposalpipe/junction/flip,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "PW" = (
@@ -6675,6 +6410,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
@@ -6729,35 +6467,11 @@
 /obj/machinery/rnd/production/protolathe/department/science,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
-"Qi" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 8
-	},
-/obj/effect/turf_decal/lumos/tile/purple/half{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/gen)
 "Qo" = (
 /obj/effect/turf_decal/lumos/tile/yellow/fulltile,
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/structure/closet/secure_closet/engineering_welding,
 /turf/open/floor/plasteel,
-/area/xenoarch/gen)
+/area/xenoarch/eng)
 "Qp" = (
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/summoning_altar)
@@ -6774,13 +6488,6 @@
 	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
 /area/ruin/unpowered/ash_walkers)
-"QD" = (
-/obj/structure/chair/office/dark{
-	dir = 4
-	},
-/obj/item/cardboard_cutout,
-/turf/open/floor/plating,
-/area/xenoarch/arch)
 "QH" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -6820,11 +6527,8 @@
 /obj/machinery/light/small,
 /turf/open/floor/engine/air,
 /area/xenoarch/eng)
-"QV" = (
-/turf/closed/mineral/random/volcanic,
-/area/xenoarch/gen)
 "QW" = (
-/obj/structure/frame,
+/obj/structure/frame/machine,
 /turf/open/floor/plating,
 /area/xenoarch/arch)
 "QX" = (
@@ -6856,24 +6560,6 @@
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"Ro" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/effect/turf_decal/lumos/tile/purple/half{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/gen)
 "Rs" = (
 /obj/structure/stone_tile/block/cracked{
 	dir = 4
@@ -6893,15 +6579,10 @@
 /turf/open/floor/engine/air,
 /area/xenoarch/eng)
 "Rw" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/xenoarch/bot)
 "RA" = (
@@ -6930,15 +6611,6 @@
 /obj/item/spear/bonespear,
 /turf/open/indestructible/boss,
 /area/ruin/unpowered/ash_walkers)
-"RE" = (
-/turf/closed/mineral/random/volcanic,
-/area/xenoarch/eng)
-"RF" = (
-/obj/machinery/door/airlock{
-	id_tag = "dorm1L"
-	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/gen)
 "RJ" = (
 /obj/item/pickaxe,
 /obj/structure/stone_tile/cracked{
@@ -6949,25 +6621,6 @@
 "RK" = (
 /turf/open/floor/engine/plasma,
 /area/xenoarch/eng)
-"RM" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/effect/turf_decal/lumos/tile/purple/half{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/gen)
 "RR" = (
 /obj/structure/stone_tile/block{
 	dir = 8
@@ -7010,16 +6663,6 @@
 	},
 /turf/closed/indestructible/riveted/boss,
 /area/ruin/unpowered/ash_walkers)
-"Sl" = (
-/obj/structure/table,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/gen)
 "Sr" = (
 /obj/structure/stone_tile/block/cracked{
 	dir = 8
@@ -7114,15 +6757,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
-"SQ" = (
-/obj/machinery/light,
-/obj/item/radio/intercom{
-	dir = 8;
-	name = "Station Intercom (General)";
-	pixel_x = -28
-	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/gen)
 "SS" = (
 /obj/docking_port/stationary{
 	area_type = /area/lavaland/surface/outdoors;
@@ -7167,32 +6801,14 @@
 	},
 /obj/machinery/portable_atmospherics/pump,
 /obj/effect/turf_decal/tile/blue,
-/turf/open/floor/plasteel/white/corner{
-	dir = 4
-	},
-/area/space)
-"SZ" = (
-/obj/structure/disposaloutlet{
-	dir = 4
-	},
-/obj/effect/turf_decal/lumos/tile/red/half{
+/turf/open/floor/plasteel/median/whitetodark/fullcorner{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
+/area/xenoarch/eng)
 "Tg" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/open/floor/grass,
 /area/lavaland/surface/outdoors)
-"Th" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/gen)
 "Tk" = (
 /obj/structure/stone_tile/slab,
 /obj/structure/table/wood,
@@ -7200,36 +6816,16 @@
 /turf/open/indestructible/boss,
 /area/ruin/unpowered/ash_walkers)
 "Tn" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
-"To" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/effect/turf_decal/lumos/tile/purple/half,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel,
-/area/xenoarch/gen)
 "Tq" = (
 /obj/effect/turf_decal/lumos/tile/purple/fullcorner{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
-"Tv" = (
-/obj/structure/table,
-/obj/item/storage/firstaid/regular,
-/turf/open/floor/plasteel/white,
-/area/lavaland/surface/outdoors)
 "TB" = (
 /turf/open/floor/engine/n2,
 /area/xenoarch/eng)
@@ -7272,9 +6868,6 @@
 /obj/structure/necropolis_gate/ashwalker,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"TR" = (
-/turf/closed/wall/r_wall,
-/area/space)
 "TS" = (
 /obj/effect/turf_decal/lumos/tile/red/checker{
 	dir = 4
@@ -7310,13 +6903,11 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
-"Ue" = (
-/obj/machinery/atmospherics/components/trinary/filter/atmos/plasma,
-/turf/open/floor/plasteel,
-/area/xenoarch/eng)
 "Uh" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
@@ -7353,36 +6944,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
-"Up" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/lumos/tile/purple/half,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/xenoarch/gen)
-"Uq" = (
-/obj/effect/turf_decal/lumos/tile/purple/half,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/structure/closet/emcloset/anchored,
-/turf/open/floor/plasteel,
-/area/xenoarch/gen)
 "Ur" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
@@ -7392,28 +6956,14 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
-"Uz" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/research/glass,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/plasteel,
-/area/xenoarch/gen)
-"UF" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/plasteel/stairs,
-/area/xenoarch/gen)
 "UG" = (
 /obj/structure/stone_tile/block{
 	dir = 4
@@ -7445,15 +6995,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
-"US" = (
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/flora/ausbushes/grassybush,
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/floor/grass,
-/area/xenoarch/gen)
 "UX" = (
 /obj/machinery/air_sensor{
 	pixel_x = -32;
@@ -7470,8 +7011,14 @@
 	},
 /obj/structure/table,
 /obj/machinery/cell_charger,
+/obj/machinery/newscaster{
+	pixel_x = 32
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
 /turf/open/floor/plasteel,
-/area/xenoarch/gen)
+/area/xenoarch/eng)
 "UZ" = (
 /obj/structure/stone_tile/cracked{
 	dir = 8
@@ -7490,7 +7037,12 @@
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 10
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
@@ -7508,27 +7060,15 @@
 /turf/open/lava/smooth/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "Vi" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4
-	},
 /obj/machinery/light{
 	dir = 8
 	},
 /obj/machinery/camera{
-	c_tag = "Xenoarchaeology Fifteen";
+	c_tag = "Xenoarchaeology Mining Storage";
 	dir = 4
 	},
 /obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
-"Vn" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/effect/turf_decal/lumos/tile/purple/half{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
@@ -7545,27 +7085,6 @@
 "VN" = (
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors/unexplored/danger)
-"VQ" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel/white,
-/area/lavaland/surface/outdoors)
-"VT" = (
-/obj/machinery/atmospherics/pipe/simple/supply/visible/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/xenoarch/eng)
-"VX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/white,
-/area/lavaland/surface/outdoors)
 "Wa" = (
 /obj/machinery/power/turbine{
 	dir = 8;
@@ -7581,22 +7100,12 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 1
+/obj/structure/disposalpipe/trunk{
+	dir = 8
 	},
-/obj/structure/table,
-/obj/machinery/cell_charger,
+/obj/machinery/disposal/bin,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
-"Wl" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/gen)
-"Wp" = (
-/turf/open/space/basic,
-/area/space)
 "Wt" = (
 /obj/structure/stone_tile/block{
 	dir = 4
@@ -7609,15 +7118,6 @@
 	},
 /turf/open/indestructible/boss,
 /area/ruin/unpowered/ash_walkers)
-"Wu" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/eng)
 "WB" = (
 /obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 1
@@ -7632,48 +7132,18 @@
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
-"WM" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/gen)
 "WR" = (
 /obj/machinery/atmospherics/components/binary/volume_pump{
 	dir = 4
 	},
 /turf/open/floor/engine,
 /area/xenoarch/eng)
-"WT" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/gen)
 "WX" = (
 /obj/structure/stone_tile/block{
 	dir = 8
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"Xe" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/gen)
-"Xj" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/gen)
 "Xr" = (
 /obj/effect/turf_decal/lumos/tile/purple/fullcorner{
 	dir = 8
@@ -7693,15 +7163,6 @@
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"XB" = (
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/flora/ausbushes/grassybush,
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/grass,
-/area/xenoarch/gen)
 "XD" = (
 /obj/structure/stone_tile/block{
 	dir = 4
@@ -7724,15 +7185,6 @@
 	},
 /turf/open/lava/smooth/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"XG" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 5
-	},
-/turf/open/floor/plasteel/white,
-/area/lavaland/surface/outdoors)
 "XH" = (
 /obj/structure/stone_tile/surrounding_tile,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
@@ -7742,6 +7194,9 @@
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/lumos/tile/purple/half,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "XJ" = (
@@ -7763,8 +7218,12 @@
 /obj/item/storage/toolbox/mechanical{
 	pixel_y = -17
 	},
+/obj/machinery/camera{
+	c_tag = "Xenoarchaeology Engineering Storage";
+	dir = 8
+	},
 /turf/open/floor/plasteel,
-/area/xenoarch/gen)
+/area/xenoarch/eng)
 "Yb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/yellow{
@@ -7795,13 +7254,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
-"Ym" = (
-/turf/open/floor/grass,
-/area/space)
 "Yn" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
 /obj/effect/turf_decal/lumos/tile/yellow/half,
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
@@ -7823,11 +7276,9 @@
 /turf/open/indestructible/boss,
 /area/ruin/unpowered/ash_walkers)
 "YA" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "YB" = (
@@ -7855,12 +7306,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
-"YE" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/gen)
 "YJ" = (
 /obj/structure/stone_tile/cracked{
 	dir = 4
@@ -7887,39 +7332,21 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/disposalpipe/junction/flip{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "YO" = (
-/obj/machinery/atmospherics/pipe/simple/supply/visible/layer1{
+/obj/machinery/atmospherics/pipe/simple/supply/visible{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
-"YT" = (
-/obj/structure/chair/sofa/corp/left{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/gen)
 "YY" = (
 /obj/effect/turf_decal/lumos/tile/yellow/fullcorner,
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
-"Za" = (
-/turf/closed/wall,
-/area/xenoarch/gen)
-"Ze" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/lavaland/surface/outdoors)
 "Zg" = (
 /obj/structure/stone_tile/cracked,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
@@ -7935,22 +7362,20 @@
 /turf/open/floor/engine/n2,
 /area/xenoarch/eng)
 "Zp" = (
+/obj/structure/frame/computer,
 /turf/open/floor/plating,
-/area/xenoarch/sec)
+/area/xenoarch/arch)
 "Zr" = (
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 6
 	},
-/turf/open/floor/plasteel,
-/area/xenoarch/gen)
-"Zz" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/disposalpipe/trunk{
+	dir = 1
 	},
-/obj/machinery/smartfridge/chemistry/preloaded,
-/turf/closed/wall,
-/area/lavaland/surface/outdoors)
+/obj/machinery/light,
+/turf/open/floor/plasteel,
+/area/xenoarch/eng)
 "ZC" = (
 /obj/machinery/light{
 	dir = 1
@@ -7965,9 +7390,6 @@
 /obj/structure/stone_tile/surrounding_tile/cracked,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
-"ZG" = (
-/turf/open/floor/plasteel/white,
-/area/lavaland/surface/outdoors)
 "ZP" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/toxin_output,
 /turf/open/floor/engine/plasma,
@@ -7994,13 +7416,6 @@
 	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
 /area/ruin/unpowered/ash_walkers)
-"ZZ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
-/turf/open/floor/plasteel/white,
-/area/lavaland/surface/outdoors)
 
 (1,1,1) = {"
 tN
@@ -9999,7 +9414,7 @@ tN
 tN
 tN
 tN
-tN
+yE
 tN
 tN
 tN
@@ -11565,7 +10980,7 @@ tN
 tN
 tN
 tN
-tN
+yE
 tN
 tN
 tN
@@ -12071,7 +11486,7 @@ tN
 tN
 tN
 tN
-tN
+yE
 tN
 tN
 tN
@@ -12605,7 +12020,7 @@ tN
 tN
 tN
 tN
-tN
+yE
 tN
 tN
 tN
@@ -12829,7 +12244,7 @@ tN
 tN
 tN
 tN
-tN
+yE
 tN
 tN
 tN
@@ -13625,7 +13040,7 @@ tN
 tN
 tN
 tN
-tN
+yE
 tN
 tN
 tN
@@ -14104,6 +13519,7 @@ tN
 tN
 tN
 tN
+yE
 tN
 tN
 tN
@@ -14132,8 +13548,7 @@ tN
 tN
 tN
 tN
-tN
-tN
+yE
 tN
 tN
 tN
@@ -14641,7 +14056,7 @@ tN
 tN
 tN
 tN
-tN
+yE
 tN
 tN
 tN
@@ -14891,6 +14306,7 @@ tN
 tN
 tN
 tN
+yE
 tN
 tN
 tN
@@ -14907,18 +14323,17 @@ tN
 tN
 tN
 tN
-oX
-oX
-oX
-oX
-oX
-oX
-oX
-oX
-oX
-oX
-oX
-oX
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -15164,18 +14579,18 @@ tN
 tN
 tN
 tN
-oX
-gP
-ZG
-ZZ
-lR
-VX
-VX
-rA
-qK
-VX
-XG
-VQ
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 yE
@@ -15421,18 +14836,18 @@ tN
 tN
 tN
 tN
-oX
-gP
-ZG
-iB
-oX
-pw
-Il
-JV
-oX
-ZG
-Ze
-ZG
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -15652,6 +15067,7 @@ tN
 tN
 tN
 tN
+yE
 tN
 tN
 tN
@@ -15674,22 +15090,21 @@ tN
 tN
 tN
 tN
+yE
 tN
 tN
 tN
 tN
-oX
-Hh
-ZG
-ZG
-oX
-oX
-oX
-oX
-oX
-uF
-Ze
-Tv
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -15918,15 +15333,12 @@ tN
 tN
 tN
 tN
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
+tN
+tN
+tN
+tN
+tN
+yE
 tN
 tN
 tN
@@ -15935,18 +15347,21 @@ tN
 tN
 tN
 tN
-oX
-Lq
-ZG
-ZG
-LD
-ZG
-ZG
-ZG
-oX
-NN
-Jy
-EL
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -16175,15 +15590,6 @@ tN
 tN
 tN
 tN
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
 tN
 tN
 tN
@@ -16192,18 +15598,6 @@ tN
 tN
 tN
 tN
-oX
-lp
-PB
-ZG
-ZG
-ZG
-ZG
-ZG
-oX
-hZ
-Ze
-fC
 tN
 tN
 tN
@@ -16212,6 +15606,27 @@ tN
 tN
 tN
 tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+yE
 tN
 tN
 tN
@@ -16432,35 +15847,35 @@ tN
 tN
 tN
 tN
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-BS
-iq
-zD
-Ma
-yT
-ZG
-ZG
-ZG
-oX
-ol
-Ze
-Tv
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -16689,35 +16104,35 @@ tN
 tN
 tN
 tN
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-BS
-BS
-BS
-Aq
-Zz
-sN
-IA
-zz
-oX
-Jp
-pa
-Jp
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+yE
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -16946,27 +16361,27 @@ tN
 tN
 tN
 tN
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
+yE
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -17187,6 +16602,7 @@ tN
 tN
 tN
 tN
+yE
 tN
 tN
 tN
@@ -17203,27 +16619,26 @@ tN
 tN
 tN
 tN
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -17460,27 +16875,27 @@ tN
 tN
 tN
 tN
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -17711,43 +17126,43 @@ tN
 tN
 tN
 tN
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
+yE
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+yE
 tN
 tN
 tN
@@ -17968,20 +17383,20 @@ tN
 tN
 tN
 tN
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 BS
 BS
 BS
@@ -17993,26 +17408,26 @@ BS
 BS
 BS
 BS
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -18225,20 +17640,20 @@ tN
 tN
 tN
 tN
-aA
-aA
-aA
-BS
-BS
-BS
-BS
-BS
-BS
-BS
-aA
-aA
-aA
-aA
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 BS
 ki
 xz
@@ -18250,26 +17665,26 @@ Ub
 xz
 TS
 BS
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -18478,24 +17893,24 @@ tN
 tN
 tN
 tN
+yE
 tN
 tN
 tN
 tN
-aA
-aA
-aA
-BS
-kh
-aH
-BS
-ds
-ds
-BS
-aA
-aA
-aA
-aA
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 BS
 xz
 KE
@@ -18507,26 +17922,26 @@ hy
 cA
 xz
 BS
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -18739,20 +18154,20 @@ tN
 tN
 tN
 tN
-aA
-aA
-aA
-BS
-jn
-Zp
-bj
-Zp
-Zp
-CT
-CT
-CT
-CT
-BS
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 BS
 kI
 xz
@@ -18764,26 +18179,26 @@ sS
 xz
 Km
 BS
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -18996,20 +18411,20 @@ tN
 tN
 tN
 tN
-aA
-aA
-aA
-BS
-cZ
-CT
-CT
-dQ
-Zp
-Zp
-Zp
-Zp
-Zp
-jn
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 BS
 nC
 pf
@@ -19021,26 +18436,26 @@ iK
 pf
 fX
 BS
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
+BS
+BS
+BS
+BS
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -19253,51 +18668,51 @@ tN
 tN
 tN
 tN
-aA
-aA
-aA
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 BS
-jn
-aU
-CT
-CT
-Zp
-Zp
-Zp
-Zp
-Zp
-jn
 BS
-AU
-AU
-AU
-AU
-AU
-AU
-AU
-AU
-AU
 BS
+BS
+BS
+lP
+AU
+AU
+AU
+mJ
+oy
+oM
+oy
+oy
+rU
 aA
 aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
+vs
+BS
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -19492,6 +18907,7 @@ tN
 tN
 tN
 tN
+yE
 tN
 tN
 tN
@@ -19510,20 +18926,19 @@ tN
 tN
 tN
 tN
-aA
-aA
-aA
 BS
-aa
-bc
-CT
-dQ
-Zp
-Zp
-Zp
-Zp
-Zp
-jn
+BS
+BS
+BS
+BS
+BS
+BS
+BS
+BS
+BS
+kh
+jL
+jL
 BS
 WD
 AU
@@ -19531,30 +18946,30 @@ AU
 wW
 Ho
 NT
-AU
+oX
 AU
 AU
 BS
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
+jn
+sN
+vP
+BS
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -19764,54 +19179,54 @@ tN
 tN
 tN
 tN
-aA
-aA
+tN
+tN
+tN
+tN
 BS
+aa
+aa
 BS
-BS
-BS
-BS
-jn
 Zp
 bj
-Zp
-Zp
-Zp
-Zp
-Zp
+bi
+jn
+cH
+ey
+jn
 io
 jn
 BS
 PO
-AU
+my
 AU
 AU
 Bf
-OH
+AU
 Wc
 IZ
 Mv
 BS
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
+jn
+sV
+vQ
+BS
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -20021,21 +19436,21 @@ tN
 tN
 tN
 tN
-aA
-aA
+tN
+tN
+tN
+tN
 BS
 jn
 jn
-jn
 BS
+ae
+bc
 jn
-Zp
-Zp
-Zp
-CT
-CT
-CT
-CT
+jn
+jn
+cZ
+jn
 CT
 GY
 BS
@@ -20044,39 +19459,39 @@ BS
 BS
 tT
 KO
-FO
+tT
 BS
 BS
 BS
 BS
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
+jn
+tV
+vP
+BS
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -20278,62 +19693,62 @@ tN
 tN
 tN
 tN
-aA
-aA
+tN
+tN
+tN
+tN
 BS
 jn
-jn
-jn
-BS
-dt
-Zp
-Zp
-Zp
-CT
 ad
-ae
-bh
-bI
+BS
+QW
+jn
+jn
+CT
+CT
+CT
+CT
+CT
 je
 PZ
 bQ
 Sy
 LM
-wu
 My
-lu
+mQ
+My
 My
 Nh
-My
+qy
 BS
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
+jn
+uv
+vP
+BS
+tN
+tN
+Yp
+Yp
+Yp
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+yE
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -20535,62 +19950,62 @@ tN
 tN
 tN
 tN
-aA
-aA
+tN
+tN
+tN
+tN
 BS
 jn
-jn
-jn
 BS
-sV
-Zp
-Zp
-Zp
+BS
+aH
+jn
+jn
 mf
 pZ
 Og
-wk
+iq
 cB
 NM
 PR
 id
 Un
 IL
-Dk
 Un
-lP
-Je
-Je
+mT
+AU
+AU
+AU
 Je
 BS
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
+BS
+BS
+wi
+BS
+tN
+Pd
+Pd
+Pd
+Yp
+Yp
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -20792,62 +20207,62 @@ tN
 tN
 tN
 tN
-aA
-aA
+tN
+tN
+tN
+tN
 BS
-jn
-jn
 jn
 GY
 jn
-Zp
+jn
 bx
 eb
 CT
 Os
-Og
+fa
 wk
 bI
 ji
 UN
 rj
 PN
-ia
+zU
 ia
 jN
 ia
 ia
-zU
+ia
 kt
 BS
-aA
-aA
-PA
-PA
-PA
-PA
-PA
-PA
-aA
-aA
-aA
-aA
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
+Yp
+Yp
+Pd
+Pd
+Pd
+Pd
+Pd
+Pd
+Pd
+Yp
+Yp
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -21049,20 +20464,20 @@ tN
 tN
 tN
 tN
-aA
-aA
+tN
+tN
+tN
+tN
+BS
+BS
 BS
 jn
 jn
-jn
-BS
-jn
-Zp
 bN
 fP
 CT
 kr
-Og
+fw
 ku
 dv
 ji
@@ -21077,34 +20492,34 @@ BS
 BS
 BS
 BS
-PA
-PA
-PA
-PA
-PA
-PA
-PA
-PA
-PA
-PA
-aA
-aA
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
+Yp
+Pd
+Pd
+Pd
+Pd
+Pd
+Pd
+Pd
+Pd
+Pd
+Yp
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -21306,25 +20721,25 @@ tN
 tN
 tN
 tN
-aA
-aA
+tN
+tN
+tN
+tN
+tN
+tN
 BS
 jn
 jn
-jn
-BS
-jn
-Zp
 bN
 gu
 CT
 zR
-Og
+fC
 wk
 ec
-SZ
+ji
 dF
-fa
+HP
 BS
 zc
 Be
@@ -21333,7 +20748,8 @@ Qf
 YC
 hJ
 BS
-tN
+Yp
+Yp
 Pd
 Pd
 Pd
@@ -21343,25 +20759,24 @@ Pd
 Pd
 Pd
 Pd
-Pd
-tN
-tN
-tN
-tN
+Yp
+Yp
 tN
 tN
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -21563,15 +20978,15 @@ tN
 tN
 tN
 tN
-aA
-aA
+tN
+tN
+tN
+tN
+tN
+tN
 BS
-eu
 jn
-dt
-BS
-jn
-Zp
+aM
 bX
 gC
 CT
@@ -21590,7 +21005,7 @@ AU
 Qd
 mR
 BS
-Pd
+Yp
 Pd
 Pd
 Pd
@@ -21602,23 +21017,23 @@ Pd
 Pd
 Pd
 Pd
+Yp
+Yp
 tN
 tN
 tN
 tN
 tN
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -21820,17 +21235,17 @@ tN
 tN
 tN
 tN
-aA
-aA
-BS
-jL
-QD
-jn
+tN
+tN
+tN
+tN
+tN
+tN
 BS
 cZ
-CT
-CT
-CT
+BS
+BS
+BS
 CT
 CT
 CT
@@ -21846,7 +21261,7 @@ AU
 AU
 AU
 HP
-pU
+yI
 Pd
 Pd
 Pd
@@ -21860,22 +21275,22 @@ Pd
 Pd
 Pd
 Pd
+Yp
+Yp
 tN
 tN
 tN
 tN
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -22077,12 +21492,12 @@ tN
 tN
 tN
 tN
-aA
-aA
-BS
-QW
-KZ
-KZ
+tN
+tN
+tN
+tN
+tN
+tN
 BS
 jn
 BS
@@ -22094,16 +21509,16 @@ FF
 Bs
 BS
 jl
-UN
-HP
+lu
+lR
 pC
 Va
 Uh
 Uh
 sf
 YA
-HP
-pU
+pq
+qK
 Pd
 Pd
 Pd
@@ -22117,22 +21532,22 @@ Pd
 Pd
 Pd
 Pd
+Yp
+Yp
 tN
 tN
 tN
 tN
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -22334,11 +21749,11 @@ tN
 tN
 tN
 tN
-aA
-aA
-BS
-BS
-BS
+tN
+tN
+tN
+tN
+tN
 BS
 BS
 jn
@@ -22346,12 +21761,12 @@ BS
 Ef
 Ma
 hE
-Ma
-Ma
+ds
+go
 EU
 pU
 Gy
-hH
+UN
 vg
 BS
 bb
@@ -22359,8 +21774,8 @@ lm
 lm
 SB
 AU
-Ih
-pU
+HP
+En
 Pd
 Pd
 Pd
@@ -22375,14 +21790,14 @@ Pd
 Pd
 Pd
 Pd
+Yp
 tN
 tN
 tN
-QV
-QV
-QV
-QV
-QV
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -22591,21 +22006,21 @@ tN
 tN
 tN
 tN
-aA
-aA
-aA
-aA
-aA
+tN
+tN
+tN
+tN
+tN
 BS
 QW
 jn
 BS
 hx
-Ma
+by
 hK
-Ma
-Ma
-EU
+ds
+gP
+iz
 vY
 bp
 iD
@@ -22616,8 +22031,8 @@ Ig
 Ig
 AU
 AU
-GW
-BS
+HP
+rA
 Pd
 Pd
 Pd
@@ -22632,14 +22047,14 @@ Pd
 Pd
 Pd
 Pd
+Yp
 tN
 tN
 tN
-QV
-QV
-QV
-QV
-QV
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -22848,25 +22263,25 @@ tN
 tN
 tN
 tN
-aA
-aA
-aA
-aA
-aA
+tN
+tN
+tN
+tN
+tN
 BS
 aK
 jn
 BS
 BS
-ha
+BS
 BS
 hR
-Ma
-EU
+gZ
+iB
 pU
-bs
+Gy
 bv
-HP
+mg
 BS
 rw
 AU
@@ -22883,20 +22298,20 @@ rl
 LR
 QK
 Ge
+Yp
+Yp
 Pd
 Pd
 Pd
 Pd
-Pd
-Pd
+Yp
 tN
 tN
 tN
-QV
-QV
-QV
-QV
-QV
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -23105,21 +22520,21 @@ tN
 tN
 tN
 tN
-aA
-aA
-aA
-aA
-aA
+tN
+tN
+tN
+tN
+tN
 BS
 jn
 jn
 BS
 cY
-Ma
+bG
 BS
-BS
-Ma
-BS
+pU
+ha
+pU
 BS
 WB
 gQ
@@ -23140,20 +22555,20 @@ WR
 lY
 Ku
 Ge
+Yp
+Yp
+Yp
+Yp
 Pd
-Pd
-Pd
-Pd
-Pd
-Pd
+Yp
+Yp
 tN
 tN
 tN
-QV
-QV
-QV
-QV
-QV
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -23362,23 +22777,23 @@ tN
 tN
 tN
 tN
-aA
-aA
-aA
-aA
-aA
+tN
+tN
+tN
+tN
+tN
 BS
 aW
 jn
-BS
+aU
 dh
-Ma
-tV
-Ma
-Ma
-EU
+cd
 BS
-AI
+dQ
+hi
+iS
+ka
+Gy
 UN
 oR
 hs
@@ -23387,7 +22802,7 @@ hs
 hs
 hs
 hs
-BS
+hs
 BS
 tN
 tN
@@ -23400,17 +22815,17 @@ Ge
 Ge
 Ge
 Ge
-Pd
-Pd
-Pd
+Yp
+Yp
+Yp
 tN
 tN
 tN
-QV
-QV
-QV
-QV
-QV
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -23619,32 +23034,32 @@ tN
 tN
 tN
 tN
-aA
-aA
-aA
-aA
-aA
+tN
+tN
+tN
+tN
+tN
 BS
 BS
 jn
-bi
-Ma
-Ma
-Kf
-Ma
-Ma
-EU
 BS
-hw
-cd
-FK
+bh
+cv
+Kf
+eu
+hH
+EU
+lo
+Gy
+UN
+HP
 hs
 qI
 jS
 GD
 jS
 Kl
-oX
+hs
 tN
 tN
 tN
@@ -23658,16 +23073,16 @@ Iu
 Lw
 Nn
 OB
-Pd
-Pd
+Yp
 tN
 tN
 tN
-QV
-QV
-QV
-QV
-QV
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -23876,12 +23291,12 @@ tN
 tN
 tN
 tN
-aA
-aA
-aA
-aA
-aA
-aA
+tN
+tN
+tN
+tN
+tN
+tN
 BS
 jn
 BS
@@ -23889,10 +23304,10 @@ MB
 wU
 BS
 EQ
-EQ
+hW
 oo
-BS
-Xr
+pU
+lp
 KR
 Dp
 hs
@@ -23901,16 +23316,16 @@ eV
 Ha
 eV
 KT
-LN
-RE
-RE
-RE
+hs
+tN
+tN
+tN
 Ge
 xE
 FB
 SO
 KC
-FB
+xI
 FB
 qo
 Ge
@@ -23920,11 +23335,11 @@ Ge
 Ge
 tN
 tN
-QV
-QV
-QV
-QV
-QV
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -24133,12 +23548,12 @@ tN
 tN
 tN
 tN
-aA
-aA
-aA
-aA
-aA
-aA
+tN
+tN
+tN
+tN
+tN
+tN
 BS
 cZ
 BS
@@ -24155,10 +23570,10 @@ pU
 hs
 fI
 eV
-ka
+Ha
 eV
 mk
-Ge
+pw
 Ge
 Ge
 Ge
@@ -24168,7 +23583,7 @@ BD
 mA
 zM
 Hu
-Hu
+Aq
 GM
 DJ
 OF
@@ -24177,11 +23592,11 @@ yP
 Ge
 tN
 tN
-QV
-QV
-QV
-QV
-QV
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -24390,12 +23805,12 @@ tN
 tN
 tN
 tN
-aA
-aA
-aA
-aA
-aA
-aA
+tN
+tN
+tN
+tN
+tN
+tN
 BS
 jn
 DI
@@ -24412,10 +23827,10 @@ tl
 eA
 Bv
 eV
-Eo
+Ha
 eV
 mB
-Ge
+pw
 vU
 ok
 AZ
@@ -24423,8 +23838,8 @@ lH
 CL
 st
 BF
-KC
-FB
+wu
+yR
 IP
 ct
 Pb
@@ -24434,11 +23849,11 @@ QS
 Ge
 tN
 tN
-QV
-QV
-QV
-QV
-QV
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -24647,12 +24062,12 @@ tN
 tN
 tN
 tN
-aA
-aA
-aA
-aA
-aA
-aA
+tN
+tN
+tN
+tN
+tN
+tN
 BS
 jn
 jn
@@ -24669,10 +24084,10 @@ oR
 eA
 Bv
 eV
-Eo
+Ha
 eV
 Im
-Ge
+pw
 RK
 eh
 ZP
@@ -24681,9 +24096,9 @@ pn
 KL
 CD
 Df
-FB
+FZ
 Vd
-Gs
+Mi
 Ge
 Ge
 Ge
@@ -24691,11 +24106,11 @@ Ge
 Ge
 tN
 tN
-QV
-QV
-QV
-QV
-QV
+tN
+tN
+tN
+tN
+yE
 tN
 tN
 tN
@@ -24904,12 +24319,12 @@ tN
 tN
 tN
 tN
-aA
-aA
-aA
-aA
-aA
-aA
+tN
+tN
+tN
+tN
+tN
+tN
 BS
 jn
 dt
@@ -24922,21 +24337,21 @@ AY
 bq
 sm
 Lv
-HP
+mm
 Uj
 zo
 EW
 Rw
 HQ
 lO
-Ge
+pw
 Ge
 Ge
 Ge
 Ge
 lF
 YO
-Wu
+SO
 Do
 Hw
 Kd
@@ -24948,11 +24363,11 @@ Af
 Ge
 tN
 tN
-QV
-QV
-QV
-QV
-QV
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -25164,9 +24579,9 @@ tN
 tN
 tN
 tN
-aA
-aA
-aA
+tN
+tN
+tN
 BS
 jn
 kh
@@ -25179,21 +24594,21 @@ bn
 En
 Ng
 YM
-HP
+mu
 vk
 zO
 eV
 Hl
 eV
 kK
-Ge
+pw
 mp
 ps
 pE
 sw
 lf
-BK
-Wu
+YO
+SO
 FB
 Ki
 HF
@@ -25205,11 +24620,11 @@ sK
 Ge
 tN
 tN
-QV
-QV
-QV
-QV
-QV
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -25421,9 +24836,9 @@ tN
 tN
 tN
 tN
-aA
-aA
-aA
+tN
+tN
+tN
 BS
 BS
 BS
@@ -25443,14 +24858,14 @@ eV
 kD
 eV
 sT
-Ge
+pw
 jw
 oL
 Zn
 tR
 tR
 oT
-Wu
+SO
 FB
 FZ
 Vd
@@ -25462,11 +24877,11 @@ Ge
 Ge
 tN
 tN
-QV
-QV
-QV
-QV
-QV
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -25678,9 +25093,9 @@ tN
 tN
 tN
 tN
-aA
-aA
-aA
+tN
+tN
+tN
 BS
 tB
 tB
@@ -25700,7 +25115,7 @@ eV
 AP
 eV
 MV
-Ge
+pw
 jK
 Hq
 FB
@@ -25719,11 +25134,11 @@ TB
 Ge
 tN
 tN
-QV
-QV
-QV
-QV
-QV
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -25935,9 +25350,9 @@ tN
 tN
 tN
 tN
-aA
-aA
-aA
+tN
+tN
+tN
 BS
 an
 tB
@@ -25949,25 +25364,25 @@ My
 My
 lT
 SA
-pQ
-oJ
+PW
+HP
 hs
 Gu
 Fv
 eV
 Ib
 ym
-Ge
+pw
 TH
 IF
 QH
 QH
 QH
 qu
-FZ
 FB
-FZ
-Ki
+FB
+yT
+lw
 ib
 Pc
 Rj
@@ -25976,11 +25391,11 @@ eT
 Ge
 tN
 tN
-QV
-QV
-QV
-QV
-QV
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -26192,17 +25607,17 @@ tN
 tN
 tN
 tN
-aA
-aA
-aA
+tN
+tN
+tN
 BS
 zn
 xz
 Ac
 Ng
-pq
+wW
 Tn
-rU
+ly
 ly
 AX
 ly
@@ -26214,17 +25629,17 @@ FI
 fn
 FI
 kx
-Ge
+pw
 Um
 rX
 FB
 FB
-Ki
-lw
-yR
-lw
-HL
+FB
+FB
+FB
+FB
 FZ
+FB
 Yn
 Ge
 Ge
@@ -26233,11 +25648,11 @@ Ge
 Ge
 tN
 tN
-QV
-QV
-QV
-QV
-QV
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -26451,15 +25866,15 @@ tN
 tN
 tN
 tN
-aA
+tN
 BS
 av
 tB
 BS
 Xr
-vP
-Vn
-cH
+ia
+ia
+ia
 zU
 lT
 Dy
@@ -26471,30 +25886,30 @@ hs
 hs
 hs
 hs
-Ge
+pw
 Nu
 sL
-qy
-lw
-sc
-lw
-Ue
 lw
 lw
-yR
+lw
+lw
+lw
+lw
+zz
+FB
 Mi
 Ge
-RE
-RE
-RE
-RE
 tN
 tN
-QV
-QV
-QV
-QV
-QV
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -26708,7 +26123,7 @@ tN
 tN
 tN
 tN
-aA
+tN
 BS
 tB
 tB
@@ -26735,23 +26150,23 @@ KJ
 ui
 BC
 BZ
-tx
-Du
-HM
+MC
+MC
+MC
 Lc
 YY
 Ge
-RE
-RE
-RE
-RE
 tN
 tN
-QV
-QV
-QV
-QV
-QV
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -26965,7 +26380,7 @@ tN
 tN
 tN
 tN
-aA
+tN
 BS
 BS
 BS
@@ -26975,14 +26390,14 @@ xM
 pX
 xM
 rt
-ac
+BS
 km
 mX
 qb
 ac
 Av
 FY
-MC
+mY
 Iw
 Lr
 Ge
@@ -26992,23 +26407,23 @@ Ge
 Ge
 Ge
 Ge
-Ge
+wm
 OX
+wm
 Ge
 Ge
 Ge
-Ge
-RE
-RE
-RE
-RE
 tN
 tN
-QV
-QV
-QV
-QV
-QV
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -27232,16 +26647,16 @@ AU
 im
 AU
 zg
-ac
-km
+BS
+Ng
 mX
 qg
 fE
-ix
+BY
 js
 FB
 Ix
-FB
+pa
 LV
 nx
 of
@@ -27249,23 +26664,23 @@ rr
 Ge
 xx
 Dw
-CX
+Dw
 Dw
 Dw
 Cm
-Nb
-QV
-QV
-aM
-aM
-aM
-QV
-QV
-QV
-QV
-QV
-QV
-QV
+Ge
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -27489,8 +26904,8 @@ lB
 uy
 lx
 wj
-ac
-km
+BS
+Ng
 mZ
 qX
 vO
@@ -27498,38 +26913,38 @@ Bl
 GC
 Ht
 IS
-Ht
-Ht
-Ht
+ph
+ph
+ph
 qN
-FB
-Ge
+sl
+uF
 GS
 Ox
 Ox
-Ox
-Ox
+xe
+FB
 Cu
-Nb
-QV
-QV
-aM
-aM
-aM
-aM
-aM
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
+Ge
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -27746,47 +27161,47 @@ BS
 BS
 BS
 BS
-ac
-km
+BS
+Ng
 nt
 qg
-wm
+fE
 BY
-MC
-MC
-MC
-MC
-MC
-MC
+FB
+nb
+oI
 FB
 FB
-Ge
+FB
+FB
+Mi
+uX
 Qo
-Ox
-Ox
-Ox
-Ox
+FB
+FB
+xv
+FB
 oQ
-Nb
-QV
-QV
-aM
-aM
-aM
-aM
-aM
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
+Ge
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -27999,10 +27414,10 @@ tN
 tN
 tN
 tN
-aM
-aM
-aM
-aM
+tN
+tN
+tN
+tN
 BS
 kW
 bM
@@ -28010,40 +27425,40 @@ sE
 ac
 Cb
 MC
-MC
-MC
+ol
+oJ
 Ls
 MA
 Pn
-Pn
-Pn
-TR
+sc
+sB
+Ge
 zx
 CV
 XJ
 UY
-CV
+zD
 Zr
-Nb
-QV
-QV
-aM
-aM
-aM
-aM
-aM
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
+Ge
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -28256,10 +27671,10 @@ tN
 tN
 tN
 tN
-aM
-aM
-aM
-aM
+tN
+tN
+tN
+tN
 BS
 pU
 co
@@ -28269,38 +27684,38 @@ ac
 ac
 ac
 ac
-TR
-TR
+Ge
+Ge
 Od
 Od
 Od
-TR
-Nb
-Nb
-Nb
-Nb
-Nb
-Nb
-Nb
-QV
-QV
-aM
-aM
-aM
-aM
-aM
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
+Ge
+Ge
+Ge
+Ge
+Ge
+Ge
+Ge
+Ge
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -28513,51 +27928,51 @@ tN
 tN
 tN
 tN
-aM
-aM
-aM
-aM
+tN
+tN
+tN
+tN
 BS
 bF
 cG
 dV
-ac
-aM
-aM
-aM
-aM
-TR
+BS
+tN
+tN
+tN
+tN
+Ge
 NH
 rC
 Or
 rC
 RU
-TR
-aM
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-aM
-aM
-aM
-aM
-aM
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
+Ge
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -28770,51 +28185,51 @@ tN
 tN
 tN
 tN
-aM
-aM
-aM
-aM
+tN
+tN
+tN
+tN
 BS
 lv
 do
 tv
-ac
-aM
-aM
-aM
-aM
-TR
+BS
+tN
+tN
+tN
+tN
+Ge
 Ob
 JG
 JG
 JG
 qG
-TR
-aM
-aM
-aM
-aM
-aM
-aM
-aM
-aM
-Za
-Mk
-Mk
-Mk
-Za
-Za
-Za
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
+Ge
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+yE
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -29027,51 +28442,51 @@ tN
 tN
 tN
 tN
-aM
-aM
-aM
-aM
-ac
-mg
+tN
+tN
+tN
+tN
+BS
+pU
 pl
-mg
-ac
-aM
-aM
-aM
-aM
-TR
+pU
+BS
+tN
+tN
+tN
+tN
+Ge
 Ob
 JG
 JG
 JG
 qG
-TR
-aM
-aM
-aM
-aM
-aM
-aM
-aM
-aM
-lo
-YE
-YE
-YE
-Xe
-uv
-Za
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
+Ge
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -29284,51 +28699,51 @@ tN
 tN
 tN
 tN
-aM
-aM
-aM
-aM
-Ym
+tN
+tN
+tN
+tN
+SG
 mI
 px
 ty
-Ym
-aM
-aM
-aM
-aM
-TR
+SG
+tN
+tN
+tN
+tN
+Ge
 Ob
 JG
 JG
 JG
 qG
-TR
-aM
-aM
-aM
-aM
-aM
-aM
-aM
-aM
-Fq
-Fq
-Fq
-Fq
-vQ
-Fq
-Za
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
+Ge
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+yE
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -29541,51 +28956,51 @@ tN
 tN
 tN
 tN
-aM
-aM
-aM
-aM
-Ym
-Ym
-mJ
-mJ
-Ym
-Ym
-aM
-aM
-aM
-TR
+tN
+tN
+tN
+tN
+SG
+SG
+Yp
+Yp
+SG
+SG
+tN
+tN
+tN
+Ge
 Oc
 qH
 PJ
 qH
 aT
-TR
-aM
-aM
-aM
-aM
-aM
-aM
-aM
-aM
-oI
-oI
-oI
-NQ
-my
-Nc
-Za
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
+Ge
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -29798,51 +29213,51 @@ tN
 tN
 tN
 tN
-aM
-aM
-aM
-aM
-Ym
-Ym
-mJ
-mJ
-Ym
-Ym
-Ym
-aM
-aM
-TR
-TR
-TR
-TR
-TR
-TR
-TR
-aM
-aM
-aM
-aM
-aM
-aM
-aM
-aM
-sB
-sB
-Za
-Za
-Za
-Za
-Za
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
+tN
+tN
+tN
+tN
+SG
+SG
+Yp
+Yp
+SG
+SG
+SG
+tN
+tN
+Ge
+Ge
+Ge
+Ge
+Ge
+Ge
+Ge
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -30055,51 +29470,51 @@ tN
 tN
 tN
 tN
-aM
-aM
-aM
-ac
-iz
-mJ
-mJ
-mJ
-xD
-ac
-Ym
-Ym
-aM
-aM
-aM
-aM
-aM
-aM
-aM
-aM
-aM
-aM
-aM
-aM
-aM
-aM
-aM
-aM
-sB
-sB
-SQ
-Za
-Jf
-NK
-Za
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
+tN
+tN
+tN
+BS
+ja
+Yp
+Yp
+Yp
+xL
+BS
+SG
+SG
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -30312,51 +29727,51 @@ tN
 tN
 tN
 tN
-aM
-aM
-aM
-Ym
-Ym
-mJ
-mJ
-mJ
-mJ
-Ym
-Ym
-Ym
-Ym
-Ym
-aM
-aM
-aM
-aM
-aM
-Za
-US
-US
-Za
-oy
-xv
-Nx
-uX
-sl
-sB
-sB
-sB
-RF
-Kc
-Kc
-Za
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
+tN
+tN
+tN
+SG
+SG
+Yp
+Yp
+Yp
+Yp
+SG
+SG
+SG
+SG
+SG
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -30569,51 +29984,51 @@ tN
 tN
 tN
 tN
-aM
-aM
-aM
-Ym
-Ym
-Ym
-mJ
-mJ
-mJ
-Ym
-Ym
-Ym
-Ym
-Ym
-aM
-aM
-Pm
-Qi
-To
-Pm
-WM
-sB
-Hd
-Wl
-vs
-Fq
-Fq
-Fq
-sB
-sB
-sB
-Za
-Kz
-Kc
-Za
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
+tN
+tN
+tN
+SG
+SG
+SG
+Yp
+Yp
+Yp
+SG
+bH
+SG
+SG
+SG
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -30841,36 +30256,36 @@ SG
 Tg
 SG
 SG
-aM
-Po
-Ro
-Up
-Uz
-WT
-mu
-UF
-bG
-ey
-oI
-oI
-gZ
-sB
-sB
-sB
-Za
-Za
-Za
-Za
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
-QV
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -31086,41 +30501,41 @@ tN
 tN
 tN
 SG
-oX
-iX
+BS
+ja
 vi
 Yp
 Yp
 xL
-oX
+BS
 SG
-bH
+iX
 SG
 vi
 SG
 tN
-Pm
-RM
-Uq
-Pm
-Xj
-sB
-mm
-fw
-go
-sB
-sB
-Ks
-sB
-sB
-sB
-Za
-Lg
-NK
-Za
-QV
-QV
-QV
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -31356,28 +30771,28 @@ SG
 vi
 SG
 tN
-Za
-Za
-Za
-Za
-XB
-XB
-Za
-Za
-Za
-YT
-xI
-Ks
-mQ
-sB
-sB
-IE
-Kc
-Kc
-Za
-QV
-QV
-QV
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -31600,41 +31015,41 @@ tN
 tN
 SG
 SG
-hW
-hW
+SG
+SG
 Yp
 Yp
 Yp
-hW
-hW
+SG
+SG
 VA
 SG
 SG
+hZ
 SG
-bH
 tN
-aM
-aM
-aM
-Za
-Za
-Za
-Za
 tN
-Za
-nb
-oM
-Ks
-Za
-CI
-Dt
-Za
-Kz
-Kc
-Za
-QV
-QV
-QV
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -31856,9 +31271,9 @@ tN
 tN
 tN
 SG
-hW
-hW
-hW
+SG
+SG
+SG
 Yp
 Yp
 Yp
@@ -31870,25 +31285,25 @@ SG
 vi
 Tg
 tN
-aM
-aM
-aM
-aM
-aM
 tN
 tN
 tN
-Za
-by
-mT
-Th
-oX
-oX
-oX
-oX
-oX
-oX
-oX
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -32113,32 +31528,32 @@ tN
 tN
 tN
 VA
-hW
+SG
 BS
 ja
 Yp
 Yp
 Yp
 yr
-oX
+BS
 Yp
 Yp
 Yp
 Yp
 VA
 SG
-aM
-aM
-aM
-aM
-aM
 tN
 tN
 tN
-Za
-YT
-xI
-ph
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -32370,9 +31785,9 @@ tN
 tN
 tN
 Tg
-hW
-hW
-hW
+SG
+SG
+SG
 Yp
 Yp
 Yp
@@ -32384,18 +31799,18 @@ Yp
 Yp
 SG
 SG
-aM
-aM
-aM
-aM
-aM
 tN
 tN
 tN
-Za
-Sl
-oM
-sB
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -32628,31 +32043,31 @@ tN
 tN
 SG
 SG
-hW
-hW
+SG
+SG
 Yp
 Yp
 Yp
-mY
-mY
+Yp
+Yp
 FU
 FU
 Yp
 Yp
 VA
 pJ
-aM
-aM
-aM
-aM
-aM
 tN
 tN
 tN
-Za
-by
-hi
-OP
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -32884,7 +32299,7 @@ tN
 tN
 tN
 SG
-bH
+hZ
 vi
 bJ
 Yp
@@ -32898,18 +32313,18 @@ Yp
 Yp
 Yp
 SG
-aM
-aM
-aM
-aM
-aM
 tN
 tN
 tN
-Za
-Za
-Za
-Za
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -33142,13 +32557,13 @@ tN
 tN
 vi
 SG
-oX
+BS
 jd
 Yp
 Yp
 Yp
 yK
-oX
+BS
 FU
 FU
 FU
@@ -33158,8 +32573,6 @@ SG
 tN
 tN
 tN
-aM
-aM
 tN
 tN
 tN
@@ -33168,10 +32581,12 @@ tN
 tN
 tN
 tN
-LN
-LN
-VT
-Ge
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -33422,18 +32837,18 @@ tN
 tN
 tN
 tN
-tN
-tN
-tN
-Wp
-LN
-VT
-Ge
+yE
 tN
 tN
 tN
 tN
 tN
+tN
+tN
+tN
+tN
+tN
+yE
 tN
 tN
 tN
@@ -33656,21 +33071,20 @@ tN
 tN
 tN
 SG
-hW
-cv
+SG
+bJ
 Yp
 Yp
 Yp
-iS
-iS
 FU
 FU
 FU
-mY
+FU
+FU
+Yp
 VA
 Tg
 sZ
-aA
 tN
 tN
 tN
@@ -33682,10 +33096,11 @@ tN
 tN
 tN
 tN
-Wp
-LN
-Gn
-Ge
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -33913,21 +33328,21 @@ tN
 tN
 tN
 SG
+iX
 SG
-SG
 Yp
 Yp
 Yp
 Yp
-iS
 FU
 FU
 FU
-mY
+FU
+Yp
 nw
 SG
 tr
-wi
+VA
 Tg
 tN
 tN
@@ -33939,10 +33354,10 @@ tN
 tN
 tN
 tN
-Wp
-LN
-MH
-LN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -34428,7 +33843,7 @@ tN
 tN
 SG
 SG
-SG
+bH
 VA
 Yp
 Yp
@@ -34941,21 +34356,21 @@ tN
 tN
 tN
 tN
-hW
+SG
 SG
 SG
 Tg
 bJ
 Tg
-wi
+VA
 tN
 tN
 Yp
-mY
+Yp
 Yp
 bJ
 uf
-xe
+vi
 tN
 vi
 tN
@@ -35198,21 +34613,21 @@ tN
 tN
 tN
 tN
-hW
-hW
 SG
 SG
-bH
 SG
-aA
+SG
+hZ
+SG
 tN
 tN
 tN
-aA
+tN
+tN
 tN
 rB
 Tg
-aA
+tN
 tN
 tN
 tN
@@ -94327,7 +93742,7 @@ ef
 ef
 Mu
 Yp
-Yp
+Pd
 Pd
 Pd
 Yp
@@ -94840,7 +94255,7 @@ ef
 ef
 ef
 Mu
-Yp
+Pd
 Pd
 Pd
 Pd
@@ -95097,7 +94512,7 @@ ef
 ef
 ef
 vD
-Yp
+Pd
 Pd
 Pd
 Pd
@@ -95354,7 +94769,7 @@ Mu
 Mu
 mh
 De
-Yp
+Pd
 Pd
 Pd
 Pd
@@ -104880,7 +104295,7 @@ up
 up
 up
 up
-tN
+up
 Yp
 Yp
 Yp
@@ -105137,8 +104552,8 @@ up
 up
 up
 up
-tN
-Yp
+up
+up
 Yp
 Yp
 Pd
@@ -105393,9 +104808,9 @@ up
 up
 up
 up
-tN
-Yp
-Pd
+up
+up
+up
 Pd
 Yp
 Pd
@@ -105651,8 +105066,8 @@ up
 up
 up
 up
-Pd
-Pd
+up
+up
 Pd
 Pd
 Pd
@@ -105908,7 +105323,7 @@ up
 up
 up
 up
-Pd
+up
 Pd
 Pd
 Yp

--- a/_maps/map_files/Mining/Lavaland_Lumos.dmm
+++ b/_maps/map_files/Mining/Lavaland_Lumos.dmm
@@ -30,21 +30,29 @@
 /turf/closed/wall,
 /area/space)
 "ad" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 30
+	},
+/obj/machinery/newscaster/security_unit{
+	pixel_x = -32
+	},
+/obj/effect/turf_decal/lumos/tile/red/fullcorner{
 	dir = 4
 	},
-/obj/effect/turf_decal/lumos/tile/purple/half{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/xenoarch/sec)
 "ae" = (
-/obj/effect/turf_decal/lumos/tile/purple/half{
-	dir = 1
+/obj/machinery/computer/card{
+	dir = 4
 	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
+/obj/effect/turf_decal/lumos/tile/red/half{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/xenoarch/sec)
 "af" = (
 /obj/structure/rack,
 /obj/item/mining_scanner,
@@ -92,9 +100,6 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "as" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
 /obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 1
 	},
@@ -102,6 +107,7 @@
 	dir = 4;
 	id = "garbageL"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "at" = (
@@ -371,6 +377,9 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
+/obj/machinery/camera{
+	c_tag = "Xenoarchaeology Twelve"
+	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "bc" = (
@@ -397,11 +406,11 @@
 /turf/open/floor/plating,
 /area/xenoarch/arch)
 "bh" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8
+/obj/effect/turf_decal/lumos/tile/red/fullcorner{
+	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
+/turf/open/floor/plasteel/dark,
+/area/xenoarch/sec)
 "bi" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/flora/ausbushes/grassybush,
@@ -444,9 +453,6 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "bp" = (
-/obj/effect/turf_decal/lumos/tile/purple/half{
-	dir = 1
-	},
 /obj/machinery/mineral/stacking_unit_console{
 	machinedir = 8;
 	pixel_x = 28
@@ -455,6 +461,12 @@
 	dir = 8;
 	id = "garbageL";
 	name = "disposal conveyor"
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
@@ -496,10 +508,10 @@
 "bs" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/lumos/tile/purple/half{
+/obj/structure/disposalpipe/segment{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
+/obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -555,12 +567,6 @@
 	},
 /turf/open/lava/smooth/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"bE" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/sec)
 "bF" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /obj/machinery/light{
@@ -580,15 +586,9 @@
 /turf/open/floor/grass,
 /area/lavaland/surface/outdoors)
 "bI" = (
-/obj/machinery/camera{
-	c_tag = "Xenoarchaeology Eleven";
-	dir = 8
-	},
-/obj/effect/turf_decal/lumos/tile/purple/half{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/xenoarch/sec)
 "bJ" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/grass,
@@ -758,21 +758,19 @@
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
 "cB" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/security/glass{
+	name = "Security Checkpoint";
+	req_access_txt = "1"
+	},
 /turf/open/floor/plasteel,
-/area/xenoarch/arch)
+/area/xenoarch/sec)
 "cC" = (
 /obj/structure/stone_tile/slab,
 /turf/closed/indestructible/riveted/boss,
@@ -830,6 +828,10 @@
 	},
 /turf/open/indestructible/boss,
 /area/lavaland/surface/outdoors)
+"cY" = (
+/obj/structure/closet/secure_closet/medical2,
+/turf/open/floor/plasteel/white,
+/area/xenoarch/arch)
 "cZ" = (
 /obj/structure/grille/broken,
 /turf/open/floor/plating,
@@ -906,22 +908,13 @@
 /turf/closed/mineral/random/high_chance/volcanic,
 /area/ruin/unpowered/ash_walkers)
 "dv" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/machinery/door/firedoor,
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/northleft{
+	name = "Security Checkpoint";
+	req_access_txt = "1"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/lumos/tile/red/half{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plating,
 /area/xenoarch/sec)
 "dx" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -1029,17 +1022,14 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "ec" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 8
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/window/northright{
+	name = "Security Checkpoint";
+	req_access_txt = "1"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/lumos/tile/purple/half{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
+/turf/open/floor/plating,
+/area/xenoarch/sec)
 "eh" = (
 /obj/machinery/air_sensor/atmos/toxin_tank,
 /turf/open/floor/engine/plasma,
@@ -1073,6 +1063,7 @@
 	dir = 8;
 	id = "garbageL"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "eu" = (
@@ -1257,18 +1248,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/bot)
-"fM" = (
-/obj/machinery/requests_console{
-	department = "Xenoarchaeology Security";
-	departmentType = 5;
-	pixel_y = 30
-	},
-/obj/machinery/computer/security,
-/obj/effect/turf_decal/lumos/tile/red/fullcorner{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/sec)
 "fP" = (
 /obj/machinery/light{
 	dir = 4
@@ -1281,6 +1260,9 @@
 /area/xenoarch/gen)
 "fX" = (
 /obj/machinery/light,
+/obj/effect/turf_decal/lumos/loading_area{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "ga" = (
@@ -1355,10 +1337,9 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "gx" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/stairs,
+/obj/effect/turf_decal/lumos/tile/purple/half,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "gC" = (
 /obj/machinery/light,
@@ -1496,12 +1477,6 @@
 	},
 /turf/closed/indestructible/riveted/boss,
 /area/ruin/unpowered/ash_walkers)
-"hp" = (
-/obj/effect/turf_decal/lumos/tile/red/fullcorner{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/sec)
 "hs" = (
 /turf/closed/wall,
 /area/xenoarch/bot)
@@ -1527,7 +1502,13 @@
 /obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 1
 	},
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/plasteel,
+/area/xenoarch/arch)
+"hx" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/backpack/duffelbag/med/surgery,
+/turf/open/floor/plasteel/white/side,
 /area/xenoarch/arch)
 "hy" = (
 /obj/structure/window/reinforced{
@@ -1583,18 +1564,6 @@
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
-"hP" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/lumos/tile/purple/half{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/sec)
 "hR" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
@@ -1691,11 +1660,6 @@
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"ik" = (
-/obj/machinery/light,
-/obj/effect/turf_decal/lumos/tile/red/half,
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/sec)
 "im" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/green,
@@ -1798,10 +1762,8 @@
 /turf/closed/indestructible/riveted/boss,
 /area/ruin/unpowered/ash_walkers)
 "iK" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/disposalpipe/junction/flip{
-	dir = 1
+/obj/effect/turf_decal/lumos/loading_area{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
@@ -1837,14 +1799,6 @@
 	},
 /turf/open/water,
 /area/xenoarch/arch)
-"iT" = (
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
-/obj/effect/turf_decal/lumos/tile/red/half,
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/sec)
 "iV" = (
 /obj/structure/stone_tile,
 /turf/open/lava/smooth/lava_land_surface,
@@ -1959,7 +1913,14 @@
 /turf/open/floor/plating,
 /area/xenoarch/arch)
 "jN" = (
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/lumos/tile/purple/half{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 30
+	},
+/obj/machinery/camera{
+	c_tag = "Xenoarchaeology Eleven";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -2031,42 +1992,35 @@
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"km" = (
+/obj/effect/turf_decal/lumos/tile/blue/fulltile,
+/turf/open/floor/plasteel/white,
+/area/xenoarch/arch)
 "kr" = (
-/obj/structure/table,
-/obj/item/paper_bin{
-	pixel_y = 6
+/obj/structure/disposalpipe/trunk,
+/obj/machinery/disposal/bin,
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = 28
 	},
-/obj/item/pen,
 /obj/effect/turf_decal/lumos/tile/red/half{
-	dir = 8
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/sec)
 "kt" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+/obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 4
+/obj/machinery/status_display/evac{
+	layer = 4;
+	pixel_x = 32
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "ku" = (
-/obj/structure/table,
-/obj/machinery/recharger{
-	pixel_y = 4
-	},
-/obj/item/radio/intercom{
-	dir = 8;
-	name = "Station Intercom (General)";
-	pixel_x = -28
-	},
-/obj/effect/turf_decal/lumos/tile/red/fullcorner{
-	dir = 1
-	},
+/obj/structure/chair/office/dark,
+/obj/effect/turf_decal/lumos/tile/red/half,
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/sec)
 "kv" = (
@@ -2191,12 +2145,9 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "lj" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/lumos/tile/purple/half{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/sec)
+/obj/machinery/computer/operating,
+/turf/open/floor/plasteel/white/side,
+/area/xenoarch/arch)
 "lm" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -2351,39 +2302,12 @@
 /obj/effect/turf_decal/vg_decals/radiation,
 /turf/open/floor/engine,
 /area/xenoarch/eng)
-"ma" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
-"mb" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/lumos/tile/purple/half{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "mf" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
+/obj/machinery/door/airlock/security{
+	name = "Security Checkpoint";
+	req_access_txt = "1"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
-/obj/effect/turf_decal/lumos/tile/purple/half{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/xenoarch/sec)
 "mg" = (
 /obj/structure/chair/office/dark,
@@ -2490,16 +2414,10 @@
 	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
 /area/ruin/unpowered/ash_walkers)
-"mV" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/effect/turf_decal/lumos/tile/red/fullcorner,
-/obj/item/kirbyplants{
-	icon_state = "plant-10"
-	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/sec)
+"mX" = (
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/plasteel/white,
+/area/xenoarch/arch)
 "mY" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -2510,11 +2428,6 @@
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/seeds,
 /turf/open/floor/plating,
-/area/xenoarch/arch)
-"nd" = (
-/obj/effect/turf_decal/lumos/tile/purple/half,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "nf" = (
 /obj/machinery/atmospherics/pipe/simple/dark/visible,
@@ -2591,6 +2504,9 @@
 "nC" = (
 /obj/machinery/light{
 	dir = 1
+	},
+/obj/effect/turf_decal/lumos/loading_area{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
@@ -2681,12 +2597,6 @@
 /obj/item/flashlight/lantern,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
-"oc" = (
-/obj/effect/turf_decal/lumos/tile/red/fullcorner{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/sec)
 "of" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
@@ -2715,6 +2625,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/lavaland/surface/outdoors)
+"oo" = (
+/obj/effect/turf_decal/lumos/tile/blue/fullcorner,
+/turf/open/floor/plasteel/white,
+/area/xenoarch/arch)
+"op" = (
+/obj/effect/turf_decal/lumos/tile/blue/half{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/xenoarch/arch)
 "ox" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/lumos/tile/purple/half{
@@ -2761,12 +2681,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
-"oU" = (
-/obj/effect/turf_decal/lumos/tile/red/half{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/sec)
 "oX" = (
 /turf/closed/wall,
 /area/lavaland/surface/outdoors)
@@ -2802,7 +2716,8 @@
 /area/xenoarch/bot)
 "pf" = (
 /obj/effect/turf_decal/caution{
-	dir = 4
+	dir = 4;
+	pixel_x = -4
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
@@ -2888,15 +2803,8 @@
 	req_access_txt = "47"
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
-/area/xenoarch/arch)
-"pD" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/disposalpipe/segment{
-	dir = 1
-	},
-/turf/open/floor/plasteel/stairs,
 /area/xenoarch/arch)
 "pE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
@@ -2969,18 +2877,10 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "pZ" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/effect/turf_decal/lumos/tile/red/half{
+	dir = 1
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/turf_decal/lumos/tile/purple/half{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/xenoarch/sec)
 "qb" = (
 /obj/effect/turf_decal/stripes/line{
@@ -3030,9 +2930,6 @@
 	},
 /turf/open/floor/plasteel/elevatorshaft,
 /area/mining_level_access/lower)
-"qi" = (
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/sec)
 "ql" = (
 /obj/machinery/atmospherics/pipe/simple/supply/visible/layer1{
 	dir = 4
@@ -3047,19 +2944,6 @@
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plating,
 /area/xenoarch/eng)
-"qm" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 1
-	},
-/obj/effect/turf_decal/plaque,
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "qn" = (
 /obj/structure/stone_tile,
 /obj/structure/stone_tile{
@@ -3179,20 +3063,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
-"qO" = (
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/effect/turf_decal/lumos/tile/red/half{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/sec)
 "qW" = (
 /obj/structure/stone_tile/slab,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
@@ -3313,18 +3183,6 @@
 	},
 /turf/open/floor/plating,
 /area/xenoarch/eng)
-"rG" = (
-/obj/machinery/camera{
-	c_tag = "Xenoarchaeology Security Checkpoint Lobby"
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/turf_decal/lumos/tile/red/half{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/sec)
 "rH" = (
 /obj/structure/stone_tile/cracked,
 /turf/closed/indestructible/riveted/boss,
@@ -3472,12 +3330,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/xenoarch/gen)
-"sA" = (
-/obj/effect/turf_decal/lumos/tile/purple/half{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/sec)
 "sB" = (
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/gen)
@@ -3511,15 +3363,6 @@
 	},
 /turf/open/floor/plating,
 /area/lavaland/surface/outdoors)
-"sP" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/obj/effect/turf_decal/lumos/tile/red/half{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/sec)
 "sS" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -3657,27 +3500,12 @@
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"tE" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4
-	},
-/obj/effect/turf_decal/lumos/tile/red/half{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/sec)
 "tF" = (
 /obj/structure/stone_tile/surrounding/cracked{
 	dir = 1
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
-"tJ" = (
-/obj/effect/turf_decal/lumos/tile/red/half{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/sec)
 "tL" = (
 /obj/structure/stone_tile/block{
 	dir = 1
@@ -3712,6 +3540,11 @@
 /obj/structure/stone_tile/slab,
 /turf/closed/indestructible/riveted/boss,
 /area/lavaland/surface/outdoors)
+"tV" = (
+/obj/structure/table/reinforced,
+/obj/machinery/cell_charger,
+/turf/open/floor/plasteel/white,
+/area/xenoarch/arch)
 "uf" = (
 /obj/structure/flora/grass/jungle,
 /obj/structure/flora/ausbushes/lavendergrass,
@@ -3832,12 +3665,6 @@
 /obj/structure/stone_tile,
 /turf/open/indestructible/boss,
 /area/lavaland/surface/outdoors)
-"uM" = (
-/obj/effect/turf_decal/lumos/tile/red/half{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/sec)
 "uN" = (
 /obj/structure/stone_tile/surrounding/cracked,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
@@ -3860,16 +3687,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
-"uU" = (
-/obj/machinery/status_display/evac{
-	layer = 4;
-	pixel_x = 32
-	},
-/obj/effect/turf_decal/lumos/tile/purple/half{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "uX" = (
 /obj/structure/table,
 /turf/open/floor/plasteel/dark,
@@ -4024,18 +3841,13 @@
 	},
 /turf/open/floor/engine/plasma,
 /area/xenoarch/eng)
-"wf" = (
-/obj/structure/window/reinforced{
-	dir = 4
+"vY" = (
+/obj/effect/turf_decal/lumos/tile/blue/fulltile,
+/obj/machinery/door/airlock/glass_large{
+	name = "Medbay"
 	},
-/obj/effect/turf_decal/lumos/tile/red/fullcorner{
-	dir = 8
-	},
-/obj/item/kirbyplants{
-	icon_state = "plant-10"
-	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/sec)
+/turf/open/floor/plasteel/white,
+/area/xenoarch/arch)
 "wh" = (
 /obj/structure/stone_tile/cracked{
 	dir = 8
@@ -4063,17 +3875,16 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "wk" = (
-/obj/machinery/camera{
-	c_tag = "Xenoarchaeology Security Checkpoint";
-	dir = 1
-	},
-/obj/machinery/light,
 /obj/effect/turf_decal/lumos/tile/red/half,
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/sec)
+"wm" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/effect/turf_decal/lumos/tile/blue/half,
+/turf/open/floor/plasteel/white,
+/area/xenoarch/arch)
 "ws" = (
 /obj/structure/fluff/drake_statue,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
@@ -4122,8 +3933,18 @@
 /obj/item/radio/off,
 /obj/item/crowbar,
 /obj/item/assembly/flash/handheld,
-/obj/effect/turf_decal/lumos/tile/red/half{
-	dir = 4
+/obj/machinery/airalarm/directional/east,
+/obj/machinery/requests_console{
+	department = "Xenoarchaeology Security";
+	departmentType = 5;
+	pixel_y = 30
+	},
+/obj/machinery/recharger{
+	pixel_x = -8;
+	pixel_y = 7
+	},
+/obj/effect/turf_decal/lumos/tile/red/fullcorner{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/sec)
@@ -4147,6 +3968,18 @@
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"wU" = (
+/obj/machinery/computer/med_data{
+	dir = 8
+	},
+/obj/machinery/requests_console{
+	department = "Medbay";
+	departmentType = 1;
+	name = "Medbay RC";
+	pixel_x = 30
+	},
+/turf/open/floor/plasteel/white,
+/area/xenoarch/arch)
 "wW" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/plasteel,
@@ -4347,16 +4180,6 @@
 /obj/item/storage/toolbox/mechanical,
 /turf/open/floor/plating,
 /area/xenoarch/arch)
-"yt" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/effect/turf_decal/lumos/tile/red/half{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/sec)
 "yv" = (
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 4
@@ -4422,6 +4245,14 @@
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"yK" = (
+/obj/machinery/door/airlock/medical/glass{
+	id_tag = null;
+	name = "Medbay";
+	req_access_txt = "5"
+	},
+/turf/open/floor/plasteel/white,
+/area/xenoarch/arch)
 "yL" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -4477,12 +4308,6 @@
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
-"yY" = (
-/obj/effect/turf_decal/lumos/tile/purple/half{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/sec)
 "za" = (
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 1
@@ -4519,12 +4344,6 @@
 	},
 /obj/machinery/light,
 /obj/effect/turf_decal/lumos/tile/yellow/half,
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
-"zi" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "zn" = (
@@ -4620,11 +4439,19 @@
 /turf/open/lava/smooth/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "zR" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+/obj/structure/table,
+/obj/item/paper_bin{
+	pixel_y = 6
+	},
+/obj/item/pen,
+/obj/structure/reagent_dispensers/peppertank{
+	pixel_y = 30
+	},
+/obj/machinery/light{
 	dir = 1
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/effect/turf_decal/lumos/tile/red/half{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/sec)
@@ -4725,6 +4552,15 @@
 	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
 /area/ruin/unpowered/ash_walkers)
+"AI" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "AN" = (
 /obj/structure/stone_tile/cracked,
 /turf/open/lava/smooth/lava_land_surface,
@@ -4797,20 +4633,6 @@
 "Bg" = (
 /turf/closed/mineral/random/high_chance/volcanic,
 /area/lavaland/surface/outdoors/unexplored/danger)
-"Bh" = (
-/obj/machinery/door/airlock/research{
-	name = "Research Division Access";
-	req_access_txt = "47"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/lumos/tile/purple/fulltile,
-/obj/structure/disposalpipe/segment{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "Bk" = (
 /obj/structure/stone_tile/block{
 	dir = 8
@@ -4836,6 +4658,14 @@
 	},
 /turf/open/floor/engine,
 /area/xenoarch/eng)
+"Bs" = (
+/obj/structure/table,
+/obj/item/storage/firstaid/regular,
+/obj/effect/turf_decal/lumos/tile/blue/fullcorner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/xenoarch/arch)
 "Bv" = (
 /obj/machinery/hydroponics/constructable,
 /obj/effect/turf_decal/tile/green{
@@ -5230,18 +5060,9 @@
 /turf/open/indestructible/boss,
 /area/lavaland/surface/outdoors)
 "Ef" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/lumos/tile/purple/half{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/sec)
+/obj/structure/table/optable,
+/turf/open/floor/plasteel/white/side,
+/area/xenoarch/arch)
 "El" = (
 /obj/structure/stone_tile/block,
 /obj/structure/stone_tile/block{
@@ -5269,16 +5090,6 @@
 	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
 /area/ruin/unpowered/ash_walkers)
-"EK" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/westright{
-	dir = 4;
-	name = "Security Checkpoint";
-	req_access_txt = "1"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel,
-/area/xenoarch/sec)
 "EL" = (
 /obj/structure/chair{
 	dir = 1
@@ -5288,21 +5099,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/lavaland/surface/outdoors)
-"EM" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/sec)
 "EN" = (
 /obj/structure/stone_tile{
 	dir = 4
@@ -5320,6 +5116,15 @@
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"EQ" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/turf_decal/lumos/tile/blue/half{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/xenoarch/arch)
 "ES" = (
 /obj/structure/stone_tile/block,
 /obj/structure/stone_tile{
@@ -5327,6 +5132,10 @@
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"EU" = (
+/obj/effect/turf_decal/lumos/tile/blue/half,
+/turf/open/floor/plasteel/white,
+/area/xenoarch/arch)
 "EW" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/structure/table,
@@ -5366,6 +5175,13 @@
 "FB" = (
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
+"FF" = (
+/obj/structure/table,
+/obj/effect/turf_decal/lumos/tile/blue/half{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/xenoarch/arch)
 "FG" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
@@ -5403,13 +5219,6 @@
 	},
 /turf/closed/indestructible/riveted/boss,
 /area/lavaland/surface/outdoors)
-"FT" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 30
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "FU" = (
 /turf/open/water,
 /area/lavaland/surface/outdoors)
@@ -5480,22 +5289,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/bot)
-"Gw" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/structure/sign/poster/official/random{
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "Gy" = (
-/obj/machinery/atm{
-	pixel_y = 30
-	},
 /obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 1
 	},
@@ -5737,24 +5531,12 @@
 /obj/structure/table,
 /obj/item/stack/sheet/glass/fifty,
 /obj/item/stack/sheet/glass/fifty,
+/obj/machinery/cell_charger,
 /turf/open/floor/plasteel,
 /area/xenoarch/gen)
-"Ia" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 30
-	},
-/obj/effect/turf_decal/lumos/tile/purple/half{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "Ib" = (
 /obj/machinery/door/airlock/maintenance,
 /turf/open/floor/plating,
-/area/xenoarch/sec)
-"Id" = (
-/obj/effect/turf_decal/lumos/tile/red/half,
-/turf/open/floor/plasteel/dark,
 /area/xenoarch/sec)
 "Ie" = (
 /obj/structure/stone_tile/block/cracked,
@@ -5784,10 +5566,6 @@
 	dir = 4
 	},
 /obj/structure/disposaloutlet{
-	dir = 1
-	},
-/obj/machinery/camera{
-	c_tag = "Xenoarchaeology Twelve";
 	dir = 1
 	},
 /obj/effect/turf_decal/lumos/tile/purple/half,
@@ -5821,13 +5599,6 @@
 /mob/living/simple_animal/hostile/asteroid/gutlunch/guthen,
 /turf/open/indestructible/boss,
 /area/ruin/unpowered/ash_walkers)
-"Ik" = (
-/obj/structure/chair/office/dark{
-	dir = 1
-	},
-/obj/effect/landmark/start/depsec/science,
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/sec)
 "Il" = (
 /obj/machinery/cell_charger,
 /obj/structure/table/reinforced,
@@ -6026,6 +5797,14 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/lavaland/surface/outdoors)
+"JA" = (
+/obj/effect/turf_decal/lumos/tile/purple/half,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "JG" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
@@ -6084,6 +5863,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
+"Kf" = (
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/white,
+/area/xenoarch/arch)
 "Kh" = (
 /obj/structure/stone_tile{
 	dir = 8
@@ -6467,15 +6250,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/xenoarch/gen)
-"Mm" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/obj/effect/turf_decal/lumos/tile/red/half{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/sec)
 "Mn" = (
 /obj/structure/stone_tile/cracked{
 	dir = 8
@@ -6506,6 +6280,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
+"MB" = (
+/obj/machinery/computer/crew{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/xenoarch/arch)
 "MC" = (
 /turf/open/floor/plasteel,
 /area/space)
@@ -6543,12 +6323,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/bot)
-"MX" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1
-	},
-/turf/closed/wall,
-/area/xenoarch/arch)
 "Nb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2
@@ -6665,9 +6439,6 @@
 /turf/open/floor/carpet,
 /area/xenoarch/gen)
 "NM" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
@@ -6698,12 +6469,10 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "NY" = (
-/obj/machinery/vending/wardrobe/sec_wardrobe,
 /obj/machinery/power/apc/auto_name/east,
-/obj/structure/cable/yellow,
 /obj/effect/turf_decal/lumos/tile/red/fullcorner,
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
+/obj/machinery/computer/secure_data{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/sec)
@@ -6722,12 +6491,6 @@
 /turf/open/floor/plating,
 /area/xenoarch/arch)
 "Og" = (
-/obj/structure/chair/office/dark{
-	dir = 8
-	},
-/obj/effect/turf_decal/lumos/tile/red/half{
-	dir = 8
-	},
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/sec)
 "Oh" = (
@@ -6763,15 +6526,6 @@
 	},
 /turf/open/floor/engine/n2,
 /area/xenoarch/eng)
-"On" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/lumos/tile/purple/half{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/sec)
 "Or" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/yellow{
@@ -6781,9 +6535,14 @@
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/gen)
 "Os" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable/yellow,
-/turf/open/floor/plating,
+/obj/machinery/camera{
+	c_tag = "Xenoarchaeology Security Checkpoint"
+	},
+/obj/structure/closet/secure_closet/security_xenoarch,
+/obj/effect/turf_decal/lumos/tile/red/half{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
 /area/xenoarch/sec)
 "Ot" = (
 /obj/structure/stone_tile/block{
@@ -6875,13 +6634,6 @@
 	},
 /turf/open/floor/engine/o2,
 /area/xenoarch/eng)
-"OW" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/lumos/tile/purple/half{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "Pb" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
@@ -6946,11 +6698,11 @@
 /turf/open/lava/smooth/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "PN" = (
-/obj/structure/sign/poster/official/random{
-	pixel_x = 32
-	},
 /obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 4
+	},
+/obj/machinery/atm{
+	pixel_x = 30
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
@@ -7036,19 +6788,6 @@
 /obj/structure/chair/office/dark,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
-"Qe" = (
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_y = 30
-	},
-/obj/machinery/newscaster/security_unit{
-	pixel_x = -32
-	},
-/obj/machinery/computer/secure_data,
-/obj/effect/turf_decal/lumos/tile/red/fullcorner{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/sec)
 "Qf" = (
 /obj/item/radio/intercom{
 	dir = 8;
@@ -7108,9 +6847,18 @@
 /turf/closed/wall/r_wall,
 /area/xenoarch/eng)
 "QM" = (
-/obj/structure/closet/secure_closet/security_xenoarch,
 /obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/computer/security{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/sec)
@@ -7149,15 +6897,6 @@
 	},
 /turf/open/lava/smooth/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"Rh" = (
-/obj/structure/sign/poster/official/random{
-	pixel_x = -32
-	},
-/obj/effect/turf_decal/lumos/tile/purple/half{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "Rj" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/nitrogen_input{
 	dir = 1
@@ -7449,9 +7188,6 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/bot)
 "SZ" = (
-/obj/machinery/airalarm{
-	pixel_y = 23
-	},
 /obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 1
 	},
@@ -7645,14 +7381,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
-"Uu" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/machinery/camera{
-	c_tag = "Xenoarchaeology Ten";
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "Uz" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -7830,6 +7558,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
+"WB" = (
+/obj/effect/turf_decal/lumos/tile/blue/half{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "WD" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
@@ -7837,38 +7571,6 @@
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
-"WI" = (
-/obj/machinery/door/airlock/security{
-	name = "Security Checkpoint";
-	req_access_txt = "1"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/lumos/tile/red/half{
-	dir = 4
-	},
-/obj/effect/turf_decal/lumos/tile/purple/half{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/sec)
 "WM" = (
 /obj/structure/reagent_dispensers/foamtank,
 /turf/open/floor/plating,
@@ -7898,20 +7600,15 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/gen)
-"Xh" = (
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = 28
+"Xj" = (
+/obj/effect/turf_decal/lumos/tile/purple/fullcorner{
+	dir = 8
 	},
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/firealarm{
+	pixel_y = 24
 	},
-/obj/machinery/computer/card,
-/obj/effect/turf_decal/lumos/tile/red/half{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/sec)
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "Xr" = (
 /obj/effect/turf_decal/lumos/tile/purple/fullcorner{
 	dir = 8
@@ -7985,15 +7682,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/gen)
-"XX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/lumos/tile/purple/half,
-/obj/structure/disposalpipe/segment{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "Yb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/yellow{
@@ -8153,10 +7841,6 @@
 /turf/open/floor/engine/n2,
 /area/xenoarch/eng)
 "Zp" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
-	},
 /turf/open/floor/plating,
 /area/xenoarch/sec)
 "Zz" = (
@@ -8182,9 +7866,6 @@
 /obj/structure/stone_tile/surrounding_tile/cracked,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
-"ZF" = (
-/turf/open/space/basic,
-/area/xenoarch/arch)
 "ZG" = (
 /turf/open/floor/plasteel/white,
 /area/lavaland/surface/outdoors)
@@ -18214,17 +17895,17 @@ BS
 BS
 BS
 aA
-ZF
-ZF
-ZF
-ZF
-ZF
-ZF
-ZF
-ZF
-ZF
-ZF
-ZF
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
 QV
 QV
 QV
@@ -18470,18 +18151,18 @@ Ub
 xz
 TS
 BS
-ZF
-ZF
-ZF
-ZF
-ZF
-ZF
-ZF
-ZF
-ZF
-ZF
-ZF
-ZF
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
 QV
 QV
 QV
@@ -18727,18 +18408,18 @@ hy
 cA
 xz
 BS
-ZF
-ZF
-ZF
-ZF
-ZF
-ZF
-ZF
-ZF
-ZF
-ZF
-ZF
-ZF
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
 QV
 QV
 QV
@@ -18964,14 +18645,14 @@ cZ
 BS
 BS
 Ix
-CT
-CT
-CT
-CT
-CT
-CT
-CT
-CT
+Zp
+Zp
+Zp
+Zp
+Zp
+Zp
+Zp
+Zp
 jn
 BS
 kI
@@ -18984,18 +18665,18 @@ sS
 xz
 Km
 BS
-ZF
-ZF
-ZF
-ZF
-ZF
-ZF
-ZF
-ZF
-ZF
-ZF
-ZF
-ZF
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
 QV
 QV
 QV
@@ -19221,38 +18902,38 @@ jn
 zo
 BS
 BS
-CT
-oc
-tJ
-tJ
-tJ
-tJ
-hp
-CT
+Zp
+Zp
+Zp
+Zp
+Zp
+Zp
+Zp
+Zp
 jn
 BS
 nC
 pf
-AU
-AU
+iK
+iK
 pf
-AU
-AU
+iK
+iK
 pf
 fX
 BS
-ZF
-ZF
-ZF
-ZF
-ZF
-ZF
-ZF
-ZF
-ZF
-ZF
-ZF
-ZF
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
 QV
 QV
 QV
@@ -19478,14 +19159,14 @@ Kl
 mZ
 BS
 Ix
-CT
-oU
-qi
-qi
-qi
-qi
-Id
-CT
+Zp
+Zp
+Zp
+Zp
+Zp
+Zp
+Zp
+Zp
 jn
 BS
 AU
@@ -19498,18 +19179,18 @@ AU
 AU
 AU
 BS
-ZF
-ZF
-ZF
-ZF
-ZF
-ZF
-ZF
-ZF
-ZF
-ZF
-ZF
-ZF
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
 QV
 QV
 QV
@@ -19735,14 +19416,14 @@ jn
 jn
 cZ
 jn
-CT
-rG
-qi
-qi
-qi
-qi
-ik
-CT
+Zp
+Zp
+Zp
+Zp
+Zp
+Zp
+Zp
+Zp
 jn
 BS
 WD
@@ -19755,18 +19436,18 @@ AU
 AU
 AU
 BS
-ZF
-ZF
-ZF
-ZF
-ZF
-ZF
-ZF
-ZF
-ZF
-ZF
-ZF
-ZF
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
 QV
 QV
 QV
@@ -19992,14 +19673,14 @@ BS
 BS
 BS
 jn
-CT
-sP
-qi
-qi
-qi
-qi
-iT
-CT
+Zp
+Zp
+Zp
+Zp
+Zp
+Zp
+Zp
+Zp
 jn
 BS
 PO
@@ -20012,18 +19693,18 @@ Wc
 IZ
 Mv
 BS
-ZF
-ZF
-ZF
-ZF
-ZF
-ZF
-ZF
-ZF
-ZF
-ZF
-ZF
-ZF
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
 QV
 QV
 QV
@@ -20249,13 +19930,13 @@ mI
 Od
 BS
 jn
+Zp
+Zp
+Zp
 CT
-wf
-uM
-Mm
-tE
-uM
-mV
+CT
+CT
+CT
 CT
 GY
 BS
@@ -20269,18 +19950,18 @@ BS
 BS
 BS
 BS
-ZF
-ZF
-ZF
-ZF
-ZF
-ZF
-ZF
-ZF
-ZF
-ZF
-ZF
-ZF
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
 QV
 QV
 QV
@@ -20506,14 +20187,14 @@ mI
 jn
 BS
 dt
+Zp
+Zp
+Zp
 CT
-sA
-sA
-On
 ad
-sA
-sA
-lj
+ae
+bh
+bI
 My
 PZ
 bQ
@@ -20522,22 +20203,22 @@ LM
 wu
 My
 lu
-mb
+My
 Nh
 My
-ec
-My
-gx
-My
-Rh
-My
-AU
-Bf
-bh
-jN
-jN
-Gw
 BS
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
 QV
 QV
 QV
@@ -20764,13 +20445,13 @@ jn
 BS
 sV
 Ib
-yY
-yY
+Zp
+Zp
 mf
 pZ
-hP
-hP
-Ef
+Og
+wk
+cB
 NM
 PR
 id
@@ -20779,22 +20460,22 @@ IL
 Dk
 Un
 lP
-ma
-Je
-Je
-kt
-Je
-pD
 Je
 Je
 Je
-Je
-qm
-iK
-zi
-zi
-zi
 BS
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
 QV
 QV
 QV
@@ -21020,38 +20701,38 @@ aU
 jn
 GY
 jn
-CT
-CT
 Zp
-WI
+Zp
+Zp
+CT
 Os
-EK
-CT
-CT
-Ia
+Og
+wk
+bI
+AU
 UN
 rj
 PN
 ia
 ia
+jN
 ia
-ia
-OW
-bI
-ia
-ia
-uU
-lT
 ia
 zU
-ia
-rj
-FT
-rj
-rj
-rj
-Uu
+kt
 BS
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
 QV
 QV
 QV
@@ -21277,17 +20958,17 @@ jn
 jn
 BS
 jn
+Zp
+Zp
+Zp
 CT
-Qe
-tJ
-dv
 kr
 Og
 ku
-CT
-ae
-cB
-nd
+dv
+Ng
+UN
+HP
 BS
 BS
 BS
@@ -21297,18 +20978,18 @@ BS
 BS
 BS
 BS
-BS
-pU
-pU
-BS
-pU
-pU
-BS
-pU
-pU
-BS
-BS
-BS
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
 QV
 QV
 QV
@@ -21534,14 +21215,14 @@ jn
 jn
 BS
 jn
+Zp
+Zp
+Zp
 CT
-Xh
-Ik
-EM
 zR
-bE
+Og
 wk
-CT
+ec
 SZ
 dF
 fa
@@ -21554,8 +21235,8 @@ YC
 hJ
 BS
 tN
-Pd
-Pd
+tN
+tN
 Pd
 Pd
 Pd
@@ -21791,17 +21472,17 @@ jn
 dt
 BS
 jn
+Zp
+Zp
+Zp
 CT
-fM
-yt
-qO
 wI
 QM
 NY
 CT
 Dm
 UN
-HP
+oR
 BS
 Yh
 jV
@@ -22058,7 +21739,7 @@ CT
 CT
 as
 eo
-HP
+gx
 BS
 iC
 AU
@@ -22066,7 +21747,7 @@ AU
 AU
 AU
 HP
-BS
+pU
 Pd
 Pd
 Pd
@@ -22306,24 +21987,24 @@ KZ
 BS
 jn
 BS
-ZF
-ZF
-ZF
-ZF
-ZF
-ZF
+lj
+Ma
+Ma
+op
+FF
+Bs
 BS
 Ng
 UN
-di
+HP
 pC
 Va
 Uh
 Uh
 sf
 YA
-XX
-Bh
+HP
+pU
 Pd
 Pd
 Pd
@@ -22563,13 +22244,13 @@ BS
 BS
 jn
 BS
-ZF
-ZF
-ZF
-ZF
-ZF
-ZF
-BS
+Ef
+Ma
+Ma
+Ma
+Ma
+EU
+pU
 Gy
 hH
 vg
@@ -22580,10 +22261,10 @@ lm
 SB
 AU
 Ih
-BS
+pU
 Pd
 Pd
-tN
+Pd
 Ge
 AT
 rZ
@@ -22820,16 +22501,16 @@ BS
 QW
 jn
 BS
-ZF
-ZF
-ZF
-ZF
-ZF
-ZF
-BS
+hx
+Ma
+Ma
+Ma
+Ma
+EU
+vY
 bp
 iD
-HP
+JA
 BS
 vz
 Ig
@@ -22839,7 +22520,7 @@ AU
 GW
 BS
 Pd
-tN
+Pd
 tN
 Ge
 Br
@@ -23077,13 +22758,13 @@ BS
 aK
 jn
 BS
-ZF
-ZF
-ZF
-ZF
-ZF
-ZF
-BS
+cY
+Ma
+Ma
+Ma
+Ma
+EU
+km
 bs
 bv
 HP
@@ -23094,7 +22775,7 @@ AU
 AU
 Qd
 OQ
-MX
+BS
 tN
 tN
 tN
@@ -23334,14 +23015,14 @@ BS
 jn
 jn
 BS
-ZF
-ZF
-ZF
-ZF
-ZF
-ZF
 BS
-Ng
+yK
+BS
+Ma
+Ma
+EU
+pU
+WB
 gQ
 XI
 BS
@@ -23591,14 +23272,14 @@ BS
 aW
 jn
 BS
-ZF
-ZF
-ZF
-ZF
-ZF
-ZF
+Ma
+Ma
+tV
+Ma
+Ma
+wm
 BS
-Yj
+AI
 UN
 oR
 BS
@@ -23621,7 +23302,7 @@ Ge
 Ge
 Ge
 Pd
-Yp
+Pd
 Pd
 tN
 tN
@@ -23848,12 +23529,12 @@ BS
 BS
 dt
 BS
-ZF
-ZF
-ZF
-ZF
-ZF
-ZF
+mX
+Ma
+Kf
+Ma
+Ma
+wm
 BS
 hw
 cd
@@ -23878,7 +23559,7 @@ Iu
 Lw
 Nn
 OB
-Yp
+Pd
 Pd
 tN
 tN
@@ -24105,14 +23786,14 @@ aA
 BS
 jn
 BS
-ZF
-ZF
-ZF
-ZF
-ZF
-ZF
+MB
+wU
 BS
-Xr
+EQ
+EQ
+oo
+BS
+Xj
 KR
 Dp
 hs

--- a/_maps/map_files/Mining/Lavaland_Lumos.dmm
+++ b/_maps/map_files/Mining/Lavaland_Lumos.dmm
@@ -75,10 +75,13 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "ai" = (
-/obj/machinery/light{
-	dir = 1
+/obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
 "aj" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/nitrogen_output{
@@ -91,18 +94,6 @@
 	req_one_access_txt = "48"
 	},
 /turf/open/floor/plating,
-/area/xenoarch/arch)
-"al" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/effect/turf_decal/lumos/tile/purple/checker{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
 "am" = (
 /obj/effect/turf_decal/lumos/tile/purple/half{
@@ -122,7 +113,6 @@
 /obj/structure/chair/office/dark{
 	dir = 1
 	},
-/obj/effect/landmark/start/scientist,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "ap" = (
@@ -173,10 +163,6 @@
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
-/obj/structure/rack,
-/obj/item/t_scanner/adv_mining_scanner/lesser,
-/obj/item/storage/bag/strangerock,
-/obj/item/gps/mining,
 /obj/effect/turf_decal/lumos/tile/brown/half{
 	dir = 1
 	},
@@ -267,17 +253,11 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "aE" = (
-/obj/structure/table,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/metal/fifty,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
 /obj/machinery/airalarm{
 	pixel_y = 23
+	},
+/obj/effect/turf_decal/lumos/tile/yellow/half{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
@@ -311,6 +291,10 @@
 /obj/effect/turf_decal/lumos/tile/brown/half{
 	dir = 4
 	},
+/obj/structure/rack,
+/obj/item/t_scanner/adv_mining_scanner/lesser,
+/obj/item/storage/bag/strangerock,
+/obj/item/gps/mining,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "aJ" = (
@@ -323,7 +307,6 @@
 /area/xenoarch/arch)
 "aK" = (
 /obj/structure/table,
-/obj/item/relic,
 /turf/open/floor/plating,
 /area/xenoarch/arch)
 "aL" = (
@@ -384,8 +367,6 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/structure/disposalpipe/trunk,
-/obj/machinery/disposal/bin,
 /obj/effect/turf_decal/lumos/tile/brown/half{
 	dir = 4
 	},
@@ -401,15 +382,11 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/bot)
 "aR" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "aT" = (
@@ -423,10 +400,10 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/gen)
 "aU" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/xenoarch/arch)
 "aV" = (
 /obj/structure/stone_tile/block{
@@ -447,10 +424,10 @@
 /turf/open/floor/plating,
 /area/xenoarch/arch)
 "aX" = (
-/obj/structure/rack,
 /obj/effect/turf_decal/lumos/tile/brown/half{
 	dir = 8
 	},
+/obj/structure/closet/secure_closet/miner,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "aY" = (
@@ -467,34 +444,22 @@
 /obj/item/reagent_containers/glass/beaker/waterbottle/large,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
-"ba" = (
-/obj/structure/bed,
-/obj/item/bedsheet/brown,
-/obj/machinery/button/door{
-	id = "dorm2L";
-	normaldoorcontrol = 1;
-	pixel_y = 28;
-	specialfunctions = 4
-	},
-/turf/open/floor/carpet,
-/area/xenoarch/gen)
 "bb" = (
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "garbageL"
-	},
 /obj/machinery/status_display/evac{
 	layer = 4;
 	pixel_y = 32
 	},
-/turf/open/floor/plasteel/dark,
+/obj/machinery/conveyor{
+	dir = 6;
+	id = "garbageL"
+	},
+/turf/open/floor/plating,
 /area/xenoarch/arch)
 "bc" = (
-/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/structure/closet/cardboard,
 /turf/open/floor/plating,
 /area/xenoarch/arch)
 "bd" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
@@ -522,11 +487,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
-"bg" = (
-/obj/structure/flora/tree/jungle/small,
-/obj/structure/flora/grass/jungle,
-/turf/open/floor/grass,
-/area/lavaland/surface/outdoors)
 "bh" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -544,11 +504,8 @@
 /turf/open/floor/grass,
 /area/xenoarch/gen)
 "bj" = (
-/obj/structure/rack,
-/obj/item/tank/internals/nitrogen,
-/obj/item/tank/internals/nitrogen,
-/obj/item/tank/internals/nitrogen,
-/obj/item/tank/internals/nitrogen,
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/xenoarch/arch)
 "bk" = (
@@ -581,9 +538,9 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "bo" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/closet/secure_closet/miner,
 /obj/effect/turf_decal/lumos/tile/brown/fullcorner,
+/obj/structure/disposalpipe/trunk,
+/obj/machinery/disposal/bin,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "bp" = (
@@ -675,7 +632,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/structure/disposalpipe/junction/flip,
+/obj/structure/disposalpipe/junction{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "bw" = (
@@ -692,44 +651,28 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/gen)
-"by" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/visible{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/landmark/start/mining_engineer,
-/turf/open/floor/plasteel,
-/area/xenoarch/eng)
-"bz" = (
-/obj/structure/table,
-/obj/item/holosign_creator/atmos,
-/obj/item/holosign_creator/firelock,
-/turf/open/floor/plasteel,
-/area/xenoarch/eng)
 "bA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/visible{
 	dir = 9
 	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/effect/landmark/start/mining_engineer,
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "bB" = (
-/obj/machinery/chem_heater,
-/turf/open/floor/plasteel/white,
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "bC" = (
-/obj/structure/closet/secure_closet/engineering_electrical,
-/obj/structure/window/reinforced{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/eng)
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "bD" = (
 /obj/structure/stone_tile/cracked{
 	dir = 4
@@ -737,10 +680,11 @@
 /turf/open/lava/smooth/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "bE" = (
-/obj/structure/closet/secure_closet/engineering_welding,
-/obj/structure/window/reinforced,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/dark,
-/area/xenoarch/eng)
+/area/xenoarch/sec)
 "bF" = (
 /obj/machinery/hydroponics/constructable,
 /obj/effect/turf_decal/tile/green{
@@ -755,20 +699,16 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/bot)
 "bG" = (
-/obj/structure/closet/secure_closet/engineering_personal,
-/obj/structure/window/reinforced,
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/eng)
-"bH" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/structure/window/reinforced{
-	dir = 4;
-	layer = 2.9
+/obj/effect/turf_decal/lumos/tile/purple/half{
+	dir = 4
 	},
-/obj/structure/closet/secure_closet/engineering_personal,
-/obj/structure/window/reinforced,
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/eng)
+/obj/structure/table,
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
+"bH" = (
+/obj/structure/flora/tree/jungle/small,
+/turf/open/floor/grass,
+/area/lavaland/surface/outdoors)
 "bI" = (
 /obj/machinery/camera{
 	c_tag = "Xenoarchaeology Eleven";
@@ -780,48 +720,26 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "bJ" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/autolathe,
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/eng)
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/grass,
+/area/lavaland/surface/outdoors)
 "bK" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 6
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/vending/wardrobe/engi_wardrobe,
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/eng)
-"bL" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
+/obj/machinery/light/small{
 	dir = 4
 	},
-/obj/structure/window/reinforced{
+/turf/open/floor/grass,
+/area/xenoarch/arch)
+"bL" = (
+/obj/machinery/light/small{
 	dir = 1
 	},
-/obj/machinery/vending/tool,
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/eng)
+/turf/open/floor/grass,
+/area/xenoarch/arch)
 "bM" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 9
 	},
-/obj/structure/window/reinforced{
-	dir = 4;
-	layer = 2.9
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/vending/engivend,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "bN" = (
 /turf/open/openspace,
@@ -906,17 +824,6 @@
 /obj/effect/landmark/start/scientist,
 /turf/open/floor/plasteel,
 /area/xenoarch/bot)
-"ch" = (
-/obj/structure/bed,
-/obj/item/bedsheet/brown,
-/obj/machinery/button/door{
-	id = "dorm3L";
-	normaldoorcontrol = 1;
-	pixel_y = 28;
-	specialfunctions = 4
-	},
-/turf/open/floor/carpet,
-/area/xenoarch/gen)
 "ci" = (
 /obj/structure/stone_tile{
 	dir = 1
@@ -929,12 +836,6 @@
 	dir = 8
 	},
 /turf/open/indestructible/boss,
-/area/lavaland/surface/outdoors)
-"cn" = (
-/obj/structure/flora/grass/jungle/b,
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/flora/ausbushes/grassybush,
-/turf/open/floor/grass,
 /area/lavaland/surface/outdoors)
 "co" = (
 /obj/structure/disposalpipe/segment{
@@ -970,23 +871,20 @@
 /obj/machinery/atmospherics/components/binary/volume_pump{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/yellow/half,
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "cv" = (
-/obj/machinery/airalarm{
-	pixel_y = 23
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/machinery/light/small{
+	dir = 1
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/grass,
 /area/xenoarch/arch)
 "cA" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/table/reinforced,
 /turf/open/floor/plasteel/white,
 /area/xenoarch/arch)
 "cB" = (
@@ -1017,11 +915,6 @@
 /obj/item/flashlight/lantern,
 /obj/structure/stone_tile/center,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
-"cN" = (
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/flora/ausbushes/grassybush,
-/turf/open/floor/grass,
 /area/lavaland/surface/outdoors)
 "cO" = (
 /obj/effect/turf_decal/vg_decals/atmos/air,
@@ -1067,9 +960,11 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "dh" = (
-/obj/machinery/chem_dispenser,
-/turf/open/floor/plasteel/white,
-/area/xenoarch/arch)
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/grass,
+/area/lavaland/surface/outdoors)
 "di" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/lumos/tile/purple/half,
@@ -1088,12 +983,6 @@
 "dn" = (
 /obj/structure/window/reinforced{
 	dir = 1
-	},
-/obj/effect/turf_decal/lumos/tile/red/checker{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
@@ -1174,15 +1063,17 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "dF" = (
-/obj/structure/chair/office/light{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
-/obj/effect/landmark/start/medical_doctor,
-/turf/open/floor/plasteel/white,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/junction/yjunction,
+/turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "dL" = (
 /obj/structure/stone_tile/slab/cracked,
@@ -1212,10 +1103,6 @@
 /area/lavaland/surface/outdoors)
 "dQ" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
 /obj/structure/fireaxecabinet{
 	pixel_x = 32
 	},
@@ -1223,13 +1110,21 @@
 	c_tag = "Xenoarchaeology Fourteen";
 	dir = 9
 	},
+/obj/effect/turf_decal/lumos/tile/yellow/half{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "dV" = (
-/obj/structure/sign/poster/official/random{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/obj/machinery/status_display/evac{
+	layer = 4;
 	pixel_x = 32
 	},
-/turf/open/floor/plasteel/dark,
+/obj/structure/closet/secure_closet/engineering_electrical,
+/turf/open/floor/plasteel,
 /area/xenoarch/gen)
 "dY" = (
 /obj/structure/stone_tile/block/cracked{
@@ -1241,15 +1136,11 @@
 /turf/open/lava/smooth/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "eb" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plating,
-/area/xenoarch/arch)
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "ec" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
@@ -1281,11 +1172,10 @@
 /turf/open/floor/plating,
 /area/xenoarch/eng)
 "eo" = (
-/obj/machinery/status_display/evac{
-	layer = 4;
-	pixel_x = -32
+/obj/machinery/airalarm{
+	pixel_y = 23
 	},
-/turf/open/floor/plasteel/stairs,
+/turf/open/floor/plasteel/white,
 /area/xenoarch/arch)
 "eu" = (
 /obj/structure/table,
@@ -1329,8 +1219,11 @@
 /turf/closed/indestructible/riveted/boss,
 /area/lavaland/surface/outdoors)
 "fa" = (
-/obj/machinery/light/small,
-/turf/open/water,
+/obj/effect/turf_decal/lumos/tile/purple/half,
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "fb" = (
 /obj/structure/stone_tile{
@@ -1348,6 +1241,10 @@
 "fd" = (
 /obj/structure/window/reinforced{
 	dir = 1
+	},
+/obj/effect/turf_decal/lumos/tile/purple/checker,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
@@ -1392,10 +1289,7 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/yellow/half,
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "fn" = (
@@ -1421,16 +1315,15 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "fs" = (
-/obj/machinery/door/airlock{
-	id_tag = "dorm2L"
-	},
-/turf/open/floor/plasteel/dark,
+/obj/structure/table,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/turf/open/floor/plasteel,
 /area/xenoarch/gen)
 "fy" = (
 /obj/structure/chair/office/dark,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/landmark/start/paramedic,
 /turf/open/floor/plasteel/white,
 /area/xenoarch/arch)
 "fE" = (
@@ -1471,14 +1364,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/gen)
-"fL" = (
-/obj/structure/window/reinforced,
-/obj/effect/turf_decal/lumos/tile/purple/checker,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/arch)
 "fM" = (
 /obj/machinery/requests_console{
 	department = "Xenoarchaeology Security";
@@ -1643,10 +1528,11 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "gR" = (
-/obj/structure/table/reinforced,
-/obj/machinery/cell_charger,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/lumos/tile/purple/fullcorner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "gS" = (
 /obj/structure/stone_tile/surrounding_tile/cracked{
@@ -1671,11 +1557,8 @@
 /turf/open/floor/engine,
 /area/xenoarch/eng)
 "gZ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/gen)
@@ -1767,35 +1650,33 @@
 /turf/open/floor/plasteel/white,
 /area/xenoarch/arch)
 "hB" = (
-/obj/machinery/button/door{
-	desc = "A remote control switch for the medbay foyer.";
-	id = "xemed";
-	name = "Medbay Doors Control";
-	normaldoorcontrol = 1;
-	pixel_x = -26;
-	req_access_txt = "5"
-	},
-/turf/open/floor/plasteel/white,
-/area/xenoarch/arch)
-"hE" = (
-/obj/machinery/light/small{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/obj/effect/turf_decal/lumos/tile/purple/half{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/xenoarch/arch)
-"hF" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+"hE" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/grass,
 /area/lavaland/surface/outdoors)
 "hH" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
 /obj/machinery/disposal/bin,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/xenoarch/arch)
 "hK" = (
@@ -1839,18 +1720,12 @@
 /turf/closed/indestructible/riveted/boss,
 /area/ruin/unpowered/ash_walkers)
 "hW" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
+/obj/machinery/light/small,
+/turf/open/floor/grass,
 /area/xenoarch/arch)
 "hX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/turf/open/floor/plasteel/white,
+/obj/machinery/light/small,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/xenoarch/arch)
 "ia" = (
 /obj/effect/turf_decal/lumos/tile/purple/half{
@@ -1863,10 +1738,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/yellow/half,
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "ic" = (
@@ -1912,16 +1784,8 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "ih" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/machinery/button/door{
-	id = "xp2";
-	normaldoorcontrol = 1;
-	pixel_x = -28;
-	specialfunctions = 4
-	},
-/turf/open/floor/plasteel/white,
+/obj/machinery/light/small,
+/turf/open/water,
 /area/xenoarch/arch)
 "ij" = (
 /obj/structure/stone_tile/slab/cracked{
@@ -1982,10 +1846,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
-/obj/structure/sign/poster/official/random{
-	pixel_x = 32
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel,
 /area/xenoarch/gen)
 "iz" = (
 /obj/structure/sign/poster/official/random{
@@ -1994,10 +1858,15 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "iC" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/structure/barricade/wooden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "garbageL"
+	},
 /turf/open/floor/plating,
-/area/xenoarch/gen)
+/area/xenoarch/arch)
 "iD" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -2047,8 +1916,10 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "iS" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/open/floor/plating,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/water,
 /area/xenoarch/arch)
 "iT" = (
 /obj/machinery/airalarm{
@@ -2072,8 +1943,9 @@
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
-/obj/machinery/vending/clothing,
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/lumos/tile/yellow/fulltile,
+/obj/machinery/portable_atmospherics/scrubber/huge/movable,
+/turf/open/floor/plasteel,
 /area/xenoarch/gen)
 "jd" = (
 /turf/open/floor/plating,
@@ -2082,8 +1954,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plating,
 /area/xenoarch/gen)
 "ji" = (
 /obj/machinery/status_display/evac{
@@ -2122,22 +1993,16 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "jv" = (
-/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/grass/jungle,
 /obj/machinery/light/small{
-	dir = 1
+	dir = 4
 	},
 /turf/open/floor/grass,
 /area/xenoarch/arch)
 "jw" = (
 /obj/machinery/suit_storage_unit/atmos,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/fullcorner{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
@@ -2148,11 +2013,8 @@
 /area/lavaland/surface/outdoors)
 "jK" = (
 /obj/machinery/suit_storage_unit/atmos,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
@@ -2167,12 +2029,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
-"jR" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
 "jS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -2192,9 +2048,10 @@
 /turf/open/indestructible/boss,
 /area/lavaland/surface/outdoors)
 "jV" = (
-/obj/structure/chair/office/dark,
-/obj/effect/landmark/start/chemist,
-/turf/open/floor/plasteel/white,
+/obj/machinery/conveyor{
+	id = "garbageL"
+	},
+/turf/open/floor/plating,
 /area/xenoarch/arch)
 "jY" = (
 /obj/structure/stone_tile/block/cracked,
@@ -2228,7 +2085,6 @@
 /turf/open/floor/plating,
 /area/xenoarch/arch)
 "ki" = (
-/obj/effect/landmark/start/medical_doctor,
 /obj/structure/chair/office/dark{
 	dir = 1
 	},
@@ -2310,7 +2166,6 @@
 /area/ruin/unpowered/ash_walkers)
 "kC" = (
 /obj/structure/chair/office/dark,
-/obj/effect/landmark/start/scientist,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "kD" = (
@@ -2325,13 +2180,14 @@
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/sec)
 "kI" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/obj/effect/turf_decal/lumos/tile/purple/half{
-	dir = 8
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "garbageL"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/xenoarch/arch)
 "kK" = (
 /obj/machinery/hydroponics/constructable,
@@ -2366,9 +2222,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
-	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/plasteel/white,
 /area/xenoarch/arch)
 "kU" = (
@@ -2406,7 +2260,10 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "la" = (
-/obj/structure/ore_box,
+/obj/machinery/conveyor{
+	dir = 10;
+	id = "garbageL"
+	},
 /turf/open/floor/plating,
 /area/xenoarch/arch)
 "le" = (
@@ -2436,14 +2293,12 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/sec)
 "lm" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 6
+/obj/machinery/mineral/stacking_machine{
+	input_dir = 1;
+	stack_amt = 10
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/eng)
+/turf/open/floor/plating,
+/area/xenoarch/arch)
 "lo" = (
 /obj/machinery/computer/shuttle/elevator/mining,
 /turf/open/floor/plasteel/dark,
@@ -2453,11 +2308,13 @@
 /turf/open/lava/smooth/lava_land_surface,
 /area/template_noop)
 "lu" = (
-/obj/effect/turf_decal/lumos/tile/blue/checker,
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
+/obj/effect/turf_decal/lumos/tile/purple/half{
+	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "lv" = (
 /obj/machinery/light/small{
@@ -2551,17 +2408,13 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/bot)
 "lP" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/disposalpipe/segment{
+	dir = 1
 	},
 /obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
+	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
@@ -2605,6 +2458,7 @@
 /area/xenoarch/arch)
 "mc" = (
 /obj/effect/turf_decal/lumos/tile/purple/fullcorner,
+/obj/structure/table,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "mf" = (
@@ -2659,8 +2513,10 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "mq" = (
-/obj/effect/turf_decal/lumos/tile/blue/fulltile,
-/turf/open/floor/plasteel/dark,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/xenoarch/arch)
 "my" = (
 /obj/effect/turf_decal/tile/purple{
@@ -2726,20 +2582,20 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/lumos/tile/red/fullcorner,
+/obj/item/kirbyplants{
+	icon_state = "plant-10"
+	},
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/sec)
-"mW" = (
-/obj/machinery/telecomms/relay/preset/mining,
-/turf/open/floor/plating,
-/area/xenoarch/arch)
 "mY" = (
-/obj/effect/turf_decal/lumos/tile/red/fulltile,
-/turf/open/floor/plasteel/dark,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/xenoarch/arch)
 "mZ" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/seeds,
-/obj/item/relic,
 /turf/open/floor/plating,
 /area/xenoarch/arch)
 "nd" = (
@@ -2749,12 +2605,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
-"ne" = (
-/obj/structure/flora/grass/jungle/b,
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/floor/grass,
-/area/lavaland/surface/outdoors)
 "nf" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -2809,19 +2659,16 @@
 /turf/open/floor/grass,
 /area/xenoarch/gen)
 "nw" = (
-/obj/structure/closet/secure_closet/medical3,
-/turf/open/floor/plasteel/white,
-/area/xenoarch/arch)
+/obj/structure/flora/grass/jungle/b,
+/turf/open/floor/grass,
+/area/lavaland/surface/outdoors)
 "nx" = (
 /obj/machinery/atmospherics/components/binary/volume_pump,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
+	},
+/obj/effect/turf_decal/lumos/tile/yellow/half{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
@@ -2836,9 +2683,6 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/airalarm{
-	pixel_y = 23
-	},
 /turf/open/floor/plasteel/white,
 /area/xenoarch/arch)
 "nE" = (
@@ -2852,13 +2696,10 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "nH" = (
-/obj/machinery/door/airlock/medical{
-	name = "Patient Room";
-	req_access_txt = "5"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/white,
-/area/xenoarch/arch)
+/obj/structure/flora/grass/jungle,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/grass,
+/area/lavaland/surface/outdoors)
 "nJ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -2989,13 +2830,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 6
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/machinery/meter,
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 8
 	},
-/obj/machinery/meter,
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "oO" = (
@@ -3055,10 +2893,11 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "pf" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
+/obj/machinery/conveyor{
+	id = "garbageL"
 	},
-/turf/open/floor/plasteel/white,
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
 /area/xenoarch/arch)
 "pg" = (
 /obj/structure/stone_tile/surrounding_tile,
@@ -3077,11 +2916,9 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "pl" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/xenoarch/gen)
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/grass,
+/area/lavaland/surface/outdoors)
 "pn" = (
 /obj/machinery/computer/atmos_control/tank/toxin_tank,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
@@ -3149,11 +2986,13 @@
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/sec)
 "pJ" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/grassybush,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
 	},
-/turf/open/water,
-/area/xenoarch/arch)
+/turf/open/floor/grass,
+/area/lavaland/surface/outdoors)
 "pM" = (
 /obj/structure/stone_tile/surrounding_tile,
 /obj/structure/stone_tile/surrounding_tile{
@@ -3322,20 +3161,16 @@
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/obj/machinery/meter,
+/obj/effect/turf_decal/lumos/tile/yellow/fullcorner{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/machinery/meter,
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "qu" = (
 /obj/machinery/power/smes/engineering,
 /obj/structure/cable{
-	icon_state = "0-8"
+	icon_state = "0-4"
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
@@ -3380,6 +3215,10 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/lumos/tile/purple/half,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel,
 /area/xenoarch/gen)
 "qH" = (
@@ -3436,9 +3275,6 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -3493,10 +3329,6 @@
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
-"rk" = (
-/obj/machinery/light/small,
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/xenoarch/arch)
 "rl" = (
 /obj/machinery/atmospherics/pipe/manifold/dark/hidden{
 	dir = 1
@@ -3539,11 +3371,6 @@
 /turf/open/floor/grass,
 /area/lavaland/surface/outdoors)
 "rw" = (
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "garbage"
-	},
-/obj/machinery/recycler,
 /obj/structure/sign/warning/securearea{
 	name = "\improper STAY CLEAR HEAVY MACHINERY";
 	pixel_y = 32
@@ -3551,12 +3378,10 @@
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
 "rB" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/medical{
-	id_tag = "xp1"
-	},
-/turf/open/floor/plasteel/white,
-/area/xenoarch/arch)
+/obj/structure/flora/grass/jungle,
+/obj/structure/flora/ausbushes/grassybush,
+/turf/open/floor/grass,
+/area/lavaland/surface/outdoors)
 "rC" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/tile/purple{
@@ -3614,10 +3439,9 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "rS" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/lumos/tile/yellow/fulltile,
+/obj/machinery/portable_atmospherics/scrubber/huge/movable,
+/turf/open/floor/plasteel,
 /area/xenoarch/gen)
 "rT" = (
 /obj/machinery/door/firedoor,
@@ -3631,12 +3455,17 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "rX" = (
-/obj/effect/turf_decal/lumos/tile/red/checker,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/arch)
+/obj/machinery/atmospherics/pipe/simple/supply/visible/layer1{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/eng)
 "rZ" = (
 /obj/machinery/power/compressor{
 	comp_id = "incineratorturbineL";
@@ -3727,7 +3556,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/research/glass,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -3751,12 +3579,17 @@
 /turf/open/floor/plasteel/elevatorshaft,
 /area/mining_level_access/lower)
 "sL" = (
-/obj/effect/turf_decal/lumos/tile/purple/half,
-/obj/structure/disposalpipe/junction{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/visible/layer1{
 	dir = 8
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
-/area/xenoarch/arch)
+/area/xenoarch/eng)
 "sP" = (
 /obj/machinery/firealarm{
 	pixel_y = 24
@@ -3798,18 +3631,15 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/yellow/half,
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "sZ" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/open/floor/carpet/red,
-/area/xenoarch/gen)
+/obj/structure/flora/grass/jungle/b,
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/grassybush,
+/turf/open/floor/grass,
+/area/lavaland/surface/outdoors)
 "tc" = (
 /obj/structure/stone_tile/cracked{
 	dir = 4
@@ -3851,15 +3681,10 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "tr" = (
-/obj/structure/window/reinforced,
-/obj/effect/turf_decal/lumos/tile/blue/checker{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/arch)
+/obj/structure/flora/tree/jungle/small,
+/obj/structure/flora/grass/jungle,
+/turf/open/floor/grass,
+/area/lavaland/surface/outdoors)
 "tv" = (
 /turf/open/floor/plasteel/stairs,
 /area/xenoarch/gen)
@@ -3868,10 +3693,12 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "ty" = (
-/obj/machinery/door/airlock{
-	id_tag = "dorm3L"
-	},
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/structure/table,
+/obj/item/holosign_creator/firelock,
+/obj/item/holosign_creator/atmos,
+/obj/machinery/light,
+/turf/open/floor/plasteel,
 /area/xenoarch/gen)
 "tB" = (
 /obj/machinery/suit_storage_unit/mining,
@@ -3932,13 +3759,10 @@
 /area/ruin/unpowered/ash_walkers)
 "tR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/light{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -3947,6 +3771,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/smartfridge/chemistry/preloaded,
 /turf/closed/wall,
 /area/xenoarch/arch)
 "tU" = (
@@ -3964,14 +3789,14 @@
 /obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 4
 	},
+/obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "uf" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/xenoarch/arch)
+/obj/structure/flora/grass/jungle,
+/obj/structure/flora/ausbushes/lavendergrass,
+/turf/open/floor/grass,
+/area/lavaland/surface/outdoors)
 "ug" = (
 /obj/structure/stone_tile/block{
 	dir = 8
@@ -3988,7 +3813,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/xenoarch/gen)
 "uj" = (
 /obj/structure/stone_tile/block/cracked{
@@ -4060,6 +3888,7 @@
 /obj/effect/turf_decal/lumos/tile/purple/fullcorner{
 	dir = 8
 	},
+/obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "uE" = (
@@ -4104,22 +3933,16 @@
 /turf/closed/wall/r_wall,
 /area/xenoarch/eng)
 "uU" = (
-/obj/effect/turf_decal/lumos/tile/purple/half,
-/obj/structure/disposalpipe/segment{
-	dir = 9
+/obj/machinery/status_display/evac{
+	layer = 4;
+	pixel_x = 32
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/stairs,
 /area/xenoarch/arch)
 "uX" = (
 /obj/structure/table,
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/gen)
-"vd" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/eng)
 "vf" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/research/glass,
@@ -4132,9 +3955,6 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "vg" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
 /obj/machinery/camera{
 	c_tag = "Xenoarchaeology Eight";
 	dir = 1
@@ -4159,6 +3979,10 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/door/airlock/research/glass,
+/obj/effect/turf_decal/lumos/tile/purple/checker{
+	dir = 4
+	},
+/obj/effect/turf_decal/lumos/tile/green/checker,
 /turf/open/floor/plasteel,
 /area/xenoarch/bot)
 "vn" = (
@@ -4278,6 +4102,9 @@
 /obj/effect/turf_decal/lumos/tile/red/fullcorner{
 	dir = 8
 	},
+/obj/item/kirbyplants{
+	icon_state = "plant-10"
+	},
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/sec)
 "wh" = (
@@ -4292,10 +4119,11 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "wi" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/item/relic,
-/turf/open/floor/plating,
+/obj/structure/flora/grass/jungle,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/grass,
 /area/xenoarch/arch)
 "wj" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
@@ -4312,6 +4140,9 @@
 	},
 /obj/machinery/light,
 /obj/effect/turf_decal/lumos/tile/red/half,
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/sec)
 "wp" = (
@@ -4340,6 +4171,9 @@
 /obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 8
 	},
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "wy" = (
@@ -4356,9 +4190,12 @@
 /area/lavaland/surface/outdoors)
 "wF" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 4
+	},
+/obj/machinery/status_display/evac{
+	layer = 4;
+	pixel_x = 32
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
@@ -4367,36 +4204,21 @@
 /obj/item/radio/off,
 /obj/item/crowbar,
 /obj/item/assembly/flash/handheld,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/sec)
-"wK" = (
-/obj/structure/flora/ausbushes/grassybush,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/grass,
-/area/xenoarch/arch)
 "wM" = (
 /obj/structure/flora/rock/jungle,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "wO" = (
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
-	},
-/obj/machinery/camera{
-	c_tag = "Xenoarchaeology Nine";
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/arch)
+/obj/structure/flora/grass/jungle/b,
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/grass,
+/area/lavaland/surface/outdoors)
 "wQ" = (
 /obj/structure/stone_tile/block,
 /obj/structure/stone_tile{
@@ -4412,9 +4234,12 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "xe" = (
-/obj/machinery/light/small,
-/turf/open/floor/plating,
-/area/xenoarch/gen)
+/obj/structure/flora/ausbushes/grassybush,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/grass,
+/area/xenoarch/arch)
 "xf" = (
 /obj/structure/stone_tile/block/cracked{
 	dir = 1
@@ -4433,17 +4258,13 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "xk" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/cell_charger,
+/obj/structure/table/reinforced,
 /turf/open/floor/plasteel/white,
 /area/xenoarch/arch)
 "xl" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/visible{
 	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
@@ -4458,10 +4279,6 @@
 /area/xenoarch/gen)
 "xx" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
 /obj/machinery/light{
 	dir = 4
 	},
@@ -4469,6 +4286,9 @@
 	dir = 8;
 	name = "Station Intercom (General)";
 	pixel_x = 28
+	},
+/obj/effect/turf_decal/lumos/tile/yellow/half{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
@@ -4523,14 +4343,8 @@
 /obj/machinery/computer/turbine_computer{
 	id = "incineratorturbineL"
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/fullcorner{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
@@ -4538,11 +4352,8 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
 /obj/machinery/light,
+/obj/effect/turf_decal/lumos/tile/yellow/half,
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "xI" = (
@@ -4552,7 +4363,6 @@
 /obj/structure/sign/poster/official/random{
 	pixel_x = 32
 	},
-/obj/effect/landmark/start/assistant,
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/gen)
 "xL" = (
@@ -4618,16 +4428,11 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "yk" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/effect/turf_decal/lumos/tile/blue/checker,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
 	},
-/obj/machinery/button/door{
-	id = "xp1";
-	normaldoorcontrol = 1;
-	pixel_x = -28;
-	specialfunctions = 4
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
 "yl" = (
 /obj/structure/stone_tile/cracked{
@@ -4670,11 +4475,14 @@
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/sec)
 "yu" = (
-/obj/machinery/quantumpad{
-	map_pad_id = "tostation";
-	map_pad_link_id = "toxenoarch"
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
 	},
-/obj/effect/turf_decal/lumos/tile/purple/fulltile,
+/obj/machinery/camera{
+	c_tag = "Xenoarchaeology Nine";
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
 "yv" = (
@@ -4743,10 +4551,10 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "yK" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 30
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "yL" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
@@ -4761,12 +4569,6 @@
 	},
 /turf/closed/indestructible/riveted/boss,
 /area/lavaland/surface/outdoors)
-"yO" = (
-/obj/machinery/door/airlock{
-	id_tag = "dorm1L"
-	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/gen)
 "yP" = (
 /obj/machinery/light/small,
 /turf/open/floor/engine/air,
@@ -4824,22 +4626,29 @@
 /turf/open/indestructible/boss,
 /area/lavaland/surface/outdoors)
 "zc" = (
-/obj/structure/closet/crate{
-	icon_state = "crateopen"
+/obj/structure/disposalpipe/trunk{
+	dir = 1
 	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel/dark,
+/obj/structure/disposaloutlet{
+	dir = 4
+	},
+/turf/open/floor/plating,
 /area/xenoarch/arch)
 "zd" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/medical/glass{
-	name = "Medbay"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
+	},
+/obj/machinery/door/airlock/medical/glass{
+	id_tag = "xemed";
+	name = "Medbay";
+	req_access_txt = "5"
+	},
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/xenoarch/arch)
@@ -4851,12 +4660,6 @@
 /obj/effect/turf_decal/lumos/tile/yellow/half,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
-"zh" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/grass,
-/area/xenoarch/arch)
 "zi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -4865,6 +4668,12 @@
 /area/xenoarch/arch)
 "zl" = (
 /obj/structure/window/reinforced,
+/obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
 "zn" = (
@@ -4879,12 +4688,11 @@
 /turf/open/floor/plating,
 /area/xenoarch/arch)
 "zr" = (
-/obj/structure/fans/tiny,
-/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/research/glass,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
+/obj/effect/turf_decal/lumos/tile/purple/fulltile,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "zu" = (
@@ -4897,18 +4705,13 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "zx" = (
-/obj/machinery/status_display/evac{
-	layer = 4;
-	pixel_x = -32
+/obj/machinery/autolathe,
+/obj/effect/turf_decal/lumos/tile/yellow/fulltile,
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
-/turf/open/floor/plasteel/white,
-/area/xenoarch/arch)
+/turf/open/floor/plasteel,
+/area/xenoarch/gen)
 "zB" = (
 /obj/structure/stone_tile{
 	dir = 1
@@ -4916,9 +4719,8 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "zC" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/turf/open/floor/plasteel/white,
-/area/xenoarch/arch)
+/turf/closed/wall/r_wall,
+/area/xenoarch/gen)
 "zH" = (
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 1
@@ -4965,6 +4767,9 @@
 "zR" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/sec)
@@ -5058,31 +4863,17 @@
 /area/ruin/unpowered/ash_walkers)
 "AG" = (
 /obj/structure/window/reinforced,
-/obj/effect/turf_decal/lumos/tile/blue/checker,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
 "AH" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/lumos/tile/blue/fulltile,
+/turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
 "AK" = (
-/obj/machinery/door/airlock/medical/glass{
-	id_tag = "xemed";
-	name = "Medbay";
-	req_access_txt = "5"
+/obj/effect/turf_decal/caution{
+	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 8
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "AN" = (
 /obj/structure/stone_tile/cracked,
@@ -5101,14 +4892,11 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/bot)
 "AT" = (
-/obj/effect/turf_decal/lumos/tile/blue/checker{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/arch)
+/turf/open/floor/plasteel,
+/area/xenoarch/gen)
 "AU" = (
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
@@ -5148,9 +4936,6 @@
 "Be" = (
 /obj/machinery/light,
 /obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
 /obj/effect/turf_decal/lumos/tile/purple/half,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
@@ -5187,15 +4972,11 @@
 /turf/open/indestructible/boss,
 /area/ruin/unpowered/ash_walkers)
 "Bl" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/effect/turf_decal/lumos/tile/red/checker,
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/xenoarch/arch)
+/area/xenoarch/gen)
 "Br" = (
 /obj/machinery/atmospherics/pipe/simple/dark/hidden{
 	dir = 6
@@ -5227,8 +5008,9 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "BD" = (
-/obj/structure/table,
-/obj/item/inducer,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "BF" = (
@@ -5278,11 +5060,11 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "Cb" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 1
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
 	},
-/turf/open/floor/plasteel/white,
-/area/xenoarch/arch)
+/turf/open/floor/plasteel/dark,
+/area/xenoarch/gen)
 "Ce" = (
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 4
@@ -5297,8 +5079,12 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "Cj" = (
-/obj/machinery/chem_master,
-/turf/open/floor/plasteel/white,
+/obj/structure/window/reinforced,
+/obj/effect/turf_decal/lumos/tile/blue/checker,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
 "Cp" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
@@ -5307,10 +5093,6 @@
 /obj/machinery/meter,
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
-"Cq" = (
-/obj/structure/flora/tree/jungle/small,
-/turf/open/floor/grass,
-/area/lavaland/surface/outdoors)
 "Ct" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/yellow{
@@ -5358,10 +5140,14 @@
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/gen)
 "CJ" = (
-/obj/machinery/light{
-	dir = 4
+/obj/machinery/camera{
+	c_tag = "Xenoarchaeology Four";
+	dir = 5
 	},
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/xenoarch/gen)
 "CK" = (
 /obj/item/reagent_containers/glass/bucket/wood,
@@ -5384,13 +5170,16 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "CR" = (
-/obj/structure/table,
-/obj/item/folder/white,
-/obj/item/clothing/neck/stethoscope,
-/obj/machinery/vending/wallmed{
-	pixel_y = 28
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/lumos/tile/purple/checker{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
 "CS" = (
 /obj/structure/well_foundation,
@@ -5416,15 +5205,11 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "CV" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/xenoarch/arch)
+/obj/structure/table,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/turf/open/floor/plasteel,
+/area/xenoarch/gen)
 "CX" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible/layer3{
 	dir = 10
@@ -5433,35 +5218,31 @@
 /area/xenoarch/eng)
 "CZ" = (
 /obj/machinery/light,
+/obj/machinery/disposal/bin,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 6
+	},
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
-/obj/machinery/disposal/bin,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel,
 /area/xenoarch/gen)
 "Db" = (
-/obj/structure/window/reinforced,
-/obj/effect/turf_decal/lumos/tile/purple/checker{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
+/obj/structure/closet/secure_closet/engineering_welding,
+/turf/open/floor/plasteel,
+/area/xenoarch/gen)
+"Dc" = (
+/obj/machinery/quantumpad{
+	map_pad_id = "tostation";
+	map_pad_link_id = "toxenoarch"
 	},
+/obj/effect/turf_decal/lumos/tile/purple/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
-"Dc" = (
-/obj/structure/rack,
-/obj/item/tank/internals/plasmaman,
-/obj/item/tank/internals/plasmaman,
-/obj/item/tank/internals/plasmaman,
-/obj/item/tank/internals/plasmaman,
-/turf/open/floor/plating,
-/area/xenoarch/arch)
 "Df" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
@@ -5475,10 +5256,7 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/yellow/half,
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "Dk" = (
@@ -5538,15 +5316,13 @@
 /turf/open/indestructible/boss,
 /area/ruin/unpowered/ash_walkers)
 "Dw" = (
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/effect/turf_decal/lumos/tile/yellow/fulltile,
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Engineering";
+	req_access_txt = "32"
 	},
-/obj/effect/turf_decal/lumos/tile/purple/checker,
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/arch)
+/turf/open/floor/plasteel,
+/area/xenoarch/eng)
 "Dy" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -5583,17 +5359,26 @@
 /turf/open/floor/plating,
 /area/xenoarch/eng)
 "DM" = (
-/turf/open/floor/plating,
-/area/xenoarch/gen)
+/obj/structure/window/reinforced,
+/obj/effect/turf_decal/lumos/tile/purple/checker{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/xenoarch/arch)
 "DN" = (
 /obj/structure/ore_box,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "DP" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4
+/obj/structure/window/reinforced,
+/obj/effect/turf_decal/lumos/tile/purple/checker,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
 "DR" = (
 /obj/structure/stone_tile/surrounding_tile{
@@ -5613,6 +5398,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/visible/layer1{
 	dir = 8
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "DW" = (
@@ -5628,15 +5416,14 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "DX" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/turf/open/floor/plasteel/white,
-/area/xenoarch/arch)
-"Ea" = (
-/obj/machinery/light/small,
-/turf/open/floor/grass,
+/obj/effect/turf_decal/lumos/tile/red/checker,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
 "Eb" = (
 /obj/structure/stone_tile/block{
@@ -5648,8 +5435,16 @@
 /turf/open/indestructible/boss,
 /area/lavaland/surface/outdoors)
 "Ec" = (
-/obj/structure/closet/cardboard,
-/turf/open/floor/plating,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/effect/turf_decal/lumos/tile/red/checker{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
 "Ef" = (
 /obj/machinery/door/firedoor,
@@ -5696,8 +5491,8 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/bot)
 "Eq" = (
-/obj/machinery/suit_storage_unit/mining,
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/lumos/tile/red/fulltile,
+/turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
 "EC" = (
 /obj/structure/stone_tile/block/cracked,
@@ -5716,9 +5511,6 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/sec)
 "EM" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -5727,6 +5519,9 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/sec)
@@ -5762,13 +5557,17 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "EW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall,
-/area/xenoarch/arch)
-"EX" = (
-/obj/machinery/light,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 10
+	},
 /turf/open/floor/plasteel,
+/area/xenoarch/gen)
+"EX" = (
+/obj/effect/turf_decal/lumos/tile/red/checker,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
 "EY" = (
 /obj/structure/stone_tile,
@@ -5780,14 +5579,6 @@
 	},
 /turf/open/indestructible/boss,
 /area/lavaland/surface/outdoors)
-"Fo" = (
-/obj/item/radio/intercom{
-	dir = 8;
-	name = "Station Intercom (General)";
-	pixel_x = -28
-	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/gen)
 "Fq" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
@@ -5813,6 +5604,7 @@
 	dir = 10
 	},
 /obj/effect/turf_decal/lumos/tile/purple/half,
+/obj/structure/table,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "Fy" = (
@@ -5863,6 +5655,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
 /turf/open/floor/plating,
 /area/xenoarch/arch)
 "FQ" = (
@@ -5897,22 +5692,14 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
-/obj/structure/sign/poster/official/random{
-	pixel_x = 32
-	},
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/gen)
 "FY" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/disposalpipe/segment{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/structure/table,
+/obj/item/pipe_dispenser,
 /turf/open/floor/plasteel,
-/area/xenoarch/arch)
+/area/xenoarch/gen)
 "FZ" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
@@ -5954,12 +5741,13 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "Gr" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
 /obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 8
 	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/structure/closet/emcloset/anchored,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "Gs" = (
@@ -5969,10 +5757,7 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/yellow/half,
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "Gu" = (
@@ -6071,11 +5856,8 @@
 /obj/machinery/atmospherics/components/binary/volume_pump{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
 /obj/machinery/light,
+/obj/effect/turf_decal/lumos/tile/yellow/half,
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "GN" = (
@@ -6093,11 +5875,9 @@
 /turf/open/indestructible/boss,
 /area/ruin/unpowered/ash_walkers)
 "GS" = (
-/obj/structure/dresser,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/carpet,
+/obj/machinery/vending/tool,
+/obj/effect/turf_decal/lumos/tile/yellow/fulltile,
+/turf/open/floor/plasteel,
 /area/xenoarch/gen)
 "GT" = (
 /obj/structure/stone_tile/block,
@@ -6119,25 +5899,24 @@
 /turf/open/floor/plating,
 /area/xenoarch/arch)
 "Ha" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/structure/table,
+/obj/item/inducer,
+/turf/open/floor/plasteel,
 /area/xenoarch/gen)
 "Hc" = (
 /obj/structure/stone_tile/block/cracked,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "He" = (
-/obj/item/kirbyplants{
-	icon_state = "plant-10"
+/obj/effect/turf_decal/lumos/tile/red/checker{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
 	},
 /turf/open/floor/plasteel/dark,
-/area/xenoarch/sec)
+/area/xenoarch/arch)
 "Hl" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -6145,8 +5924,12 @@
 /turf/open/floor/plating,
 /area/xenoarch/arch)
 "Ho" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
 /turf/open/floor/plasteel/white,
 /area/xenoarch/arch)
 "Hp" = (
@@ -6188,13 +5971,15 @@
 /area/xenoarch/arch)
 "Hu" = (
 /obj/machinery/atmospherics/pipe/simple/dark/visible,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/machinery/meter,
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 8
 	},
-/obj/machinery/meter,
+/obj/item/radio/intercom{
+	dir = 8;
+	name = "Station Intercom (General)";
+	pixel_x = -28
+	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "Hw" = (
@@ -6213,7 +5998,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/research/glass,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -6221,6 +6005,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
+/obj/effect/turf_decal/lumos/tile/purple/fulltile,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "HD" = (
@@ -6251,13 +6036,11 @@
 /area/xenoarch/arch)
 "HL" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/structure/cable/yellow,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
 /obj/structure/sign/poster/official/random{
 	pixel_x = 32
+	},
+/obj/effect/turf_decal/lumos/tile/yellow/half{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
@@ -6281,15 +6064,8 @@
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/gen)
 "HS" = (
-/obj/structure/chair/office/light{
-	dir = 8
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/effect/landmark/start/paramedic,
-/turf/open/floor/plasteel/white,
+/obj/machinery/light,
+/turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "Ia" = (
 /obj/structure/extinguisher_cabinet{
@@ -6424,11 +6200,14 @@
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/sec)
 "Iw" = (
-/obj/machinery/light{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
-/area/xenoarch/arch)
+/turf/open/floor/plasteel/dark,
+/area/xenoarch/gen)
 "Ix" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -6442,10 +6221,11 @@
 /turf/closed/mineral/random/high_chance/volcanic,
 /area/lavaland/surface/outdoors/unexplored)
 "IE" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/white,
-/area/xenoarch/arch)
+/obj/machinery/door/airlock{
+	id_tag = "dorm2L"
+	},
+/turf/open/floor/plasteel/dark,
+/area/xenoarch/gen)
 "IF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
@@ -6525,9 +6305,14 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "Jf" = (
-/obj/machinery/portable_atmospherics/canister/nitrogen,
-/turf/open/floor/plating,
-/area/xenoarch/arch)
+/obj/machinery/button/door{
+	id = "dorm1L";
+	normaldoorcontrol = 1;
+	pixel_y = 28;
+	specialfunctions = 4
+	},
+/turf/open/floor/carpet,
+/area/xenoarch/gen)
 "Jh" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
@@ -6579,6 +6364,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/xenoarch/gen)
 "JH" = (
@@ -6587,13 +6375,6 @@
 	},
 /turf/closed/indestructible/riveted/boss,
 /area/ruin/unpowered/ash_walkers)
-"JL" = (
-/obj/structure/flora/grass/jungle,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/grass,
-/area/xenoarch/arch)
 "JM" = (
 /turf/closed/mineral/random/volcanic,
 /area/lavaland/surface/outdoors/unexplored/danger)
@@ -6620,10 +6401,8 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "Kc" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/seeds,
-/turf/open/floor/plating,
-/area/xenoarch/arch)
+/turf/open/floor/carpet,
+/area/xenoarch/gen)
 "Kd" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
@@ -6643,15 +6422,12 @@
 /obj/machinery/atmospherics/pipe/simple/purple/visible/layer3{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
 /obj/machinery/camera{
 	c_tag = "Xenoarchaeology Thirteen";
 	dir = 5
+	},
+/obj/effect/turf_decal/lumos/tile/yellow/half{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
@@ -6662,8 +6438,9 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "Ki" = (
-/obj/structure/table,
-/obj/item/pipe_dispenser,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "Kj" = (
@@ -6708,10 +6485,9 @@
 /turf/closed/wall/r_wall,
 /area/xenoarch/eng)
 "Kz" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/obj/structure/bed,
+/obj/item/bedsheet/brown,
+/turf/open/floor/carpet,
 /area/xenoarch/gen)
 "KC" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible/layer3{
@@ -6751,9 +6527,8 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "KJ" = (
-/obj/machinery/atmospherics/components/trinary/filter/atmos/n2,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/n2{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
@@ -6805,13 +6580,20 @@
 /turf/open/floor/engine,
 /area/xenoarch/eng)
 "Lc" = (
-/turf/open/floor/carpet,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/xenoarch/gen)
 "Lg" = (
-/obj/structure/bed,
-/obj/item/bedsheet/medical,
-/turf/open/floor/plasteel/white,
-/area/xenoarch/arch)
+/obj/machinery/button/door{
+	id = "dorm2L";
+	normaldoorcontrol = 1;
+	pixel_y = 28;
+	specialfunctions = 4
+	},
+/turf/open/floor/carpet,
+/area/xenoarch/gen)
 "Lo" = (
 /obj/structure/chair/sofa/corp,
 /turf/open/floor/plasteel/dark,
@@ -6824,10 +6606,8 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/bot)
 "Ls" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/grass,
+/obj/machinery/telecomms/relay/preset/mining,
+/turf/open/floor/plating,
 /area/xenoarch/arch)
 "Lv" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
@@ -6879,6 +6659,9 @@
 	},
 /obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/gen)
@@ -7009,13 +6792,8 @@
 /area/xenoarch/arch)
 "MA" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 4
-	},
-/obj/machinery/status_display/evac{
-	layer = 4;
-	pixel_x = 32
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
@@ -7031,6 +6809,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "ML" = (
@@ -7043,13 +6824,6 @@
 	},
 /turf/open/floor/plating,
 /area/xenoarch/eng)
-"MO" = (
-/obj/structure/chair/sofa/corp/right{
-	dir = 4
-	},
-/obj/effect/landmark/start/assistant,
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/gen)
 "MU" = (
 /obj/structure/stone_tile/block{
 	dir = 8
@@ -7084,10 +6858,17 @@
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/gen)
 "Nc" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/effect/landmark/start/station_engineer,
-/turf/open/floor/plasteel,
-/area/xenoarch/eng)
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel/dark,
+/area/xenoarch/gen)
 "Ng" = (
 /obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 1
@@ -7114,17 +6895,14 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "Nn" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 10
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = 24
 	},
+/obj/effect/turf_decal/lumos/tile/yellow/half{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "Nq" = (
@@ -7154,12 +6932,8 @@
 /turf/open/lava/smooth/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "Nu" = (
-/obj/machinery/portable_atmospherics/scrubber/huge/movable,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
@@ -7192,9 +6966,6 @@
 /obj/machinery/atmospherics/pipe/layer_manifold{
 	layer = 2.47
 	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
 /turf/open/floor/plating,
 /area/xenoarch/eng)
 "NI" = (
@@ -7204,11 +6975,9 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "NK" = (
-/obj/machinery/newscaster{
-	pixel_x = -30
-	},
-/turf/open/floor/plasteel/white,
-/area/xenoarch/arch)
+/obj/structure/dresser,
+/turf/open/floor/carpet,
+/area/xenoarch/gen)
 "NL" = (
 /obj/machinery/air_sensor/atmos/nitrogen_tank,
 /turf/open/floor/engine/n2,
@@ -7244,6 +7013,9 @@
 /obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable/yellow,
 /obj/effect/turf_decal/lumos/tile/red/fullcorner,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/sec)
 "Ob" = (
@@ -7336,20 +7108,15 @@
 /turf/open/indestructible/boss,
 /area/ruin/unpowered/ash_walkers)
 "Ox" = (
-/obj/machinery/camera{
-	c_tag = "Xenoarchaeology Four";
-	dir = 5
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel,
 /area/xenoarch/gen)
 "OB" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 30
+	},
+/obj/effect/turf_decal/lumos/tile/yellow/half{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
@@ -7435,10 +7202,7 @@
 	pixel_y = 6
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/general/visible,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -7455,31 +7219,17 @@
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/gen)
 "Pc" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc/auto_name/east,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "Pd" = (
 /turf/open/lava/smooth/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"Pe" = (
-/obj/structure/rack,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/machinery/light/small,
-/turf/open/floor/plating,
-/area/xenoarch/arch)
 "Pk" = (
 /obj/structure/stone_tile/slab/cracked,
 /turf/open/indestructible/boss,
@@ -7503,30 +7253,17 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/gen)
-"Pu" = (
-/obj/machinery/door/airlock/medical/glass{
-	id_tag = null;
-	name = "Medbay";
-	req_access_txt = "5"
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
 	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/white,
-/area/xenoarch/arch)
+/turf/open/floor/plasteel,
+/area/xenoarch/gen)
 "PA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/xenoarch/arch)
-"PF" = (
-/obj/structure/flora/grass/jungle,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/grass,
 /area/xenoarch/arch)
 "PG" = (
 /obj/machinery/atmospherics/miner/toxins,
@@ -7536,8 +7273,6 @@
 /turf/open/floor/engine/plasma,
 /area/xenoarch/eng)
 "PJ" = (
-/obj/structure/fans/tiny,
-/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/research/glass,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plasteel,
@@ -7629,22 +7364,17 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
-"Qb" = (
-/obj/structure/ore_box,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/xenoarch/arch)
 "Qe" = (
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_y = 30
@@ -7671,31 +7401,13 @@
 /turf/open/floor/engine/n2,
 /area/xenoarch/eng)
 "Qo" = (
-/obj/structure/bed,
-/obj/item/bedsheet/brown,
-/obj/machinery/button/door{
-	id = "dorm1L";
-	normaldoorcontrol = 1;
-	pixel_y = 28;
-	specialfunctions = 4
-	},
-/turf/open/floor/carpet,
+/obj/machinery/vending/engivend,
+/obj/effect/turf_decal/lumos/tile/yellow/fulltile,
+/turf/open/floor/plasteel,
 /area/xenoarch/gen)
 "Qp" = (
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/summoning_altar)
-"Qs" = (
-/obj/structure/table/glass,
-/obj/machinery/reagentgrinder,
-/turf/open/floor/plasteel/white,
-/area/xenoarch/arch)
-"Qy" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 5
-	},
-/obj/effect/landmark/start/atmospheric_technician,
-/turf/open/floor/plasteel,
-/area/xenoarch/eng)
 "QA" = (
 /obj/structure/stone_tile/surrounding_tile/cracked,
 /obj/structure/stone_tile/center,
@@ -7733,9 +7445,6 @@
 /turf/open/floor/engine,
 /area/xenoarch/eng)
 "QM" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /obj/structure/closet/secure_closet/security_xenoarch,
 /obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 4
@@ -7781,17 +7490,6 @@
 	dir = 8
 	},
 /turf/open/lava/smooth/lava_land_surface,
-/area/lavaland/surface/outdoors)
-"Rb" = (
-/obj/machinery/mineral/stacking_machine{
-	input_dir = 1;
-	stack_amt = 10
-	},
-/turf/open/floor/plating,
-/area/xenoarch/arch)
-"Rd" = (
-/obj/structure/flora/grass/jungle/b,
-/turf/open/floor/grass,
 /area/lavaland/surface/outdoors)
 "Rh" = (
 /obj/structure/sign/poster/official/random{
@@ -7851,13 +7549,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/bot)
-"Ry" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/medical{
-	id_tag = "xp2"
-	},
-/turf/open/floor/plasteel/white,
-/area/xenoarch/arch)
 "RA" = (
 /obj/structure/stone_tile/block{
 	dir = 8
@@ -7886,17 +7577,14 @@
 /area/ruin/unpowered/ash_walkers)
 "RE" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/yellow/fullcorner,
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "RF" = (
-/turf/open/floor/carpet/red,
+/obj/machinery/door/airlock{
+	id_tag = "dorm1L"
+	},
+/turf/open/floor/plasteel/dark,
 /area/xenoarch/gen)
 "RJ" = (
 /obj/item/pickaxe,
@@ -7942,12 +7630,6 @@
 	},
 /turf/open/openspace,
 /area/mining_level_access/upper)
-"RV" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/xenoarch/arch)
 "RW" = (
 /obj/machinery/atmospherics/pipe/simple/dark/visible{
 	dir = 4
@@ -7964,15 +7646,12 @@
 /turf/closed/indestructible/riveted/boss,
 /area/ruin/unpowered/ash_walkers)
 "Si" = (
-/obj/structure/table,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
+/obj/effect/turf_decal/lumos/tile/yellow/fullcorner{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable{
+	icon_state = "0-2"
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
@@ -8021,14 +7700,6 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/xenoarch/arch)
-"Sz" = (
-/obj/structure/table/glass,
-/obj/item/storage/box/beakers{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/turf/open/floor/plasteel/white,
 /area/xenoarch/arch)
 "SA" = (
 /obj/effect/turf_decal/tile/purple{
@@ -8082,16 +7753,18 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "SQ" = (
 /obj/machinery/light,
+/obj/item/radio/intercom{
+	dir = 8;
+	name = "Station Intercom (General)";
+	pixel_x = -28
+	},
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/gen)
 "SS" = (
@@ -8156,7 +7829,6 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/item/strangerock,
 /obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 1
 	},
@@ -8171,9 +7843,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
-	},
-/obj/effect/turf_decal/caution{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
@@ -8222,13 +7891,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/sec)
-"Tz" = (
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "garbageL"
-	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/arch)
 "TD" = (
 /obj/structure/stone_tile/cracked,
 /obj/structure/stone_tile/block{
@@ -8238,32 +7900,11 @@
 /area/lavaland/surface/outdoors)
 "TH" = (
 /obj/structure/tank_dispenser/oxygen,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
-"TI" = (
-/obj/effect/turf_decal/lumos/tile/red/checker{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/arch)
-"TJ" = (
-/obj/structure/rack,
-/obj/item/clothing/mask/breath/vox,
-/obj/item/clothing/mask/breath/vox,
-/obj/item/clothing/mask/breath/vox,
-/obj/item/clothing/mask/breath/vox,
-/obj/machinery/light/small,
-/turf/open/floor/plating,
-/area/xenoarch/arch)
 "TP" = (
 /obj/structure/stone_tile/block/cracked{
 	dir = 4
@@ -8287,11 +7928,11 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "TR" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/effect/turf_decal/lumos/tile/purple/half,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/structure/closet/emcloset/anchored,
 /turf/open/floor/plasteel,
 /area/xenoarch/gen)
 "TT" = (
@@ -8313,6 +7954,10 @@
 "Ub" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
 /turf/open/floor/plasteel/white,
 /area/xenoarch/arch)
 "Ue" = (
@@ -8350,14 +7995,10 @@
 /turf/open/floor/plasteel/white,
 /area/xenoarch/arch)
 "Um" = (
-/obj/machinery/portable_atmospherics/scrubber/huge/movable,
-/obj/effect/turf_decal/tile/yellow{
+/obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/machinery/light{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -8383,9 +8024,8 @@
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/gen)
 "Uq" = (
-/obj/structure/flora/grass/jungle,
-/obj/structure/flora/ausbushes/grassybush,
-/turf/open/floor/grass,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "Ur" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
@@ -8431,11 +8071,6 @@
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"UJ" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/turf/open/floor/plasteel/white,
-/area/xenoarch/arch)
 "UK" = (
 /obj/machinery/hydroponics/soil,
 /obj/structure/stone_tile/block/cracked{
@@ -8489,14 +8124,13 @@
 /turf/open/indestructible/boss,
 /area/lavaland/surface/outdoors)
 "Va" = (
-/obj/structure/disposaloutlet{
-	dir = 4
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
+	},
+/obj/machinery/recycler,
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "garbageL"
 	},
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
@@ -8547,25 +8181,13 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "Vs" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 30
+/obj/machinery/light{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
-"Vt" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/reagent_dispensers/foamtank,
-/turf/open/floor/plating,
-/area/xenoarch/arch)
 "VA" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/floor/grass,
-/area/lavaland/surface/outdoors)
-"VF" = (
 /obj/structure/flora/grass/jungle,
-/obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/grass,
 /area/lavaland/surface/outdoors)
 "VG" = (
@@ -8585,10 +8207,6 @@
 "VN" = (
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors/unexplored/danger)
-"VO" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/engine,
-/area/xenoarch/arch)
 "Wa" = (
 /obj/machinery/door/poddoor/incinerator_atmos_main{
 	id = "atmos_incinerator_mainventL"
@@ -8601,13 +8219,6 @@
 	pixel_y = 23
 	},
 /turf/open/floor/plasteel/white,
-/area/xenoarch/arch)
-"Wp" = (
-/obj/machinery/conveyor/inverted{
-	dir = 5;
-	id = "garbageL"
-	},
-/turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
 "Wt" = (
 /obj/structure/stone_tile/block{
@@ -8665,6 +8276,12 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/lumos/tile/red/half{
+	dir = 4
+	},
+/obj/effect/turf_decal/lumos/tile/purple/half{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/xenoarch/sec)
 "WM" = (
@@ -8705,18 +8322,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/gen)
-"Xf" = (
-/obj/structure/flora/grass/jungle,
-/turf/open/floor/grass,
-/area/lavaland/surface/outdoors)
-"Xg" = (
-/obj/structure/rack,
-/obj/item/tank/internals/oxygen,
-/obj/item/tank/internals/oxygen,
-/obj/item/tank/internals/oxygen,
-/obj/item/tank/internals/oxygen,
-/turf/open/floor/plating,
-/area/xenoarch/arch)
 "Xh" = (
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
@@ -8793,21 +8398,11 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "XJ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /obj/structure/chair/sofa/corp/right{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/gen)
-"XO" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/airalarm{
-	pixel_y = 23
-	},
-/turf/open/floor/plasteel/white,
-/area/xenoarch/arch)
 "XT" = (
 /obj/structure/table,
 /obj/structure/sign/poster/official/random{
@@ -8830,7 +8425,11 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "garbageL"
+	},
+/turf/open/floor/plating,
 /area/xenoarch/arch)
 "Yj" = (
 /obj/machinery/firealarm{
@@ -8842,10 +8441,8 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "Ym" = (
-/obj/structure/flora/grass/jungle,
-/obj/structure/flora/ausbushes/lavendergrass,
-/turf/open/floor/grass,
-/area/lavaland/surface/outdoors)
+/turf/open/space/basic,
+/area/space)
 "Yp" = (
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
@@ -8966,10 +8563,7 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 9
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/yellow/half,
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "Za" = (
@@ -8994,10 +8588,7 @@
 /area/lavaland/surface/outdoors)
 "Zn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -9009,13 +8600,6 @@
 	},
 /turf/open/floor/plating,
 /area/xenoarch/sec)
-"Zq" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/gen)
 "Zy" = (
 /obj/machinery/atmospherics/components/binary/volume_pump/layer3{
 	dir = 1
@@ -9077,10 +8661,6 @@
 /obj/machinery/hydroponics/constructable,
 /turf/open/floor/plasteel,
 /area/xenoarch/bot)
-"ZS" = (
-/obj/machinery/smartfridge/chemistry/preloaded,
-/turf/closed/wall,
-/area/xenoarch/arch)
 "ZT" = (
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 8
@@ -11172,6 +10752,7 @@ tN
 tN
 tN
 tN
+yE
 tN
 tN
 tN
@@ -11401,8 +10982,7 @@ tN
 tN
 tN
 tN
-tN
-tN
+yE
 tN
 tN
 tN
@@ -11887,7 +11467,7 @@ tN
 tN
 tN
 tN
-tN
+yE
 tN
 tN
 tN
@@ -12673,7 +12253,7 @@ tN
 tN
 tN
 tN
-tN
+yE
 tN
 tN
 tN
@@ -13631,7 +13211,7 @@ tN
 tN
 tN
 tN
-tN
+yE
 tN
 tN
 tN
@@ -14376,7 +13956,7 @@ tN
 tN
 tN
 tN
-tN
+yE
 tN
 tN
 tN
@@ -15048,7 +14628,7 @@ tN
 tN
 tN
 tN
-tN
+yE
 tN
 tN
 tN
@@ -15803,6 +15383,7 @@ tN
 tN
 tN
 tN
+yE
 tN
 tN
 tN
@@ -15895,8 +15476,7 @@ tN
 tN
 tN
 tN
-tN
-tN
+yE
 tN
 tN
 tN
@@ -16277,7 +15857,7 @@ tN
 tN
 tN
 tN
-tN
+yE
 tN
 tN
 tN
@@ -17017,15 +16597,15 @@ tN
 tN
 tN
 tN
-BS
-BS
-BS
-BS
-BS
-BS
-BS
-BS
-BS
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
 tN
 tN
 tN
@@ -17274,15 +16854,15 @@ tN
 tN
 tN
 tN
-BS
-Qb
-la
-jn
-Oc
-jn
-jn
-Pe
-BS
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
 tN
 tN
 tN
@@ -17531,27 +17111,27 @@ tN
 tN
 tN
 tN
-BS
-la
-la
-jn
-BS
-Xg
-iS
-iS
-BS
-BS
-BS
-BS
-BS
-BS
-BS
-BS
-BS
-BS
-BS
-BS
-BS
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
 tN
 tN
 tN
@@ -17574,7 +17154,7 @@ tN
 tN
 tN
 tN
-tN
+yE
 tN
 tN
 tN
@@ -17788,27 +17368,27 @@ tN
 tN
 tN
 tN
-BS
-BS
-BS
-jn
-BS
-BS
-BS
-BS
-BS
-Eq
-KE
-KE
-nH
-KE
-yk
-KE
-rB
-zC
-zx
-Cb
-BS
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
 tN
 tN
 tN
@@ -17849,7 +17429,7 @@ tN
 tN
 tN
 tN
-tN
+yE
 tN
 tN
 tN
@@ -18045,27 +17625,27 @@ tN
 tN
 tN
 tN
-BS
-Qb
-la
-jn
-Oc
-jn
-jn
-TJ
-BS
-Eq
-KE
-pf
-BS
-CR
-dF
-Lg
-BS
-cv
-as
-KE
-BS
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
 tN
 tN
 tN
@@ -18194,6 +17774,7 @@ tN
 tN
 tN
 tN
+yE
 tN
 tN
 tN
@@ -18222,6 +17803,18 @@ tN
 tN
 tN
 tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+yE
 tN
 tN
 tN
@@ -18289,40 +17882,27 @@ tN
 tN
 tN
 tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-BS
-la
-la
-jn
-BS
-bj
-Jf
-Jf
-BS
-BS
-XO
-hX
-EW
-EW
-EW
-EW
-EW
-AH
-UJ
-ND
-BS
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
 tN
 tN
 tN
@@ -18559,27 +18139,27 @@ tN
 tN
 tN
 tN
-BS
-BS
-BS
-jn
-BS
-BS
-BS
-BS
-BS
-nw
-KE
-yK
-nH
-KE
-ih
-KE
-Ry
-KE
-as
-KE
-BS
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
 tN
 tN
 tN
@@ -18810,43 +18390,43 @@ tN
 tN
 tN
 tN
-BS
-BS
-BS
-BS
-BS
-BS
-BS
-Qb
-la
-jn
-Oc
-jn
-jn
-Pe
-BS
-nw
-KE
-DX
-BS
-CR
-HS
-Lg
-BS
-KE
-as
-KE
-BS
-BS
-BS
-BS
-BS
-BS
-BS
-BS
-BS
-BS
-BS
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
 tN
 tN
 tN
@@ -19068,50 +18648,50 @@ tN
 tN
 tN
 BS
-Od
-Ec
-BS
-hW
-wi
-BS
-la
-la
-jn
-BS
-Dc
-bc
-bc
-BS
-BS
-Pu
 BS
 BS
 BS
 BS
 BS
 BS
-AK
-CV
-AK
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
 BS
-lu
-vz
-tr
-Dw
-wO
-Db
-Bl
-vz
-TI
 BS
-Za
-Za
-Za
-Za
-Za
-Za
-Za
-Za
+BS
+BS
+BS
+BS
+BS
+BS
+BS
+BS
+BS
+QV
+QV
+QV
+QV
+QV
+QV
+QV
+QV
 tN
 tN
 tN
@@ -19325,50 +18905,50 @@ tN
 tN
 tN
 BS
-jn
-jn
-cZ
-jn
-jn
+Od
+bc
 BS
-BS
-BS
-jn
+bj
+bj
 BS
 BS
 BS
 BS
 BS
-iG
-KE
-RV
-gR
-NK
-KE
-hB
-IE
-KE
-as
-KE
 BS
+BS
+BS
+BS
+BS
+BS
+BS
+BS
+BS
+BS
+BS
+BS
+BS
+BS
+BS
+BS
+yk
 vz
-mq
 zl
 fd
 yu
-zl
-fd
-mY
+DM
+DX
 vz
+He
 BS
-DM
-DM
-DM
-DM
-DM
-DM
-DM
-Za
+QV
+QV
+QV
+QV
+QV
+QV
+QV
+QV
 tN
 tN
 tN
@@ -19582,9 +19162,9 @@ tN
 tN
 tN
 BS
+jn
+jn
 cZ
-BS
-BS
 jn
 jn
 lv
@@ -19608,24 +19188,24 @@ Jb
 Ho
 ND
 BS
-AT
 vz
+AH
 AG
-al
-vz
-fL
 dn
+Dc
+AG
+dn
+Eq
 vz
-rX
 BS
-pl
-DM
-DM
-DM
-DM
-DM
-DM
-Za
+QV
+QV
+QV
+QV
+QV
+QV
+QV
+QV
 tN
 tN
 tN
@@ -19839,8 +19419,8 @@ tN
 tN
 tN
 BS
-jn
-Kc
+cZ
+BS
 BS
 Ix
 CT
@@ -19866,23 +19446,23 @@ as
 KE
 BS
 ai
-AU
-AU
-AU
-AU
-AU
-AU
-AU
+vz
+Cj
+CR
+vz
+DP
+Ec
+vz
 EX
 BS
-DM
-DM
-DM
-DM
-DM
-DM
-DM
-Za
+QV
+QV
+QV
+QV
+QV
+QV
+QV
+QV
 tN
 tN
 tN
@@ -20115,7 +19695,7 @@ KE
 KE
 BS
 BS
-ZS
+BS
 BS
 BS
 fX
@@ -20123,23 +19703,23 @@ as
 OM
 BS
 Vs
+AK
 AU
 AU
+AK
 AU
 AU
-AU
-AU
-AU
-AU
+AK
+HS
 BS
-DM
-DM
-DM
-DM
-DM
-DM
-DM
-Za
+QV
+QV
+QV
+QV
+QV
+QV
+QV
+QV
 tN
 tN
 tN
@@ -20176,7 +19756,7 @@ tN
 tN
 tN
 tN
-tN
+yE
 tN
 tN
 tN
@@ -20367,13 +19947,13 @@ Id
 CT
 jn
 BS
-KE
+eo
 KE
 KE
 cB
-Qs
-Iw
-bB
+KE
+KE
+KE
 BS
 Wc
 yL
@@ -20389,14 +19969,14 @@ AU
 AU
 AU
 BS
-DM
-DM
-DM
-DM
-DM
-DM
-DM
-Za
+QV
+QV
+QV
+QV
+QV
+QV
+QV
+QV
 tN
 tN
 tN
@@ -20629,14 +20209,14 @@ ki
 KE
 KE
 KE
-jV
-dh
+KE
+KE
 BS
 NT
 as
 HK
 BS
-AU
+yK
 AU
 AU
 wW
@@ -20646,14 +20226,14 @@ AU
 AU
 AU
 BS
-DM
-DM
-DM
-DM
-DM
-DM
-xe
-Za
+QV
+QV
+QV
+QV
+QV
+QV
+QV
+QV
 tN
 tN
 tN
@@ -20863,8 +20443,8 @@ tN
 tN
 tN
 tN
-BS
-BS
+aA
+aA
 BS
 BS
 BS
@@ -20873,10 +20453,10 @@ BS
 jn
 CT
 sP
-He
 qi
 qi
-He
+qi
+qi
 iT
 CT
 jn
@@ -20885,9 +20465,9 @@ PO
 Ub
 KE
 hH
-Sz
 KE
-Cj
+KE
+KE
 BS
 Mv
 as
@@ -20903,14 +20483,14 @@ sa
 JR
 JX
 BS
-DM
-DM
-DM
-DM
-DM
-DM
-DM
-Za
+QV
+QV
+QV
+QV
+QV
+QV
+QV
+QV
 tN
 tN
 tN
@@ -21120,9 +20700,9 @@ tN
 tN
 tN
 tN
+aA
+aA
 BS
-hR
-hR
 hR
 mI
 Od
@@ -21142,13 +20722,13 @@ BS
 BS
 oR
 tT
-eb
+aw
 FO
 ay
 BS
-BS
+pU
 zd
-BS
+pU
 BS
 BS
 BS
@@ -21164,18 +20744,18 @@ Za
 Za
 Za
 Za
-iC
 Za
 Za
 Za
 Za
 Za
-Za
-Za
-Za
-Za
-Za
-Za
+QV
+QV
+QV
+QV
+QV
+QV
+QV
 tN
 tN
 tN
@@ -21212,6 +20792,7 @@ tN
 tN
 tN
 tN
+yE
 tN
 tN
 tN
@@ -21376,10 +20957,9 @@ tN
 tN
 tN
 tN
-tN
+aA
+aA
 BS
-vO
-vO
 vO
 mI
 jn
@@ -21399,13 +20979,13 @@ bQ
 Sy
 LM
 wu
-kI
 My
+lu
 mb
 Nh
 My
 ec
-eo
+lT
 Sy
 My
 Rh
@@ -21426,13 +21006,13 @@ st
 Hw
 Do
 Za
-DM
-DM
-DM
-DM
-DM
-DM
-Za
+QV
+QV
+QV
+QV
+QV
+QV
+QV
 tN
 tN
 tN
@@ -21634,9 +21214,9 @@ tN
 tN
 tN
 tN
+aA
+aA
 BS
-Vt
-WM
 WM
 mI
 jn
@@ -21656,8 +21236,8 @@ id
 Un
 IL
 Dk
-FY
-Je
+Un
+lP
 ma
 Je
 Je
@@ -21683,13 +21263,13 @@ Fv
 aH
 CD
 Za
-pl
-DM
-DM
-DM
-DM
-DM
-Za
+QV
+QV
+QV
+QV
+QV
+QV
+QV
 tN
 tN
 tN
@@ -21824,6 +21404,7 @@ tN
 tN
 tN
 tN
+yE
 tN
 tN
 tN
@@ -21890,12 +21471,11 @@ tN
 tN
 tN
 tN
-tN
+aA
+aA
 BS
 Hl
-Hl
-Hl
-jn
+aU
 jn
 GY
 jn
@@ -21919,7 +21499,7 @@ OW
 bI
 ia
 ia
-lT
+uU
 Ka
 mp
 ia
@@ -21940,13 +21520,13 @@ sB
 co
 st
 Za
-DM
-DM
-DM
-DM
-DM
-DM
-Za
+QV
+QV
+QV
+QV
+QV
+QV
+QV
 tN
 tN
 tN
@@ -22148,9 +21728,9 @@ tN
 tN
 tN
 tN
+aA
+aA
 BS
-jn
-jn
 jn
 jn
 jn
@@ -22179,12 +21759,12 @@ BS
 BS
 BS
 BS
-VO
-VO
-VO
-VO
-VO
-VO
+pU
+pU
+pU
+pU
+pU
+pU
 BS
 BS
 BS
@@ -22197,13 +21777,13 @@ HQ
 co
 FT
 Za
-DM
-DM
-DM
-DM
-DM
-DM
-Za
+QV
+QV
+QV
+QV
+QV
+QV
+QV
 tN
 tN
 tN
@@ -22405,9 +21985,9 @@ tN
 tN
 tN
 tN
+aA
+aA
 BS
-jn
-jn
 jn
 jn
 jn
@@ -22418,19 +21998,19 @@ Xh
 Ik
 EM
 zR
-qi
+bE
 wk
 CT
 SZ
-UN
-HP
-BS
+dF
+fa
+qI
 zc
-zc
-zc
-zc
-zc
-zc
+vz
+vz
+vz
+vz
+vz
 BS
 tN
 tN
@@ -22453,14 +22033,14 @@ Za
 rr
 co
 st
-iC
-DM
-DM
-DM
-DM
-DM
-DM
 Za
+QV
+QV
+QV
+QV
+QV
+QV
+QV
 tN
 tN
 tN
@@ -22569,6 +22149,7 @@ tN
 tN
 tN
 tN
+yE
 tN
 tN
 tN
@@ -22661,10 +22242,9 @@ tN
 tN
 tN
 tN
-tN
+aA
+aA
 BS
-jn
-jn
 eu
 jn
 dt
@@ -22683,12 +22263,12 @@ UN
 HP
 BS
 Yh
-vz
-vz
-vz
-vz
-Iz
-BS
+jV
+jV
+jV
+jV
+jV
+pf
 Pd
 tN
 Pd
@@ -22711,13 +22291,13 @@ HQ
 co
 st
 Za
-DM
-DM
-DM
-DM
-DM
-xe
-Za
+QV
+QV
+QV
+QV
+QV
+QV
+QV
 tN
 tN
 tN
@@ -22919,9 +22499,9 @@ tN
 tN
 tN
 tN
+aA
+aA
 BS
-jn
-QD
 jL
 QD
 jn
@@ -22939,13 +22519,13 @@ Yj
 UN
 HP
 BS
+iC
+kI
 Qf
 Qf
 Qf
 Qf
-Qf
-Qf
-BS
+vz
 Pd
 Pd
 Pd
@@ -22968,13 +22548,13 @@ kW
 co
 st
 Za
-DM
-DM
-DM
-DM
-DM
-DM
-Za
+QV
+QV
+QV
+QV
+QV
+QV
+QV
 tN
 tN
 tN
@@ -23176,9 +22756,9 @@ tN
 tN
 tN
 tN
+aA
+aA
 BS
-KZ
-KZ
 QW
 KZ
 KZ
@@ -23195,10 +22775,10 @@ BS
 nd
 OH
 Be
-qI
+BS
 Va
-Wp
-sf
+Uh
+Uh
 sf
 sf
 sf
@@ -23225,13 +22805,13 @@ HQ
 co
 eA
 Za
-Za
-Za
-Za
-Za
-Za
-Za
-Za
+QV
+QV
+QV
+QV
+QV
+QV
+QV
 tN
 tN
 tN
@@ -23433,8 +23013,8 @@ tN
 tN
 tN
 tN
-BS
-BS
+aA
+aA
 BS
 BS
 BS
@@ -23454,8 +23034,8 @@ UN
 vg
 BS
 bb
-FD
-BS
+la
+lm
 pU
 BS
 pU
@@ -23703,14 +23283,14 @@ YX
 AU
 AU
 AU
-DP
+AU
 HP
 BS
 Ng
-lP
-sL
+gQ
+HP
 BS
-Tz
+vz
 FD
 Ig
 pC
@@ -23959,13 +23539,13 @@ ae
 bt
 JR
 JR
-JR
+bB
 aR
 bk
 bp
 bs
 bv
-uU
+HP
 BS
 rw
 FD
@@ -24216,8 +23796,8 @@ BS
 KG
 bP
 AU
+bC
 AU
-aU
 ZF
 BS
 Ng
@@ -24226,7 +23806,7 @@ XI
 BS
 fH
 PQ
-Rb
+jn
 SB
 vz
 Iz
@@ -24288,7 +23868,7 @@ tN
 tN
 tN
 tN
-tN
+yE
 tN
 tN
 tN
@@ -24731,7 +24311,7 @@ ag
 AU
 AU
 AU
-AU
+kC
 Fw
 LB
 hw
@@ -24988,7 +24568,7 @@ ah
 ap
 aB
 ia
-ia
+bG
 mc
 BS
 Xr
@@ -26803,12 +26383,12 @@ Ge
 jK
 Hq
 NH
-by
+xl
 xl
 bA
 Wu
-bC
-bJ
+FB
+FB
 HF
 fl
 DJ
@@ -27059,13 +26639,13 @@ ym
 Ge
 TH
 IF
-vd
+FB
 QH
 Jc
 qu
 FZ
-bE
-bK
+FB
+sc
 RQ
 ib
 lH
@@ -27315,14 +26895,14 @@ eV
 kx
 Ge
 Um
-IF
-vd
+rX
 Ki
-bz
+Ki
+Ki
 BD
 yR
-bG
-bL
+FB
+yR
 HF
 xH
 Ge
@@ -27482,7 +27062,7 @@ tN
 tN
 tN
 tN
-tN
+yE
 tN
 tN
 tN
@@ -27572,13 +27152,13 @@ eV
 im
 Ge
 Nu
-IF
-lm
-Qy
+sL
+FB
+FB
 sc
-Nc
+lw
 Ue
-bH
+lw
 bM
 Mi
 ct
@@ -27781,7 +27361,7 @@ tN
 tN
 tN
 tN
-tN
+yE
 tN
 tN
 tN
@@ -27820,7 +27400,7 @@ BS
 BS
 uD
 Ht
-mc
+gR
 hs
 pc
 cf
@@ -27831,7 +27411,7 @@ Ge
 aE
 DS
 KJ
-Ue
+lw
 BC
 lw
 tx
@@ -28334,7 +27914,7 @@ zg
 BS
 Gr
 gN
-LM
+hB
 hs
 hs
 hs
@@ -28350,7 +27930,7 @@ Ge
 Ge
 Ge
 Ge
-Ge
+Dw
 Ge
 Ge
 Ge
@@ -28602,16 +28182,16 @@ ML
 sw
 qN
 qX
-Pn
+Ge
 GS
 Lc
-Za
-GS
+CJ
 Lc
-Za
-GS
 Lc
-Za
+Lc
+Lc
+EW
+zC
 Uz
 sE
 GC
@@ -28622,13 +28202,13 @@ HQ
 co
 st
 Za
-Za
-Za
-Za
-Za
-Za
-Za
-Za
+QV
+QV
+QV
+QV
+QV
+QV
+QV
 tN
 tN
 tN
@@ -28859,16 +28439,16 @@ Pn
 Pn
 Ze
 ps
-Pn
+Ge
 Qo
-Lc
-Za
-ba
-Lc
-Za
-ch
-Lc
-Za
+Ox
+Ox
+Ox
+Ox
+Ox
+Ox
+FY
+zC
 xL
 KT
 KT
@@ -28879,13 +28459,13 @@ rr
 co
 xo
 Za
-DM
-DM
-DM
-DM
-DM
-DM
-Za
+QV
+QV
+QV
+QV
+QV
+QV
+QV
 tN
 tN
 tN
@@ -28961,6 +28541,7 @@ tN
 tN
 tN
 tN
+yE
 tN
 tN
 tN
@@ -28995,6 +28576,7 @@ tN
 tN
 tN
 tN
+yE
 tN
 tN
 tN
@@ -29096,36 +28678,34 @@ tN
 tN
 tN
 tN
-tN
-tN
-tN
-tN
-tN
-SG
-SG
-SG
-jR
-Tg
-vi
-SG
-vi
-SG
-Tg
-tN
-tN
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
 Pn
 Pn
 en
-Pn
-Za
-yO
-Za
-Za
+Ge
+zx
+Ox
+Ox
+CV
 fs
-Za
-Za
+Ox
+Ox
 ty
-Za
+zC
 xL
 KT
 KT
@@ -29136,13 +28716,13 @@ Mf
 co
 st
 Za
-DM
-DM
-DM
-DM
-DM
-DM
-Za
+QV
+QV
+QV
+QV
+QV
+QV
+QV
 tN
 tN
 tN
@@ -29355,34 +28935,34 @@ tN
 tN
 tN
 tN
-tN
-tN
-SG
-SG
-Cq
-vi
-Yp
-Yp
-SG
-SG
-SG
-Cq
-SG
-vi
-SG
-tN
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
 Pn
 en
-Pn
+Ge
 rS
-sB
-sB
 Ox
-sB
-Fo
-sB
-sB
-Za
+Ox
+Ox
+Ox
+Ox
+Ox
+Ha
+zC
 xL
 KT
 KT
@@ -29392,316 +28972,19 @@ Za
 HQ
 co
 st
-iC
-DM
-DM
-DM
-DM
-DM
-DM
 Za
+QV
+QV
+QV
+QV
+QV
+QV
+QV
 tN
 tN
 tN
 "}
 (80,1,1) = {"
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-Xf
-SG
-SG
-Tg
-Yp
-Yp
-SG
-SG
-SG
-Tg
-SG
-vi
-SG
-tN
-Pn
-en
-Pn
-ja
-sB
-dV
-sB
-Po
-ui
-ix
-CZ
-Za
-qb
-qg
-qg
-qg
-LN
-Za
-HQ
-co
-st
-Za
-DM
-DM
-DM
-DM
-DM
-DM
-Za
-tN
-tN
-tN
-"}
-(81,1,1) = {"
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
 tN
 tN
 tN
@@ -29870,33 +29153,330 @@ tN
 tN
 tN
 tN
-SG
-SG
-BS
-zh
-Yp
-Yp
-Yp
-Ea
-BS
-Xf
-SG
-SG
-SG
-Cq
 tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Pn
+en
+Ge
+ja
+AT
+dV
+Db
+Po
+ui
+ix
+CZ
+zC
+qb
+qg
+qg
+qg
+LN
+Za
+HQ
+co
+st
+Za
+QV
+QV
+QV
+QV
+QV
+QV
+QV
+tN
+tN
+tN
+"}
+(81,1,1) = {"
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+yE
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+yE
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
 Pn
 ql
-Pn
-Za
-Za
-Za
-Za
+Ge
+zC
+zC
+zC
+zC
 je
-Ha
-Za
-Za
-Za
+Up
+zC
+zC
+zC
 Za
 Mk
 Mk
@@ -29907,13 +29487,13 @@ Nq
 co
 st
 Za
-DM
-DM
-DM
-DM
-DM
-DM
-Za
+QV
+QV
+QV
+QV
+QV
+QV
+QV
 tN
 tN
 tN
@@ -30126,22 +29706,22 @@ tN
 tN
 tN
 tN
-tN
-SG
-jn
-jn
-jn
-Yp
-Yp
-Yp
-Yp
-Yp
-Yp
-Xf
-SG
-vi
-Tg
-tN
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
 Pn
 ka
 Pn
@@ -30164,13 +29744,13 @@ HQ
 co
 st
 Za
-Za
-Za
-Za
-Za
-Za
-Za
-Za
+QV
+QV
+QV
+QV
+QV
+QV
+QV
 tN
 tN
 tN
@@ -30383,27 +29963,27 @@ tN
 tN
 tN
 tN
-tN
-Xf
-jn
-mW
-jn
-Yp
-Yp
-Yp
-Yp
-Yp
-Yp
-Yp
-Yp
-Yp
-Xf
-SG
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
 nJ
 JG
 qG
 nJ
-sB
+Bl
 sB
 tv
 Ro
@@ -30640,22 +30220,22 @@ tN
 tN
 tN
 tN
-tN
-Tg
-jn
-jn
-jn
-Yp
-Yp
-Yp
-Yp
-Yp
-Yp
-Yp
-Yp
-Yp
-Yp
-hF
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
 PJ
 qH
 aT
@@ -30673,7 +30253,7 @@ oI
 oI
 NQ
 my
-If
+Nc
 If
 Df
 FW
@@ -30897,27 +30477,27 @@ tN
 tN
 tN
 tN
-tN
-SG
-SG
-BS
-zh
-Yp
-Yp
-Yp
-rk
-BS
-FU
-FU
-Yp
-Yp
-Xf
-cN
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
 nJ
 LH
 TR
 nJ
-sB
+Cb
 sB
 ji
 fP
@@ -31018,6 +30598,7 @@ tN
 tN
 tN
 tN
+yE
 tN
 tN
 tN
@@ -31153,23 +30734,22 @@ tN
 tN
 tN
 tN
-tN
-tN
-SG
-Cq
-SG
-VA
-Yp
-Yp
-Yp
-FU
-FU
-FU
-FU
-Yp
-Yp
-Yp
-SG
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
 Za
 Za
 Za
@@ -31180,18 +30760,18 @@ Za
 Za
 Za
 Ob
-MO
+XJ
 sl
 sB
 sB
 SQ
 Za
-sB
-sB
-Kz
-sB
-sB
+Jf
+NK
 Za
+QV
+QV
+QV
 QV
 QV
 QV
@@ -31411,25 +30991,25 @@ tN
 tN
 tN
 tN
-tN
-vi
-SG
-vi
-Xf
-Yp
-Yp
-Yp
-FU
-FU
-FU
-FU
-FU
-Yp
-Yp
-SG
-tN
-tN
-tN
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
 Za
 Za
 Za
@@ -31439,16 +31019,16 @@ Za
 Nx
 uX
 sl
-RF
-RF
-RF
-RF
-RF
 sB
 sB
 sB
-sB
+RF
+Kc
+Kc
 Za
+QV
+QV
+QV
 QV
 QV
 QV
@@ -31668,44 +31248,44 @@ tN
 tN
 tN
 tN
-tN
-tN
-Tg
-SG
-Tg
-Yp
-Yp
-Yp
-FU
-FU
-FU
-FU
-FU
-Yp
-Yp
-Xf
-tN
-tN
-tN
-tN
-tN
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
 tN
 tN
 tN
 Za
 YT
 WT
-sl
-RF
-RF
-RF
-RF
-RF
-sB
+Iw
 sB
 sB
 sB
 Za
+Kz
+Kc
+Za
+QV
+QV
+QV
 QV
 QV
 QV
@@ -31927,25 +31507,25 @@ tN
 tN
 tN
 tN
+tN
 SG
-BS
-jv
-Yp
-Yp
-Yp
-fa
-BS
-FU
-FU
-FU
-BS
-Xf
+SG
+dh
+eb
+hE
+vi
+SG
+vi
+SG
 Tg
-cn
-BS
 tN
 tN
-tN
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
 tN
 tN
 tN
@@ -31953,16 +31533,16 @@ Za
 Ob
 XJ
 gZ
-sZ
-RF
-RF
-RF
-RF
 sB
 sB
 sB
-Zq
 Za
+Za
+Za
+Za
+QV
+QV
+QV
 QV
 QV
 QV
@@ -32186,23 +31766,23 @@ tN
 tN
 SG
 SG
+bH
+vi
+Yp
+Yp
 SG
-Yp
-Yp
-Yp
-Yp
-pJ
-FU
-FU
-FU
-uf
-Rd
 SG
-bg
-JL
-Tg
+SG
+bH
+SG
+vi
+SG
 tN
-tN
+Ym
+Ym
+Ym
+Ym
+Ym
 tN
 tN
 tN
@@ -32210,16 +31790,16 @@ Za
 bx
 uX
 sB
-RF
-RF
-RF
-RF
-RF
-sB
 sB
 sB
 sB
 Za
+Lg
+NK
+Za
+QV
+QV
+QV
 tN
 tN
 tN
@@ -32442,24 +32022,24 @@ tN
 tN
 tN
 VA
-Xf
+SG
+SG
+Tg
+Yp
+Yp
+SG
+SG
+SG
 Tg
 SG
-Yp
-Yp
-Yp
-Yp
-Yp
-Yp
-Yp
-Yp
-VF
-Xf
-Rd
-ne
 vi
+SG
 tN
-tN
+Ym
+Ym
+Ym
+Ym
+Ym
 tN
 tN
 tN
@@ -32470,13 +32050,13 @@ Ks
 mQ
 sB
 sB
+IE
+Kc
+Kc
 Za
-sB
-sB
-CJ
-sB
-sB
-Za
+QV
+QV
+QV
 tN
 tN
 tN
@@ -32697,26 +32277,26 @@ tN
 tN
 tN
 tN
-tN
 SG
 SG
-SG
-Xf
+BS
+bL
 Yp
 Yp
 Yp
-Yp
-Yp
-Yp
-Yp
-Yp
-Yp
-Tg
-vi
-Tg
+hW
+BS
 VA
-VA
+SG
+SG
+SG
+bH
 tN
+Ym
+Ym
+Ym
+Ym
+Ym
 tN
 tN
 tN
@@ -32728,12 +32308,12 @@ Za
 CI
 Dt
 Za
+Kz
+Kc
 Za
-Za
-Za
-Za
-Za
-Za
+QV
+QV
+QV
 tN
 tN
 tN
@@ -32864,6 +32444,7 @@ tN
 tN
 tN
 tN
+yE
 tN
 tN
 tN
@@ -32953,27 +32534,26 @@ tN
 tN
 tN
 tN
-tN
-tN
-tN
+SG
+jn
+jn
+jn
+Yp
+Yp
+Yp
+Yp
+Yp
+Yp
+VA
+SG
+vi
 Tg
-VA
-SG
-SG
-Yp
-Yp
-Yp
-Yp
-Yp
-Yp
-Yp
-Yp
-ru
-VA
+tN
 Ym
-Xf
-Tg
-tN
+Ym
+Ym
+Ym
+Ym
 tN
 tN
 tN
@@ -32985,9 +32565,9 @@ oX
 oX
 oX
 oX
-tN
-tN
-tN
+oX
+oX
+oX
 tN
 tN
 tN
@@ -33211,26 +32791,26 @@ tN
 tN
 tN
 tN
-tN
-tN
+VA
+jn
 Ls
-SG
-SG
-Tg
-VA
-Tg
-PF
-SG
-FU
+jn
 Yp
-hE
+Yp
+Yp
+Yp
+Yp
+Yp
+Yp
+Yp
 Yp
 VA
+pl
 Ym
-wK
-tN
-vi
-tN
+Ym
+Ym
+Ym
+Ym
 tN
 tN
 tN
@@ -33468,26 +33048,26 @@ tN
 tN
 tN
 tN
-tN
-tN
-BS
-zh
-SG
-SG
-Cq
-SG
-BS
-VA
-FU
-FU
-BS
-FU
-Uq
 Tg
-BS
-tN
-tN
-tN
+jn
+jn
+jn
+Yp
+Yp
+Yp
+Yp
+Yp
+Yp
+Yp
+Yp
+Yp
+Yp
+Uq
+Ym
+Ym
+Ym
+Ym
+Ym
 tN
 tN
 tN
@@ -33725,26 +33305,26 @@ tN
 tN
 tN
 tN
-tN
-tN
-tN
-Xf
-Tg
 SG
+SG
+BS
+bL
+Yp
+Yp
+Yp
+hX
+BS
+FU
+FU
+Yp
+Yp
 VA
-Tg
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
+pJ
+Ym
+Ym
+Ym
+Ym
+Ym
 tN
 tN
 tN
@@ -33982,26 +33562,26 @@ tN
 tN
 tN
 tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
+SG
+bH
+SG
+bJ
+Yp
+Yp
+Yp
+FU
+FU
+FU
+FU
+Yp
+Yp
+Yp
+SG
+Ym
+Ym
+Ym
+Ym
+Ym
 tN
 tN
 tN
@@ -34239,26 +33819,26 @@ tN
 tN
 tN
 tN
+vi
+SG
+vi
+VA
+Yp
+Yp
+Yp
+FU
+FU
+FU
+FU
+FU
+Yp
+Yp
+SG
 tN
 tN
 tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
+Ym
+Ym
 tN
 tN
 tN
@@ -34497,20 +34077,20 @@ tN
 tN
 tN
 tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
+Tg
+SG
+Tg
+Yp
+Yp
+Yp
+FU
+FU
+FU
+FU
+FU
+Yp
+Yp
+VA
 tN
 tN
 tN
@@ -34754,22 +34334,22 @@ tN
 tN
 tN
 tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
+SG
+BS
+cv
+Yp
+Yp
+Yp
+ih
+BS
+FU
+FU
+FU
+BS
+VA
+Tg
+sZ
+BS
 tN
 tN
 tN
@@ -35011,23 +34591,23 @@ tN
 tN
 tN
 tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
+SG
+SG
+SG
+Yp
+Yp
+Yp
+Yp
+iS
+FU
+FU
+FU
+mq
+nw
+SG
+tr
+wi
+Tg
 tN
 tN
 tN
@@ -35268,23 +34848,23 @@ tN
 tN
 tN
 tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
+bJ
+VA
+Tg
+SG
+Yp
+Yp
+Yp
+Yp
+Yp
+Yp
+Yp
+Yp
+nH
+VA
+nw
+wO
+vi
 tN
 tN
 tN
@@ -35510,6 +35090,7 @@ tN
 tN
 tN
 tN
+yE
 tN
 tN
 tN
@@ -35524,25 +35105,24 @@ tN
 tN
 tN
 tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
+SG
+SG
+SG
+VA
+Yp
+Yp
+Yp
+Yp
+Yp
+Yp
+Yp
+Yp
+Yp
+Tg
+vi
+Tg
+bJ
+bJ
 tN
 tN
 tN
@@ -35783,23 +35363,23 @@ tN
 tN
 tN
 tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
+Tg
+bJ
+SG
+SG
+Yp
+Yp
+Yp
+Yp
+Yp
+Yp
+Yp
+Yp
+ru
+bJ
+uf
+VA
+Tg
 tN
 tN
 tN
@@ -36040,23 +35620,23 @@ tN
 tN
 tN
 tN
+bK
+SG
+SG
+Tg
+bJ
+Tg
+jv
+SG
+FU
+Yp
+mY
+Yp
+bJ
+uf
+xe
 tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
+vi
 tN
 tN
 tN
@@ -36297,21 +35877,21 @@ tN
 tN
 tN
 tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
+BS
+bL
+SG
+SG
+bH
+SG
+BS
+bJ
+FU
+FU
+BS
+FU
+rB
+Tg
+BS
 tN
 tN
 tN
@@ -36555,11 +36135,11 @@ tN
 tN
 tN
 tN
-tN
-tN
-tN
-tN
-tN
+VA
+Tg
+SG
+bJ
+Tg
 tN
 tN
 tN
@@ -37253,7 +36833,7 @@ tN
 tN
 tN
 tN
-tN
+yE
 tN
 tN
 tN
@@ -38004,6 +37584,7 @@ tN
 tN
 tN
 tN
+yE
 tN
 tN
 tN
@@ -38106,8 +37687,7 @@ tN
 tN
 tN
 tN
-tN
-tN
+yE
 tN
 tN
 tN
@@ -40045,7 +39625,7 @@ tN
 tN
 tN
 tN
-tN
+yE
 tN
 tN
 tN
@@ -40313,7 +39893,7 @@ tN
 tN
 tN
 tN
-tN
+yE
 tN
 tN
 tN
@@ -44196,7 +43776,7 @@ tN
 tN
 tN
 tN
-tN
+yE
 tN
 tN
 tN
@@ -44536,7 +44116,7 @@ tN
 tN
 tN
 tN
-tN
+yE
 tN
 tN
 tN
@@ -45201,7 +44781,7 @@ tN
 tN
 tN
 tN
-tN
+yE
 tN
 tN
 tN
@@ -47533,7 +47113,7 @@ tN
 tN
 tN
 tN
-tN
+yE
 tN
 tN
 tN
@@ -47806,7 +47386,7 @@ tN
 tN
 tN
 tN
-tN
+yE
 tN
 tN
 tN
@@ -51654,7 +51234,7 @@ tN
 tN
 tN
 tN
-tN
+yE
 tN
 tN
 tN
@@ -53410,7 +52990,7 @@ tN
 tN
 tN
 tN
-tN
+yE
 tN
 tN
 tN
@@ -55488,7 +55068,7 @@ tN
 tN
 tN
 tN
-tN
+yE
 tN
 tN
 tN
@@ -56815,7 +56395,7 @@ tN
 tN
 tN
 tN
-tN
+yE
 tN
 tN
 tN
@@ -59087,7 +58667,7 @@ tN
 tN
 tN
 tN
-tN
+yE
 tN
 tN
 tN
@@ -60436,7 +60016,7 @@ tN
 tN
 tN
 tN
-tN
+yE
 tN
 tN
 tN
@@ -60720,7 +60300,7 @@ tN
 tN
 tN
 tN
-tN
+yE
 tN
 tN
 tN
@@ -62451,7 +62031,7 @@ tN
 tN
 tN
 tN
-tN
+yE
 tN
 tN
 tN
@@ -64266,7 +63846,7 @@ tN
 tN
 tN
 tN
-tN
+yE
 tN
 tN
 tN
@@ -65100,7 +64680,7 @@ tN
 tN
 tN
 tN
-tN
+yE
 tN
 tN
 tN
@@ -65849,7 +65429,7 @@ tN
 tN
 tN
 tN
-tN
+yE
 tN
 tN
 tN
@@ -68328,7 +67908,7 @@ tN
 tN
 tN
 tN
-tN
+yE
 tN
 tN
 tN
@@ -69670,7 +69250,7 @@ tN
 tN
 tN
 tN
-tN
+yE
 tN
 tN
 tN
@@ -71437,7 +71017,7 @@ tN
 tN
 tN
 tN
-tN
+yE
 tN
 tN
 tN

--- a/_maps/map_files/Mining/Lavaland_Lumos.dmm
+++ b/_maps/map_files/Mining/Lavaland_Lumos.dmm
@@ -1,30 +1,9 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "aa" = (
-/obj/structure/rack,
-/obj/item/pickaxe,
-/obj/item/pickaxe,
-/obj/item/mining_scanner,
-/obj/item/mining_scanner,
-/obj/item/storage/bag/ore,
-/obj/item/storage/bag/plants,
-/obj/item/storage/bag/strangerock,
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
-"ab" = (
-/obj/structure/rack,
-/obj/item/pickaxe,
-/obj/item/pickaxe,
-/obj/item/mining_scanner,
-/obj/item/mining_scanner,
-/obj/item/radio/intercom{
-	dir = 8;
-	name = "Station Intercom (General)";
-	pixel_x = 28
+/obj/machinery/light/small{
+	dir = 1
 	},
-/obj/item/storage/bag/ore,
-/obj/item/storage/bag/plants,
-/obj/item/storage/bag/strangerock,
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/xenoarch/arch)
 "ac" = (
 /turf/closed/wall,
@@ -53,15 +32,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/sec)
-"af" = (
-/obj/structure/rack,
-/obj/item/mining_scanner,
-/obj/item/pickaxe,
-/obj/item/storage/bag/ore,
-/obj/item/storage/bag/plants,
-/obj/item/storage/bag/strangerock,
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "ak" = (
 /obj/machinery/door/airlock/maintenance{
 	req_one_access_txt = "48"
@@ -69,11 +39,11 @@
 /turf/open/floor/plating,
 /area/xenoarch/arch)
 "an" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
+/obj/machinery/camera{
+	c_tag = "Xenoarchaeology Telecomms"
 	},
-/turf/open/floor/plasteel/elevatorshaft,
-/area/mining_level_access/lower)
+/turf/open/floor/plasteel/dark,
+/area/xenoarch/arch)
 "aq" = (
 /obj/machinery/requests_console{
 	department = "Xenoarchaeology";
@@ -131,16 +101,11 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "av" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/machinery/airalarm{
+	pixel_y = 24
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel/dark,
-/area/xenoarch/gen)
+/area/xenoarch/arch)
 "aw" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/yellow{
@@ -190,10 +155,11 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
+/obj/effect/turf_decal/stripes/corner,
+/obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "aF" = (
-/obj/effect/landmark/start/mining_foreman,
 /obj/structure/chair/office/dark{
 	dir = 8
 	},
@@ -206,14 +172,8 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "aH" = (
-/obj/effect/turf_decal/lumos/tile/purple/half{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/structure/closet/emcloset/anchored,
-/turf/open/floor/plasteel,
+/obj/structure/closet/cardboard,
+/turf/open/floor/plating,
 /area/xenoarch/arch)
 "aI" = (
 /obj/structure/cable/yellow{
@@ -295,38 +255,29 @@
 /area/xenoarch/arch)
 "aQ" = (
 /obj/structure/table,
-/obj/machinery/smartfridge/disks,
+/obj/machinery/plantgenes,
+/obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/requests_console{
-	department = "Xenoarchaeology";
-	pixel_y = 28
-	},
 /turf/open/floor/plasteel,
 /area/xenoarch/bot)
 "aT" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/lumos/tile/purple/half,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/xenoarch/gen)
+/turf/open/floor/plasteel/elevatorshaft,
+/area/mining_level_access/lower)
 "aU" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
+/obj/structure/closet/crate{
+	icon_state = "crateopen"
 	},
+/obj/item/poster/random_official,
 /turf/open/floor/plating,
-/area/xenoarch/arch)
+/area/xenoarch/sec)
 "aV" = (
 /obj/structure/stone_tile/block{
 	dir = 4
@@ -380,12 +331,14 @@
 /obj/machinery/camera{
 	c_tag = "Xenoarchaeology Twelve"
 	},
+/obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "bc" = (
-/obj/structure/closet/cardboard,
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/seeds,
 /turf/open/floor/plating,
-/area/xenoarch/arch)
+/area/xenoarch/sec)
 "bd" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -412,20 +365,17 @@
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/sec)
 "bi" = (
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/flora/ausbushes/grassybush,
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/machinery/door/airlock/medical/glass{
+	id_tag = null;
+	name = "Medbay";
+	req_access_txt = "5"
 	},
-/obj/structure/window/reinforced,
-/turf/open/floor/grass,
-/area/xenoarch/gen)
-"bj" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/xenoarch/arch)
+"bj" = (
+/obj/structure/grille/broken,
+/turf/open/floor/plating,
+/area/xenoarch/sec)
 "bl" = (
 /obj/structure/rack,
 /obj/structure/sign/poster/official/random{
@@ -462,11 +412,8 @@
 	id = "garbageL";
 	name = "disposal conveyor"
 	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
@@ -517,16 +464,21 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "bu" = (
+/obj/structure/table,
+/obj/machinery/smartfridge/disks,
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/obj/structure/disposalpipe/trunk{
+/obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/disposal/bin,
+/obj/machinery/requests_console{
+	department = "Xenoarchaeology";
+	pixel_y = 28
+	},
 /turf/open/floor/plasteel,
 /area/xenoarch/bot)
 "bv" = (
@@ -545,12 +497,12 @@
 /turf/open/indestructible/boss,
 /area/ruin/unpowered/ash_walkers)
 "bx" = (
-/obj/structure/table,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/newscaster{
-	pixel_y = 32
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plating,
+/area/xenoarch/sec)
+"by" = (
+/obj/structure/chair/sofa/corp/right{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/gen)
@@ -568,19 +520,25 @@
 /turf/open/lava/smooth/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "bF" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
-/obj/machinery/light{
+/obj/effect/turf_decal/lumos/tile/purple/half{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/obj/machinery/airalarm{
-	pixel_y = 23
-	},
-/obj/effect/turf_decal/lumos/tile/purple/half{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner,
+/obj/structure/closet/emcloset/anchored,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
+"bG" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/plasteel/dark,
+/area/xenoarch/gen)
 "bH" = (
 /obj/structure/flora/tree/jungle/small,
 /turf/open/floor/grass,
@@ -593,38 +551,25 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/grass,
 /area/lavaland/surface/outdoors)
-"bK" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/grass,
-/area/xenoarch/arch)
-"bL" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/grass,
-/area/xenoarch/arch)
 "bM" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/research/glass,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
-/obj/effect/turf_decal/lumos/tile/purple/fulltile,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "bN" = (
-/turf/open/openspace,
-/area/mining_level_access/upper)
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating,
+/area/xenoarch/sec)
 "bO" = (
 /obj/item/seeds/glowshroom{
 	potency = 50;
@@ -666,14 +611,10 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "bX" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/space_heater,
+/turf/open/floor/plating,
+/area/xenoarch/sec)
 "cd" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -709,18 +650,14 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/machinery/door/airlock/research/glass,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
-/obj/effect/turf_decal/lumos/tile/purple/half{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/purple/fulltile,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "cp" = (
@@ -748,9 +685,6 @@
 /area/xenoarch/eng)
 "cv" = (
 /obj/structure/flora/ausbushes/fullgrass,
-/obj/machinery/light/small{
-	dir = 1
-	},
 /turf/open/floor/grass,
 /area/xenoarch/arch)
 "cA" = (
@@ -776,20 +710,17 @@
 /turf/closed/indestructible/riveted/boss,
 /area/ruin/unpowered/ash_walkers)
 "cG" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
 	},
 /obj/effect/turf_decal/lumos/tile/purple/half{
-	dir = 4
+	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
-	dir = 4
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
@@ -829,7 +760,8 @@
 /turf/open/indestructible/boss,
 /area/lavaland/surface/outdoors)
 "cY" = (
-/obj/structure/closet/secure_closet/medical2,
+/obj/machinery/airalarm/directional/north,
+/obj/machinery/computer/crew,
 /turf/open/floor/plasteel/white,
 /area/xenoarch/arch)
 "cZ" = (
@@ -854,11 +786,9 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "dh" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/grass,
-/area/lavaland/surface/outdoors)
+/obj/machinery/computer/med_data,
+/turf/open/floor/plasteel/white,
+/area/xenoarch/arch)
 "di" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/lumos/tile/purple/half,
@@ -875,11 +805,18 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "do" = (
-/obj/machinery/door/airlock/research/glass,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
 	},
-/obj/effect/turf_decal/lumos/tile/purple/fulltile,
+/obj/effect/turf_decal/lumos/tile/purple/half{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "dr" = (
@@ -889,14 +826,10 @@
 /turf/open/lava/smooth/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "ds" = (
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/flora/ausbushes/grassybush,
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/floor/grass,
-/area/xenoarch/gen)
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/xenoarch/arch)
 "dt" = (
 /obj/machinery/light/small,
 /turf/open/floor/plating,
@@ -923,6 +856,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/lumos/tile/purple/half,
+/obj/machinery/camera{
+	c_tag = "Xenoarchaeology Seven";
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "dC" = (
@@ -977,32 +914,16 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "dQ" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/obj/effect/turf_decal/lumos/tile/purple/half{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/corner,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/xenoarch/sec)
 "dV" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/lumos/tile/purple/half{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/corner{
 	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
@@ -1017,10 +938,10 @@
 /area/lavaland/surface/outdoors)
 "eb" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 8
+	dir = 4
 	},
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/turf/open/floor/plating,
+/area/xenoarch/sec)
 "ec" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -1030,21 +951,12 @@
 	},
 /turf/open/floor/plating,
 /area/xenoarch/sec)
+"ef" = (
+/turf/open/openspace,
+/area/mining_level_access/upper)
 "eh" = (
 /obj/machinery/air_sensor/atmos/toxin_tank,
 /turf/open/floor/engine/plasma,
-/area/xenoarch/eng)
-"en" = (
-/obj/machinery/atmospherics/pipe/simple/supply/visible/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
 /area/xenoarch/eng)
 "eo" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -1071,19 +983,19 @@
 /obj/item/newspaper,
 /turf/open/floor/plating,
 /area/xenoarch/arch)
-"eA" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/door/airlock/research/glass,
-/obj/effect/turf_decal/lumos/tile/purple/checker{
+"ey" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/effect/turf_decal/lumos/tile/green/checker,
-/turf/open/floor/plasteel,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel/dark,
+/area/xenoarch/gen)
+"eA" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/xenoarch/bot)
 "eK" = (
 /obj/structure/stone_tile/block/cracked{
@@ -1095,13 +1007,6 @@
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"eL" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4
-	},
-/obj/machinery/hydroponics/constructable,
-/turf/open/floor/plasteel,
-/area/xenoarch/bot)
 "eT" = (
 /obj/machinery/atmospherics/miner/nitrogen,
 /obj/machinery/light/small,
@@ -1185,11 +1090,15 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "fn" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
+/obj/machinery/vending/hydronutrients,
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
 	},
-/obj/machinery/biogenerator,
-/obj/item/reagent_containers/glass/bucket,
+/obj/machinery/status_display/evac{
+	layer = 4;
+	pixel_x = 32
+	},
 /turf/open/floor/plasteel,
 /area/xenoarch/bot)
 "fq" = (
@@ -1203,6 +1112,16 @@
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
+"fw" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel/dark,
+/area/xenoarch/gen)
 "fC" = (
 /obj/structure/chair{
 	dir = 1
@@ -1210,15 +1129,8 @@
 /turf/open/floor/plasteel/white,
 /area/lavaland/surface/outdoors)
 "fE" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/maintenance,
 /obj/machinery/door/firedoor/heavy,
+/obj/effect/turf_decal/lumos/tile/yellow/fulltile,
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "fF" = (
@@ -1240,24 +1152,22 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "fI" = (
+/obj/machinery/hydroponics/constructable,
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
-/obj/effect/turf_decal/lumos/tile/purple/checker{
+/obj/effect/turf_decal/tile/purple{
 	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/bot)
 "fP" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/gen)
+/obj/structure/reagent_dispensers/foamtank,
+/turf/open/floor/plating,
+/area/xenoarch/sec)
 "fX" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/lumos/loading_area{
@@ -1310,6 +1220,13 @@
 /obj/structure/stone_tile,
 /turf/open/indestructible/boss,
 /area/ruin/unpowered/ash_walkers)
+"go" = (
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc/auto_name/east,
+/turf/open/floor/plasteel/dark,
+/area/xenoarch/gen)
 "gq" = (
 /obj/structure/stone_tile/surrounding,
 /obj/structure/stone_tile/center/cracked,
@@ -1317,18 +1234,9 @@
 /turf/open/indestructible/boss,
 /area/lavaland/surface/outdoors)
 "gu" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/bot)
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plating,
+/area/xenoarch/sec)
 "gw" = (
 /obj/structure/stone_tile{
 	dir = 4
@@ -1342,14 +1250,9 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "gC" = (
-/obj/machinery/light,
-/obj/machinery/camera{
-	c_tag = "Xenoarchaeology Seven";
-	dir = 1
-	},
-/obj/effect/turf_decal/lumos/tile/purple/half,
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plating,
+/area/xenoarch/sec)
 "gE" = (
 /obj/structure/stone_tile/cracked{
 	dir = 8
@@ -1394,11 +1297,9 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "gR" = (
-/obj/effect/turf_decal/lumos/tile/purple/fullcorner,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
+/turf/open/floor/plasteel/white/side{
+	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "gS" = (
 /obj/structure/stone_tile/surrounding_tile/cracked{
@@ -1407,17 +1308,12 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "gV" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/xenoarch/bot)
 "gX" = (
@@ -1435,26 +1331,31 @@
 /turf/open/floor/engine,
 /area/xenoarch/eng)
 "gZ" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/gen)
 "ha" = (
-/obj/structure/table,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
+/obj/machinery/door/airlock/medical/glass{
+	id_tag = null;
+	name = "Medbay";
+	req_access_txt = "5"
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
+/turf/open/floor/plasteel/white,
+/area/xenoarch/arch)
+"hi" = (
+/obj/structure/chair/sofa/corp/left{
+	dir = 8
 	},
-/obj/item/storage/box/disks_plantgene,
-/obj/item/storage/box/disks_plantgene,
-/obj/machinery/newscaster{
-	pixel_y = 32
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
 	},
-/turf/open/floor/plasteel,
-/area/xenoarch/bot)
+/turf/open/floor/plasteel/dark,
+/area/xenoarch/gen)
 "hk" = (
 /obj/structure/stone_tile/slab/cracked,
 /obj/effect/decal/cleanable/blood,
@@ -1481,11 +1382,15 @@
 /turf/closed/wall,
 /area/xenoarch/bot)
 "hu" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/structure/table/reinforced,
+/obj/item/storage/backpack/duffelbag/med/surgery{
+	pixel_y = 6
 	},
-/turf/open/floor/plating,
-/area/mining_level_access)
+/obj/structure/window/reinforced,
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
+/area/xenoarch/arch)
 "hv" = (
 /obj/structure/stone_tile/block{
 	dir = 8
@@ -1502,12 +1407,10 @@
 /obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 1
 	},
-/obj/machinery/airalarm/directional/north,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "hx" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/structure/closet/secure_closet/medical2,
 /turf/open/floor/plasteel/white/side,
 /area/xenoarch/arch)
 "hy" = (
@@ -1517,12 +1420,9 @@
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
 "hE" = (
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/grass,
-/area/lavaland/surface/outdoors)
+/obj/structure/window/reinforced,
+/turf/open/floor/plasteel/white,
+/area/xenoarch/arch)
 "hH" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -1550,14 +1450,12 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "hK" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 8
+/obj/machinery/door/window/southleft{
+	name = "Surgery";
+	req_access_txt = "5"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/gen)
+/turf/open/floor/plasteel/white,
+/area/xenoarch/arch)
 "hM" = (
 /obj/machinery/grill{
 	name = "old rusty grill"
@@ -1565,8 +1463,10 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "hR" = (
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/plating,
+/obj/item/kirbyplants{
+	icon_state = "plant-10"
+	},
+/turf/open/floor/plasteel/white,
 /area/xenoarch/arch)
 "hV" = (
 /obj/structure/stone_tile/block{
@@ -1578,12 +1478,7 @@
 /turf/closed/indestructible/riveted/boss,
 /area/ruin/unpowered/ash_walkers)
 "hW" = (
-/obj/machinery/light/small,
 /turf/open/floor/grass,
-/area/xenoarch/arch)
-"hX" = (
-/obj/machinery/light/small,
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/xenoarch/arch)
 "hZ" = (
 /obj/machinery/light{
@@ -1647,10 +1542,6 @@
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
-"ih" = (
-/obj/machinery/light/small,
-/turf/open/water,
-/area/xenoarch/arch)
 "ij" = (
 /obj/structure/stone_tile/slab/cracked{
 	dir = 4
@@ -1661,22 +1552,15 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "im" = (
-/obj/structure/table,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/item/storage/box/disks_plantgene,
-/obj/item/storage/box/disks_plantgene,
+/obj/structure/tank_dispenser/oxygen,
 /turf/open/floor/plasteel,
-/area/xenoarch/bot)
+/area/xenoarch/arch)
 "io" = (
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
+/obj/machinery/light/small{
+	dir = 4
 	},
-/obj/machinery/power/apc/auto_name/east,
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/gen)
+/turf/open/floor/plating,
+/area/xenoarch/sec)
 "iq" = (
 /obj/machinery/computer/operating{
 	dir = 8
@@ -1702,24 +1586,17 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "ix" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "iz" = (
-/obj/structure/sign/poster/official/random{
-	pixel_y = 32
+/obj/machinery/light/small{
+	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
+/turf/open/floor/grass,
+/area/space)
 "iB" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -1794,9 +1671,6 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "iS" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
 /turf/open/water,
 /area/xenoarch/arch)
 "iV" = (
@@ -1804,90 +1678,80 @@
 /turf/open/lava/smooth/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "iX" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
+/obj/machinery/light/small{
+	dir = 1
 	},
-/obj/item/reagent_containers/glass/bucket,
-/obj/effect/turf_decal/tile/green{
+/turf/open/floor/grass,
+/area/lavaland/surface/outdoors)
+"ja" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/grass,
+/area/xenoarch/arch)
+"jd" = (
+/obj/structure/flora/grass/jungle,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/grass,
+/area/lavaland/surface/outdoors)
+"je" = (
+/obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/xenoarch/bot)
-"ja" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/plasteel,
-/area/xenoarch/bot)
-"jd" = (
-/turf/open/floor/plating,
-/area/mining_level_access)
-"je" = (
-/obj/structure/chair/office/dark{
+/area/xenoarch/arch)
+"ji" = (
+/obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 1
 	},
-/obj/effect/landmark/start/scientist,
 /turf/open/floor/plasteel,
-/area/xenoarch/bot)
-"ji" = (
-/obj/machinery/status_display/evac{
-	layer = 4;
-	pixel_x = 32
-	},
-/obj/machinery/camera{
-	c_tag = "Xenoarchaeology Seventeen";
-	dir = 8
-	},
-/turf/open/floor/plasteel/stairs,
-/area/xenoarch/gen)
+/area/xenoarch/arch)
 "jl" = (
-/obj/machinery/atmospherics/pipe/simple/supply/visible/layer1{
-	dir = 4
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
-/area/xenoarch/eng)
+/area/xenoarch/arch)
 "jm" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
 	},
-/obj/effect/turf_decal/lumos/tile/yellow/fullcorner{
+/obj/effect/turf_decal/lumos/tile/brown/fullcorner{
 	dir = 4
 	},
+/obj/machinery/suit_storage_unit/mining,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "jn" = (
 /turf/open/floor/plating,
 /area/xenoarch/arch)
-"js" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 1
+"jo" = (
+/obj/docking_port/stationary{
+	area_type = /area/mining_level_access/upper;
+	dir = 4;
+	dwidth = 2;
+	height = 5;
+	id = "lavaland_mining_top";
+	name = "lavaland mining top";
+	roundstart_template = /datum/map_template/shuttle/lavaland/mining;
+	width = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/turf/open/openspace,
+/area/mining_level_access/upper)
+"js" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
-"jv" = (
-/obj/structure/flora/grass/jungle,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/grass,
-/area/xenoarch/arch)
 "jw" = (
 /obj/machinery/suit_storage_unit/atmos,
 /obj/effect/turf_decal/lumos/tile/yellow/half{
@@ -1926,11 +1790,14 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "jS" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
+/obj/effect/turf_decal/tile/green{
+	dir = 1
 	},
-/turf/open/floor/plating,
-/area/xenoarch/arch)
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/bot)
 "jU" = (
 /obj/structure/stone_tile/block/cracked{
 	dir = 4
@@ -1957,21 +1824,13 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "ka" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 1
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/item/radio/intercom{
-	dir = 8;
-	name = "Station Intercom (General)";
-	pixel_x = -28
-	},
+/obj/machinery/hydroponics/constructable,
 /turf/open/floor/plasteel,
 /area/xenoarch/bot)
 "kh" = (
-/obj/machinery/light/small,
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/xenoarch/arch)
@@ -1993,9 +1852,11 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "km" = (
-/obj/effect/turf_decal/lumos/tile/blue/fulltile,
-/turf/open/floor/plasteel/white,
-/area/xenoarch/arch)
+/obj/effect/turf_decal/lumos/tile/purple/half{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/space)
 "kr" = (
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/disposal/bin,
@@ -2028,14 +1889,10 @@
 /area/ruin/unpowered/ash_walkers)
 "kx" = (
 /obj/structure/table,
-/obj/machinery/smartfridge/disks,
+/obj/machinery/plantgenes,
 /obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/machinery/light,
-/obj/structure/sign/poster/official/random{
-	pixel_y = -32
+/obj/effect/turf_decal/lumos/tile/purple/checker{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/bot)
@@ -2047,28 +1904,25 @@
 /area/ruin/unpowered/ash_walkers)
 "kD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
+	dir = 4
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
+/obj/structure/table,
+/obj/machinery/reagentgrinder{
+	desc = "Used to grind things up into raw materials and liquids.";
+	pixel_y = 5
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/bot)
 "kF" = (
-/obj/machinery/vending/hydronutrients,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
 /obj/machinery/status_display/evac{
 	layer = 4;
-	pixel_x = 32
+	pixel_x = -32
+	},
+/obj/machinery/light{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/xenoarch/bot)
+/area/space)
 "kI" = (
 /obj/effect/turf_decal/lumos/tile/blue/checker{
 	dir = 4
@@ -2079,13 +1933,13 @@
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
 "kK" = (
-/obj/machinery/hydroponics/constructable,
+/obj/machinery/power/apc/auto_name/south,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/bot)
@@ -2113,11 +1967,12 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "kW" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/effect/turf_decal/lumos/tile/purple/fullcorner{
+	dir = 8
 	},
+/obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel,
-/area/xenoarch/bot)
+/area/xenoarch/arch)
 "kY" = (
 /obj/structure/stone_tile/block,
 /turf/open/lava/smooth/lava_land_surface,
@@ -2146,7 +2001,7 @@
 /area/xenoarch/eng)
 "lj" = (
 /obj/machinery/computer/operating,
-/turf/open/floor/plasteel/white/side,
+/turf/open/floor/plasteel/white/corner,
 /area/xenoarch/arch)
 "lm" = (
 /obj/structure/window/reinforced{
@@ -2176,23 +2031,31 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "lv" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/structure/grille/broken,
-/turf/open/floor/plating,
+/obj/machinery/airalarm{
+	pixel_y = 23
+	},
+/obj/effect/turf_decal/lumos/tile/purple/half{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "lw" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "lx" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
-	},
-/obj/machinery/portable_atmospherics/pump,
 /obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 4
+	},
+/obj/item/radio/intercom{
+	dir = 8;
+	name = "Station Intercom (General)";
+	pixel_x = 28
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
@@ -2202,12 +2065,12 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "lB" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
-	},
-/obj/machinery/portable_atmospherics/scrubber,
 /obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 28
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
@@ -2256,10 +2119,20 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "lO" = (
-/obj/machinery/hydroponics/constructable,
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -22
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
+	},
+/obj/machinery/camera{
+	c_tag = "Xenoarchaeology Six";
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/bot)
@@ -2310,10 +2183,13 @@
 /turf/open/floor/plating,
 /area/xenoarch/sec)
 "mg" = (
-/obj/structure/chair/office/dark,
-/obj/effect/landmark/start/scientist,
-/turf/open/floor/plasteel,
-/area/xenoarch/bot)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/space)
+"mh" = (
+/obj/machinery/light/small,
+/turf/open/floor/plating,
+/area/mining_level_access)
 "mj" = (
 /obj/structure/stone_tile/cracked{
 	dir = 8
@@ -2324,15 +2200,25 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "mk" = (
+/obj/machinery/hydroponics/constructable,
 /obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/xenoarch/bot)
+"mm" = (
+/obj/machinery/status_display/evac{
+	layer = 4;
+	pixel_x = 32
+	},
+/obj/machinery/camera{
+	c_tag = "Xenoarchaeology Seventeen";
+	dir = 8
+	},
+/turf/open/floor/plasteel/stairs,
+/area/xenoarch/gen)
 "mp" = (
 /obj/machinery/suit_storage_unit/atmos,
 /obj/effect/turf_decal/lumos/tile/yellow/fullcorner{
@@ -2340,12 +2226,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
-"mq" = (
-/obj/machinery/light/small{
-	dir = 8
+"mu" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/xenoarch/arch)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/plasteel/dark,
+/area/xenoarch/gen)
 "my" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -2368,27 +2256,17 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
-/obj/structure/sign/poster/official/random{
-	pixel_y = -32
-	},
 /turf/open/floor/plasteel,
 /area/xenoarch/bot)
 "mI" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/turf/open/floor/plating,
-/area/xenoarch/arch)
+/turf/open/floor/grass,
+/area/space)
 "mJ" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/gen)
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/space)
 "mQ" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 30
@@ -2406,6 +2284,12 @@
 /obj/item/clipboard,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
+"mT" = (
+/obj/structure/chair/sofa/corp/left{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/xenoarch/gen)
 "mU" = (
 /obj/structure/stone_tile/block{
 	dir = 8
@@ -2415,20 +2299,39 @@
 	},
 /area/ruin/unpowered/ash_walkers)
 "mX" = (
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/plasteel/white,
-/area/xenoarch/arch)
-"mY" = (
-/obj/machinery/light/small{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
+/area/space)
+"mY" = (
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/xenoarch/arch)
 "mZ" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/seeds,
-/turf/open/floor/plating,
-/area/xenoarch/arch)
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel,
+/area/space)
+"nb" = (
+/obj/structure/table,
+/obj/machinery/newscaster{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/dark,
+/area/xenoarch/gen)
 "nf" = (
 /obj/machinery/atmospherics/pipe/simple/dark/visible,
 /obj/structure/cable/yellow{
@@ -2470,29 +2373,22 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "nt" = (
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/flora/ausbushes/grassybush,
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/light{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
-/turf/open/floor/grass,
-/area/xenoarch/gen)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/space)
 "nw" = (
 /obj/structure/flora/grass/jungle/b,
 /turf/open/floor/grass,
 /area/lavaland/surface/outdoors)
 "nx" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+/obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "nz" = (
@@ -2525,10 +2421,6 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/grass,
 /area/lavaland/surface/outdoors)
-"nJ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/xenoarch/gen)
 "nO" = (
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 4
@@ -2577,6 +2469,12 @@
 	},
 /turf/open/indestructible/boss,
 /area/lavaland/surface/outdoors)
+"nV" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/mining_level_access)
 "nY" = (
 /obj/structure/stone_tile/block/cracked,
 /obj/structure/stone_tile{
@@ -2598,20 +2496,17 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "of" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
 /obj/structure/cable/yellow{
-	icon_state = "1-8"
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
@@ -2633,6 +2528,8 @@
 /obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 8
 	},
+/obj/structure/closet/crate/freezer/blood,
+/obj/machinery/iv_drip,
 /turf/open/floor/plasteel/white,
 /area/xenoarch/arch)
 "ox" = (
@@ -2642,6 +2539,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
+"oy" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/airalarm{
+	pixel_y = 23
+	},
+/turf/open/floor/plasteel/dark,
+/area/xenoarch/gen)
 "oI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -2661,15 +2567,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
-"oO" = (
-/obj/machinery/atmospherics/components/binary/volume_pump{
-	dir = 8
-	},
-/obj/effect/turf_decal/lumos/tile/yellow/half{
-	dir = 8
-	},
+"oM" = (
+/obj/structure/table,
+/turf/open/floor/plasteel/dark,
+/area/xenoarch/gen)
+"oQ" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/structure/table,
+/obj/item/holosign_creator/firelock,
+/obj/item/holosign_creator/atmos,
+/obj/machinery/light,
+/obj/item/construction/rcd,
 /turf/open/floor/plasteel,
-/area/xenoarch/arch)
+/area/xenoarch/gen)
 "oR" = (
 /obj/effect/turf_decal/lumos/tile/purple/half,
 /obj/machinery/light,
@@ -2702,18 +2612,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/lavaland/surface/outdoors)
-"pc" = (
-/obj/structure/table,
-/obj/machinery/plantgenes,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/bot)
 "pf" = (
 /obj/effect/turf_decal/caution{
 	dir = 4;
@@ -2732,15 +2630,25 @@
 	},
 /turf/open/lava/smooth/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"ph" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/xenoarch/gen)
 "pi" = (
 /obj/structure/bonfire/dense,
 /obj/structure/stone_tile/center,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "pl" = (
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/grass,
-/area/lavaland/surface/outdoors)
+/obj/machinery/door/airlock/research/glass,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/effect/turf_decal/lumos/tile/purple/fulltile,
+/turf/open/floor/plasteel,
+/area/space)
 "pn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
@@ -2769,6 +2677,9 @@
 /obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 8
 	},
+/obj/structure/fireaxecabinet{
+	pixel_x = -32
+	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "pw" = (
@@ -2785,11 +2696,11 @@
 /turf/open/floor/plasteel/white,
 /area/lavaland/surface/outdoors)
 "px" = (
-/obj/machinery/computer/shuttle/elevator/mining{
-	dir = 1
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/turf/open/floor/plating,
-/area/mining_level_access)
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/space)
 "pB" = (
 /obj/structure/stone_tile{
 	dir = 4
@@ -2804,7 +2715,8 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/firedoor,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/lumos/tile/purple/fulltile,
+/turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "pE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
@@ -2816,9 +2728,6 @@
 "pJ" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/flora/ausbushes/grassybush,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
 /turf/open/floor/grass,
 /area/lavaland/surface/outdoors)
 "pM" = (
@@ -2871,7 +2780,7 @@
 /turf/open/floor/engine/air,
 /area/xenoarch/eng)
 "pX" = (
-/obj/effect/turf_decal/lumos/tile/yellow/half{
+/obj/effect/turf_decal/lumos/tile/brown/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -2883,11 +2792,10 @@
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/sec)
 "qb" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel/elevatorshaft,
-/area/mining_level_access/lower)
+/obj/effect/turf_decal/lumos/tile/purple/half,
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel,
+/area/space)
 "qd" = (
 /obj/structure/stone_tile/cracked{
 	dir = 4
@@ -2925,25 +2833,10 @@
 /turf/open/indestructible/boss,
 /area/ruin/unpowered/ash_walkers)
 "qg" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/elevatorshaft,
-/area/mining_level_access/lower)
-"ql" = (
-/obj/machinery/atmospherics/pipe/simple/supply/visible/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/maintenance,
-/obj/machinery/door/firedoor/heavy,
-/turf/open/floor/plating,
-/area/xenoarch/eng)
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/lumos/tile/yellow/half,
+/turf/open/floor/plasteel,
+/area/space)
 "qn" = (
 /obj/structure/stone_tile,
 /obj/structure/stone_tile{
@@ -3003,40 +2896,30 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "qG" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/effect/turf_decal/lumos/tile/purple/half,
-/obj/effect/turf_decal/stripes/corner{
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/elevatorshaft,
+/area/mining_level_access/lower)
+"qH" = (
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel,
-/area/xenoarch/gen)
-"qH" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/effect/turf_decal/lumos/tile/purple/half{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/gen)
+/turf/open/floor/plasteel/elevatorshaft,
+/area/mining_level_access/lower)
 "qI" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2
+/obj/effect/turf_decal/tile/green{
+	dir = 1
 	},
-/turf/open/floor/plating,
-/area/xenoarch/arch)
+/obj/effect/turf_decal/lumos/tile/purple/checker{
+	dir = 4
+	},
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/glass/bucket,
+/turf/open/floor/plasteel,
+/area/xenoarch/bot)
 "qJ" = (
 /obj/structure/stone_tile,
 /obj/structure/stone_tile{
@@ -3051,34 +2934,39 @@
 /turf/open/floor/plasteel/white,
 /area/lavaland/surface/outdoors)
 "qN" = (
-/obj/structure/rack,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/storage/toolbox/mechanical,
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
+"qV" = (
+/obj/machinery/computer/shuttle/elevator/mining{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/mining_level_access)
 "qW" = (
 /obj/structure/stone_tile/slab,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/summoning_altar)
 "qX" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 1
+	},
 /obj/structure/cable/yellow{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/visible/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/lumos/tile/yellow/half,
 /turf/open/floor/plasteel,
-/area/xenoarch/eng)
+/area/space)
 "re" = (
 /obj/structure/stone_tile/cracked{
 	dir = 4
@@ -3126,21 +3014,21 @@
 /turf/open/lava/smooth/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "rr" = (
-/obj/machinery/atmospherics/pipe/simple/supply/visible/layer1{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "rt" = (
-/obj/effect/turf_decal/lumos/tile/yellow/fullcorner{
+/obj/effect/turf_decal/lumos/tile/brown/fullcorner{
 	dir = 1
 	},
+/obj/structure/rack,
+/obj/item/mining_scanner,
+/obj/item/storage/bag/plants,
+/obj/item/storage/bag/ore,
+/obj/item/storage/bag/strangerock,
+/obj/item/pickaxe,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "ru" = (
@@ -3169,20 +3057,11 @@
 /turf/open/floor/grass,
 /area/lavaland/surface/outdoors)
 "rC" = (
-/obj/machinery/atmospherics/pipe/simple/supply/visible/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line{
-	dir = 4
+	dir = 8
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/xenoarch/eng)
+/turf/open/floor/plasteel/elevatorshaft,
+/area/mining_level_access/lower)
 "rH" = (
 /obj/structure/stone_tile/cracked,
 /turf/closed/indestructible/riveted/boss,
@@ -3218,14 +3097,6 @@
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"rS" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/obj/effect/turf_decal/lumos/tile/yellow/fulltile,
-/obj/machinery/portable_atmospherics/scrubber/huge/movable,
-/turf/open/floor/plasteel,
-/area/xenoarch/gen)
 "rU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
@@ -3282,13 +3153,14 @@
 /turf/open/indestructible/boss,
 /area/ruin/unpowered/ash_walkers)
 "sl" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/grassybush,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
+/obj/structure/window/reinforced,
+/turf/open/floor/grass,
 /area/xenoarch/gen)
 "sm" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -3318,27 +3190,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
-"sy" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/research/glass,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/plasteel,
-/area/xenoarch/gen)
 "sB" = (
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/gen)
 "sE" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/lumos/tile/purple/fullcorner,
+/obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
-/turf/open/floor/plasteel/elevatorshaft,
-/area/mining_level_access/lower)
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "sK" = (
 /obj/machinery/atmospherics/miner/oxygen,
 /obj/machinery/light/small,
@@ -3376,21 +3240,15 @@
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
 "sT" = (
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
-/obj/machinery/camera{
-	c_tag = "Xenoarchaeology Six";
-	dir = 1
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
 	},
+/obj/structure/reagent_dispensers/watertank/high,
 /turf/open/floor/plasteel,
 /area/xenoarch/bot)
 "sV" = (
@@ -3462,18 +3320,28 @@
 /obj/structure/flora/grass/jungle,
 /turf/open/floor/grass,
 /area/lavaland/surface/outdoors)
+"tt" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/mining_level_access)
 "tv" = (
-/turf/open/floor/plasteel/stairs,
-/area/xenoarch/gen)
+/obj/effect/turf_decal/lumos/tile/purple/half{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "tx" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/machinery/light{
 	dir = 4
-	},
-/obj/item/radio/intercom{
-	dir = 8;
-	name = "Station Intercom (General)";
-	pixel_x = 28
 	},
 /obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 4
@@ -3481,15 +3349,14 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "ty" = (
-/obj/machinery/disposal/bin,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 6
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/xenoarch/gen)
+/turf/open/floor/grass,
+/area/space)
 "tB" = (
-/obj/machinery/suit_storage_unit/mining,
-/turf/open/floor/plasteel,
+/turf/open/floor/circuit,
 /area/xenoarch/arch)
 "tD" = (
 /obj/structure/stone_tile/block/cracked{
@@ -3541,9 +3408,8 @@
 /turf/closed/indestructible/riveted/boss,
 /area/lavaland/surface/outdoors)
 "tV" = (
-/obj/structure/table/reinforced,
-/obj/machinery/cell_charger,
-/turf/open/floor/plasteel/white,
+/obj/machinery/smartfridge/chemistry/preloaded,
+/turf/closed/wall,
 /area/xenoarch/arch)
 "uf" = (
 /obj/structure/flora/grass/jungle,
@@ -3615,7 +3481,10 @@
 /turf/open/lava/smooth/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "uy" = (
-/obj/effect/turf_decal/lumos/tile/yellow/half{
+/obj/effect/turf_decal/lumos/tile/brown/half{
+	dir = 4
+	},
+/obj/machinery/light{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -3633,10 +3502,9 @@
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/lumos/tile/purple/fullcorner{
-	dir = 8
+/obj/effect/turf_decal/lumos/tile/purple/half{
+	dir = 1
 	},
-/obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "uE" = (
@@ -3688,8 +3556,16 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "uX" = (
-/obj/structure/table,
-/turf/open/floor/plasteel/dark,
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/grassybush,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/grass,
 /area/xenoarch/gen)
 "vf" = (
 /obj/machinery/door/firedoor,
@@ -3697,7 +3573,7 @@
 /obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 8
 	},
-/obj/effect/turf_decal/lumos/tile/yellow/half{
+/obj/effect/turf_decal/lumos/tile/brown/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -3750,6 +3626,15 @@
 /obj/item/stack/sheet/mineral/coal,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
+"vs" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/xenoarch/gen)
 "vt" = (
 /obj/structure/stone_tile{
 	dir = 1
@@ -3781,6 +3666,12 @@
 /obj/item/clothing/glasses/meson,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
+"vD" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/mining_level_access)
 "vF" = (
 /obj/structure/summoning_altar,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
@@ -3804,9 +3695,17 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "vO" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plating,
-/area/xenoarch/arch)
+/obj/machinery/door/firedoor/heavy,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/lumos/tile/yellow/fulltile,
+/turf/open/floor/plasteel,
+/area/xenoarch/eng)
 "vP" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -3843,7 +3742,7 @@
 /area/xenoarch/eng)
 "vY" = (
 /obj/effect/turf_decal/lumos/tile/blue/fulltile,
-/obj/machinery/door/airlock/glass_large{
+/obj/machinery/door/airlock/public/glass{
 	name = "Medbay"
 	},
 /turf/open/floor/plasteel/white,
@@ -3861,17 +3760,16 @@
 /area/ruin/unpowered/ash_walkers)
 "wi" = (
 /obj/structure/flora/grass/jungle,
-/obj/machinery/light/small{
-	dir = 8
-	},
 /turf/open/floor/grass,
 /area/xenoarch/arch)
 "wj" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
-	},
-/obj/machinery/portable_atmospherics/pump,
-/obj/effect/turf_decal/lumos/tile/yellow/fullcorner,
+/obj/effect/turf_decal/lumos/tile/brown/fullcorner,
+/obj/structure/rack,
+/obj/item/mining_scanner,
+/obj/item/storage/bag/plants,
+/obj/item/storage/bag/ore,
+/obj/item/storage/bag/strangerock,
+/obj/item/pickaxe,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "wk" = (
@@ -3879,12 +3777,10 @@
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/sec)
 "wm" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/obj/effect/turf_decal/lumos/tile/blue/half,
-/turf/open/floor/plasteel/white,
-/area/xenoarch/arch)
+/obj/machinery/door/firedoor/heavy,
+/obj/effect/turf_decal/lumos/tile/yellow/fulltile,
+/turf/open/floor/plasteel,
+/area/space)
 "ws" = (
 /obj/structure/fluff/drake_statue,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
@@ -3969,9 +3865,6 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "wU" = (
-/obj/machinery/computer/med_data{
-	dir = 8
-	},
 /obj/machinery/requests_console{
 	department = "Medbay";
 	departmentType = 1;
@@ -3986,9 +3879,6 @@
 /area/xenoarch/arch)
 "xe" = (
 /obj/structure/flora/ausbushes/grassybush,
-/obj/machinery/light/small{
-	dir = 4
-	},
 /turf/open/floor/grass,
 /area/xenoarch/arch)
 "xf" = (
@@ -4028,18 +3918,25 @@
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
+"xv" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/xenoarch/gen)
 "xx" = (
 /obj/effect/turf_decal/lumos/tile/yellow/fulltile,
+/obj/machinery/vending/tool,
 /turf/open/floor/plasteel,
 /area/xenoarch/gen)
 "xy" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+/obj/effect/turf_decal/lumos/tile/brown/fullcorner{
 	dir = 8
 	},
-/obj/machinery/portable_atmospherics/scrubber,
-/obj/effect/turf_decal/lumos/tile/yellow/fullcorner{
-	dir = 8
-	},
+/obj/machinery/suit_storage_unit/mining,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "xz" = (
@@ -4055,14 +3952,9 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "xD" = (
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/flora/ausbushes/grassybush,
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
+/obj/machinery/light/small,
 /turf/open/floor/grass,
-/area/xenoarch/gen)
+/area/space)
 "xE" = (
 /obj/machinery/atmospherics/components/binary/volume_pump{
 	dir = 8
@@ -4079,24 +3971,16 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "xI" = (
-/obj/structure/chair/sofa/corp/left{
-	dir = 8
-	},
-/obj/structure/sign/poster/official/random{
-	pixel_x = 32
+/obj/structure/chair/sofa/corp/right{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/gen)
 "xL" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/elevatorshaft,
-/area/mining_level_access/lower)
+/obj/machinery/light/small,
+/turf/open/floor/grass,
+/area/lavaland/surface/outdoors)
 "xM" = (
-/obj/machinery/atmospherics/components/binary/volume_pump{
-	dir = 4
-	},
 /obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 8
 	},
@@ -4157,14 +4041,13 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "ym" = (
+/obj/structure/table,
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
+/obj/item/storage/box/disks_plantgene,
+/obj/item/storage/box/disks_plantgene,
 /turf/open/floor/plasteel,
 /area/xenoarch/bot)
 "yp" = (
@@ -4175,11 +4058,9 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "yr" = (
-/obj/structure/rack,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/storage/toolbox/mechanical,
-/turf/open/floor/plating,
-/area/xenoarch/arch)
+/obj/machinery/light/small,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "yv" = (
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 4
@@ -4246,13 +4127,9 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "yK" = (
-/obj/machinery/door/airlock/medical/glass{
-	id_tag = null;
-	name = "Medbay";
-	req_access_txt = "5"
-	},
-/turf/open/floor/plasteel/white,
-/area/xenoarch/arch)
+/obj/machinery/light/small,
+/turf/open/water,
+/area/lavaland/surface/outdoors)
 "yL" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -4339,24 +4216,35 @@
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
 "zg" = (
-/obj/machinery/atmospherics/pipe/simple/supply/visible{
-	dir = 5
-	},
 /obj/machinery/light,
 /obj/effect/turf_decal/lumos/tile/yellow/half,
+/obj/structure/rack,
+/obj/item/mining_scanner,
+/obj/item/storage/bag/plants,
+/obj/item/storage/bag/ore,
+/obj/item/storage/bag/strangerock,
+/obj/item/pickaxe,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "zn" = (
-/obj/structure/tank_dispenser/oxygen,
-/turf/open/floor/plasteel,
+/obj/machinery/telecomms/relay/preset/mining,
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
+/turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
 "zo" = (
-/obj/structure/closet/crate{
-	icon_state = "crateopen"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/obj/item/poster/random_official,
-/turf/open/floor/plating,
-/area/xenoarch/arch)
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/plasteel,
+/area/xenoarch/bot)
 "zu" = (
 /obj/structure/stone_tile/cracked{
 	dir = 4
@@ -4368,7 +4256,10 @@
 /area/lavaland/surface/outdoors)
 "zx" = (
 /obj/effect/turf_decal/lumos/tile/yellow/fulltile,
-/obj/machinery/portable_atmospherics/scrubber/huge/movable,
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/obj/structure/closet/secure_closet/engineering_electrical,
 /turf/open/floor/plasteel,
 /area/xenoarch/gen)
 "zz" = (
@@ -4382,9 +4273,6 @@
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"zC" = (
-/turf/closed/wall/r_wall,
-/area/xenoarch/gen)
 "zD" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/backpack/duffelbag/med/surgery,
@@ -4422,9 +4310,18 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "zO" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/machinery/disposal/bin,
 /turf/open/floor/plasteel,
-/area/xenoarch/arch)
+/area/xenoarch/bot)
 "zQ" = (
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 4
@@ -4478,9 +4375,11 @@
 /turf/open/indestructible/boss,
 /area/lavaland/surface/outdoors)
 "Ac" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/research/glass,
-/turf/open/floor/plasteel,
+/obj/machinery/door/airlock/maintenance{
+	name = "Xenoarch Communications";
+	req_access_txt = "48"
+	},
+/turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
 "Ad" = (
 /obj/structure/stone_tile/cracked{
@@ -4521,15 +4420,14 @@
 /turf/open/floor/plasteel/white,
 /area/xenoarch/arch)
 "Av" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/gen)
+/turf/open/floor/plasteel,
+/area/space)
 "AB" = (
 /obj/structure/stone_tile/cracked{
 	dir = 4
@@ -4566,10 +4464,11 @@
 /turf/open/lava/smooth/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "AP" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
 	},
-/obj/machinery/chem_master,
+/obj/machinery/biogenerator,
+/obj/item/reagent_containers/glass/bucket,
 /turf/open/floor/plasteel,
 /area/xenoarch/bot)
 "AT" = (
@@ -4647,11 +4546,18 @@
 /turf/open/indestructible/boss,
 /area/ruin/unpowered/ash_walkers)
 "Bl" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/gen)
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/eng)
 "Br" = (
 /obj/machinery/atmospherics/pipe/manifold/dark/hidden{
 	dir = 1
@@ -4689,11 +4595,11 @@
 /area/xenoarch/arch)
 "BC" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/structure/sign/poster/official/random{
-	pixel_x = 32
-	},
 /obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 30
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
@@ -4733,18 +4639,13 @@
 /turf/open/floor/plating,
 /area/xenoarch/arch)
 "BY" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/plasteel/stairs,
-/area/xenoarch/gen)
+/turf/open/floor/plasteel,
+/area/space)
 "BZ" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/structure/fireaxecabinet{
-	pixel_x = 32
-	},
 /obj/machinery/camera{
 	c_tag = "Xenoarchaeology Fourteen";
 	dir = 9
@@ -4761,11 +4662,14 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "Cb" = (
+/obj/machinery/atm{
+	pixel_x = 30
+	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/gen)
+/turf/open/floor/plasteel,
+/area/space)
 "Ce" = (
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 4
@@ -4779,12 +4683,26 @@
 /obj/structure/stone_tile/center/cracked,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"Cm" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 10
+	},
+/obj/machinery/autolathe,
+/turf/open/floor/plasteel,
+/area/xenoarch/gen)
 "Ct" = (
 /obj/machinery/door/poddoor/incinerator_atmos_main{
 	id = "atmos_incinerator_mainventL"
 	},
 /turf/open/floor/engine,
 /area/xenoarch/eng)
+"Cu" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/structure/table,
+/obj/item/pipe_dispenser,
+/obj/item/inducer,
+/turf/open/floor/plasteel,
+/area/xenoarch/gen)
 "Cx" = (
 /obj/structure/stone_tile/block/cracked{
 	dir = 8
@@ -4895,20 +4813,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/gen)
-"CZ" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
-/obj/machinery/status_display/evac{
-	layer = 4;
-	pixel_x = 32
-	},
-/obj/structure/closet/secure_closet/engineering_electrical,
-/turf/open/floor/plasteel,
-/area/xenoarch/gen)
 "Db" = (
 /turf/open/floor/engine,
 /area/xenoarch/eng)
+"De" = (
+/turf/closed/wall,
+/area/mining_level_access)
 "Df" = (
 /obj/machinery/atmospherics/pipe/manifold/purple/visible/layer3,
 /turf/open/floor/plasteel,
@@ -4929,10 +4839,13 @@
 	layer = 4;
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/lumos/tile/purple/half{
+/obj/machinery/recycler,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/machinery/recycler,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "Do" = (
@@ -4954,9 +4867,6 @@
 /area/xenoarch/gen)
 "Du" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 30
-	},
 /obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 4
 	},
@@ -5006,7 +4916,8 @@
 /turf/closed/mineral/random/high_chance/volcanic,
 /area/lavaland/surface/outdoors)
 "DI" = (
-/obj/structure/reagent_dispensers/water_cooler,
+/obj/structure/rack,
+/obj/item/storage/toolbox/mechanical,
 /turf/open/floor/plating,
 /area/xenoarch/arch)
 "DJ" = (
@@ -5036,9 +4947,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/visible/layer1{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 4
 	},
@@ -5047,6 +4955,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "1-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
@@ -5082,6 +4993,9 @@
 /area/xenoarch/arch)
 "Eo" = (
 /obj/machinery/hydroponics/constructable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/xenoarch/bot)
 "EC" = (
@@ -5117,9 +5031,6 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "EQ" = (
-/obj/structure/chair{
-	dir = 8
-	},
 /obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 4
 	},
@@ -5137,12 +5048,13 @@
 /turf/open/floor/plasteel/white,
 /area/xenoarch/arch)
 "EW" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/obj/structure/table,
-/obj/item/pipe_dispenser,
-/obj/item/inducer,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
-/area/xenoarch/gen)
+/area/xenoarch/bot)
 "EY" = (
 /obj/structure/stone_tile,
 /obj/structure/stone_tile{
@@ -5167,11 +5079,11 @@
 /turf/closed/indestructible/riveted/boss,
 /area/lavaland/surface/outdoors)
 "Fv" = (
-/obj/structure/table,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/metal/fifty,
+/obj/structure/chair/office/dark{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
-/area/xenoarch/gen)
+/area/xenoarch/bot)
 "FB" = (
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
@@ -5180,19 +5092,17 @@
 /obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 8
 	},
+/obj/item/storage/firstaid/fire,
 /turf/open/floor/plasteel/white,
 /area/xenoarch/arch)
-"FG" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+"FI" = (
+/obj/machinery/seed_extractor,
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/obj/structure/closet/secure_closet/engineering_welding,
 /turf/open/floor/plasteel,
-/area/xenoarch/gen)
-"FI" = (
-/obj/machinery/light/small,
-/turf/open/floor/plating,
-/area/mining_level_access)
+/area/xenoarch/bot)
 "FJ" = (
 /obj/structure/stone_tile/cracked{
 	dir = 1
@@ -5235,14 +5145,10 @@
 /turf/open/floor/engine,
 /area/xenoarch/eng)
 "FY" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/obj/structure/table,
-/obj/item/holosign_creator/firelock,
-/obj/item/holosign_creator/atmos,
-/obj/machinery/light,
-/obj/item/construction/rcd,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/machinery/meter,
 /turf/open/floor/plasteel,
-/area/xenoarch/gen)
+/area/space)
 "FZ" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
@@ -5265,14 +5171,31 @@
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
-"Go" = (
-/obj/machinery/seed_extractor,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/purple{
+"Gn" = (
+/obj/machinery/atmospherics/pipe/simple/supply/visible/layer1{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/xenoarch/bot)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/xenoarch/eng)
+"Go" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/plasteel/white/corner{
+	dir = 4
+	},
+/area/space)
 "Gs" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
@@ -5281,21 +5204,27 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "Gu" = (
+/obj/structure/table,
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
+/obj/item/storage/box/disks_plantgene,
+/obj/item/storage/box/disks_plantgene,
+/obj/machinery/newscaster{
+	pixel_y = 32
+	},
 /turf/open/floor/plasteel,
 /area/xenoarch/bot)
 "Gy" = (
-/obj/effect/turf_decal/lumos/tile/purple/half{
-	dir = 1
-	},
 /obj/machinery/conveyor{
 	dir = 6;
 	id = "garbageL"
+	},
+/obj/effect/turf_decal/lumos/tile/blue/half{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
@@ -5311,29 +5240,31 @@
 /turf/open/lava/smooth/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "GC" = (
-/obj/docking_port/stationary{
-	area_type = /area/mining_level_access/lower;
-	dir = 4;
-	dwidth = 2;
-	height = 5;
-	id = "lavaland_mining_down";
-	name = "lavaland mining bottom";
-	width = 5
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/elevatorshaft,
-/area/mining_level_access/lower)
-"GD" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/visible{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
-/area/xenoarch/arch)
+/area/xenoarch/eng)
+"GD" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/item/radio/intercom{
+	dir = 8;
+	name = "Station Intercom (General)";
+	pixel_x = -28
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/bot)
 "GF" = (
 /obj/structure/stone_tile,
 /obj/structure/stone_tile{
@@ -5384,7 +5315,7 @@
 /area/ruin/unpowered/ash_walkers)
 "GS" = (
 /obj/effect/turf_decal/lumos/tile/yellow/fulltile,
-/obj/machinery/vending/tool,
+/obj/machinery/vending/engivend,
 /turf/open/floor/plasteel,
 /area/xenoarch/gen)
 "GT" = (
@@ -5406,17 +5337,16 @@
 /turf/open/floor/plating,
 /area/xenoarch/arch)
 "Ha" = (
-/obj/machinery/light,
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
+/obj/machinery/hydroponics/constructable,
 /turf/open/floor/plasteel,
-/area/xenoarch/gen)
+/area/xenoarch/bot)
 "Hc" = (
 /obj/structure/stone_tile/block/cracked,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"Hd" = (
+/turf/open/floor/plasteel/stairs,
+/area/xenoarch/gen)
 "Hh" = (
 /obj/structure/closet/secure_closet/medical2,
 /obj/machinery/light{
@@ -5425,11 +5355,12 @@
 /turf/open/floor/plasteel/white,
 /area/lavaland/surface/outdoors)
 "Hl" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/xenoarch/arch)
+/obj/machinery/chem_master,
+/turf/open/floor/plasteel,
+/area/xenoarch/bot)
 "Ho" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
@@ -5462,23 +5393,15 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "Ht" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 1
 	},
 /obj/structure/cable/yellow{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 8
-	},
-/obj/effect/turf_decal/lumos/tile/purple/half{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
-/area/xenoarch/arch)
+/area/xenoarch/eng)
 "Hu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/visible/layer1,
 /turf/open/floor/plasteel,
@@ -5490,9 +5413,16 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "HD" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/elevatorshaft,
-/area/mining_level_access/lower)
+/obj/effect/turf_decal/lumos/tile/purple/half{
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	dir = 8;
+	name = "Station Intercom (General)";
+	pixel_x = 28
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "HF" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
@@ -5521,6 +5451,10 @@
 /obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 4
 	},
+/obj/machinery/status_display/evac{
+	layer = 4;
+	pixel_x = 32
+	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "HP" = (
@@ -5528,16 +5462,15 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "HQ" = (
-/obj/structure/table,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/machinery/cell_charger,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
-/area/xenoarch/gen)
+/area/xenoarch/bot)
 "Ib" = (
-/obj/machinery/door/airlock/maintenance,
-/turf/open/floor/plating,
-/area/xenoarch/sec)
+/obj/structure/chair/office/dark,
+/turf/open/floor/plasteel,
+/area/xenoarch/bot)
 "Ie" = (
 /obj/structure/stone_tile/block/cracked,
 /obj/structure/stone_tile{
@@ -5546,15 +5479,6 @@
 /obj/item/t_scanner/adv_mining_scanner/lesser,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
-"If" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/gen)
 "Ig" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/closet/wardrobe/xenoarch,
@@ -5610,7 +5534,9 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
-/obj/machinery/light,
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -30
+	},
 /turf/open/floor/plasteel,
 /area/xenoarch/bot)
 "In" = (
@@ -5645,19 +5571,18 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "Iw" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/obj/machinery/meter,
+/turf/open/floor/plasteel,
+/area/space)
+"Ix" = (
+/obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/gen)
-"Ix" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/xenoarch/arch)
+/turf/open/floor/plasteel,
+/area/xenoarch/eng)
 "Iz" = (
 /obj/effect/turf_decal/lumos/tile/purple/fullcorner,
 /obj/structure/table,
@@ -5725,12 +5650,15 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "IS" = (
-/obj/machinery/atmospherics/pipe/layer_manifold{
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/xenoarch/arch)
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/xenoarch/eng)
 "IX" = (
 /obj/structure/stone_tile,
 /obj/structure/stone_tile{
@@ -5806,26 +5734,8 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "JG" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 8
-	},
-/obj/effect/turf_decal/lumos/tile/purple/half{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/gen)
+/turf/open/floor/plasteel/elevatorshaft,
+/area/mining_level_access/lower)
 "JH" = (
 /obj/structure/stone_tile/block{
 	dir = 1
@@ -5865,6 +5775,7 @@
 /area/xenoarch/eng)
 "Kf" = (
 /obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/white,
 /area/xenoarch/arch)
 "Kh" = (
@@ -5886,11 +5797,21 @@
 /turf/closed/indestructible/riveted/boss,
 /area/lavaland/surface/outdoors)
 "Kl" = (
-/obj/machinery/light/small{
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
-/turf/open/floor/plating,
-/area/xenoarch/arch)
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/glass/bucket,
+/turf/open/floor/plasteel,
+/area/xenoarch/bot)
 "Km" = (
 /obj/effect/turf_decal/lumos/tile/red/checker,
 /obj/effect/turf_decal/stripes/line{
@@ -5915,9 +5836,11 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors/unexplored)
 "Ks" = (
-/obj/machinery/requests_console{
-	department = "Xenoarchaeology";
-	pixel_x = 32
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/gen)
@@ -5964,6 +5887,9 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 10
 	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "KL" = (
@@ -6002,8 +5928,16 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "KT" = (
-/turf/open/floor/plasteel/elevatorshaft,
-/area/mining_level_access/lower)
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/bot)
 "KZ" = (
 /obj/structure/frame/computer{
 	dir = 8
@@ -6026,10 +5960,6 @@
 /obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 4
 	},
-/obj/machinery/status_display/evac{
-	layer = 4;
-	pixel_x = 32
-	},
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 9
 	},
@@ -6044,18 +5974,6 @@
 	},
 /turf/open/floor/carpet,
 /area/xenoarch/gen)
-"Lo" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/gen)
 "Lq" = (
 /obj/machinery/airalarm{
 	pixel_y = 23
@@ -6063,20 +5981,21 @@
 /turf/open/floor/plasteel/white,
 /area/lavaland/surface/outdoors)
 "Lr" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/table,
-/obj/machinery/reagentgrinder{
-	desc = "Used to grind things up into raw materials and liquids.";
-	pixel_y = 5
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
 	},
 /turf/open/floor/plasteel,
-/area/xenoarch/bot)
+/area/space)
 "Ls" = (
-/obj/machinery/telecomms/relay/preset/mining,
-/turf/open/floor/plating,
-/area/xenoarch/arch)
+/obj/structure/rack,
+/obj/item/storage/bag/ore,
+/obj/item/pickaxe,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 28
+	},
+/turf/open/floor/plasteel,
+/area/space)
 "Lv" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
@@ -6129,25 +6048,6 @@
 	},
 /turf/open/indestructible/boss,
 /area/ruin/unpowered/ash_walkers)
-"LH" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/effect/turf_decal/lumos/tile/purple/half{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/gen)
 "LJ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/yellow{
@@ -6157,11 +6057,6 @@
 /turf/open/floor/plating,
 /area/xenoarch/arch)
 "LK" = (
-/obj/item/radio/intercom{
-	dir = 8;
-	name = "Station Intercom (General)";
-	pixel_x = 28
-	},
 /obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 4
 	},
@@ -6178,11 +6073,8 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "LN" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel/elevatorshaft,
-/area/mining_level_access/lower)
+/turf/closed/wall,
+/area/xenoarch/eng)
 "LR" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -6202,14 +6094,11 @@
 /turf/open/lava/smooth/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "LV" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+/obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/gen)
+/turf/open/floor/plasteel,
+/area/xenoarch/eng)
 "Ma" = (
 /turf/open/floor/plasteel/white,
 /area/xenoarch/arch)
@@ -6259,6 +6148,9 @@
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"Mu" = (
+/turf/open/floor/plating,
+/area/mining_level_access)
 "Mv" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -6273,22 +6165,35 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "MA" = (
-/obj/effect/turf_decal/lumos/tile/yellow/fulltile,
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Engineering";
-	req_access_txt = "32"
+/obj/effect/turf_decal/stripes/corner,
+/obj/machinery/computer/shuttle/elevator/mining{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/xenoarch/eng)
+/area/space)
 "MB" = (
-/obj/machinery/computer/crew{
-	dir = 8
+/obj/machinery/vending/medical{
+	pixel_x = -2
 	},
 /turf/open/floor/plasteel/white,
 /area/xenoarch/arch)
 "MC" = (
 /turf/open/floor/plasteel,
 /area/space)
+"MH" = (
+/obj/machinery/atmospherics/pipe/simple/supply/visible/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/maintenance,
+/obj/machinery/door/firedoor/heavy,
+/turf/open/floor/plating,
+/area/xenoarch/eng)
 "ML" = (
 /obj/structure/window/reinforced,
 /obj/effect/turf_decal/lumos/tile/purple/checker{
@@ -6313,24 +6218,20 @@
 /turf/closed/indestructible/riveted/boss,
 /area/ruin/unpowered/ash_walkers)
 "MV" = (
-/obj/machinery/power/apc/auto_name/south,
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
+/obj/structure/table,
+/obj/machinery/smartfridge/disks,
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/obj/machinery/light,
+/obj/structure/sign/poster/official/random{
+	pixel_y = -32
+	},
 /turf/open/floor/plasteel,
 /area/xenoarch/bot)
 "Nb" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
+/turf/closed/wall/r_wall,
 /area/xenoarch/gen)
 "Nc" = (
 /obj/effect/turf_decal/tile/purple{
@@ -6398,14 +6299,20 @@
 /obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 1
 	},
+/obj/structure/reagent_dispensers/foamtank,
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "Nx" = (
-/obj/structure/table,
-/obj/machinery/newscaster{
-	pixel_y = 32
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/grassybush,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/grass,
 /area/xenoarch/gen)
 "NB" = (
 /obj/structure/stone_tile/block{
@@ -6422,12 +6329,11 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "NH" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 10
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
 	},
-/obj/machinery/autolathe,
-/turf/open/floor/plasteel,
-/area/xenoarch/gen)
+/turf/open/floor/plasteel/elevatorshaft,
+/area/mining_level_access/lower)
 "NI" = (
 /obj/structure/stone_tile/block{
 	dir = 4
@@ -6445,6 +6351,9 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/lumos/tile/red/half{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "NN" = (
@@ -6477,19 +6386,22 @@
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/sec)
 "Ob" = (
-/obj/structure/chair/sofa/corp/left{
-	dir = 4
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/gen)
+/turf/open/floor/plasteel/elevatorshaft,
+/area/mining_level_access/lower)
 "Oc" = (
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/xenoarch/arch)
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel/elevatorshaft,
+/area/mining_level_access/lower)
 "Od" = (
-/obj/machinery/space_heater,
+/obj/structure/fans/tiny,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
-/area/xenoarch/arch)
+/area/space)
 "Og" = (
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/sec)
@@ -6527,13 +6439,20 @@
 /turf/open/floor/engine/n2,
 /area/xenoarch/eng)
 "Or" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/docking_port/stationary{
+	area_type = /area/mining_level_access/lower;
+	dir = 4;
+	dwidth = 2;
+	height = 5;
+	id = "lavaland_mining_down";
+	name = "lavaland mining bottom";
+	width = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/gen)
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/elevatorshaft,
+/area/mining_level_access/lower)
 "Os" = (
 /obj/machinery/camera{
 	c_tag = "Xenoarchaeology Security Checkpoint"
@@ -6606,6 +6525,13 @@
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"OP" = (
+/obj/machinery/requests_console{
+	department = "Xenoarchaeology";
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel/dark,
+/area/xenoarch/gen)
 "OQ" = (
 /obj/machinery/light,
 /obj/structure/disposalpipe/segment{
@@ -6634,6 +6560,14 @@
 	},
 /turf/open/floor/engine/o2,
 /area/xenoarch/eng)
+"OX" = (
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Engineering";
+	req_access_txt = "32"
+	},
+/obj/effect/turf_decal/lumos/tile/yellow/fulltile,
+/turf/open/floor/plasteel,
+/area/xenoarch/eng)
 "Pb" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
@@ -6652,32 +6586,22 @@
 /turf/open/indestructible/boss,
 /area/lavaland/surface/outdoors)
 "Pm" = (
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/flora/ausbushes/grassybush,
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/grass,
-/area/xenoarch/gen)
-"Pn" = (
-/turf/closed/wall,
-/area/xenoarch/eng)
-"Po" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/xenoarch/gen)
-"PA" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
+/area/xenoarch/gen)
+"Pn" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/space)
+"Po" = (
+/obj/machinery/door/airlock/research/glass,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/plasteel,
+/area/xenoarch/gen)
+"PA" = (
+/turf/open/lava/smooth/lava_land_surface,
 /area/xenoarch/arch)
 "PB" = (
 /obj/structure/chair/office/dark{
@@ -6686,10 +6610,14 @@
 /turf/open/floor/plasteel/white,
 /area/lavaland/surface/outdoors)
 "PJ" = (
-/obj/machinery/door/airlock/research/glass,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/floor/plasteel,
-/area/xenoarch/gen)
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/elevatorshaft,
+/area/mining_level_access/lower)
 "PL" = (
 /obj/structure/stone_tile/block/cracked,
 /obj/structure/stone_tile/block/cracked{
@@ -6768,12 +6696,6 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "Qa" = (
-/obj/machinery/atmospherics/pipe/simple/supply/visible/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -6782,7 +6704,14 @@
 	name = "Engineering";
 	req_access_txt = "32"
 	},
-/turf/open/floor/plating,
+/obj/effect/turf_decal/lumos/tile/yellow/fulltile,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "Qd" = (
 /obj/structure/chair/office/dark,
@@ -6801,14 +6730,32 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "Qi" = (
-/turf/closed/wall/r_wall,
-/area/space)
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/effect/turf_decal/lumos/tile/purple/half{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/gen)
 "Qo" = (
 /obj/effect/turf_decal/lumos/tile/yellow/fulltile,
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/vending/engivend,
+/obj/structure/closet/secure_closet/engineering_welding,
 /turf/open/floor/plasteel,
 /area/xenoarch/gen)
 "Qp" = (
@@ -6910,10 +6857,22 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "Ro" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/lumos/tile/purple/half{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
 /area/xenoarch/gen)
 "Rs" = (
 /obj/structure/stone_tile/block/cracked{
@@ -6934,9 +6893,14 @@
 /turf/open/floor/engine/air,
 /area/xenoarch/eng)
 "Rw" = (
-/obj/machinery/hydroponics/constructable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 8
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/bot)
@@ -6986,8 +6950,24 @@
 /turf/open/floor/engine/plasma,
 /area/xenoarch/eng)
 "RM" = (
-/turf/closed/wall,
-/area/mining_level_access)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/effect/turf_decal/lumos/tile/purple/half{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/gen)
 "RR" = (
 /obj/structure/stone_tile/block{
 	dir = 8
@@ -6999,18 +6979,11 @@
 /turf/open/indestructible/boss,
 /area/ruin/unpowered/ash_walkers)
 "RU" = (
-/obj/docking_port/stationary{
-	area_type = /area/mining_level_access/upper;
-	dir = 4;
-	dwidth = 2;
-	height = 5;
-	id = "lavaland_mining_top";
-	name = "lavaland mining top";
-	roundstart_template = /datum/map_template/shuttle/lavaland/mining;
-	width = 5
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
 	},
-/turf/open/openspace,
-/area/mining_level_access/upper)
+/turf/open/floor/plasteel/elevatorshaft,
+/area/mining_level_access/lower)
 "RW" = (
 /obj/machinery/button/door/incinerator_vent_atmos_aux{
 	id = "atmos_incinerator_auxventL";
@@ -7037,6 +7010,16 @@
 	},
 /turf/closed/indestructible/riveted/boss,
 /area/ruin/unpowered/ash_walkers)
+"Sl" = (
+/obj/structure/table,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/newscaster{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/dark,
+/area/xenoarch/gen)
 "Sr" = (
 /obj/structure/stone_tile/block/cracked{
 	dir = 8
@@ -7179,20 +7162,21 @@
 /turf/closed/indestructible/riveted/boss/see_through,
 /area/lavaland/surface/outdoors)
 "SY" = (
-/obj/structure/table,
-/obj/machinery/plantgenes,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/lumos/tile/purple/checker{
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/xenoarch/bot)
-"SZ" = (
-/obj/effect/turf_decal/lumos/tile/purple/half{
-	dir = 1
+/obj/machinery/portable_atmospherics/pump,
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel/white/corner{
+	dir = 4
 	},
+/area/space)
+"SZ" = (
 /obj/structure/disposaloutlet{
 	dir = 4
+	},
+/obj/effect/turf_decal/lumos/tile/red/half{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
@@ -7200,6 +7184,15 @@
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/open/floor/grass,
 /area/lavaland/surface/outdoors)
+"Th" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/xenoarch/gen)
 "Tk" = (
 /obj/structure/stone_tile/slab,
 /obj/structure/table/wood,
@@ -7216,13 +7209,15 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "To" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/effect/turf_decal/lumos/tile/purple/half,
+/obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/obj/machinery/airalarm{
-	pixel_y = 23
-	},
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel,
 /area/xenoarch/gen)
 "Tq" = (
 /obj/effect/turf_decal/lumos/tile/purple/fullcorner{
@@ -7252,6 +7247,7 @@
 /obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 1
 	},
+/obj/machinery/portable_atmospherics/scrubber/huge/movable,
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "TP" = (
@@ -7277,13 +7273,8 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "TR" = (
-/obj/effect/turf_decal/lumos/tile/purple/half,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/structure/closet/emcloset/anchored,
-/turf/open/floor/plasteel,
-/area/xenoarch/gen)
+/turf/closed/wall/r_wall,
+/area/space)
 "TS" = (
 /obj/effect/turf_decal/lumos/tile/red/checker{
 	dir = 4
@@ -7330,12 +7321,29 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "Uj" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/door/airlock/research/glass{
+	name = "Xenobotany"
+	},
+/obj/effect/turf_decal/lumos/tile/purple/checker{
+	dir = 4
+	},
+/obj/effect/turf_decal/lumos/tile/green/checker,
+/turf/open/floor/plasteel,
 /area/xenoarch/bot)
 "Um" = (
 /obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 1
+	},
+/obj/machinery/portable_atmospherics/scrubber/huge/movable,
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = 20
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
@@ -7351,18 +7359,23 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "Up" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/lumos/tile/purple/half,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
 /area/xenoarch/gen)
 "Uq" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/obj/effect/turf_decal/lumos/tile/purple/half,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/structure/closet/emcloset/anchored,
+/turf/open/floor/plasteel,
+/area/xenoarch/gen)
 "Ur" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
@@ -7382,11 +7395,25 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "Uz" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/elevatorshaft,
-/area/mining_level_access/lower)
+/obj/machinery/door/airlock/research/glass,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/plasteel,
+/area/xenoarch/gen)
+"UF" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/plasteel/stairs,
+/area/xenoarch/gen)
 "UG" = (
 /obj/structure/stone_tile/block{
 	dir = 4
@@ -7419,11 +7446,14 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "US" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/grassybush,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/mining_level_access)
+/turf/open/floor/grass,
+/area/xenoarch/gen)
 "UX" = (
 /obj/machinery/air_sensor{
 	pixel_x = -32;
@@ -7434,6 +7464,14 @@
 	},
 /turf/open/floor/engine,
 /area/xenoarch/eng)
+"UY" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/turf/open/floor/plasteel,
+/area/xenoarch/gen)
 "UZ" = (
 /obj/structure/stone_tile/cracked{
 	dir = 8
@@ -7511,6 +7549,18 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/white,
 /area/lavaland/surface/outdoors)
+"VT" = (
+/obj/machinery/atmospherics/pipe/simple/supply/visible/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/xenoarch/eng)
 "VX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -7535,8 +7585,18 @@
 	dir = 1
 	},
 /obj/structure/table,
+/obj/machinery/cell_charger,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
+"Wl" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/xenoarch/gen)
+"Wp" = (
+/turf/open/space/basic,
+/area/space)
 "Wt" = (
 /obj/structure/stone_tile/block{
 	dir = 4
@@ -7562,6 +7622,7 @@
 /obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 1
 	},
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "WD" = (
@@ -7572,9 +7633,11 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "WM" = (
-/obj/structure/reagent_dispensers/foamtank,
-/turf/open/floor/plating,
-/area/xenoarch/arch)
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/xenoarch/gen)
 "WR" = (
 /obj/machinery/atmospherics/components/binary/volume_pump{
 	dir = 4
@@ -7582,9 +7645,14 @@
 /turf/open/floor/engine,
 /area/xenoarch/eng)
 "WT" = (
-/obj/structure/chair/sofa/corp/left{
-	dir = 8
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/gen)
 "WX" = (
@@ -7601,14 +7669,11 @@
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/gen)
 "Xj" = (
-/obj/effect/turf_decal/lumos/tile/purple/fullcorner{
-	dir = 8
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
+/turf/open/floor/plasteel/dark,
+/area/xenoarch/gen)
 "Xr" = (
 /obj/effect/turf_decal/lumos/tile/purple/fullcorner{
 	dir = 8
@@ -7629,11 +7694,14 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "XB" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/grassybush,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/turf/open/floor/plating,
-/area/mining_level_access)
+/turf/open/floor/grass,
+/area/xenoarch/gen)
 "XD" = (
 /obj/structure/stone_tile/block{
 	dir = 4
@@ -7677,10 +7745,25 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "XJ" = (
-/obj/structure/chair/sofa/corp/right{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
+/obj/machinery/status_display/evac{
+	layer = 4;
+	pixel_x = 32
+	},
+/obj/structure/table,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/storage/toolbox/mechanical{
+	pixel_y = -10
+	},
+/obj/item/storage/toolbox/mechanical{
+	pixel_y = -17
+	},
+/turf/open/floor/plasteel,
 /area/xenoarch/gen)
 "Yb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -7713,8 +7796,19 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "Ym" = (
-/turf/open/space/basic,
+/turf/open/floor/grass,
 /area/space)
+"Yn" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/lumos/tile/yellow/half,
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = -35
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/eng)
 "Yp" = (
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
@@ -7805,8 +7899,8 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "YT" = (
-/obj/structure/chair/sofa/corp/right{
-	dir = 8
+/obj/structure/chair/sofa/corp/left{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/gen)
@@ -7843,6 +7937,13 @@
 "Zp" = (
 /turf/open/floor/plating,
 /area/xenoarch/sec)
+"Zr" = (
+/obj/machinery/disposal/bin,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/gen)
 "Zz" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -7851,15 +7952,13 @@
 /turf/closed/wall,
 /area/lavaland/surface/outdoors)
 "ZC" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 6
-	},
 /obj/machinery/light{
 	dir = 1
 	},
 /obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 1
 	},
+/obj/machinery/suit_storage_unit/mining,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "ZE" = (
@@ -17869,13 +17968,13 @@ tN
 tN
 tN
 tN
-BS
-BS
-BS
-BS
-BS
-BS
-BS
+aA
+aA
+aA
+aA
+aA
+aA
+aA
 aA
 aA
 aA
@@ -18126,12 +18225,9 @@ tN
 tN
 tN
 tN
-BS
-Od
-bc
-BS
-bj
-bj
+aA
+aA
+aA
 BS
 BS
 BS
@@ -18139,7 +18235,10 @@ BS
 BS
 BS
 BS
-BS
+aA
+aA
+aA
+aA
 BS
 ki
 xz
@@ -18383,20 +18482,20 @@ tN
 tN
 tN
 tN
+aA
+aA
+aA
 BS
-jn
-jn
-cZ
-jn
-jn
-lv
-jn
-jn
-jn
-cZ
-sV
-jn
-jn
+kh
+aH
+BS
+ds
+ds
+BS
+aA
+aA
+aA
+aA
 BS
 xz
 KE
@@ -18640,20 +18739,20 @@ tN
 tN
 tN
 tN
+aA
+aA
+aA
 BS
-cZ
-BS
-BS
-Ix
-Zp
-Zp
-Zp
-Zp
-Zp
-Zp
-Zp
-Zp
 jn
+Zp
+bj
+Zp
+Zp
+CT
+CT
+CT
+CT
+BS
 BS
 kI
 xz
@@ -18897,14 +18996,14 @@ tN
 tN
 tN
 tN
+aA
+aA
+aA
 BS
-jn
-zo
-BS
-BS
-Zp
-Zp
-Zp
+cZ
+CT
+CT
+dQ
 Zp
 Zp
 Zp
@@ -19154,14 +19253,14 @@ tN
 tN
 tN
 tN
+aA
+aA
+aA
 BS
-Kl
-mZ
-BS
-Ix
-Zp
-Zp
-Zp
+jn
+aU
+CT
+CT
 Zp
 Zp
 Zp
@@ -19411,14 +19510,14 @@ tN
 tN
 tN
 tN
+aA
+aA
+aA
 BS
-jn
-jn
-cZ
-jn
-Zp
-Zp
-Zp
+aa
+bc
+CT
+dQ
 Zp
 Zp
 Zp
@@ -19674,13 +19773,13 @@ BS
 BS
 jn
 Zp
+bj
 Zp
 Zp
 Zp
 Zp
 Zp
-Zp
-Zp
+io
 jn
 BS
 PO
@@ -19925,9 +20024,9 @@ tN
 aA
 aA
 BS
-hR
-mI
-Od
+jn
+jn
+jn
 BS
 jn
 Zp
@@ -20182,8 +20281,8 @@ tN
 aA
 aA
 BS
-vO
-mI
+jn
+jn
 jn
 BS
 dt
@@ -20195,7 +20294,7 @@ ad
 ae
 bh
 bI
-My
+je
 PZ
 bQ
 Sy
@@ -20439,12 +20538,12 @@ tN
 aA
 aA
 BS
-WM
-mI
+jn
+jn
 jn
 BS
 sV
-Ib
+Zp
 Zp
 Zp
 mf
@@ -20696,20 +20795,20 @@ tN
 aA
 aA
 BS
-Hl
-aU
+jn
+jn
 jn
 GY
 jn
 Zp
-Zp
-Zp
+bx
+eb
 CT
 Os
 Og
 wk
 bI
-AU
+ji
 UN
 rj
 PN
@@ -20723,12 +20822,12 @@ kt
 BS
 aA
 aA
-aA
-aA
-aA
-aA
-aA
-aA
+PA
+PA
+PA
+PA
+PA
+PA
 aA
 aA
 aA
@@ -20959,14 +21058,14 @@ jn
 BS
 jn
 Zp
-Zp
-Zp
+bN
+fP
 CT
 kr
 Og
 ku
 dv
-Ng
+ji
 UN
 HP
 BS
@@ -20978,16 +21077,16 @@ BS
 BS
 BS
 BS
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
-aA
+PA
+PA
+PA
+PA
+PA
+PA
+PA
+PA
+PA
+PA
 aA
 aA
 QV
@@ -21216,8 +21315,8 @@ jn
 BS
 jn
 Zp
-Zp
-Zp
+bN
+gu
 CT
 zR
 Og
@@ -21235,8 +21334,8 @@ YC
 hJ
 BS
 tN
-tN
-tN
+Pd
+Pd
 Pd
 Pd
 Pd
@@ -21473,8 +21572,8 @@ dt
 BS
 jn
 Zp
-Zp
-Zp
+bX
+gC
 CT
 wI
 QM
@@ -21988,13 +22087,13 @@ BS
 jn
 BS
 lj
-Ma
-Ma
+gR
+hu
 op
 FF
 Bs
 BS
-Ng
+jl
 UN
 HP
 pC
@@ -22246,7 +22345,7 @@ jn
 BS
 Ef
 Ma
-Ma
+hE
 Ma
 Ma
 EU
@@ -22503,7 +22602,7 @@ jn
 BS
 hx
 Ma
-Ma
+hK
 Ma
 Ma
 EU
@@ -22521,7 +22620,7 @@ GW
 BS
 Pd
 Pd
-tN
+Pd
 Ge
 Br
 cU
@@ -22758,13 +22857,13 @@ BS
 aK
 jn
 BS
-cY
-Ma
-Ma
-Ma
+BS
+ha
+BS
+hR
 Ma
 EU
-km
+pU
 bs
 bv
 HP
@@ -22776,8 +22875,8 @@ AU
 Qd
 OQ
 BS
-tN
-tN
+Pd
+Pd
 tN
 Ge
 rl
@@ -23015,13 +23114,13 @@ BS
 jn
 jn
 BS
+cY
+Ma
 BS
-yK
 BS
 Ma
-Ma
-EU
-pU
+BS
+BS
 WB
 gQ
 XI
@@ -23029,7 +23128,7 @@ BS
 fH
 PQ
 LK
-ia
+HD
 MR
 Iz
 BS
@@ -23272,22 +23371,22 @@ BS
 aW
 jn
 BS
-Ma
+dh
 Ma
 tV
 Ma
 Ma
-wm
+EU
 BS
 AI
 UN
 oR
-BS
-BS
-BS
-BS
-BS
-BS
+hs
+hs
+hs
+hs
+hs
+hs
 BS
 BS
 tN
@@ -23527,25 +23626,25 @@ aA
 aA
 BS
 BS
-dt
-BS
-mX
+jn
+bi
+Ma
 Ma
 Kf
 Ma
 Ma
-wm
+EU
 BS
 hw
 cd
 FK
-qI
-qI
-qI
+hs
 qI
 jS
-jn
-tN
+GD
+jS
+Kl
+oX
 tN
 tN
 tN
@@ -23793,16 +23892,16 @@ EQ
 EQ
 oo
 BS
-Xj
+Xr
 KR
 Dp
 hs
-hs
-hs
-hs
-hs
-hs
-Ge
+Bv
+eV
+Ha
+eV
+KT
+LN
 RE
 RE
 RE
@@ -24041,7 +24140,7 @@ aA
 aA
 aA
 BS
-Oc
+cZ
 BS
 BS
 BS
@@ -24055,9 +24154,9 @@ iR
 pU
 hs
 fI
-iX
+eV
 ka
-iX
+eV
 mk
 Ge
 Ge
@@ -24310,7 +24409,7 @@ yI
 Tq
 ic
 tl
-hs
+eA
 Bv
 eV
 Eo
@@ -24566,11 +24665,11 @@ bm
 BT
 Ng
 cp
-XI
-hs
-gu
+oR
+eA
+Bv
 eV
-eL
+Eo
 eV
 Im
 Ge
@@ -24813,7 +24912,7 @@ aA
 aA
 BS
 jn
-yr
+dt
 BS
 ar
 wW
@@ -24823,12 +24922,12 @@ AY
 bq
 sm
 Lv
-gC
+HP
 Uj
-Bv
-eV
+zo
+EW
 Rw
-eV
+HQ
 lO
 Ge
 Ge
@@ -25081,10 +25180,10 @@ En
 Ng
 YM
 HP
-Uj
-Bv
+vk
+zO
 eV
-Rw
+Hl
 eV
 kK
 Ge
@@ -25324,7 +25423,7 @@ tN
 tN
 aA
 aA
-BS
+aA
 BS
 BS
 BS
@@ -25340,9 +25439,9 @@ Bc
 HP
 eA
 gV
-ja
+eV
 kD
-kW
+eV
 sT
 Ge
 jw
@@ -25581,8 +25680,8 @@ tN
 tN
 aA
 aA
+aA
 BS
-tB
 tB
 tB
 BS
@@ -25595,7 +25694,7 @@ BS
 Yj
 Ur
 dx
-vk
+hs
 bu
 eV
 AP
@@ -25838,11 +25937,11 @@ tN
 tN
 aA
 aA
+aA
 BS
-AU
-AU
-AU
-pU
+an
+tB
+BS
 Tq
 My
 Vi
@@ -25852,11 +25951,11 @@ lT
 SA
 pQ
 oJ
-Uj
+hs
 Gu
+Fv
 eV
-Lr
-eV
+Ib
 ym
 Ge
 TH
@@ -26095,10 +26194,10 @@ tN
 tN
 aA
 aA
+aA
 BS
-bX
 zn
-AU
+xz
 Ac
 Ng
 pq
@@ -26111,9 +26210,9 @@ it
 HP
 hs
 aQ
-eV
+FI
 fn
-eV
+FI
 kx
 Ge
 Um
@@ -26126,7 +26225,7 @@ yR
 lw
 HL
 FZ
-Gs
+Yn
 Ge
 Ge
 Ge
@@ -26352,11 +26451,11 @@ tN
 tN
 tN
 tN
+aA
 BS
-iz
-AU
-AU
-pU
+av
+tB
+BS
 Xr
 vP
 Vn
@@ -26367,11 +26466,11 @@ Dy
 PW
 di
 hs
-ha
-je
-eV
-mg
-im
+hs
+hs
+hs
+hs
+hs
 Ge
 Nu
 sL
@@ -26609,25 +26708,25 @@ tN
 tN
 tN
 tN
+aA
 BS
-aa
-ab
-af
+tB
+tB
 BS
 BS
-PA
+pU
 vf
-IS
+pU
 BS
 BS
 uD
-Ht
-gR
-hs
-pc
+PW
+HP
+ac
+Go
 Go
 kF
-Go
+SY
 SY
 Ge
 aE
@@ -26866,26 +26965,26 @@ tN
 tN
 tN
 tN
-BS
+aA
 BS
 BS
 BS
 BS
 jm
-oO
+xM
 pX
 xM
 rt
 ac
+km
+mX
+qb
+ac
+Av
+FY
 MC
-MC
-MC
-hs
-hs
-hs
-hs
-hs
-hs
+Iw
+Lr
 Ge
 Ge
 Qa
@@ -26894,12 +26993,12 @@ Ge
 Ge
 Ge
 Ge
-Ge
-MA
-Ge
+OX
 Ge
 Ge
 Ge
+Ge
+RE
 RE
 RE
 RE
@@ -27129,21 +27228,21 @@ tN
 tN
 BS
 ZC
-zO
 AU
-GD
+im
+AU
 zg
 ac
-MC
-MC
-MC
+km
+mX
+qg
 fE
 ix
 js
-js
-js
-js
-js
+FB
+Ix
+FB
+LV
 nx
 of
 rr
@@ -27153,16 +27252,16 @@ Dw
 CX
 Dw
 Dw
-Dw
-Dw
-NH
-zC
-Qi
-Qi
-Qi
-zC
-zC
-zC
+Cm
+Nb
+QV
+QV
+aM
+aM
+aM
+QV
+QV
+QV
 QV
 QV
 QV
@@ -27391,35 +27490,35 @@ uy
 lx
 wj
 ac
-MC
-MC
-MC
-FB
-FB
-FB
-FB
-FB
-FB
-FB
-FB
-qN
+km
+mZ
 qX
+vO
+Bl
+GC
+Ht
+IS
+Ht
+Ht
+Ht
+qN
+FB
 Ge
 GS
 Ox
 Ox
 Ox
 Ox
-Ox
-Ox
-EW
-zC
-Uz
-sE
-GC
-sE
-an
-zC
+Cu
+Nb
+QV
+QV
+aM
+aM
+aM
+aM
+aM
+QV
 QV
 QV
 QV
@@ -27648,11 +27747,11 @@ BS
 BS
 BS
 ac
-MC
-MC
-MC
-MC
-MC
+km
+nt
+qg
+wm
+BY
 MC
 MC
 MC
@@ -27660,23 +27759,23 @@ MC
 MC
 MC
 FB
-jl
+FB
 Ge
 Qo
 Ox
 Ox
-Fv
-HQ
 Ox
 Ox
-FY
-zC
-xL
-KT
-KT
-KT
-HD
-zC
+oQ
+Nb
+QV
+QV
+aM
+aM
+aM
+aM
+aM
+QV
 QV
 QV
 QV
@@ -27905,35 +28004,35 @@ aM
 aM
 aM
 BS
-pU
+kW
 bM
-pU
+sE
 ac
-ac
-ac
-ac
-ac
-ac
-ac
+Cb
+MC
+MC
+MC
+Ls
+MA
 Pn
 Pn
-en
-Ge
+Pn
+TR
 zx
 CV
+XJ
+UY
 CV
-CV
-CV
-CV
-CV
-ty
-zC
-xL
-KT
-KT
-KT
-HD
-zC
+Zr
+Nb
+QV
+QV
+aM
+aM
+aM
+aM
+aM
+QV
 QV
 QV
 QV
@@ -28162,35 +28261,35 @@ aM
 aM
 aM
 BS
-aH
+pU
 co
-dQ
+pU
 ac
-Ym
-Ym
-Ym
-Ym
-Ym
-Ym
-Ym
-Pn
-en
-Ge
-rS
-CV
-CZ
-FG
-If
-Lo
+ac
+ac
+ac
+ac
+TR
+TR
+Od
+Od
+Od
+TR
 Nb
-Ha
-zC
-xL
-KT
-KT
-KT
-HD
-zC
+Nb
+Nb
+Nb
+Nb
+Nb
+Nb
+QV
+QV
+aM
+aM
+aM
+aM
+aM
+QV
 QV
 QV
 QV
@@ -28423,31 +28522,31 @@ bF
 cG
 dV
 ac
-Ym
-Ym
-Ym
-Ym
-Ym
-Ym
-Ym
-Pn
+aM
+aM
+aM
+aM
+TR
+NH
 rC
-Ge
-zC
-zC
-zC
-zC
-Po
-Up
-zC
-zC
-zC
-qb
-qg
-qg
-qg
-LN
-zC
+Or
+rC
+RU
+TR
+aM
+QV
+QV
+QV
+QV
+QV
+QV
+QV
+aM
+aM
+aM
+aM
+aM
+QV
 QV
 QV
 QV
@@ -28676,29 +28775,29 @@ aM
 aM
 aM
 BS
-pU
+lv
 do
-pU
+tv
 ac
-Ym
-Ym
-Ym
-Ym
-Ym
-Ym
-Ym
-Pn
-ql
-Pn
-Ym
-Ym
-Ym
-Ym
-Ym
-Ym
-Ym
-Ym
-Ym
+aM
+aM
+aM
+aM
+TR
+Ob
+JG
+JG
+JG
+qG
+TR
+aM
+aM
+aM
+aM
+aM
+aM
+aM
+aM
 Za
 Mk
 Mk
@@ -28932,30 +29031,30 @@ aM
 aM
 aM
 aM
-Ym
-Ym
-Ym
-Ym
-Ym
-Ym
-Ym
-Ym
-Ym
-Ym
-Ym
-Ym
-Ym
-Ym
-Ym
-Za
-ds
-ds
-Za
-To
-Up
-Pm
-nt
-bi
+ac
+mg
+pl
+mg
+ac
+aM
+aM
+aM
+aM
+TR
+Ob
+JG
+JG
+JG
+qG
+TR
+aM
+aM
+aM
+aM
+aM
+aM
+aM
+aM
 lo
 YE
 YE
@@ -29190,29 +29289,29 @@ aM
 aM
 aM
 Ym
+mI
+px
+ty
 Ym
-Ym
-Ym
-Ym
-Ym
-Ym
-Ym
-Ym
-Ym
-Ym
-Ym
-nJ
+aM
+aM
+aM
+aM
+TR
+Ob
+JG
+JG
 JG
 qG
-nJ
-Bl
-sB
-tv
-Ro
-hK
-Fq
-Fq
-Fq
+TR
+aM
+aM
+aM
+aM
+aM
+aM
+aM
+aM
 Fq
 Fq
 Fq
@@ -29448,28 +29547,28 @@ aM
 aM
 Ym
 Ym
+mJ
+mJ
 Ym
 Ym
-Ym
-Ym
-Ym
-Ym
-Ym
-Ym
-Ym
-Ym
+aM
+aM
+aM
+TR
+Oc
+qH
 PJ
 qH
 aT
-sy
-av
-Or
-BY
-mJ
-Av
-oI
-oI
-LV
+TR
+aM
+aM
+aM
+aM
+aM
+aM
+aM
+aM
 oI
 oI
 oI
@@ -29705,28 +29804,28 @@ aM
 aM
 Ym
 Ym
+mJ
+mJ
 Ym
 Ym
 Ym
-Ym
-Ym
-Ym
-Ym
-Ym
-Ym
-Ym
-nJ
-LH
+aM
+aM
 TR
-nJ
-Cb
-sB
-ji
-fP
-io
-sB
-sB
-sl
+TR
+TR
+TR
+TR
+TR
+TR
+aM
+aM
+aM
+aM
+aM
+aM
+aM
+aM
 sB
 sB
 Za
@@ -29959,31 +30058,31 @@ tN
 aM
 aM
 aM
+ac
+iz
+mJ
+mJ
+mJ
+xD
+ac
+Ym
+Ym
 aM
-Ym
-Ym
-Ym
-Ym
-Ym
-Ym
-Ym
-Ym
-Ym
-Ym
-Ym
-Ym
-Za
-Za
-Za
-Za
-xD
-xD
-Za
-Za
-Za
-Ob
-XJ
-sl
+aM
+aM
+aM
+aM
+aM
+aM
+aM
+aM
+aM
+aM
+aM
+aM
+aM
+aM
+aM
 sB
 sB
 SQ
@@ -30218,26 +30317,26 @@ aM
 aM
 Ym
 Ym
+mJ
+mJ
+mJ
+mJ
 Ym
 Ym
 Ym
 Ym
 Ym
-Ym
-Ym
-Ym
-Ym
-Ym
-Ym
-Ym
-Ym
-Ym
+aM
+aM
+aM
+aM
+aM
 Za
+US
+US
 Za
-Za
-Za
-tN
-Za
+oy
+xv
 Nx
 uX
 sl
@@ -30476,28 +30575,28 @@ aM
 Ym
 Ym
 Ym
+mJ
+mJ
+mJ
 Ym
 Ym
 Ym
 Ym
 Ym
-Ym
-Ym
-Ym
-Ym
-Ym
-Ym
-Ym
-Ym
-Ym
-Ym
-tN
-tN
-tN
-Za
-YT
-WT
-Iw
+aM
+aM
+Pm
+Qi
+To
+Pm
+WM
+sB
+Hd
+Wl
+vs
+Fq
+Fq
+Fq
 sB
 sB
 sB
@@ -30731,29 +30830,29 @@ tN
 tN
 tN
 SG
+bH
 SG
-dh
-eb
-hE
+Yp
+Yp
 vi
 SG
 vi
 SG
 Tg
-tN
-tN
-Ym
-Ym
-Ym
-Ym
-Ym
-Ym
-tN
-tN
-tN
-Za
-Ob
-XJ
+SG
+SG
+aM
+Po
+Ro
+Up
+Uz
+WT
+mu
+UF
+bG
+ey
+oI
+oI
 gZ
 sB
 sB
@@ -30987,31 +31086,31 @@ tN
 tN
 tN
 SG
-SG
-bH
+oX
+iX
 vi
 Yp
 Yp
-SG
-SG
+xL
+oX
 SG
 bH
 SG
 vi
 SG
 tN
-Ym
-Ym
-Ym
-Ym
-Ym
-tN
-tN
-tN
-Za
-bx
-uX
+Pm
+RM
+Uq
+Pm
+Xj
 sB
+mm
+fw
+go
+sB
+sB
+Ks
 sB
 sB
 sB
@@ -31257,14 +31356,14 @@ SG
 vi
 SG
 tN
-Ym
-Ym
-Ym
-Ym
-Ym
-tN
-tN
-tN
+Za
+Za
+Za
+Za
+XB
+XB
+Za
+Za
 Za
 YT
 xI
@@ -31501,31 +31600,31 @@ tN
 tN
 SG
 SG
-BS
-bL
+hW
+hW
 Yp
 Yp
 Yp
 hW
-BS
+hW
 VA
 SG
 SG
 SG
 bH
 tN
-Ym
-Ym
-Ym
-Ym
-Ym
+aM
+aM
+aM
+Za
+Za
+Za
+Za
 tN
-tN
-tN
 Za
-Za
-Za
-Za
+nb
+oM
+Ks
 Za
 CI
 Dt
@@ -31757,9 +31856,9 @@ tN
 tN
 tN
 SG
-jn
-jn
-jn
+hW
+hW
+hW
 Yp
 Yp
 Yp
@@ -31771,18 +31870,18 @@ SG
 vi
 Tg
 tN
-Ym
-Ym
-Ym
-Ym
-Ym
+aM
+aM
+aM
+aM
+aM
 tN
 tN
 tN
-tN
-tN
-tN
-tN
+Za
+by
+mT
+Th
 oX
 oX
 oX
@@ -32014,32 +32113,32 @@ tN
 tN
 tN
 VA
-jn
-Ls
-jn
+hW
+BS
+ja
 Yp
 Yp
 Yp
-Yp
-Yp
+yr
+oX
 Yp
 Yp
 Yp
 Yp
 VA
-pl
-Ym
-Ym
-Ym
-Ym
-Ym
+SG
+aM
+aM
+aM
+aM
+aM
 tN
 tN
 tN
-tN
-tN
-tN
-tN
+Za
+YT
+xI
+ph
 tN
 tN
 tN
@@ -32271,9 +32370,9 @@ tN
 tN
 tN
 Tg
-jn
-jn
-jn
+hW
+hW
+hW
 Yp
 Yp
 Yp
@@ -32283,20 +32382,20 @@ Yp
 Yp
 Yp
 Yp
-Yp
-Uq
-Ym
-Ym
-Ym
-Ym
-Ym
+SG
+SG
+aM
+aM
+aM
+aM
+aM
 tN
 tN
 tN
-tN
-tN
-tN
-tN
+Za
+Sl
+oM
+sB
 tN
 tN
 tN
@@ -32529,31 +32628,31 @@ tN
 tN
 SG
 SG
-BS
-bL
+hW
+hW
 Yp
 Yp
 Yp
-hX
-BS
+mY
+mY
 FU
 FU
 Yp
 Yp
 VA
 pJ
-Ym
-Ym
-Ym
-Ym
-Ym
+aM
+aM
+aM
+aM
+aM
 tN
 tN
 tN
-tN
-tN
-tN
-tN
+Za
+by
+hi
+OP
 tN
 tN
 tN
@@ -32786,7 +32885,7 @@ tN
 tN
 SG
 bH
-SG
+vi
 bJ
 Yp
 Yp
@@ -32799,18 +32898,18 @@ Yp
 Yp
 Yp
 SG
-Ym
-Ym
-Ym
-Ym
-Ym
+aM
+aM
+aM
+aM
+aM
 tN
 tN
 tN
-tN
-tN
-tN
-tN
+Za
+Za
+Za
+Za
 tN
 tN
 tN
@@ -33043,13 +33142,13 @@ tN
 tN
 vi
 SG
-vi
-VA
+oX
+jd
 Yp
 Yp
 Yp
-FU
-FU
+yK
+oX
 FU
 FU
 FU
@@ -33059,8 +33158,8 @@ SG
 tN
 tN
 tN
-Ym
-Ym
+aM
+aM
 tN
 tN
 tN
@@ -33069,10 +33168,10 @@ tN
 tN
 tN
 tN
-tN
-tN
-tN
-tN
+LN
+LN
+VT
+Ge
 tN
 tN
 tN
@@ -33326,10 +33425,10 @@ tN
 tN
 tN
 tN
-tN
-tN
-tN
-tN
+Wp
+LN
+VT
+Ge
 tN
 tN
 tN
@@ -33557,21 +33656,21 @@ tN
 tN
 tN
 SG
-BS
+hW
 cv
 Yp
 Yp
 Yp
-ih
-BS
+iS
+iS
 FU
 FU
 FU
-BS
+mY
 VA
 Tg
 sZ
-BS
+aA
 tN
 tN
 tN
@@ -33583,10 +33682,10 @@ tN
 tN
 tN
 tN
-tN
-tN
-tN
-tN
+Wp
+LN
+Gn
+Ge
 tN
 tN
 tN
@@ -33824,7 +33923,7 @@ iS
 FU
 FU
 FU
-mq
+mY
 nw
 SG
 tr
@@ -33840,10 +33939,10 @@ tN
 tN
 tN
 tN
-tN
-tN
-tN
-tN
+Wp
+LN
+MH
+LN
 tN
 tN
 tN
@@ -34071,7 +34170,7 @@ tN
 tN
 tN
 bJ
-VA
+SG
 Tg
 SG
 Yp
@@ -34842,15 +34941,15 @@ tN
 tN
 tN
 tN
-bK
+hW
 SG
 SG
 Tg
 bJ
 Tg
-jv
-SG
-FU
+wi
+tN
+tN
 Yp
 mY
 Yp
@@ -35099,21 +35198,21 @@ tN
 tN
 tN
 tN
-BS
-bL
+hW
+hW
 SG
 SG
 bH
 SG
-BS
-bJ
-FU
-FU
-BS
-FU
+aA
+tN
+tN
+tN
+aA
+tN
 rB
 Tg
-BS
+aA
 tN
 tN
 tN
@@ -92692,13 +92791,13 @@ tN
 tN
 Yp
 Yp
-RM
-US
-jd
-jd
-jd
-FI
-RM
+Yp
+Yp
+Yp
+Yp
+Yp
+Yp
+Yp
 Yp
 Yp
 Yp
@@ -92949,13 +93048,13 @@ tN
 Yp
 Yp
 Yp
-hu
-bN
-bN
-RU
-bN
-bN
-hu
+Yp
+Yp
+Yp
+Yp
+Yp
+Yp
+Yp
 Yp
 Yp
 Yp
@@ -93205,14 +93304,14 @@ tN
 Yp
 Yp
 Yp
-jd
-jd
-bN
-bN
-bN
-bN
-bN
-jd
+Yp
+Yp
+Yp
+Yp
+Yp
+Yp
+Yp
+Yp
 Yp
 Yp
 Yp
@@ -93462,14 +93561,14 @@ Yp
 Yp
 Yp
 Yp
-jd
-px
-bN
-bN
-bN
-bN
-bN
-jd
+Yp
+Yp
+Yp
+Yp
+Yp
+Yp
+Yp
+Yp
 Yp
 Yp
 Yp
@@ -93706,6 +93805,13 @@ Yp
 Yp
 Yp
 Yp
+De
+tt
+Mu
+Mu
+Mu
+mh
+De
 Yp
 Yp
 Yp
@@ -93719,14 +93825,7 @@ Yp
 Yp
 Yp
 Yp
-jd
-jd
-bN
-bN
-bN
-bN
-bN
-jd
+Yp
 Yp
 Yp
 Yp
@@ -93963,27 +94062,27 @@ Yp
 Yp
 Yp
 Yp
-Yp
-Yp
+nV
+ef
+ef
+jo
+ef
+ef
+nV
 Yp
 Yp
 Pd
-Pd
-Pd
-Pd
-Pd
 Yp
 Yp
 Yp
 Yp
 Yp
-XB
-bN
-bN
-bN
-bN
-bN
-XB
+Yp
+Yp
+Yp
+Yp
+Yp
+Yp
 Yp
 Yp
 Yp
@@ -94219,28 +94318,28 @@ tN
 Yp
 Yp
 Yp
+Mu
+Mu
+ef
+ef
+ef
+ef
+ef
+Mu
+Yp
+Yp
+Pd
+Pd
 Yp
 Yp
 Yp
 Yp
-Pd
-Pd
-Pd
-Pd
-Pd
-Pd
-Pd
-Pd
 Yp
 Yp
 Yp
-RM
-US
-jd
-jd
-jd
-FI
-RM
+Yp
+Yp
+Yp
 Yp
 Yp
 Yp
@@ -94476,15 +94575,15 @@ Yp
 Yp
 Yp
 Yp
+Mu
+qV
+ef
+ef
+ef
+ef
+ef
+Mu
 Yp
-Yp
-Yp
-Yp
-Yp
-Yp
-Yp
-Yp
-Pd
 Pd
 Pd
 Pd
@@ -94733,16 +94832,16 @@ Yp
 Yp
 Yp
 Yp
+Mu
+Mu
+ef
+ef
+ef
+ef
+ef
+Mu
 Yp
-Yp
-Yp
-Yp
-Yp
-tN
-tN
-tN
-tN
-Yp
+Pd
 Pd
 Pd
 Pd
@@ -94991,15 +95090,15 @@ Yp
 Yp
 Yp
 Yp
+vD
+ef
+ef
+ef
+ef
+ef
+vD
 Yp
-Yp
-Yp
-Yp
-tN
-up
-up
-up
-tN
+Pd
 Pd
 Pd
 Pd
@@ -95248,15 +95347,15 @@ Yp
 Yp
 Yp
 Yp
+De
+tt
+Mu
+Mu
+Mu
+mh
+De
 Yp
-Yp
-Yp
-Yp
-Yp
-tN
-up
-up
-tN
+Pd
 Pd
 Pd
 Yp

--- a/_maps/map_files/Mining/Lavaland_Lumos.dmm
+++ b/_maps/map_files/Mining/Lavaland_Lumos.dmm
@@ -80,10 +80,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
-"aj" = (
-/obj/machinery/air_sensor/atmos/nitrogen_tank,
-/turf/open/floor/engine/n2,
-/area/xenoarch/eng)
 "ak" = (
 /obj/machinery/door/airlock/maintenance{
 	req_one_access_txt = "48"
@@ -312,37 +308,27 @@
 	pixel_x = -32
 	},
 /obj/structure/table,
-/obj/item/pipe_dispenser,
-/obj/item/construction/rcd,
 /obj/effect/turf_decal/lumos/tile/brown/half{
 	dir = 8
 	},
+/obj/item/paper_bin{
+	pixel_x = -4;
+	pixel_y = 6
+	},
+/obj/item/pen,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "aM" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4
-	},
-/obj/structure/table,
-/obj/item/paper_bin,
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
+/turf/closed/mineral/random/volcanic,
+/area/space)
 "aN" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "aO" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
@@ -871,13 +857,11 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "ct" = (
-/obj/machinery/computer/atmos_control/tank/air_tank{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
 /obj/effect/turf_decal/lumos/tile/yellow/half,
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "cv" = (
@@ -1069,7 +1053,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
@@ -1175,8 +1158,8 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "eh" = (
-/obj/machinery/air_sensor/atmos/oxygen_tank,
-/turf/open/floor/engine/o2,
+/obj/machinery/air_sensor/atmos/toxin_tank,
+/turf/open/floor/engine/plasma,
 /area/xenoarch/eng)
 "en" = (
 /obj/machinery/atmospherics/pipe/simple/supply/visible/layer1{
@@ -1232,6 +1215,11 @@
 /obj/machinery/hydroponics/constructable,
 /turf/open/floor/plasteel,
 /area/xenoarch/bot)
+"eT" = (
+/obj/machinery/atmospherics/miner/nitrogen,
+/obj/machinery/light/small,
+/turf/open/floor/engine/n2,
+/area/xenoarch/eng)
 "eV" = (
 /turf/open/floor/plasteel,
 /area/xenoarch/bot)
@@ -1312,8 +1300,11 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/effect/turf_decal/lumos/tile/yellow/half,
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/machinery/computer/atmos_control/tank/nitrogen_tank{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "fn" = (
@@ -1359,7 +1350,9 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "fG" = (
-/obj/machinery/air_sensor/atmos/air_tank,
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/air_input{
+	dir = 1
+	},
 /turf/open/floor/engine/air,
 /area/xenoarch/eng)
 "fH" = (
@@ -1481,11 +1474,11 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "gx" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/air_input{
-	dir = 1
+/obj/machinery/light{
+	dir = 8
 	},
-/turf/open/floor/engine/air,
-/area/xenoarch/eng)
+/turf/open/floor/plasteel/stairs,
+/area/xenoarch/arch)
 "gC" = (
 /obj/machinery/light,
 /obj/machinery/camera{
@@ -1735,8 +1728,8 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
-/obj/machinery/light,
 /obj/effect/turf_decal/lumos/tile/yellow/half,
+/obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "ic" = (
@@ -2346,9 +2339,6 @@
 	dir = 8
 	},
 /obj/machinery/portable_atmospherics/scrubber,
-/obj/structure/sign/poster/official/random{
-	pixel_x = 32
-	},
 /obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 4
 	},
@@ -2372,6 +2362,7 @@
 /area/xenoarch/eng)
 "lH" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/open/floor/plating,
 /area/xenoarch/eng)
 "lM" = (
@@ -2519,9 +2510,6 @@
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/gen)
 "mA" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 5
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/visible/layer1,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -2658,13 +2646,13 @@
 /turf/open/floor/grass,
 /area/lavaland/surface/outdoors)
 "nx" = (
-/obj/machinery/atmospherics/components/binary/volume_pump,
-/obj/machinery/atmospherics/components/binary/volume_pump/layer1{
-	dir = 1
-	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/xenoarch/eng)
 "nz" = (
@@ -2910,15 +2898,14 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/binary/volume_pump/layer1,
-/obj/machinery/atmospherics/components/binary/volume_pump/layer3,
-/obj/machinery/atmospherics/components/binary/volume_pump,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/purple/visible/layer3,
+/obj/machinery/computer/atmos_control/tank/toxin_tank,
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "pq" = (
@@ -2954,9 +2941,13 @@
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
 "pD" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/toxin_input,
-/turf/open/floor/engine/plasma,
-/area/xenoarch/eng)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/turf/open/floor/plasteel/stairs,
+/area/xenoarch/arch)
 "pE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/effect/turf_decal/lumos/tile/yellow/half{
@@ -3251,14 +3242,14 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/summoning_altar)
 "qX" = (
-/obj/machinery/atmospherics/components/binary/volume_pump{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/binary/volume_pump/layer1{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/visible/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/xenoarch/eng)
@@ -3453,6 +3444,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
+/obj/structure/table,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "sc" = (
@@ -3499,9 +3491,11 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "st" = (
+/obj/machinery/atmospherics/pipe/simple/supply/visible/layer1{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "sw" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
@@ -3540,6 +3534,11 @@
 	},
 /turf/open/floor/plasteel/elevatorshaft,
 /area/mining_level_access/lower)
+"sK" = (
+/obj/machinery/atmospherics/miner/oxygen,
+/obj/machinery/light/small,
+/turf/open/floor/engine/o2,
+/area/xenoarch/eng)
 "sL" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
 	dir = 1
@@ -3600,6 +3599,13 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/lumos/tile/yellow/half,
+/obj/machinery/atmospherics/pipe/simple/purple/visible/layer3,
+/obj/machinery/atmospherics/components/binary/volume_pump{
+	dir = 1
+	},
+/obj/machinery/computer/atmos_control/tank/oxygen_tank{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "sZ" = (
@@ -3819,10 +3825,6 @@
 /turf/open/lava/smooth/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "uy" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 4
 	},
@@ -3900,7 +3902,10 @@
 	layer = 4;
 	pixel_x = 32
 	},
-/turf/open/floor/plasteel/stairs,
+/obj/effect/turf_decal/lumos/tile/purple/half{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "uX" = (
 /obj/structure/table,
@@ -3987,10 +3992,6 @@
 	},
 /turf/open/indestructible/boss,
 /area/lavaland/surface/outdoors)
-"vx" = (
-/obj/effect/turf_decal/vg_decals/atmos/nitrogen,
-/turf/open/floor/engine/n2,
-/area/xenoarch/eng)
 "vz" = (
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
@@ -4227,7 +4228,6 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "xx" = (
-/obj/machinery/vending/tool,
 /obj/effect/turf_decal/lumos/tile/yellow/fulltile,
 /turf/open/floor/plasteel,
 /area/xenoarch/gen)
@@ -4734,6 +4734,9 @@
 /obj/item/storage/bag/strangerock,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
+"Af" = (
+/turf/open/floor/engine/o2,
+/area/xenoarch/eng)
 "Ak" = (
 /obj/structure/stone_tile/block{
 	dir = 1
@@ -4836,7 +4839,7 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "AZ" = (
-/obj/machinery/air_sensor/atmos/toxin_tank,
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/toxin_input,
 /turf/open/floor/engine/plasma,
 /area/xenoarch/eng)
 "Bc" = (
@@ -4935,18 +4938,20 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "BD" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/machinery/atmospherics/pipe/simple/supply/visible/layer1{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "BF" = (
-/obj/machinery/atmospherics/pipe/simple/dark/visible{
-	dir = 9
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/eng)
 "BK" = (
 /obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4;
@@ -5087,7 +5092,6 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "CL" = (
-/obj/machinery/computer/atmos_control/tank/toxin_tank,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
 	},
@@ -5097,6 +5101,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "CR" = (
@@ -5612,6 +5617,7 @@
 /obj/item/holosign_creator/firelock,
 /obj/item/holosign_creator/atmos,
 /obj/machinery/light,
+/obj/item/construction/rcd,
 /turf/open/floor/plasteel,
 /area/xenoarch/gen)
 "FZ" = (
@@ -5655,7 +5661,6 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/effect/turf_decal/lumos/tile/yellow/half,
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
@@ -5751,16 +5756,11 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/binary/volume_pump/layer3{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/binary/volume_pump/layer1{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/binary/volume_pump{
-	dir = 1
-	},
 /obj/effect/turf_decal/lumos/tile/yellow/half,
+/obj/machinery/atmospherics/pipe/simple/supply/visible/layer1,
+/obj/machinery/computer/atmos_control/tank/air_tank{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "GN" = (
@@ -5778,8 +5778,8 @@
 /turf/open/indestructible/boss,
 /area/ruin/unpowered/ash_walkers)
 "GS" = (
-/obj/machinery/vending/engivend,
 /obj/effect/turf_decal/lumos/tile/yellow/fulltile,
+/obj/machinery/vending/tool,
 /turf/open/floor/plasteel,
 /area/xenoarch/gen)
 "GT" = (
@@ -5837,9 +5837,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/xenoarch/arch)
-"Hp" = (
-/turf/open/floor/engine/n2,
-/area/xenoarch/eng)
 "Hq" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
@@ -5895,10 +5892,10 @@
 /turf/open/floor/plasteel/elevatorshaft,
 /area/mining_level_access/lower)
 "HF" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible/layer3,
-/obj/machinery/atmospherics/components/trinary/mixer/flipped{
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "HI" = (
@@ -6243,17 +6240,17 @@
 /area/xenoarch/arch)
 "Ka" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "Kc" = (
 /turf/open/floor/carpet,
 /area/xenoarch/gen)
 "Kd" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 10
+/obj/machinery/atmospherics/pipe/simple/purple/visible/layer3,
+/obj/machinery/atmospherics/components/trinary/mixer/flipped{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
@@ -6414,13 +6411,15 @@
 /turf/open/floor/engine,
 /area/xenoarch/eng)
 "Lc" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 4
 	},
 /obj/machinery/status_display/evac{
 	layer = 4;
 	pixel_x = 32
+	},
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
@@ -6589,13 +6588,11 @@
 /turf/open/indestructible/boss,
 /area/ruin/unpowered/ash_walkers)
 "Mf" = (
-/obj/machinery/computer/atmos_control/tank/oxygen_tank{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
 /obj/effect/turf_decal/lumos/tile/yellow/half,
+/obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "Mg" = (
@@ -6603,9 +6600,6 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "Mi" = (
-/obj/machinery/computer/atmos_control/tank/nitrogen_tank{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 9
 	},
@@ -6730,10 +6724,12 @@
 /turf/open/floor/plating,
 /area/xenoarch/eng)
 "Nq" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/turf/open/floor/plating,
-/area/xenoarch/eng)
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/obj/structure/table,
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "Nr" = (
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 8
@@ -6802,12 +6798,6 @@
 /obj/structure/dresser,
 /turf/open/floor/carpet,
 /area/xenoarch/gen)
-"NL" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/nitrogen_input{
-	dir = 1
-	},
-/turf/open/floor/engine/n2,
-/area/xenoarch/eng)
 "NM" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -6895,10 +6885,10 @@
 	},
 /area/ruin/unpowered/ash_walkers)
 "Om" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/oxygen_input{
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/nitrogen_output{
 	dir = 1
 	},
-/turf/open/floor/engine/o2,
+/turf/open/floor/engine/n2,
 /area/xenoarch/eng)
 "On" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -6939,9 +6929,11 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/gen)
 "OB" = (
-/obj/machinery/atmospherics/pipe/simple/dark/visible,
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 1
+	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/area/xenoarch/eng)
 "OC" = (
 /obj/structure/stone_tile/block{
 	dir = 1
@@ -6981,6 +6973,10 @@
 /obj/item/book/granter/crafting_recipe/bone_bow,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"OJ" = (
+/obj/effect/turf_decal/vg_decals/atmos/nitrogen,
+/turf/open/floor/engine/n2,
+/area/xenoarch/eng)
 "OK" = (
 /obj/structure/stone_tile,
 /obj/structure/stone_tile{
@@ -7013,7 +7009,7 @@
 /turf/open/indestructible/boss,
 /area/lavaland/surface/outdoors)
 "OU" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/oxygen_output{
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/oxygen_input{
 	dir = 1
 	},
 /turf/open/floor/engine/o2,
@@ -7026,16 +7022,14 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "Pb" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/nitrogen_output{
-	dir = 1
-	},
-/turf/open/floor/engine/n2,
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/turf/open/floor/plating,
 /area/xenoarch/eng)
 "Pc" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on{
-	dir = 4
-	},
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/plating,
 /area/xenoarch/eng)
 "Pd" = (
 /turf/open/lava/smooth/lava_land_surface,
@@ -7197,6 +7191,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/machinery/vending/engivend,
 /turf/open/floor/plasteel,
 /area/xenoarch/gen)
 "Qp" = (
@@ -7260,7 +7255,9 @@
 /turf/open/floor/plating,
 /area/xenoarch/arch)
 "QX" = (
-/obj/effect/turf_decal/vg_decals/atmos/oxygen,
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/oxygen_output{
+	dir = 1
+	},
 /turf/open/floor/engine/o2,
 /area/xenoarch/eng)
 "Ra" = (
@@ -7284,9 +7281,10 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "Rj" = (
-/obj/machinery/atmospherics/miner/oxygen,
-/obj/machinery/light/small,
-/turf/open/floor/engine/o2,
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/nitrogen_input{
+	dir = 1
+	},
+/turf/open/floor/engine/n2,
 /area/xenoarch/eng)
 "Rl" = (
 /obj/structure/stone_tile/block{
@@ -7315,13 +7313,9 @@
 /turf/open/indestructible/boss,
 /area/ruin/unpowered/ash_walkers)
 "Rt" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/disposalpipe/segment{
-	dir = 1
-	},
-/turf/open/floor/plasteel/stairs,
-/area/xenoarch/arch)
+/obj/machinery/air_sensor/atmos/air_tank,
+/turf/open/floor/engine/air,
+/area/xenoarch/eng)
 "Rw" = (
 /obj/machinery/hydroponics/constructable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -7356,9 +7350,7 @@
 /turf/open/indestructible/boss,
 /area/ruin/unpowered/ash_walkers)
 "RE" = (
-/obj/machinery/atmospherics/miner/nitrogen,
-/obj/machinery/light/small,
-/turf/open/floor/engine/n2,
+/turf/closed/mineral/random/volcanic,
 /area/xenoarch/eng)
 "RF" = (
 /obj/machinery/door/airlock{
@@ -7451,6 +7443,7 @@
 /turf/open/indestructible/boss,
 /area/ruin/unpowered/ash_walkers)
 "Sv" = (
+/obj/effect/turf_decal/vg_decals/atmos/oxygen,
 /turf/open/floor/engine/o2,
 /area/xenoarch/eng)
 "Sx" = (
@@ -7488,6 +7481,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
+"SC" = (
+/obj/machinery/air_sensor/atmos/oxygen_tank,
+/turf/open/floor/engine/o2,
+/area/xenoarch/eng)
 "SD" = (
 /obj/structure/stone_tile/block{
 	dir = 8
@@ -7641,6 +7638,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
+"TB" = (
+/turf/open/floor/engine/n2,
+/area/xenoarch/eng)
 "TD" = (
 /obj/structure/stone_tile/cracked,
 /obj/structure/stone_tile/block{
@@ -8129,7 +8129,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "Yh" = (
@@ -8250,7 +8250,6 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "YY" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/effect/turf_decal/lumos/tile/yellow/fullcorner,
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
@@ -8266,6 +8265,10 @@
 	layer = 2.47
 	},
 /turf/open/floor/plating,
+/area/xenoarch/eng)
+"Zo" = (
+/obj/machinery/air_sensor/atmos/nitrogen_tank,
+/turf/open/floor/engine/n2,
 /area/xenoarch/eng)
 "Zp" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -20130,7 +20133,7 @@ AU
 Bf
 km
 sa
-JR
+Nq
 JX
 BS
 QV
@@ -20635,8 +20638,8 @@ mb
 Nh
 My
 ec
-lT
-Sy
+My
+gx
 My
 Rh
 My
@@ -20892,8 +20895,8 @@ ma
 Je
 Je
 kt
-Rt
 Je
+pD
 Je
 Je
 Je
@@ -21150,7 +21153,7 @@ bI
 ia
 ia
 uU
-ia
+lT
 ia
 zU
 ia
@@ -23445,7 +23448,7 @@ jn
 BS
 KG
 bP
-AU
+bP
 bC
 AU
 ZF
@@ -23702,7 +23705,7 @@ jn
 BS
 AC
 ju
-AU
+ju
 AU
 AU
 Ug
@@ -23730,7 +23733,7 @@ Ge
 Ge
 Ge
 Pd
-Pc
+Yp
 Pd
 tN
 tN
@@ -23987,7 +23990,7 @@ Iu
 Lw
 Nn
 OB
-BF
+Yp
 Pd
 tN
 tN
@@ -24231,9 +24234,9 @@ hs
 hs
 hs
 Ge
-Ge
-Ge
-Ge
+RE
+RE
+RE
 Ge
 xE
 FB
@@ -24488,10 +24491,10 @@ ka
 iX
 mk
 Ge
-RK
-RK
-pD
-st
+Ge
+Ge
+Ge
+Ge
 dC
 BD
 mA
@@ -24501,7 +24504,7 @@ Hu
 GM
 DJ
 OF
-yP
+Rt
 yP
 Ge
 tN
@@ -24750,13 +24753,13 @@ ok
 AZ
 lH
 CL
-YO
-Wu
+st
+BF
 KC
 FB
-FB
+IP
 ct
-lH
+Pb
 fG
 pW
 QS
@@ -24988,7 +24991,7 @@ jn
 ak
 um
 aF
-aM
+AU
 AU
 bm
 BT
@@ -25003,7 +25006,7 @@ eV
 Im
 Ge
 RK
-RK
+eh
 ZP
 DJ
 pn
@@ -25011,12 +25014,12 @@ KL
 CD
 Df
 FB
-IP
+Vd
 Gs
-Nq
-gx
-yP
-yP
+Ge
+Ge
+Ge
+Ge
 Ge
 tN
 tN
@@ -25244,7 +25247,7 @@ jn
 yr
 BS
 ar
-AU
+wW
 aN
 Yb
 AY
@@ -25266,14 +25269,14 @@ Ge
 lF
 YO
 Wu
-KC
-FB
-Vd
+Do
+Hw
+Kd
 sY
-Ge
-Ge
-Ge
-Ge
+DJ
+QX
+SC
+Af
 Ge
 tN
 tN
@@ -25523,14 +25526,14 @@ sw
 lf
 BK
 Wu
-Do
-Hw
+FB
+Ki
 HF
-GM
-DJ
+ib
+lH
 OU
 Sv
-Sv
+sK
 Ge
 tN
 tN
@@ -25781,13 +25784,13 @@ tR
 oT
 Wu
 FB
-FB
+FZ
 Vd
 Mf
-lH
-eh
-QX
-Rj
+Ge
+Ge
+Ge
+Ge
 Ge
 tN
 tN
@@ -26038,13 +26041,13 @@ xo
 bA
 CJ
 FB
-Ki
+FZ
 Ka
 fl
-st
+DJ
 Om
-Sv
-Sv
+Zo
+TB
 Ge
 tN
 tN
@@ -26296,12 +26299,12 @@ qu
 FZ
 FB
 FZ
-Vd
+Ki
 ib
-Ge
-Ge
-Ge
-Ge
+Pc
+Rj
+OJ
+eT
 Ge
 tN
 tN
@@ -26553,12 +26556,12 @@ lw
 yR
 lw
 HL
-Kd
-GM
-DJ
-Pb
-Hp
-Hp
+FZ
+Gs
+Ge
+Ge
+Ge
+Ge
 Ge
 tN
 tN
@@ -26789,7 +26792,7 @@ Xr
 vP
 Vn
 cH
-ia
+zU
 lT
 Dy
 PW
@@ -26810,13 +26813,13 @@ lw
 Ue
 lw
 lw
-lw
+yR
 Mi
-lH
-aj
-vx
-RE
 Ge
+RE
+RE
+RE
+RE
 tN
 tN
 QV
@@ -27069,11 +27072,11 @@ Du
 HM
 Lc
 YY
-st
-NL
-Hp
-Hp
 Ge
+RE
+RE
+RE
+RE
 tN
 tN
 QV
@@ -27328,9 +27331,9 @@ Ge
 Ge
 Ge
 Ge
-Ge
-Ge
-Ge
+RE
+RE
+RE
 tN
 tN
 QV
@@ -28328,10 +28331,10 @@ tN
 tN
 tN
 tN
-Ym
-Ym
-Ym
-Ym
+aM
+aM
+aM
+aM
 BS
 pU
 bM
@@ -28585,15 +28588,15 @@ tN
 tN
 tN
 tN
-Ym
-Ym
-Ym
-Ym
+aM
+aM
+aM
+aM
 BS
 aH
 co
 dQ
-Ym
+ac
 Ym
 Ym
 Ym
@@ -28842,15 +28845,15 @@ tN
 tN
 tN
 tN
-Ym
-Ym
-Ym
-Ym
+aM
+aM
+aM
+aM
 BS
 bF
 cG
 dV
-Ym
+ac
 Ym
 Ym
 Ym
@@ -29099,15 +29102,15 @@ tN
 tN
 tN
 tN
-Ym
-Ym
-Ym
-Ym
+aM
+aM
+aM
+aM
 BS
 pU
 do
 pU
-Ym
+ac
 Ym
 Ym
 Ym
@@ -29356,10 +29359,10 @@ tN
 tN
 tN
 tN
-Ym
-Ym
-Ym
-Ym
+aM
+aM
+aM
+aM
 Ym
 Ym
 Ym
@@ -29613,10 +29616,10 @@ tN
 tN
 tN
 tN
-Ym
-Ym
-Ym
-Ym
+aM
+aM
+aM
+aM
 Ym
 Ym
 Ym
@@ -29870,10 +29873,10 @@ tN
 tN
 tN
 tN
-Ym
-Ym
-Ym
-Ym
+aM
+aM
+aM
+aM
 Ym
 Ym
 Ym
@@ -30127,10 +30130,10 @@ tN
 tN
 tN
 tN
-Ym
-Ym
-Ym
-Ym
+aM
+aM
+aM
+aM
 Ym
 Ym
 Ym
@@ -30384,10 +30387,10 @@ tN
 tN
 tN
 tN
-Ym
-Ym
-Ym
-Ym
+aM
+aM
+aM
+aM
 Ym
 Ym
 Ym
@@ -30641,9 +30644,9 @@ tN
 tN
 tN
 tN
-Ym
-Ym
-Ym
+aM
+aM
+aM
 Ym
 Ym
 Ym
@@ -30898,9 +30901,9 @@ tN
 tN
 tN
 tN
-Ym
-Ym
-Ym
+aM
+aM
+aM
 Ym
 Ym
 Ym

--- a/_maps/map_files/Mining/Lavaland_Lumos.dmm
+++ b/_maps/map_files/Mining/Lavaland_Lumos.dmm
@@ -27,11 +27,8 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "ac" = (
-/obj/machinery/atmospherics/pipe/simple/dark/visible{
-	dir = 9
-	},
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/turf/closed/wall,
+/area/space)
 "ad" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -84,9 +81,7 @@
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
 "aj" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/nitrogen_output{
-	dir = 1
-	},
+/obj/machinery/air_sensor/atmos/nitrogen_tank,
 /turf/open/floor/engine/n2,
 /area/xenoarch/eng)
 "ak" = (
@@ -103,9 +98,8 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "an" = (
-/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
-	dir = 8
+	dir = 10
 	},
 /turf/open/floor/plasteel/elevatorshaft,
 /area/mining_level_access/lower)
@@ -253,11 +247,12 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "aE" = (
-/obj/machinery/airalarm{
-	pixel_y = 23
+/obj/effect/turf_decal/lumos/tile/yellow/fullcorner{
+	dir = 8
 	},
-/obj/effect/turf_decal/lumos/tile/yellow/half{
-	dir = 1
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable{
+	icon_state = "0-2"
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
@@ -275,15 +270,15 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "aH" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
+/obj/effect/turf_decal/lumos/tile/purple/half{
+	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/gen)
+/obj/structure/closet/emcloset/anchored,
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "aI" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -373,11 +368,20 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "aQ" = (
+/obj/structure/table,
+/obj/machinery/smartfridge/disks,
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/requests_console{
+	department = "Xenoarchaeology";
+	pixel_y = 28
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/bot)
@@ -478,15 +482,6 @@
 	},
 /turf/open/floor/plating,
 /area/xenoarch/arch)
-"bf" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 9
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/eng)
 "bh" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -613,17 +608,16 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "bu" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/machinery/disposal/bin,
 /turf/open/floor/plasteel,
 /area/xenoarch/bot)
 "bv" = (
@@ -652,8 +646,9 @@
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/gen)
 "bA" = (
-/obj/machinery/atmospherics/pipe/simple/supply/visible{
-	dir = 9
+/obj/machinery/power/smes/engineering,
+/obj/structure/cable{
+	icon_state = "0-4"
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
@@ -686,18 +681,19 @@
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/sec)
 "bF" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/machinery/airalarm{
+	pixel_y = 23
+	},
+/obj/effect/turf_decal/lumos/tile/purple/half{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel,
-/area/xenoarch/bot)
+/area/xenoarch/arch)
 "bG" = (
 /obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 4
@@ -736,11 +732,22 @@
 /turf/open/floor/grass,
 /area/xenoarch/arch)
 "bM" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 9
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/research/glass,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/effect/turf_decal/lumos/tile/purple/fulltile,
 /turf/open/floor/plasteel,
-/area/xenoarch/eng)
+/area/xenoarch/arch)
 "bN" = (
 /turf/open/openspace,
 /area/mining_level_access/upper)
@@ -817,13 +824,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
-"cf" = (
-/obj/structure/chair/office/dark{
-	dir = 1
-	},
-/obj/effect/landmark/start/scientist,
-/turf/open/floor/plasteel,
-/area/xenoarch/bot)
 "ci" = (
 /obj/structure/stone_tile{
 	dir = 1
@@ -838,11 +838,23 @@
 /turf/open/indestructible/boss,
 /area/lavaland/surface/outdoors)
 "co" = (
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/gen)
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/effect/turf_decal/lumos/tile/purple/half{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "cp" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -859,17 +871,11 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "ct" = (
+/obj/machinery/computer/atmos_control/tank/air_tank{
+	dir = 1
+	},
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
-	},
-/obj/machinery/atmospherics/components/binary/volume_pump/layer3{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/binary/volume_pump/layer1{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/binary/volume_pump{
-	dir = 1
 	},
 /obj/effect/turf_decal/lumos/tile/yellow/half,
 /turf/open/floor/plasteel,
@@ -899,9 +905,23 @@
 /turf/closed/indestructible/riveted/boss,
 /area/ruin/unpowered/ash_walkers)
 "cG" = (
-/obj/machinery/atmospherics/pipe/simple/supply/visible/layer1,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/lumos/tile/purple/half{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
-/area/xenoarch/eng)
+/area/xenoarch/arch)
 "cH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
@@ -916,11 +936,10 @@
 /obj/structure/stone_tile/center,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"cO" = (
-/obj/effect/turf_decal/vg_decals/atmos/air,
-/turf/open/floor/engine/air,
-/area/xenoarch/eng)
 "cU" = (
+/obj/machinery/igniter{
+	id = "IncineratorL"
+	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
@@ -987,14 +1006,13 @@
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
 "do" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 1
+/obj/machinery/door/airlock/research/glass,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
 	},
-/obj/effect/turf_decal/lumos/tile/purple/checker{
-	dir = 4
-	},
+/obj/effect/turf_decal/lumos/tile/purple/fulltile,
 /turf/open/floor/plasteel,
-/area/xenoarch/bot)
+/area/xenoarch/arch)
 "dr" = (
 /obj/structure/stone_tile/block{
 	dir = 8
@@ -1048,17 +1066,15 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "dC" = (
-/obj/machinery/atmospherics/components/binary/volume_pump{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
-	},
-/obj/machinery/light{
-	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
@@ -1102,30 +1118,35 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "dQ" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/structure/fireaxecabinet{
-	pixel_x = 32
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
 	},
-/obj/machinery/camera{
-	c_tag = "Xenoarchaeology Fourteen";
-	dir = 9
+/obj/effect/turf_decal/lumos/tile/purple/half{
+	dir = 8
 	},
-/obj/effect/turf_decal/lumos/tile/yellow/half{
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/xenoarch/eng)
+/area/xenoarch/arch)
 "dV" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/status_display/evac{
-	layer = 4;
-	pixel_x = 32
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/obj/structure/closet/secure_closet/engineering_electrical,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/lumos/tile/purple/half{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
-/area/xenoarch/gen)
+/area/xenoarch/arch)
 "dY" = (
 /obj/structure/stone_tile/block/cracked{
 	dir = 8
@@ -1154,9 +1175,7 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "eh" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/oxygen_output{
-	dir = 1
-	},
+/obj/machinery/air_sensor/atmos/oxygen_tank,
 /turf/open/floor/engine/o2,
 /area/xenoarch/eng)
 "en" = (
@@ -1183,15 +1202,19 @@
 /turf/open/floor/plating,
 /area/xenoarch/arch)
 "eA" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/obj/machinery/status_display/evac{
-	layer = 4;
-	pixel_y = -32
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/door/airlock/research/glass,
+/obj/effect/turf_decal/lumos/tile/purple/checker{
+	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/gen)
+/obj/effect/turf_decal/lumos/tile/green/checker,
+/turf/open/floor/plasteel,
+/area/xenoarch/bot)
 "eK" = (
 /obj/structure/stone_tile/block/cracked{
 	dir = 1
@@ -1203,6 +1226,9 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "eL" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
+	},
 /obj/machinery/hydroponics/constructable,
 /turf/open/floor/plasteel,
 /area/xenoarch/bot)
@@ -1283,24 +1309,19 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "fl" = (
-/obj/machinery/computer/atmos_control/tank/oxygen_tank{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/effect/turf_decal/lumos/tile/yellow/half,
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "fn" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
 	},
-/obj/structure/table,
-/obj/machinery/reagentgrinder{
-	desc = "Used to grind things up into raw materials and liquids.";
-	pixel_y = 5
-	},
+/obj/machinery/biogenerator,
+/obj/item/reagent_containers/glass/bucket,
 /turf/open/floor/plasteel,
 /area/xenoarch/bot)
 "fq" = (
@@ -1315,11 +1336,17 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "fs" = (
-/obj/structure/table,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/turf/open/floor/plasteel,
-/area/xenoarch/gen)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/maintenance,
+/obj/machinery/door/firedoor/heavy,
+/turf/open/floor/plating,
+/area/xenoarch/eng)
 "fy" = (
 /obj/structure/chair/office/dark,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -1327,22 +1354,21 @@
 /turf/open/floor/plasteel/white,
 /area/xenoarch/arch)
 "fE" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
+/obj/effect/turf_decal/tile/green{
+	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/gen)
+/obj/effect/turf_decal/lumos/tile/purple/checker{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/bot)
 "fF" = (
 /obj/structure/stone_tile/slab,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "fG" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/nitrogen_output{
-	dir = 1
-	},
+/obj/machinery/air_sensor/atmos/air_tank,
 /turf/open/floor/engine/air,
 /area/xenoarch/eng)
 "fH" = (
@@ -1356,14 +1382,18 @@
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
 "fI" = (
-/obj/effect/turf_decal/tile/purple{
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/gen)
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/bot)
 "fM" = (
 /obj/machinery/requests_console{
 	department = "Xenoarchaeology Security";
@@ -1444,14 +1474,19 @@
 /turf/open/indestructible/boss,
 /area/lavaland/surface/outdoors)
 "gu" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
+/obj/effect/turf_decal/tile/green{
+	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/gen)
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/plasteel,
+/area/xenoarch/bot)
 "gw" = (
 /obj/structure/stone_tile{
 	dir = 4
@@ -1460,7 +1495,9 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "gx" = (
-/obj/machinery/air_sensor/atmos/air_tank,
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/air_input{
+	dir = 1
+	},
 /turf/open/floor/engine/air,
 /area/xenoarch/eng)
 "gC" = (
@@ -1491,24 +1528,6 @@
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"gN" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 8
-	},
-/obj/effect/turf_decal/lumos/tile/purple/half{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "gO" = (
 /turf/open/lava/smooth/lava_land_surface,
 /area/summoning_altar)
@@ -1547,12 +1566,16 @@
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/sec)
 "gX" = (
-/obj/machinery/power/turbine{
-	dir = 8;
+/obj/machinery/power/compressor{
+	comp_id = "incineratorturbineL";
+	dir = 4;
 	luminosity = 2
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
 	},
 /turf/open/floor/engine,
 /area/xenoarch/eng)
@@ -1564,19 +1587,16 @@
 /area/xenoarch/gen)
 "ha" = (
 /obj/structure/table,
-/obj/machinery/smartfridge/disks,
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/requests_console{
-	department = "Xenoarchaeology";
-	pixel_y = 28
+/obj/item/storage/box/disks_plantgene,
+/obj/item/storage/box/disks_plantgene,
+/obj/machinery/newscaster{
+	pixel_y = 32
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/bot)
@@ -1648,19 +1668,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/white,
-/area/xenoarch/arch)
-"hB" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/obj/effect/turf_decal/lumos/tile/purple/half{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/corner,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "hE" = (
 /obj/structure/flora/ausbushes/lavendergrass,
@@ -1737,7 +1744,7 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/machinery/light,
 /obj/effect/turf_decal/lumos/tile/yellow/half,
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
@@ -1806,15 +1813,12 @@
 /area/xenoarch/sec)
 "im" = (
 /obj/structure/table,
-/obj/machinery/smartfridge/disks,
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
-/obj/machinery/light,
-/obj/structure/sign/poster/official/random{
-	pixel_y = -32
-	},
+/obj/item/storage/box/disks_plantgene,
+/obj/item/storage/box/disks_plantgene,
 /turf/open/floor/plasteel,
 /area/xenoarch/bot)
 "io" = (
@@ -1843,14 +1847,18 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "ix" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel,
-/area/xenoarch/gen)
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/xenoarch/eng)
 "iz" = (
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
@@ -1934,28 +1942,38 @@
 /turf/open/lava/smooth/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "iX" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/glass/bucket,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/bot)
 "ja" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/lumos/tile/yellow/fulltile,
-/obj/machinery/portable_atmospherics/scrubber/huge/movable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
-/area/xenoarch/gen)
+/area/xenoarch/bot)
 "jd" = (
 /turf/open/floor/plating,
 /area/mining_level_access)
 "je" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/structure/chair/office/dark{
+	dir = 1
 	},
-/turf/open/floor/plating,
-/area/xenoarch/gen)
+/obj/effect/landmark/start/scientist,
+/turf/open/floor/plasteel,
+/area/xenoarch/bot)
 "ji" = (
 /obj/machinery/status_display/evac{
 	layer = 4;
@@ -1980,12 +1998,15 @@
 /turf/open/floor/plating,
 /area/xenoarch/arch)
 "js" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 1
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/xenoarch/eng)
 "ju" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/closet/wardrobe/xenoarch,
@@ -2001,8 +2022,8 @@
 /area/xenoarch/arch)
 "jw" = (
 /obj/machinery/suit_storage_unit/atmos,
-/obj/effect/turf_decal/lumos/tile/yellow/fullcorner{
-	dir = 4
+/obj/effect/turf_decal/lumos/tile/yellow/half{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
@@ -2012,7 +2033,7 @@
 /turf/open/indestructible/boss,
 /area/lavaland/surface/outdoors)
 "jK" = (
-/obj/machinery/suit_storage_unit/atmos,
+/obj/structure/tank_dispenser/oxygen,
 /obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 1
 	},
@@ -2061,24 +2082,19 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "ka" = (
-/obj/machinery/atmospherics/pipe/simple/supply/visible/layer1{
-	dir = 4
+/obj/effect/turf_decal/tile/green{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/item/radio/intercom{
+	dir = 8;
+	name = "Station Intercom (General)";
+	pixel_x = -28
 	},
-/obj/machinery/door/airlock/maintenance,
-/obj/machinery/door/firedoor/heavy,
-/turf/open/floor/plating,
-/area/xenoarch/eng)
-"kg" = (
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/turf/open/floor/plating,
-/area/xenoarch/eng)
+/turf/open/floor/plasteel,
+/area/xenoarch/bot)
 "kh" = (
 /obj/machinery/light/small,
 /obj/machinery/space_heater,
@@ -2148,13 +2164,15 @@
 /turf/closed/indestructible/riveted/boss/see_through,
 /area/ruin/unpowered/ash_walkers)
 "kx" = (
+/obj/structure/table,
+/obj/machinery/smartfridge/disks,
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
+/obj/machinery/light,
+/obj/structure/sign/poster/official/random{
+	pixel_y = -32
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/bot)
@@ -2169,12 +2187,17 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "kD" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
 	},
-/obj/machinery/door/firedoor,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
 /turf/open/floor/plasteel,
-/area/xenoarch/arch)
+/area/xenoarch/bot)
 "kF" = (
 /obj/structure/chair/sofa/corp/left,
 /turf/open/floor/plasteel/dark,
@@ -2195,21 +2218,11 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -30
+	},
 /turf/open/floor/plasteel,
 /area/xenoarch/bot)
-"kR" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/xenoarch/eng)
 "kS" = (
 /obj/structure/stone_tile{
 	dir = 8
@@ -2237,14 +2250,17 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "kW" = (
+/obj/machinery/vending/hydronutrients,
+/obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/purple{
-	dir = 1
+	dir = 4
 	},
-/obj/machinery/camera{
-	c_tag = "Xenoarchaeology One"
+/obj/machinery/status_display/evac{
+	layer = 4;
+	pixel_x = 32
 	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/gen)
+/turf/open/floor/plasteel,
+/area/xenoarch/bot)
 "kY" = (
 /obj/structure/stone_tile/block,
 /turf/open/lava/smooth/lava_land_surface,
@@ -2271,17 +2287,10 @@
 /area/summoning_altar)
 "lf" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
+	dir = 9
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/machinery/requests_console{
-	department = "Xenoarchaeology";
-	pixel_y = 28
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
@@ -2359,19 +2368,19 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/binary/volume_pump/layer1,
-/obj/machinery/atmospherics/components/binary/volume_pump/layer3,
-/obj/machinery/atmospherics/components/binary/volume_pump,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/machinery/requests_console{
+	department = "Xenoarchaeology";
+	pixel_y = 28
+	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "lH" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating,
 /area/xenoarch/eng)
@@ -2404,7 +2413,6 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
-/obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/xenoarch/bot)
 "lP" = (
@@ -2432,12 +2440,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/fans/tiny,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/structure/fans/tiny/invisible,
-/obj/machinery/door/airlock/public/glass/incinerator/atmos_exterior,
+/obj/effect/turf_decal/vg_decals/radiation,
 /turf/open/floor/engine,
 /area/xenoarch/eng)
 "ma" = (
@@ -2480,14 +2483,11 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/sec)
 "mg" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/obj/structure/sign/poster/official/random{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/gen)
+/turf/open/floor/plasteel,
+/area/xenoarch/bot)
 "mj" = (
 /obj/structure/stone_tile/cracked{
 	dir = 8
@@ -2498,20 +2498,20 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "mk" = (
-/obj/structure/flora/ausbushes/grassybush,
-/obj/structure/flora/ausbushes/lavendergrass,
-/turf/open/floor/grass,
-/area/lavaland/surface/outdoors)
+/obj/structure/chair/office/dark,
+/obj/effect/landmark/start/scientist,
+/turf/open/floor/plasteel,
+/area/xenoarch/bot)
 "mp" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
 	},
-/obj/effect/turf_decal/lumos/tile/purple/half{
-	dir = 4
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/xenoarch/arch)
+/area/xenoarch/bot)
 "mq" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -2528,18 +2528,23 @@
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/gen)
 "mA" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/visible/layer1,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "mB" = (
+/obj/machinery/hydroponics/constructable,
 /obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_y = -32
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/bot)
@@ -2606,15 +2611,14 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "nf" = (
+/obj/machinery/atmospherics/pipe/simple/dark/visible,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 8
 	},
-/obj/structure/fans/tiny/invisible,
-/obj/machinery/door/airlock/public/glass/incinerator/atmos_interior,
-/turf/open/floor/engine,
+/turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "nh" = (
 /obj/structure/stone_tile/block,
@@ -2663,12 +2667,9 @@
 /turf/open/floor/grass,
 /area/lavaland/surface/outdoors)
 "nx" = (
-/obj/machinery/atmospherics/components/binary/volume_pump,
-/obj/structure/sign/poster/official/random{
-	pixel_x = -32
-	},
-/obj/effect/turf_decal/lumos/tile/yellow/half{
-	dir = 8
+/obj/machinery/suit_storage_unit/atmos,
+/obj/effect/turf_decal/lumos/tile/yellow/fullcorner{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
@@ -2787,27 +2788,32 @@
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/sec)
 "of" = (
-/obj/machinery/atmospherics/pipe/simple/supply/visible/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
 	},
-/obj/machinery/door/firedoor/heavy,
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Engineering";
-	req_access_txt = "32"
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
 	},
 /turf/open/floor/plating,
 /area/xenoarch/eng)
 "ok" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/oxygen_input{
+/obj/machinery/atmospherics/components/binary/volume_pump,
+/obj/machinery/atmospherics/components/binary/volume_pump/layer1{
 	dir = 1
 	},
-/turf/open/floor/engine/o2,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
 /area/xenoarch/eng)
 "ox" = (
 /obj/structure/disposalpipe/segment,
@@ -2828,11 +2834,10 @@
 /area/xenoarch/arch)
 "oL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 6
+	dir = 4
 	},
-/obj/machinery/meter,
-/obj/effect/turf_decal/lumos/tile/yellow/half{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/supply/visible/layer1{
+	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
@@ -2855,11 +2860,10 @@
 /turf/open/floor/plasteel/white,
 /area/xenoarch/arch)
 "oT" = (
-/obj/machinery/atmospherics/pipe/layer_manifold{
-	dir = 4;
-	layer = 2.47
+/obj/machinery/atmospherics/pipe/simple/supply/visible{
+	dir = 9
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "oU" = (
 /obj/structure/chair/sofa/corp,
@@ -2873,16 +2877,13 @@
 /area/lavaland/surface/outdoors)
 "pc" = (
 /obj/structure/table,
+/obj/machinery/plantgenes,
+/obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
-	},
-/obj/item/storage/box/disks_plantgene,
-/obj/item/storage/box/disks_plantgene,
-/obj/machinery/newscaster{
-	pixel_y = 32
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/bot)
@@ -2920,10 +2921,12 @@
 /turf/open/floor/grass,
 /area/lavaland/surface/outdoors)
 "pn" = (
-/obj/machinery/computer/atmos_control/tank/toxin_tank,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
 	},
+/obj/machinery/atmospherics/components/binary/volume_pump/layer1,
+/obj/machinery/atmospherics/components/binary/volume_pump/layer3,
+/obj/machinery/atmospherics/components/binary/volume_pump,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
@@ -2939,20 +2942,8 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "ps" = (
-/obj/machinery/atmospherics/components/binary/volume_pump{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/binary/volume_pump/layer1{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/xenoarch/eng)
-"pt" = (
-/obj/effect/turf_decal/vg_decals/atmos/nitrogen,
-/turf/open/floor/engine/n2,
+/obj/effect/turf_decal/vg_decals/atmos/plasma,
+/turf/open/floor/engine/plasma,
 /area/xenoarch/eng)
 "pB" = (
 /obj/structure/stone_tile{
@@ -2971,14 +2962,15 @@
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
 "pD" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 6
 	},
-/obj/machinery/camera{
-	c_tag = "Xenoarchaeology Two"
+/obj/machinery/meter,
+/obj/effect/turf_decal/lumos/tile/yellow/half{
+	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/gen)
+/turf/open/floor/plasteel,
+/area/xenoarch/eng)
 "pE" = (
 /obj/structure/chair/sofa/corp/left{
 	dir = 1
@@ -3005,10 +2997,10 @@
 /turf/open/lava/smooth/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "pO" = (
-/obj/machinery/atmospherics/components/binary/volume_pump{
+/obj/machinery/atmospherics/pipe/simple/dark/visible{
 	dir = 4
 	},
-/turf/open/floor/engine,
+/turf/closed/wall/r_wall,
 /area/xenoarch/eng)
 "pP" = (
 /obj/structure/stone_tile{
@@ -3039,6 +3031,7 @@
 /turf/open/floor/plating,
 /area/xenoarch/arch)
 "pW" = (
+/obj/effect/turf_decal/vg_decals/atmos/air,
 /turf/open/floor/engine/air,
 /area/xenoarch/eng)
 "pX" = (
@@ -3063,10 +3056,7 @@
 /area/xenoarch/sec)
 "qb" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+	dir = 5
 	},
 /turf/open/floor/plasteel/elevatorshaft,
 /area/mining_level_access/lower)
@@ -3122,12 +3112,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/machinery/door/airlock/maintenance,
+/obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plating,
 /area/xenoarch/eng)
 "qm" = (
@@ -3158,34 +3147,23 @@
 /turf/open/indestructible/boss,
 /area/ruin/unpowered/ash_walkers)
 "qo" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
+/obj/machinery/atmospherics/components/binary/volume_pump{
 	dir = 8
 	},
-/obj/machinery/meter,
-/obj/effect/turf_decal/lumos/tile/yellow/fullcorner{
-	dir = 1
-	},
+/obj/machinery/light,
+/obj/effect/turf_decal/lumos/tile/yellow/half,
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "qu" = (
-/obj/machinery/power/smes/engineering,
 /obj/structure/cable{
-	icon_state = "0-4"
+	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "qy" = (
-/obj/machinery/vending/hydronutrients,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/machinery/status_display/evac{
-	layer = 4;
-	pixel_x = 32
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/bot)
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/toxin_input,
+/turf/open/floor/engine/plasma,
+/area/xenoarch/eng)
 "qC" = (
 /obj/structure/stone_tile/block/cracked{
 	dir = 8
@@ -3253,20 +3231,15 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "qN" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 4
+/obj/structure/rack,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/storage/toolbox/mechanical,
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
+/obj/machinery/firealarm{
+	pixel_y = 24
 	},
 /turf/open/floor/plating,
 /area/xenoarch/eng)
@@ -3289,20 +3262,16 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/summoning_altar)
 "qX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/visible/layer1{
-	dir = 5
+/obj/machinery/atmospherics/components/binary/volume_pump{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
+/obj/machinery/atmospherics/components/binary/volume_pump/layer1{
+	dir = 4
 	},
 /obj/structure/cable/yellow{
-	icon_state = "1-4"
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
-/area/xenoarch/eng)
-"rd" = (
-/obj/machinery/atmospherics/pipe/manifold/purple/visible/layer3,
-/turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "re" = (
 /obj/structure/stone_tile/cracked{
@@ -3330,10 +3299,10 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "rl" = (
-/obj/machinery/atmospherics/pipe/manifold/dark/hidden{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/dark/hidden{
+	dir = 4
 	},
-/turf/open/floor/engine,
+/turf/closed/wall/r_wall,
 /area/xenoarch/eng)
 "ro" = (
 /obj/structure/stone_tile/block/cracked{
@@ -3351,14 +3320,12 @@
 /turf/open/lava/smooth/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "rr" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/obj/effect/turf_decal/lumos/tile/yellow/half{
+	dir = 8
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 30
-	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/gen)
+/turf/open/floor/plasteel,
+/area/xenoarch/eng)
 "rt" = (
 /obj/effect/turf_decal/lumos/tile/yellow/fullcorner{
 	dir = 1
@@ -3383,13 +3350,11 @@
 /turf/open/floor/grass,
 /area/lavaland/surface/outdoors)
 "rC" = (
-/obj/machinery/light,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
+/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/n2{
+	dir = 1
 	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/gen)
+/turf/open/floor/plasteel,
+/area/xenoarch/eng)
 "rG" = (
 /obj/machinery/camera{
 	c_tag = "Xenoarchaeology Security Checkpoint Lobby"
@@ -3439,6 +3404,9 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "rS" = (
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
 /obj/effect/turf_decal/lumos/tile/yellow/fulltile,
 /obj/machinery/portable_atmospherics/scrubber/huge/movable,
 /turf/open/floor/plasteel,
@@ -3462,21 +3430,16 @@
 	dir = 8
 	},
 /obj/structure/cable{
-	icon_state = "2-4"
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "rZ" = (
-/obj/machinery/power/compressor{
-	comp_id = "incineratorturbineL";
-	dir = 4;
-	luminosity = 2
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
 	},
 /obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
+	icon_state = "4-8"
 	},
 /turf/open/floor/engine,
 /area/xenoarch/eng)
@@ -3491,9 +3454,7 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "sc" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 6
-	},
+/obj/machinery/atmospherics/components/trinary/filter/atmos/o2,
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "sf" = (
@@ -3536,18 +3497,29 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "st" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/supply/visible/layer1{
+	dir = 5
 	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/gen)
-"sw" = (
-/obj/machinery/atmospherics/components/binary/volume_pump,
-/obj/machinery/atmospherics/components/binary/volume_pump/layer1{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
 	},
 /obj/structure/cable/yellow{
-	icon_state = "1-2"
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating,
+/area/xenoarch/eng)
+"sw" = (
+/obj/machinery/atmospherics/pipe/simple/supply/visible/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/xenoarch/eng)
@@ -3579,8 +3551,8 @@
 /turf/open/floor/plasteel/elevatorshaft,
 /area/mining_level_access/lower)
 "sL" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/visible/layer1{
 	dir = 8
@@ -3612,13 +3584,20 @@
 /turf/open/floor/plasteel/white,
 /area/xenoarch/arch)
 "sT" = (
-/obj/machinery/hydroponics/constructable,
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -22
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
+/obj/machinery/camera{
+	c_tag = "Xenoarchaeology Six";
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/bot)
@@ -3630,7 +3609,6 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/effect/turf_decal/lumos/tile/yellow/half,
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
@@ -3689,15 +3667,24 @@
 /turf/open/floor/plasteel/stairs,
 /area/xenoarch/gen)
 "tx" = (
-/obj/machinery/atmospherics/components/trinary/filter/atmos/plasma,
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	dir = 8;
+	name = "Station Intercom (General)";
+	pixel_x = 28
+	},
+/obj/effect/turf_decal/lumos/tile/yellow/half{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "ty" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/structure/table,
-/obj/item/holosign_creator/firelock,
-/obj/item/holosign_creator/atmos,
-/obj/machinery/light,
+/obj/item/inducer,
 /turf/open/floor/plasteel,
 /area/xenoarch/gen)
 "tB" = (
@@ -3758,11 +3745,7 @@
 /turf/closed/mineral/random/high_chance/volcanic,
 /area/ruin/unpowered/ash_walkers)
 "tR" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/turf_decal/lumos/tile/yellow/half{
+/obj/machinery/atmospherics/pipe/manifold/supply/visible{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -3778,20 +3761,6 @@
 /obj/structure/stone_tile/slab,
 /turf/closed/indestructible/riveted/boss,
 /area/lavaland/surface/outdoors)
-"tZ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/airalarm{
-	pixel_y = 23
-	},
-/obj/effect/turf_decal/lumos/tile/purple/half{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "uf" = (
 /obj/structure/flora/grass/jungle,
 /obj/structure/flora/ausbushes/lavendergrass,
@@ -3807,17 +3776,10 @@
 /turf/open/indestructible/boss,
 /area/lavaland/surface/outdoors)
 "ui" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/gen)
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/plating,
+/area/xenoarch/eng)
 "uj" = (
 /obj/structure/stone_tile/block/cracked{
 	dir = 8
@@ -3927,10 +3889,22 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "uT" = (
+/obj/machinery/atmospherics/pipe/simple/dark/visible,
+/obj/machinery/button/ignition{
+	id = "IncineratorL";
+	pixel_x = -24
+	},
 /obj/machinery/atmospherics/pipe/simple/purple/visible/layer3{
 	dir = 4
 	},
-/turf/closed/wall/r_wall,
+/obj/machinery/camera{
+	c_tag = "Xenoarchaeology Thirteen";
+	dir = 5
+	},
+/obj/effect/turf_decal/lumos/tile/yellow/half{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "uU" = (
 /obj/machinery/status_display/evac{
@@ -3972,18 +3946,9 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "vk" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/door/airlock/research/glass,
-/obj/effect/turf_decal/lumos/tile/purple/checker{
-	dir = 4
-	},
-/obj/effect/turf_decal/lumos/tile/green/checker,
-/turf/open/floor/plasteel,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
 /area/xenoarch/bot)
 "vn" = (
 /obj/structure/stone_tile/block{
@@ -4034,6 +3999,7 @@
 /turf/open/indestructible/boss,
 /area/lavaland/surface/outdoors)
 "vx" = (
+/obj/effect/turf_decal/vg_decals/atmos/nitrogen,
 /turf/open/floor/engine/n2,
 /area/xenoarch/eng)
 "vz" = (
@@ -4093,6 +4059,10 @@
 	},
 /area/ruin/unpowered/ash_walkers)
 "vU" = (
+/obj/machinery/atmospherics/miner/toxins,
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/open/floor/engine/plasma,
 /area/xenoarch/eng)
 "wf" = (
@@ -4146,20 +4116,15 @@
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/sec)
 "wp" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/item/reagent_containers/glass/bucket,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/xenoarch/bot)
+/area/xenoarch/eng)
 "ws" = (
 /obj/structure/fluff/drake_statue,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
@@ -4189,14 +4154,14 @@
 /turf/closed/mineral/random/labormineral/volcanic,
 /area/lavaland/surface/outdoors)
 "wF" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
 /obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 4
 	},
-/obj/machinery/status_display/evac{
-	layer = 4;
-	pixel_x = 32
-	},
+/obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "wI" = (
@@ -4263,32 +4228,29 @@
 /turf/open/floor/plasteel/white,
 /area/xenoarch/arch)
 "xl" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/visible{
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "xo" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
+/obj/machinery/airalarm/unlocked{
+	pixel_y = 24
 	},
-/obj/structure/sign/poster/official/random{
-	pixel_y = -32
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 6
 	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/gen)
+/obj/machinery/computer/turbine_computer{
+	id = "incineratorturbineL"
+	},
+/obj/effect/turf_decal/lumos/tile/yellow/fullcorner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/eng)
 "xx" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/item/radio/intercom{
-	dir = 8;
-	name = "Station Intercom (General)";
-	pixel_x = 28
-	},
-/obj/effect/turf_decal/lumos/tile/yellow/half{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/thermomachine/heater{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
@@ -4334,26 +4296,18 @@
 /turf/open/floor/grass,
 /area/xenoarch/gen)
 "xE" = (
-/obj/machinery/airalarm/unlocked{
-	pixel_y = 24
+/obj/machinery/atmospherics/components/binary/volume_pump{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 6
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
 	},
-/obj/machinery/computer/turbine_computer{
-	id = "incineratorturbineL"
-	},
-/obj/effect/turf_decal/lumos/tile/yellow/fullcorner{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/xenoarch/eng)
-"xH" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/machinery/light,
-/obj/effect/turf_decal/lumos/tile/yellow/half,
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "xI" = (
@@ -4441,13 +4395,13 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "ym" = (
-/obj/machinery/power/apc/auto_name/south,
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/bot)
@@ -4570,10 +4524,10 @@
 /turf/closed/indestructible/riveted/boss,
 /area/lavaland/surface/outdoors)
 "yP" = (
-/obj/machinery/light/small,
 /turf/open/floor/engine/air,
 /area/xenoarch/eng)
 "yR" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
@@ -4687,14 +4641,6 @@
 /obj/item/poster/random_official,
 /turf/open/floor/plating,
 /area/xenoarch/arch)
-"zr" = (
-/obj/machinery/door/airlock/research/glass,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/effect/turf_decal/lumos/tile/purple/fulltile,
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "zu" = (
 /obj/structure/stone_tile/cracked{
 	dir = 4
@@ -4705,11 +4651,8 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "zx" = (
-/obj/machinery/autolathe,
 /obj/effect/turf_decal/lumos/tile/yellow/fulltile,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/portable_atmospherics/scrubber/huge/movable,
 /turf/open/floor/plasteel,
 /area/xenoarch/gen)
 "zB" = (
@@ -4745,6 +4688,7 @@
 /obj/machinery/atmospherics/pipe/simple/purple/visible/layer3{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/visible/layer1,
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "zO" = (
@@ -4774,11 +4718,10 @@
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/sec)
 "zU" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/air_input{
-	dir = 1
-	},
-/turf/open/floor/engine/air,
-/area/xenoarch/eng)
+/obj/machinery/vending/tool,
+/obj/effect/turf_decal/lumos/tile/yellow/fulltile,
+/turf/open/floor/plasteel,
+/area/xenoarch/gen)
 "zW" = (
 /obj/structure/stone_tile/cracked{
 	dir = 8
@@ -4881,22 +4824,21 @@
 /area/lavaland/surface/outdoors)
 "AP" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
+	dir = 4
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
+/obj/machinery/chem_master,
 /turf/open/floor/plasteel,
 /area/xenoarch/bot)
 "AT" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 4
 	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
 /turf/open/floor/plasteel,
-/area/xenoarch/gen)
+/area/xenoarch/arch)
 "AU" = (
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
@@ -4915,7 +4857,7 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "AZ" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/toxin_input,
+/obj/machinery/air_sensor/atmos/toxin_tank,
 /turf/open/floor/engine/plasma,
 /area/xenoarch/eng)
 "Bc" = (
@@ -4978,8 +4920,8 @@
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/gen)
 "Br" = (
-/obj/machinery/atmospherics/pipe/simple/dark/hidden{
-	dir = 6
+/obj/machinery/atmospherics/pipe/manifold/dark/hidden{
+	dir = 1
 	},
 /turf/open/floor/engine,
 /area/xenoarch/eng)
@@ -5004,24 +4946,33 @@
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
 "BC" = (
-/obj/machinery/atmospherics/components/trinary/filter/atmos/o2,
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
+	},
+/obj/effect/turf_decal/lumos/tile/yellow/half{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "BD" = (
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/machinery/atmospherics/pipe/simple/dark/hidden{
+	dir = 6
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/engine,
 /area/xenoarch/eng)
 "BF" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/dark/visible{
+	dir = 9
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/xenoarch/eng)
+/area/lavaland/surface/outdoors)
 "BK" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/toxin_output,
-/turf/open/floor/engine/plasma,
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/machinery/atmospherics/pipe/simple/supply/visible/layer1{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "BS" = (
 /turf/closed/wall,
@@ -5086,21 +5037,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
-"Cp" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 6
-	},
-/obj/machinery/meter,
-/turf/open/floor/plasteel,
-/area/xenoarch/eng)
 "Ct" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4;
+	layer = 2.47
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/plasteel,
-/area/xenoarch/bot)
+/turf/open/floor/plating,
+/area/xenoarch/eng)
 "Cx" = (
 /obj/structure/stone_tile/block/cracked{
 	dir = 8
@@ -5112,14 +5055,19 @@
 /turf/open/indestructible/boss,
 /area/lavaland/surface/outdoors)
 "CD" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/structure/fireaxecabinet{
+	pixel_x = 32
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
+/obj/machinery/camera{
+	c_tag = "Xenoarchaeology Fourteen";
+	dir = 9
 	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/gen)
+/obj/effect/turf_decal/lumos/tile/yellow/half{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/eng)
 "CF" = (
 /obj/structure/stone_tile/block{
 	dir = 1
@@ -5140,12 +5088,8 @@
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/gen)
 "CJ" = (
-/obj/machinery/camera{
-	c_tag = "Xenoarchaeology Four";
-	dir = 5
-	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/gen)
@@ -5157,10 +5101,10 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "CL" = (
+/obj/machinery/computer/atmos_control/tank/toxin_tank,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
@@ -5205,33 +5149,41 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "CV" = (
-/obj/structure/table,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/metal/fifty,
-/turf/open/floor/plasteel,
-/area/xenoarch/gen)
+/obj/machinery/door/poddoor/incinerator_atmos_main{
+	id = "atmos_incinerator_mainventL"
+	},
+/turf/open/floor/engine,
+/area/xenoarch/eng)
 "CX" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible/layer3{
-	dir = 10
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/binary/volume_pump/layer3,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "CZ" = (
-/obj/machinery/light,
-/obj/machinery/disposal/bin,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 6
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/gen)
-"Db" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
-/obj/structure/closet/secure_closet/engineering_welding,
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/eng)
+"Db" = (
+/obj/machinery/camera{
+	c_tag = "Xenoarchaeology Four";
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/xenoarch/gen)
 "Dc" = (
@@ -5243,22 +5195,16 @@
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
 "Df" = (
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
+/obj/machinery/status_display/evac{
+	layer = 4;
+	pixel_x = 32
 	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/gen)
-"Dj" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/lumos/tile/yellow/half,
+/obj/structure/closet/secure_closet/engineering_electrical,
 /turf/open/floor/plasteel,
-/area/xenoarch/eng)
+/area/xenoarch/gen)
 "Dk" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -5281,14 +5227,8 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "Do" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/structure/sign/poster/official/random{
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/gen)
+/turf/open/floor/engine,
+/area/xenoarch/eng)
 "Dp" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
@@ -5301,10 +5241,9 @@
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/gen)
 "Du" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/manifold/purple/visible/layer3,
 /turf/open/floor/plasteel,
-/area/xenoarch/arch)
+/area/xenoarch/eng)
 "Dv" = (
 /obj/structure/stone_tile/block/cracked{
 	dir = 8
@@ -5316,13 +5255,11 @@
 /turf/open/indestructible/boss,
 /area/ruin/unpowered/ash_walkers)
 "Dw" = (
-/obj/effect/turf_decal/lumos/tile/yellow/fulltile,
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Engineering";
-	req_access_txt = "32"
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/xenoarch/eng)
+/area/xenoarch/gen)
 "Dy" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -5355,6 +5292,7 @@
 /turf/open/floor/plating,
 /area/xenoarch/arch)
 "DJ" = (
+/obj/machinery/atmospherics/pipe/layer_manifold,
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating,
 /area/xenoarch/eng)
@@ -5392,14 +5330,23 @@
 /turf/open/lava/smooth/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "DS" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/visible/layer1{
 	dir = 8
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/lumos/tile/yellow/half{
+	dir = 4
+	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
@@ -5477,17 +5424,7 @@
 /turf/open/floor/plating,
 /area/xenoarch/arch)
 "Eo" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/item/radio/intercom{
-	dir = 8;
-	name = "Station Intercom (General)";
-	pixel_x = -28
-	},
+/obj/machinery/hydroponics/constructable,
 /turf/open/floor/plasteel,
 /area/xenoarch/bot)
 "Eq" = (
@@ -5557,9 +5494,9 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "EW" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 10
-	},
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/structure/table,
+/obj/item/pipe_dispenser,
 /turf/open/floor/plasteel,
 /area/xenoarch/gen)
 "EX" = (
@@ -5593,11 +5530,11 @@
 /turf/closed/indestructible/riveted/boss,
 /area/lavaland/surface/outdoors)
 "Fv" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/gen)
+/obj/machinery/atmospherics/pipe/simple/purple/visible/layer3{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/eng)
 "Fw" = (
 /obj/machinery/light,
 /obj/structure/disposalpipe/segment{
@@ -5625,12 +5562,15 @@
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
 "FG" = (
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 30
+	},
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/gen)
+/turf/open/floor/plasteel,
+/area/xenoarch/eng)
 "FI" = (
 /obj/machinery/light/small,
 /turf/open/floor/plating,
@@ -5667,11 +5607,10 @@
 /turf/closed/indestructible/riveted/boss,
 /area/lavaland/surface/outdoors)
 "FT" = (
-/obj/machinery/light,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/obj/structure/table,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/turf/open/floor/plasteel,
 /area/xenoarch/gen)
 "FU" = (
 /turf/open/water,
@@ -5683,32 +5622,23 @@
 /turf/closed/indestructible/riveted/boss,
 /area/lavaland/surface/outdoors)
 "FW" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
+/obj/structure/closet/secure_closet/engineering_welding,
+/turf/open/floor/plasteel,
 /area/xenoarch/gen)
 "FY" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/structure/table,
-/obj/item/pipe_dispenser,
+/obj/item/holosign_creator/firelock,
+/obj/item/holosign_creator/atmos,
+/obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/xenoarch/gen)
 "FZ" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
-	},
-/obj/machinery/power/terminal{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
@@ -5729,8 +5659,11 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "Go" = (
-/obj/structure/chair/office/dark,
-/obj/effect/landmark/start/scientist,
+/obj/machinery/seed_extractor,
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/xenoarch/bot)
 "Gq" = (
@@ -5740,23 +5673,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
-"Gr" = (
-/obj/effect/turf_decal/lumos/tile/purple/half{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/structure/closet/emcloset/anchored,
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "Gs" = (
-/obj/machinery/computer/atmos_control/tank/air_tank{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/effect/turf_decal/lumos/tile/yellow/half,
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
@@ -5767,10 +5688,6 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/machinery/disposal/bin,
 /turf/open/floor/plasteel,
 /area/xenoarch/bot)
 "Gw" = (
@@ -5853,10 +5770,18 @@
 /turf/open/indestructible/boss,
 /area/ruin/unpowered/ash_walkers)
 "GM" = (
-/obj/machinery/atmospherics/components/binary/volume_pump{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
 	},
-/obj/machinery/light,
+/obj/machinery/atmospherics/components/binary/volume_pump/layer3{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/binary/volume_pump/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/binary/volume_pump{
+	dir = 1
+	},
 /obj/effect/turf_decal/lumos/tile/yellow/half,
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
@@ -5875,7 +5800,7 @@
 /turf/open/indestructible/boss,
 /area/ruin/unpowered/ash_walkers)
 "GS" = (
-/obj/machinery/vending/tool,
+/obj/machinery/vending/engivend,
 /obj/effect/turf_decal/lumos/tile/yellow/fulltile,
 /turf/open/floor/plasteel,
 /area/xenoarch/gen)
@@ -5899,9 +5824,14 @@
 /turf/open/floor/plating,
 /area/xenoarch/arch)
 "Ha" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/obj/structure/table,
-/obj/item/inducer,
+/obj/machinery/light,
+/obj/machinery/disposal/bin,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 6
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/xenoarch/gen)
 "Hc" = (
@@ -5933,8 +5863,6 @@
 /turf/open/floor/plasteel/white,
 /area/xenoarch/arch)
 "Hp" = (
-/obj/machinery/atmospherics/miner/nitrogen,
-/obj/machinery/light/small,
 /turf/open/floor/engine/n2,
 /area/xenoarch/eng)
 "Hq" = (
@@ -5942,15 +5870,17 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/visible/layer1{
-	dir = 6
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "Hr" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/xenoarch/bot)
+/obj/effect/turf_decal/tile/purple,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 30
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "Ht" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -5970,6 +5900,12 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "Hu" = (
+/obj/machinery/door/poddoor/incinerator_atmos_aux{
+	id = "atmos_incinerator_auxventL"
+	},
+/turf/open/floor/engine,
+/area/xenoarch/eng)
+"Hw" = (
 /obj/machinery/atmospherics/pipe/simple/dark/visible,
 /obj/machinery/meter,
 /obj/effect/turf_decal/lumos/tile/yellow/half{
@@ -5982,38 +5918,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
-"Hw" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/gen)
-"Hx" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/research/glass,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 8
-	},
-/obj/effect/turf_decal/lumos/tile/purple/fulltile,
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "HD" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/elevatorshaft,
 /area/mining_level_access/lower)
 "HF" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+/obj/machinery/atmospherics/pipe/simple/purple/visible/layer3,
+/obj/machinery/atmospherics/components/trinary/mixer/flipped{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -6035,34 +5946,25 @@
 /turf/open/floor/plasteel/white,
 /area/xenoarch/arch)
 "HL" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/structure/sign/poster/official/random{
-	pixel_x = 32
-	},
-/obj/effect/turf_decal/lumos/tile/yellow/half{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/visible/layer1,
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "HM" = (
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/atmospherics/components/binary/volume_pump/layer3{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/gen)
+/turf/open/floor/plasteel,
+/area/xenoarch/eng)
 "HP" = (
 /obj/effect/turf_decal/lumos/tile/purple/half,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "HQ" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 9
 	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/gen)
+/turf/open/floor/plasteel,
+/area/xenoarch/eng)
 "HS" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel,
@@ -6096,13 +5998,12 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "If" = (
-/obj/effect/turf_decal/tile/purple{
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/gen)
+/turf/open/floor/plasteel,
+/area/xenoarch/eng)
 "Ig" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 2
@@ -6169,9 +6070,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
-/obj/structure/sign/poster/official/random{
-	pixel_y = -32
-	},
+/obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/xenoarch/bot)
 "In" = (
@@ -6233,6 +6132,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/visible/layer1{
 	dir = 8
 	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "IG" = (
@@ -6258,15 +6160,11 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "IP" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/visible/layer1,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
+/obj/structure/table,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
 /turf/open/floor/plasteel,
-/area/xenoarch/eng)
+/area/xenoarch/gen)
 "IS" = (
 /obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
@@ -6290,12 +6188,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/white,
 /area/xenoarch/arch)
-"Jc" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/heater{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/eng)
 "Je" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -6313,24 +6205,6 @@
 	},
 /turf/open/floor/carpet,
 /area/xenoarch/gen)
-"Jh" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/effect/turf_decal/lumos/tile/purple/half{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "Jj" = (
 /obj/structure/stone_tile/block{
 	dir = 4
@@ -6343,11 +6217,6 @@
 	},
 /turf/open/indestructible/boss,
 /area/lavaland/surface/outdoors)
-"Jo" = (
-/obj/machinery/atmospherics/miner/oxygen,
-/obj/machinery/light/small,
-/turf/open/floor/engine/o2,
-/area/xenoarch/eng)
 "JG" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
@@ -6392,39 +6261,21 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "Ka" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 30
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
 	},
-/obj/effect/turf_decal/lumos/tile/purple/half{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/xenoarch/arch)
+/area/xenoarch/gen)
 "Kc" = (
 /turf/open/floor/carpet,
 /area/xenoarch/gen)
 "Kd" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/binary/volume_pump/layer3,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/eng)
-"Ke" = (
-/obj/machinery/atmospherics/pipe/simple/dark/visible,
-/obj/machinery/button/ignition{
-	id = "IncineratorL";
-	pixel_x = -24
-	},
-/obj/machinery/atmospherics/pipe/simple/purple/visible/layer3{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Xenoarchaeology Thirteen";
-	dir = 5
+/obj/machinery/atmospherics/components/binary/volume_pump,
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
 	},
 /obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 8
@@ -6438,8 +6289,8 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "Ki" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
@@ -6479,10 +6330,11 @@
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/gen)
 "Ku" = (
-/obj/machinery/atmospherics/pipe/layer_manifold{
-	dir = 4
+/obj/machinery/atmospherics/components/binary/volume_pump/layer3{
+	dir = 8
 	},
-/turf/closed/wall/r_wall,
+/obj/machinery/light,
+/turf/open/floor/engine,
 /area/xenoarch/eng)
 "Kz" = (
 /obj/structure/bed,
@@ -6493,7 +6345,6 @@
 /obj/machinery/atmospherics/pipe/simple/purple/visible/layer3{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/visible/layer1,
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "KE" = (
@@ -6527,12 +6378,16 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "KJ" = (
-/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/n2{
-	dir = 1
+/obj/effect/turf_decal/lumos/tile/yellow/half{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "KL" = (
+/obj/machinery/atmospherics/pipe/simple/purple/visible/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/visible/layer1{
 	dir = 4
 	},
@@ -6576,15 +6431,20 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/vg_decals/radiation,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/structure/fans/tiny/invisible,
+/obj/machinery/door/airlock/public/glass/incinerator/atmos_interior,
 /turf/open/floor/engine,
 /area/xenoarch/eng)
 "Lc" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 6
 	},
+/obj/machinery/meter,
 /turf/open/floor/plasteel,
-/area/xenoarch/gen)
+/area/xenoarch/eng)
 "Lg" = (
 /obj/machinery/button/door{
 	id = "dorm2L";
@@ -6602,7 +6462,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/chem_master,
+/obj/structure/table,
+/obj/machinery/reagentgrinder{
+	desc = "Used to grind things up into raw materials and liquids.";
+	pixel_y = 5
+	},
 /turf/open/floor/plasteel,
 /area/xenoarch/bot)
 "Ls" = (
@@ -6624,9 +6488,11 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "Lw" = (
-/obj/machinery/atmospherics/pipe/simple/dark/visible,
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "LB" = (
 /obj/structure/disposalpipe/segment{
@@ -6687,22 +6553,21 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "LN" = (
-/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
-	dir = 4
+	dir = 6
 	},
 /turf/open/floor/plasteel/elevatorshaft,
 /area/mining_level_access/lower)
 "LR" = (
-/obj/machinery/igniter{
-	id = "IncineratorL"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/structure/fans/tiny,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/structure/fans/tiny/invisible,
+/obj/machinery/door/airlock/public/glass/incinerator/atmos_exterior,
 /turf/open/floor/engine,
 /area/xenoarch/eng)
 "LT" = (
@@ -6734,21 +6599,23 @@
 /turf/open/indestructible/boss,
 /area/ruin/unpowered/ash_walkers)
 "Mf" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 10
 	},
-/obj/machinery/airalarm{
-	pixel_y = 23
-	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/gen)
+/turf/open/floor/plasteel,
+/area/xenoarch/eng)
 "Mg" = (
 /obj/structure/stone_tile,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "Mi" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 10
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/effect/turf_decal/lumos/tile/yellow/half{
+	dir = 4
+	},
+/obj/machinery/status_display/evac{
+	layer = 4;
+	pixel_x = 32
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
@@ -6791,37 +6658,17 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "MA" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/effect/turf_decal/lumos/tile/yellow/half{
-	dir = 4
+/obj/effect/turf_decal/lumos/tile/yellow/fulltile,
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Engineering";
+	req_access_txt = "32"
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "MC" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/lumos/tile/purple/half{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
 /turf/open/floor/plasteel,
-/area/xenoarch/arch)
+/area/space)
 "ML" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /turf/open/floor/plating,
 /area/xenoarch/eng)
 "MU" = (
@@ -6831,31 +6678,27 @@
 /turf/closed/indestructible/riveted/boss,
 /area/ruin/unpowered/ash_walkers)
 "MV" = (
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
+/obj/machinery/power/apc/auto_name/south,
 /obj/structure/cable/yellow{
-	icon_state = "1-4"
+	icon_state = "0-8"
 	},
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
-/obj/machinery/camera{
-	c_tag = "Xenoarchaeology Six";
-	dir = 1
-	},
 /turf/open/floor/plasteel,
 /area/xenoarch/bot)
 "Nb" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 1
+	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/xenoarch/gen)
 "Nc" = (
 /obj/effect/turf_decal/tile/purple{
@@ -6895,25 +6738,25 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "Nn" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 8
 	},
-/obj/effect/turf_decal/lumos/tile/yellow/half{
-	dir = 4
+/obj/machinery/meter,
+/obj/effect/turf_decal/lumos/tile/yellow/fullcorner{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "Nq" = (
-/obj/machinery/light{
+/obj/machinery/computer/atmos_control/tank/oxygen_tank{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/gen)
+/obj/effect/turf_decal/lumos/tile/yellow/half,
+/turf/open/floor/plasteel,
+/area/xenoarch/eng)
 "Nr" = (
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 8
@@ -6932,6 +6775,9 @@
 /turf/open/lava/smooth/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "Nu" = (
+/obj/machinery/airalarm{
+	pixel_y = 23
+	},
 /obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 1
 	},
@@ -6963,10 +6809,14 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "NH" = (
-/obj/machinery/atmospherics/pipe/layer_manifold{
-	layer = 2.47
+/obj/machinery/computer/atmos_control/tank/nitrogen_tank{
+	dir = 1
 	},
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 9
+	},
+/obj/effect/turf_decal/lumos/tile/yellow/half,
+/turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "NI" = (
 /obj/structure/stone_tile/block{
@@ -6979,7 +6829,9 @@
 /turf/open/floor/carpet,
 /area/xenoarch/gen)
 "NL" = (
-/obj/machinery/air_sensor/atmos/nitrogen_tank,
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/nitrogen_input{
+	dir = 1
+	},
 /turf/open/floor/engine/n2,
 /area/xenoarch/eng)
 "NM" = (
@@ -7069,7 +6921,9 @@
 	},
 /area/ruin/unpowered/ash_walkers)
 "Om" = (
-/obj/machinery/air_sensor/atmos/oxygen_tank,
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/oxygen_input{
+	dir = 1
+	},
 /turf/open/floor/engine/o2,
 /area/xenoarch/eng)
 "On" = (
@@ -7111,15 +6965,14 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/gen)
 "OB" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 30
+/obj/structure/disposalpipe/segment{
+	dir = 2
 	},
-/obj/effect/turf_decal/lumos/tile/yellow/half{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/xenoarch/eng)
+/area/xenoarch/gen)
 "OC" = (
 /obj/structure/stone_tile/block{
 	dir = 1
@@ -7131,11 +6984,10 @@
 /turf/open/indestructible/boss,
 /area/ruin/unpowered/ash_walkers)
 "OF" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/stairs,
-/area/xenoarch/gen)
+/obj/machinery/atmospherics/pipe/simple/dark/visible,
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/plating,
+/area/xenoarch/eng)
 "OH" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -7191,21 +7043,9 @@
 /turf/open/indestructible/boss,
 /area/lavaland/surface/outdoors)
 "OU" = (
-/obj/machinery/button/door/incinerator_vent_atmos_aux{
-	id = "atmos_incinerator_auxventL";
-	pixel_x = -24;
-	pixel_y = -6
-	},
-/obj/machinery/button/door/incinerator_vent_atmos_main{
-	id = "atmos_incinerator_mainventL";
-	pixel_x = -24;
-	pixel_y = 6
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/general/visible,
-/obj/effect/turf_decal/lumos/tile/yellow/half{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/plating,
 /area/xenoarch/eng)
 "OW" = (
 /obj/machinery/door/firedoor,
@@ -7215,18 +7055,15 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "Pb" = (
-/obj/effect/turf_decal/tile/purple,
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/gen)
-"Pc" = (
-/obj/effect/turf_decal/lumos/tile/yellow/half{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/green/visible{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 10
 	},
 /turf/open/floor/plasteel,
-/area/xenoarch/eng)
+/area/xenoarch/gen)
+"Pc" = (
+/obj/machinery/atmospherics/pipe/simple/dark/visible,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "Pd" = (
 /turf/open/lava/smooth/lava_land_surface,
 /area/lavaland/surface/outdoors)
@@ -7250,13 +7087,10 @@
 /turf/closed/wall,
 /area/xenoarch/eng)
 "Po" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/xenoarch/gen)
 "PA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -7265,13 +7099,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/xenoarch/arch)
-"PG" = (
-/obj/machinery/atmospherics/miner/toxins,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/engine/plasma,
-/area/xenoarch/eng)
 "PJ" = (
 /obj/machinery/door/airlock/research/glass,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
@@ -7337,11 +7164,10 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "PX" = (
-/obj/machinery/atmospherics/components/binary/volume_pump/layer3{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/purple/visible/layer3{
+	dir = 4
 	},
-/obj/machinery/light,
-/turf/open/floor/engine,
+/turf/closed/wall/r_wall,
 /area/xenoarch/eng)
 "PZ" = (
 /obj/item/radio/intercom{
@@ -7355,25 +7181,21 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "Qa" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/visible/layer1{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/lumos/tile/yellow/half{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/machinery/door/firedoor/heavy,
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Engineering";
+	req_access_txt = "32"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/xenoarch/eng)
 "Qe" = (
 /obj/structure/reagent_dispensers/peppertank{
@@ -7395,14 +7217,17 @@
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
 "Qi" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/nitrogen_input{
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/nitrogen_output{
 	dir = 1
 	},
-/turf/open/floor/engine/n2,
+/turf/open/floor/engine/air,
 /area/xenoarch/eng)
 "Qo" = (
-/obj/machinery/vending/engivend,
+/obj/machinery/autolathe,
 /obj/effect/turf_decal/lumos/tile/yellow/fulltile,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/xenoarch/gen)
 "Qp" = (
@@ -7429,20 +7254,16 @@
 /turf/open/floor/plating,
 /area/xenoarch/arch)
 "QH" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "QK" = (
-/obj/machinery/air_sensor{
-	pixel_x = -32;
-	pixel_y = -32
-	},
-/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+/obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
 	},
-/turf/open/floor/engine,
+/turf/closed/wall/r_wall,
 /area/xenoarch/eng)
 "QM" = (
 /obj/structure/closet/secure_closet/security_xenoarch,
@@ -7459,16 +7280,10 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "QS" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/oxygen_output{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/maintenance,
-/obj/machinery/door/firedoor/heavy,
-/turf/open/floor/plating,
+/turf/open/floor/engine/o2,
 /area/xenoarch/eng)
 "QV" = (
 /turf/closed/mineral/random/volcanic,
@@ -7478,6 +7293,7 @@
 /turf/open/floor/plating,
 /area/xenoarch/arch)
 "QX" = (
+/obj/effect/turf_decal/vg_decals/atmos/oxygen,
 /turf/open/floor/engine/o2,
 /area/xenoarch/eng)
 "Ra" = (
@@ -7501,13 +7317,11 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "Rj" = (
-/obj/machinery/seed_extractor,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/nitrogen_output{
+	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/xenoarch/bot)
+/turf/open/floor/engine/n2,
+/area/xenoarch/eng)
 "Rl" = (
 /obj/structure/stone_tile/block{
 	dir = 4
@@ -7576,9 +7390,10 @@
 /turf/open/indestructible/boss,
 /area/ruin/unpowered/ash_walkers)
 "RE" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/effect/turf_decal/lumos/tile/yellow/fullcorner,
-/turf/open/floor/plasteel,
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 4
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/xenoarch/eng)
 "RF" = (
 /obj/machinery/door/airlock{
@@ -7594,19 +7409,11 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "RK" = (
-/obj/effect/turf_decal/vg_decals/atmos/plasma,
 /turf/open/floor/engine/plasma,
 /area/xenoarch/eng)
 "RM" = (
 /turf/closed/wall,
 /area/mining_level_access)
-"RQ" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/turf/open/floor/plasteel,
-/area/xenoarch/eng)
 "RR" = (
 /obj/structure/stone_tile/block{
 	dir = 8
@@ -7631,10 +7438,21 @@
 /turf/open/openspace,
 /area/mining_level_access/upper)
 "RW" = (
-/obj/machinery/atmospherics/pipe/simple/dark/visible{
-	dir = 4
+/obj/machinery/button/door/incinerator_vent_atmos_aux{
+	id = "atmos_incinerator_auxventL";
+	pixel_x = -24;
+	pixel_y = -6
 	},
-/turf/closed/wall/r_wall,
+/obj/machinery/button/door/incinerator_vent_atmos_main{
+	id = "atmos_incinerator_mainventL";
+	pixel_x = -24;
+	pixel_y = 6
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/general/visible,
+/obj/effect/turf_decal/lumos/tile/yellow/half{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "RY" = (
 /obj/structure/stone_tile/block{
@@ -7646,15 +7464,8 @@
 /turf/closed/indestructible/riveted/boss,
 /area/ruin/unpowered/ash_walkers)
 "Si" = (
-/obj/effect/turf_decal/lumos/tile/yellow/fullcorner{
-	dir = 8
-	},
-/obj/machinery/power/apc/auto_name/east,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/eng)
+/turf/closed/wall/r_wall,
+/area/space)
 "Sr" = (
 /obj/structure/stone_tile/block/cracked{
 	dir = 8
@@ -7678,7 +7489,6 @@
 /turf/open/indestructible/boss,
 /area/ruin/unpowered/ash_walkers)
 "Sv" = (
-/obj/effect/turf_decal/vg_decals/atmos/oxygen,
 /turf/open/floor/engine/o2,
 /area/xenoarch/eng)
 "Sx" = (
@@ -7743,18 +7553,12 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "SL" = (
-/obj/machinery/door/poddoor/incinerator_atmos_aux{
-	id = "atmos_incinerator_auxventL"
-	},
-/turf/open/floor/engine,
+/obj/machinery/light/small,
+/turf/open/floor/engine/air,
 /area/xenoarch/eng)
 "SO" = (
-/obj/machinery/atmospherics/pipe/simple/dark/visible,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/lumos/tile/yellow/half{
-	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
@@ -7807,12 +7611,11 @@
 /area/lavaland/surface/outdoors)
 "SY" = (
 /obj/structure/table,
+/obj/machinery/plantgenes,
 /obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
+/obj/effect/turf_decal/lumos/tile/purple/checker{
+	dir = 4
 	},
-/obj/item/storage/box/disks_plantgene,
-/obj/item/storage/box/disks_plantgene,
 /turf/open/floor/plasteel,
 /area/xenoarch/bot)
 "SZ" = (
@@ -7851,9 +7654,10 @@
 /turf/open/floor/grass,
 /area/lavaland/surface/outdoors)
 "Th" = (
-/obj/machinery/atmospherics/pipe/simple/dark/visible,
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/obj/machinery/atmospherics/miner/oxygen,
+/obj/machinery/light/small,
+/turf/open/floor/engine/o2,
+/area/xenoarch/eng)
 "Tk" = (
 /obj/structure/stone_tile/slab,
 /obj/structure/table/wood,
@@ -7899,7 +7703,9 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "TH" = (
-/obj/structure/tank_dispenser/oxygen,
+/obj/machinery/light{
+	dir = 1
+	},
 /obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 1
 	},
@@ -7961,10 +7767,7 @@
 /turf/open/floor/plasteel/white,
 /area/xenoarch/arch)
 "Ue" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
+/obj/machinery/atmospherics/components/trinary/filter/atmos/plasma,
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "Ug" = (
@@ -7995,9 +7798,6 @@
 /turf/open/floor/plasteel/white,
 /area/xenoarch/arch)
 "Um" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 1
 	},
@@ -8055,10 +7855,7 @@
 /area/xenoarch/arch)
 "Uz" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+	dir = 9
 	},
 /turf/open/floor/plasteel/elevatorshaft,
 /area/mining_level_access/lower)
@@ -8108,6 +7905,13 @@
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/sec)
 "UX" = (
+/obj/machinery/air_sensor{
+	pixel_x = -32;
+	pixel_y = -32
+	},
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 4
+	},
 /turf/open/floor/engine,
 /area/xenoarch/eng)
 "UZ" = (
@@ -8135,8 +7939,7 @@
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
 "Vd" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible/layer3,
-/obj/machinery/atmospherics/components/trinary/mixer/flipped{
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -8164,13 +7967,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
-"Vj" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/visible/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/eng)
 "Vn" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -8191,13 +7987,10 @@
 /turf/open/floor/grass,
 /area/lavaland/surface/outdoors)
 "VG" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/machinery/biogenerator,
-/obj/item/reagent_containers/glass/bucket,
-/turf/open/floor/plasteel,
-/area/xenoarch/bot)
+/obj/machinery/atmospherics/miner/nitrogen,
+/obj/machinery/light/small,
+/turf/open/floor/engine/n2,
+/area/xenoarch/eng)
 "VJ" = (
 /obj/structure/flora/rock/pile/largejungle{
 	light_range = null
@@ -8208,8 +8001,12 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors/unexplored/danger)
 "Wa" = (
-/obj/machinery/door/poddoor/incinerator_atmos_main{
-	id = "atmos_incinerator_mainventL"
+/obj/machinery/power/turbine{
+	dir = 8;
+	luminosity = 2
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
 	},
 /turf/open/floor/engine,
 /area/xenoarch/eng)
@@ -8288,20 +8085,11 @@
 /obj/structure/reagent_dispensers/foamtank,
 /turf/open/floor/plating,
 /area/xenoarch/arch)
-"WQ" = (
-/obj/structure/table,
-/obj/machinery/plantgenes,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/lumos/tile/purple/checker{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/bot)
 "WR" = (
-/obj/machinery/atmospherics/pipe/simple/dark/hidden{
+/obj/machinery/atmospherics/components/binary/volume_pump{
 	dir = 4
 	},
-/turf/closed/wall/r_wall,
+/turf/open/floor/engine,
 /area/xenoarch/eng)
 "WT" = (
 /obj/structure/chair/sofa/corp/left{
@@ -8342,9 +8130,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
-"Xt" = (
-/turf/open/floor/plating/beach/sand,
-/area/lavaland/surface/outdoors)
 "Xy" = (
 /obj/structure/stone_tile,
 /obj/structure/stone_tile/cracked{
@@ -8514,35 +8299,17 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "YO" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/machinery/atmospherics/pipe/simple/supply/visible/layer1{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/eng)
-"YP" = (
-/obj/structure/table,
-/obj/machinery/plantgenes,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/xenoarch/bot)
+/area/xenoarch/eng)
 "YT" = (
 /obj/structure/chair/sofa/corp/right{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/gen)
-"YW" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/turf/open/floor/plating,
-/area/xenoarch/eng)
 "YX" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
@@ -8557,41 +8324,22 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "YY" = (
-/obj/machinery/computer/atmos_control/tank/nitrogen_tank{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 9
-	},
-/obj/effect/turf_decal/lumos/tile/yellow/half,
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/effect/turf_decal/lumos/tile/yellow/fullcorner,
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "Za" = (
 /turf/closed/wall,
 /area/xenoarch/gen)
-"Ze" = (
-/obj/structure/rack,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/storage/toolbox/mechanical,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/turf/open/floor/plating,
-/area/xenoarch/eng)
 "Zg" = (
 /obj/structure/stone_tile/cracked,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "Zn" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/obj/effect/turf_decal/lumos/tile/yellow/half{
-	dir = 8
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	layer = 2.47
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/xenoarch/eng)
 "Zp" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -8600,23 +8348,6 @@
 	},
 /turf/open/floor/plating,
 /area/xenoarch/sec)
-"Zy" = (
-/obj/machinery/atmospherics/components/binary/volume_pump/layer3{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/eng)
-"ZA" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/item/radio/intercom{
-	dir = 8;
-	name = "Station Intercom (General)";
-	pixel_x = -28
-	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/gen)
 "ZC" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 6
@@ -8648,19 +8379,12 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "ZP" = (
-/obj/machinery/air_sensor/atmos/toxin_tank,
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/toxin_output,
 /turf/open/floor/engine/plasma,
 /area/xenoarch/eng)
 "ZQ" = (
 /turf/closed/indestructible/riveted/boss/see_through,
 /area/lavaland/surface/outdoors)
-"ZR" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4
-	},
-/obj/machinery/hydroponics/constructable,
-/turf/open/floor/plasteel,
-/area/xenoarch/bot)
 "ZT" = (
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 8
@@ -20740,15 +20464,15 @@ BS
 BS
 BS
 BS
-Za
-Za
-Za
-Za
-Za
-Za
-Za
-Za
-Za
+QV
+QV
+QV
+QV
+QV
+QV
+QV
+QV
+QV
 QV
 QV
 QV
@@ -20996,16 +20720,16 @@ bh
 jN
 jN
 Gw
-kD
-tv
-ZA
-st
-HM
-st
-st
-Hw
-Do
-Za
+BS
+QV
+QV
+QV
+QV
+QV
+QV
+QV
+QV
+QV
 QV
 QV
 QV
@@ -21253,16 +20977,16 @@ iK
 zi
 zi
 zi
-js
-OF
-Fv
-Fv
-Fv
-Fv
-Fv
-aH
-CD
-Za
+BS
+QV
+QV
+QV
+QV
+QV
+QV
+QV
+QV
+QV
 QV
 QV
 QV
@@ -21500,26 +21224,26 @@ bI
 ia
 ia
 uU
-Ka
-mp
 ia
 ia
+AT
+ia
 rj
-rj
+Hr
 rj
 rj
 rj
 Uu
-Du
-tv
-Pb
-Pb
-fE
-Pb
-sB
-co
-st
-Za
+BS
+QV
+QV
+QV
+QV
+QV
+QV
+QV
+QV
+QV
 QV
 QV
 QV
@@ -21757,26 +21481,26 @@ BS
 BS
 BS
 BS
-BS
-BS
-pU
-pU
-pU
-pU
 pU
 pU
 BS
+pU
+pU
+BS
+pU
+pU
 BS
 BS
-Za
-Za
-Za
-Za
-Za
-HQ
-co
-FT
-Za
+BS
+QV
+QV
+QV
+QV
+QV
+QV
+QV
+QV
+QV
 QV
 QV
 QV
@@ -22013,8 +21737,6 @@ vz
 vz
 BS
 tN
-tN
-tN
 Pd
 Pd
 Pd
@@ -22023,17 +21745,19 @@ Pd
 Pd
 Pd
 Pd
+Pd
+Pd
 tN
 tN
 tN
 tN
 tN
 tN
-Za
-rr
-co
-st
-Za
+QV
+QV
+QV
+QV
+QV
 QV
 QV
 QV
@@ -22270,27 +21994,27 @@ jV
 jV
 pf
 Pd
-tN
+Pd
+Pd
+Pd
+Ge
+CV
+Ge
 Pd
 Pd
 Pd
 Pd
 Pd
-Pd
-Pd
-Pd
-Pd
-tN
-tN
-tN
 tN
 tN
 tN
-Za
-HQ
-co
-st
-Za
+tN
+tN
+QV
+QV
+QV
+QV
+QV
 QV
 QV
 QV
@@ -22538,16 +22262,16 @@ Pd
 Pd
 Pd
 Pd
+Pd
 tN
 tN
 tN
 tN
-tN
-Za
-kW
-co
-st
-Za
+QV
+QV
+QV
+QV
+QV
 QV
 QV
 QV
@@ -22786,11 +22510,11 @@ Bh
 Pd
 Pd
 Pd
-Pd
+Ge
 Ge
 gX
 Ge
-Pd
+Ge
 Pd
 Pd
 Pd
@@ -22800,11 +22524,11 @@ tN
 tN
 tN
 tN
-Za
-HQ
-co
-eA
-Za
+QV
+QV
+QV
+QV
+QV
 QV
 QV
 QV
@@ -23042,12 +22766,13 @@ pU
 BS
 Pd
 Pd
-Pd
+tN
 Ge
-Ge
+BD
 rZ
+Do
 Ge
-Ge
+Pd
 Pd
 Pd
 Pd
@@ -23056,12 +22781,11 @@ Pd
 tN
 tN
 tN
-tN
-Za
-Mf
-co
-st
-Za
+QV
+QV
+QV
+QV
+QV
 tN
 tN
 tN
@@ -23298,13 +23022,13 @@ xT
 GW
 BS
 Pd
-Pd
+tN
 tN
 Ge
 Br
 cU
 UX
-Ge
+Hu
 Pd
 Pd
 Pd
@@ -23314,11 +23038,11 @@ Pd
 tN
 tN
 tN
-Za
-mg
-co
-st
-Za
+QV
+QV
+QV
+QV
+QV
 tN
 tN
 tN
@@ -23554,14 +23278,14 @@ SB
 vz
 OQ
 BS
-Pd
+tN
 tN
 tN
 Ge
 rl
 LR
 QK
-SL
+Ge
 Pd
 Pd
 Pd
@@ -23571,16 +23295,16 @@ Pd
 tN
 tN
 tN
-Za
-Xe
-FG
-rC
-Za
-Xt
-Xt
-Xt
-Xt
-Xt
+QV
+QV
+QV
+QV
+QV
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -23828,18 +23552,18 @@ Pd
 tN
 tN
 tN
-Za
-HQ
-co
-st
-nJ
-Xt
-Tg
-SG
-SG
-Xt
-Xt
-Xt
+QV
+QV
+QV
+QV
+QV
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -24070,34 +23794,34 @@ iD
 BS
 tN
 tN
-tN
+Ge
 Ge
 pO
 La
 PX
 Ge
+Ge
+Ge
+Ge
 Pd
-Pd
-Pd
-Pd
-Pd
+RE
 Pd
 tN
 tN
 tN
-Za
-HQ
-co
-st
-nJ
-vi
-SG
-Tg
-vi
-SG
-SG
-Xt
-Xt
+QV
+QV
+QV
+QV
+QV
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 "}
@@ -24323,39 +24047,39 @@ qI
 qI
 jS
 BS
-BS
-BS
+tN
+tN
 tN
 tN
 Ge
-Ge
+xo
 RW
 nf
 uT
-Ge
-Ge
-Ge
-Ge
-Pd
+Hw
+Kd
+Nn
+OF
+Pc
 BF
 Pd
 tN
 tN
 tN
-Za
-HQ
-co
-st
-nJ
-SG
-vi
-SG
-FU
-FU
-FU
-FU
-Xt
-Xt
+QV
+QV
+QV
+QV
+QV
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 "}
 (62,1,1) = {"
@@ -24574,45 +24298,45 @@ BS
 Xr
 KR
 Dp
-BS
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
+hs
+hs
+hs
+hs
+hs
+hs
+Ge
+Ge
+Ge
+Ge
 Ge
 xE
-OU
+FB
 SO
-Ke
-Hu
-nx
+KC
+FB
+FB
 qo
-Lw
-Th
-ac
-Pd
+Ge
+Ge
+Ge
+Ge
+Ge
+tN
+tN
+QV
+QV
+QV
+QV
+QV
 tN
 tN
 tN
-Za
-HQ
-co
-st
-nJ
-SG
-Tg
-SG
-FU
-FU
-FU
-FU
-FU
-Xt
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 "}
 (63,1,1) = {"
@@ -24832,44 +24556,44 @@ pU
 iR
 pU
 hs
-hs
-hs
-hs
-hs
-hs
+fE
+iX
+ka
+iX
+mp
 Ge
-Ge
-Ge
-Ge
-Ge
+RK
+RK
+qy
+ui
 dC
-FB
+BK
 mA
 zM
-FB
-FB
+HL
+HL
 GM
-Ge
-Ge
-Ge
-Ge
+DJ
+Qi
+yP
+yP
 Ge
 tN
 tN
-Za
-HQ
-co
-st
-nJ
-Tg
-SG
-FU
-FU
-FU
-FU
-FU
-FU
-Xt
+QV
+QV
+QV
+QV
+QV
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 "}
 (64,1,1) = {"
@@ -25089,44 +24813,44 @@ Tq
 ic
 tl
 hs
-do
-wp
+Bv
+eV
 Eo
-wp
+eV
 mB
 Ge
 vU
-vU
+ps
 AZ
 lH
 CL
 YO
-IP
+Wu
 KC
-cG
-cG
+FB
+FB
 ct
-kg
+lH
 fG
 pW
-pW
+SL
 Ge
 tN
 tN
-Za
-HQ
-co
-st
-nJ
-vi
-SG
-FU
-FU
-FU
-FU
-FU
-FU
-Xt
+QV
+QV
+QV
+QV
+QV
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 "}
 (65,1,1) = {"
@@ -25346,44 +25070,44 @@ Ng
 cp
 XI
 hs
-Bv
+fI
 eV
 eL
 eV
 Im
 Ge
-PG
+RK
 RK
 ZP
 DJ
 pn
 KL
-Wu
-zM
+CX
+Du
 FB
-FB
+Lc
 Gs
-DJ
+OU
 gx
-cO
+yP
 yP
 Ge
 tN
 tN
-Za
-fI
-co
-st
-nJ
-SG
-FU
-FU
-FU
-FU
-FU
-FU
-FU
-Xt
+QV
+QV
+QV
+QV
+QV
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 "}
 (66,1,1) = {"
@@ -25602,45 +25326,45 @@ bq
 sm
 Lv
 gC
-hs
-bF
+Uj
+Bv
 eV
-ZR
+Rw
 eV
 lO
 Ge
-vU
-vU
-BK
-kg
+Ge
+Ge
+Ge
+Ge
 lF
-Vj
-Kd
-rd
+YO
+Wu
+KC
 FB
-Cp
+Vd
 sY
-YW
-zU
-pW
-pW
+Ge
+Ge
+Ge
+Ge
 Ge
 tN
 tN
-Za
-Nq
-co
-st
-nJ
-SG
-FU
-FU
-FU
-FU
-FU
-FU
-FU
-Xt
+QV
+QV
+QV
+QV
+QV
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 "}
 (67,1,1) = {"
@@ -25866,38 +25590,38 @@ Rw
 eV
 kK
 Ge
-Ge
-Ge
-Ge
-Ge
-lf
-KL
-Wu
-zM
-FB
-HF
-Dj
-Ge
-Ge
-Ge
-Ge
-Ge
-tN
-tN
-Za
+nx
 pD
-co
-st
-nJ
-SG
-FU
-FU
-FU
-FU
-FU
-FU
-FU
-Xt
+rr
+wp
+lf
+Ct
+Wu
+Fv
+HM
+HF
+GM
+DJ
+QS
+Sv
+Sv
+Ge
+tN
+tN
+QV
+QV
+QV
+QV
+QV
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 "}
 (68,1,1) = {"
@@ -26116,45 +25840,45 @@ LJ
 ox
 Bc
 HP
-Uj
-Bv
-eV
-Rw
-eV
+eA
+gu
+ja
+kD
+mg
 sT
 Ge
 jw
 oL
 Zn
 tR
-bf
+tR
 oT
 Wu
-CX
-Zy
+FB
+FB
 Vd
-ct
-kg
+Nq
+lH
 eh
 QX
-QX
+Th
 Ge
 tN
 tN
-Za
-mg
-co
-st
-nJ
-mk
-FU
-FU
-FU
-FU
-FU
-FU
-FU
-Xt
+QV
+QV
+QV
+QV
+QV
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 "}
 (69,1,1) = {"
@@ -26375,42 +26099,42 @@ Ur
 dx
 vk
 bu
-Ct
+eV
 AP
-iX
+eV
 MV
 Ge
 jK
 Hq
-NH
+FB
 xl
-xl
+xx
 bA
-Wu
+CZ
 FB
-FB
-HF
+Ki
+Lw
 fl
-DJ
+ui
 Om
 Sv
-Jo
+Sv
 Ge
 tN
 tN
-Za
-HQ
-co
-st
-nJ
-SG
-FU
-FU
-FU
-FU
-FU
-FU
-Xt
+QV
+QV
+QV
+QV
+QV
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 "}
@@ -26630,7 +26354,7 @@ lT
 SA
 pQ
 oJ
-Hr
+Uj
 Gu
 eV
 Lr
@@ -26639,35 +26363,35 @@ ym
 Ge
 TH
 IF
-FB
 QH
-Jc
+QH
+QH
 qu
 FZ
 FB
-sc
-RQ
+FZ
+Vd
 ib
-lH
-ok
-QX
-QX
+Ge
+Ge
+Ge
+Ge
 Ge
 tN
 tN
-Za
-HQ
-co
-st
-nJ
-SG
-FU
-FU
-FU
-FU
-FU
-Xt
-Xt
+QV
+QV
+QV
+QV
+QV
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 "}
@@ -26887,7 +26611,7 @@ AX
 ly
 it
 HP
-Uj
+hs
 aQ
 eV
 fn
@@ -26896,34 +26620,34 @@ kx
 Ge
 Um
 rX
-Ki
-Ki
-Ki
-BD
-yR
 FB
+FB
+Ki
+lw
 yR
-HF
-xH
-Ge
-Ge
-Ge
-Ge
-Ge
-tN
-tN
-Za
+lw
 HQ
-co
-st
-nJ
-Tg
-SG
-mk
-Tg
-SG
-Xt
-Xt
+Mf
+GM
+DJ
+Rj
+Hp
+Hp
+Ge
+tN
+tN
+QV
+QV
+QV
+QV
+QV
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -27146,40 +26870,40 @@ PW
 di
 hs
 ha
+je
 eV
-VG
-eV
+mk
 im
 Ge
 Nu
 sL
-FB
-FB
+rC
+lw
 sc
 lw
 Ue
 lw
-bM
-Mi
-ct
-kg
+lw
+lw
+NH
+lH
 aj
 vx
-vx
+VG
 Ge
 tN
 tN
-Za
-HQ
-co
-st
-nJ
-SG
-mk
-SG
-Xt
-Xt
-Xt
+QV
+QV
+QV
+QV
+QV
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -27403,38 +27127,38 @@ Ht
 gR
 hs
 pc
-cf
-eV
+Go
+kW
 Go
 SY
 Ge
 aE
 DS
 KJ
-lw
+wF
 BC
-lw
+CD
 tx
-lw
-lw
-lw
+FG
+If
+Mi
 YY
-DJ
+ui
 NL
-pt
+Hp
 Hp
 Ge
 tN
 tN
-Za
-Xe
-FG
-rC
-Za
-Xt
-Xt
-Xt
-Xt
+QV
+QV
+QV
+QV
+QV
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -27654,40 +27378,40 @@ oO
 pX
 xM
 rt
-BS
-pU
-Hx
-pU
+ac
+MC
+MC
+MC
 hs
-YP
-Rj
-qy
-Rj
-WQ
+hs
+hs
+hs
+hs
+hs
 Ge
-Si
+Ge
 Qa
-Pc
-Nn
-HL
-dQ
-xx
-OB
+Ge
+Ge
+Ge
+Ge
+Ge
+Ge
 MA
-wF
-RE
-lH
-Qi
-vx
-vx
+Ge
+Ge
+Ge
+Ge
+Ge
+Ge
 Ge
 tN
 tN
-Za
-HQ
-co
-st
-Za
+QV
+QV
+QV
+QV
+QV
 tN
 tN
 tN
@@ -27911,40 +27635,40 @@ zO
 AU
 GD
 zg
-BS
-Gr
-gN
-hB
-hs
-hs
-hs
-hs
-hs
-hs
-Ge
-Ge
+ac
+MC
+MC
+MC
+fs
+ix
+js
+js
+js
+js
+js
+ok
 of
+st
 Ge
-Ge
-Ge
-Ge
-Ge
-Ge
+zU
 Dw
-Ge
-Ge
-Ge
-Ge
-Ge
-Ge
-Ge
-Za
-Za
-Za
-HQ
-co
-eA
-Za
+Db
+Dw
+Dw
+Dw
+Dw
+Pb
+zC
+Si
+Si
+Si
+zC
+zC
+zC
+QV
+QV
+QV
+QV
 tN
 tN
 tN
@@ -28168,28 +27892,28 @@ lB
 uy
 lx
 wj
-BS
-tZ
-Jh
+ac
 MC
-QS
-kR
+MC
+MC
+Pn
 ML
 ML
 ML
 ML
 ML
-sw
+ML
+Pn
 qN
 qX
 Ge
 GS
-Lc
-CJ
-Lc
-Lc
-Lc
-Lc
+Ox
+Ox
+Ox
+Ox
+Ox
+Ox
 EW
 zC
 Uz
@@ -28197,11 +27921,11 @@ sE
 GC
 sE
 an
-Za
-HQ
-co
-st
-Za
+zC
+QV
+QV
+QV
+QV
 QV
 QV
 QV
@@ -28425,26 +28149,26 @@ BS
 BS
 BS
 BS
-BS
-pU
-zr
-pU
+ac
+MC
+MC
+MC
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
 Pn
-Pn
-Pn
-Pn
-Pn
-Pn
-Pn
-Pn
-Ze
-ps
+en
 Ge
 Qo
 Ox
 Ox
-Ox
-Ox
+FT
+IP
 Ox
 Ox
 FY
@@ -28454,11 +28178,11 @@ KT
 KT
 KT
 HD
-Za
-rr
-co
-xo
-Za
+zC
+QV
+QV
+QV
+QV
 QV
 QV
 QV
@@ -28682,17 +28406,17 @@ Ym
 Ym
 Ym
 Ym
-Ym
-Ym
-Ym
-Ym
-Ym
-Ym
-Ym
-Ym
-Ym
-Ym
-Ym
+BS
+pU
+bM
+pU
+ac
+ac
+ac
+ac
+ac
+ac
+ac
 Pn
 Pn
 en
@@ -28700,8 +28424,8 @@ Ge
 zx
 Ox
 Ox
-CV
-fs
+Ox
+Ox
 Ox
 Ox
 ty
@@ -28711,11 +28435,11 @@ KT
 KT
 KT
 HD
-Za
-Mf
-co
-st
-Za
+zC
+QV
+QV
+QV
+QV
 QV
 QV
 QV
@@ -28939,10 +28663,10 @@ Ym
 Ym
 Ym
 Ym
-Ym
-Ym
-Ym
-Ym
+BS
+aH
+co
+dQ
 Ym
 Ym
 Ym
@@ -28955,12 +28679,12 @@ Pn
 en
 Ge
 rS
-Ox
-Ox
-Ox
-Ox
-Ox
-Ox
+CJ
+Df
+FW
+Ka
+Nb
+OB
 Ha
 zC
 xL
@@ -28968,11 +28692,11 @@ KT
 KT
 KT
 HD
-Za
-HQ
-co
-st
-Za
+zC
+QV
+QV
+QV
+QV
 QV
 QV
 QV
@@ -29196,10 +28920,10 @@ Ym
 Ym
 Ym
 Ym
-Ym
-Ym
-Ym
-Ym
+BS
+bF
+cG
+dV
 Ym
 Ym
 Ym
@@ -29209,27 +28933,27 @@ Ym
 Ym
 Ym
 Pn
-en
+sw
 Ge
-ja
-AT
-dV
-Db
+zC
+zC
+zC
+zC
 Po
-ui
-ix
-CZ
+Up
+zC
+zC
 zC
 qb
 qg
 qg
 qg
 LN
-Za
-HQ
-co
-st
-Za
+zC
+QV
+QV
+QV
+QV
 QV
 QV
 QV
@@ -29453,10 +29177,10 @@ Ym
 Ym
 Ym
 Ym
-Ym
-Ym
-Ym
-Ym
+BS
+pU
+do
+pU
 Ym
 Ym
 Ym
@@ -29467,26 +29191,26 @@ Ym
 Ym
 Pn
 ql
-Ge
-zC
-zC
-zC
-zC
-je
-Up
-zC
-zC
-zC
+Pn
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
+Ym
 Za
 Mk
 Mk
 Mk
 Za
 Za
-Nq
-co
-st
 Za
+QV
+QV
+QV
 QV
 QV
 QV
@@ -29722,9 +29446,9 @@ Ym
 Ym
 Ym
 Ym
-Pn
-ka
-Pn
+Ym
+Ym
+Ym
 Za
 ds
 ds
@@ -29740,10 +29464,10 @@ YE
 YE
 Xe
 uv
-HQ
-co
-st
 Za
+QV
+QV
+QV
 QV
 QV
 QV
@@ -29997,10 +29721,10 @@ Fq
 Fq
 vQ
 Fq
-Fq
-gu
-Nb
 Za
+QV
+QV
+QV
 QV
 QV
 QV
@@ -30254,10 +29978,10 @@ oI
 NQ
 my
 Nc
-If
-Df
-FW
 Za
+QV
+QV
+QV
 QV
 QV
 QV
@@ -30512,9 +30236,9 @@ Za
 Za
 Za
 Za
-Za
-Za
-Za
+QV
+QV
+QV
 QV
 QV
 QV

--- a/_maps/map_files/Mining/Lavaland_Lumos.dmm
+++ b/_maps/map_files/Mining/Lavaland_Lumos.dmm
@@ -3616,6 +3616,9 @@
 	},
 /turf/open/floor/plating,
 /area/xenoarch/eng)
+"ve" = (
+/turf/open/water/lavaland_jungle,
+/area/lavaland/surface/outdoors)
 "vf" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/research/glass,
@@ -4178,7 +4181,7 @@
 /area/lavaland/surface/outdoors)
 "yK" = (
 /obj/machinery/light/small,
-/turf/open/water,
+/turf/open/water/lavaland_jungle,
 /area/xenoarch/arch)
 "yL" = (
 /obj/structure/window/reinforced{
@@ -32065,8 +32068,8 @@ Yp
 Yp
 Yp
 Yp
-FU
-FU
+ve
+ve
 Yp
 Yp
 VA
@@ -32320,10 +32323,10 @@ bJ
 Yp
 Yp
 Yp
-FU
-FU
-FU
-FU
+ve
+ve
+ve
+ve
 Yp
 Yp
 Yp
@@ -32579,9 +32582,9 @@ Yp
 Yp
 yK
 BS
-FU
-FU
-FU
+ve
+ve
+ve
 Yp
 Yp
 SG
@@ -32834,11 +32837,11 @@ Tg
 Yp
 Yp
 Yp
-FU
-FU
-FU
-FU
-FU
+ve
+ve
+ve
+ve
+ve
 Yp
 Yp
 VA
@@ -33091,11 +33094,11 @@ bJ
 Yp
 Yp
 Yp
-FU
-FU
-FU
-FU
-FU
+ve
+ve
+ve
+ve
+ve
 Yp
 VA
 Tg
@@ -33349,10 +33352,10 @@ Yp
 Yp
 Yp
 Yp
-FU
-FU
-FU
-FU
+ve
+ve
+ve
+ve
 Yp
 nw
 SG

--- a/_maps/map_files/Mining/Lavaland_Lumos.dmm
+++ b/_maps/map_files/Mining/Lavaland_Lumos.dmm
@@ -361,6 +361,9 @@
 /obj/machinery/newscaster{
 	pixel_y = 32
 	},
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/plasteel/white,
 /area/xenoarch/arch)
 "bi" = (
@@ -1294,6 +1297,9 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "gR" = (
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/open/floor/plasteel/white/side{
 	dir = 4
 	},
@@ -1468,6 +1474,9 @@
 	dir = 8
 	},
 /obj/machinery/airalarm/directional/north,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/plasteel/white,
 /area/xenoarch/arch)
 "hV" = (
@@ -1485,6 +1494,9 @@
 	},
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/xenoarch/arch)
 "hZ" = (
@@ -5068,6 +5080,9 @@
 /obj/item/storage/firstaid/fire,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/xenoarch/arch)

--- a/_maps/map_files/Mining/Lavaland_Lumos.dmm
+++ b/_maps/map_files/Mining/Lavaland_Lumos.dmm
@@ -1335,7 +1335,13 @@
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
-"fs" = (
+"fy" = (
+/obj/structure/chair/office/dark,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/white,
+/area/xenoarch/arch)
+"fE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 1
 	},
@@ -1347,21 +1353,6 @@
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plating,
 /area/xenoarch/eng)
-"fy" = (
-/obj/structure/chair/office/dark,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/white,
-/area/xenoarch/arch)
-"fE" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/lumos/tile/purple/checker{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/bot)
 "fF" = (
 /obj/structure/stone_tile/slab,
 /obj/effect/decal/cleanable/blood,
@@ -1382,15 +1373,11 @@
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
 "fI" = (
-/obj/machinery/hydroponics/constructable,
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/lumos/tile/purple/checker{
 	dir = 4
-	},
-/obj/machinery/light{
-	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/bot)
@@ -1474,17 +1461,16 @@
 /turf/open/indestructible/boss,
 /area/lavaland/surface/outdoors)
 "gu" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
+/obj/machinery/hydroponics/constructable,
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/xenoarch/bot)
 "gw" = (
@@ -1560,11 +1546,19 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "gV" = (
-/obj/structure/chair/sofa/corp{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/sec)
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/plasteel,
+/area/xenoarch/bot)
 "gX" = (
 /obj/machinery/power/compressor{
 	comp_id = "incineratorturbineL";
@@ -1623,9 +1617,6 @@
 /turf/closed/indestructible/riveted/boss,
 /area/ruin/unpowered/ash_walkers)
 "hp" = (
-/obj/structure/chair/sofa/corp/right{
-	dir = 1
-	},
 /obj/effect/turf_decal/lumos/tile/red/fullcorner{
 	dir = 1
 	},
@@ -1805,9 +1796,6 @@
 /area/lavaland/surface/outdoors)
 "ik" = (
 /obj/machinery/light,
-/obj/structure/chair/sofa/corp/left{
-	dir = 1
-	},
 /obj/effect/turf_decal/lumos/tile/red/half,
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/sec)
@@ -2199,9 +2187,17 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/bot)
 "kF" = (
-/obj/structure/chair/sofa/corp/left,
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/sec)
+/obj/machinery/vending/hydronutrients,
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/machinery/status_display/evac{
+	layer = 4;
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/bot)
 "kI" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -2250,14 +2246,8 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "kW" = (
-/obj/machinery/vending/hydronutrients,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/machinery/status_display/evac{
-	layer = 4;
-	pixel_x = 32
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/bot)
@@ -2483,9 +2473,8 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/sec)
 "mg" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
+/obj/structure/chair/office/dark,
+/obj/effect/landmark/start/scientist,
 /turf/open/floor/plasteel,
 /area/xenoarch/bot)
 "mj" = (
@@ -2498,11 +2487,6 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "mk" = (
-/obj/structure/chair/office/dark,
-/obj/effect/landmark/start/scientist,
-/turf/open/floor/plasteel,
-/area/xenoarch/bot)
-"mp" = (
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -2512,6 +2496,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/bot)
+"mp" = (
+/obj/machinery/suit_storage_unit/atmos,
+/obj/effect/turf_decal/lumos/tile/yellow/fullcorner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/eng)
 "mq" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -2667,11 +2658,14 @@
 /turf/open/floor/grass,
 /area/lavaland/surface/outdoors)
 "nx" = (
-/obj/machinery/suit_storage_unit/atmos,
-/obj/effect/turf_decal/lumos/tile/yellow/fullcorner{
-	dir = 4
+/obj/machinery/atmospherics/components/binary/volume_pump,
+/obj/machinery/atmospherics/components/binary/volume_pump/layer1{
+	dir = 1
 	},
-/turf/open/floor/plasteel,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
 /area/xenoarch/eng)
 "nz" = (
 /obj/structure/stone_tile/block{
@@ -2781,7 +2775,6 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "oc" = (
-/obj/structure/chair/sofa/corp/right,
 /obj/effect/turf_decal/lumos/tile/red/fullcorner{
 	dir = 4
 	},
@@ -2806,14 +2799,8 @@
 /turf/open/floor/plating,
 /area/xenoarch/eng)
 "ok" = (
-/obj/machinery/atmospherics/components/binary/volume_pump,
-/obj/machinery/atmospherics/components/binary/volume_pump/layer1{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
+/obj/effect/turf_decal/vg_decals/atmos/plasma,
+/turf/open/floor/engine/plasma,
 /area/xenoarch/eng)
 "ox" = (
 /obj/structure/disposalpipe/segment,
@@ -2866,7 +2853,6 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "oU" = (
-/obj/structure/chair/sofa/corp,
 /obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 1
 	},
@@ -2942,8 +2928,14 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "ps" = (
-/obj/effect/turf_decal/vg_decals/atmos/plasma,
-/turf/open/floor/engine/plasma,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 6
+	},
+/obj/machinery/meter,
+/obj/effect/turf_decal/lumos/tile/yellow/half{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "pB" = (
 /obj/structure/stone_tile{
@@ -2962,21 +2954,16 @@
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
 "pD" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 6
-	},
-/obj/machinery/meter,
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/toxin_input,
+/turf/open/floor/engine/plasma,
+/area/xenoarch/eng)
+"pE" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
-"pE" = (
-/obj/structure/chair/sofa/corp/left{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/sec)
 "pJ" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/flora/ausbushes/grassybush,
@@ -3161,8 +3148,10 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "qy" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/toxin_input,
-/turf/open/floor/engine/plasma,
+/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/n2{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "qC" = (
 /obj/structure/stone_tile/block/cracked{
@@ -3320,11 +3309,16 @@
 /turf/open/lava/smooth/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "rr" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/obj/effect/turf_decal/lumos/tile/yellow/half{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/supply/visible/layer1{
+	dir = 5
 	},
-/turf/open/floor/plasteel,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating,
 /area/xenoarch/eng)
 "rt" = (
 /obj/effect/turf_decal/lumos/tile/yellow/fullcorner{
@@ -3350,10 +3344,19 @@
 /turf/open/floor/grass,
 /area/lavaland/surface/outdoors)
 "rC" = (
-/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/n2{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/visible/layer1{
+	dir = 4
 	},
-/turf/open/floor/plasteel,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
 /area/xenoarch/eng)
 "rG" = (
 /obj/machinery/camera{
@@ -3362,7 +3365,6 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/structure/chair/sofa/corp/left,
 /obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 1
 	},
@@ -3497,31 +3499,19 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "st" = (
-/obj/machinery/atmospherics/pipe/simple/supply/visible/layer1{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/effect/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating,
 /area/xenoarch/eng)
 "sw" = (
-/obj/machinery/atmospherics/pipe/simple/supply/visible/layer1{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/effect/turf_decal/lumos/tile/yellow/half{
+	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "sy" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -3682,9 +3672,10 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "ty" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/obj/structure/table,
-/obj/item/inducer,
+/obj/machinery/disposal/bin,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 6
+	},
 /turf/open/floor/plasteel,
 /area/xenoarch/gen)
 "tB" = (
@@ -3701,9 +3692,6 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "tE" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
@@ -3776,9 +3764,15 @@
 /turf/open/indestructible/boss,
 /area/lavaland/surface/outdoors)
 "ui" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/effect/turf_decal/lumos/tile/yellow/half{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "uj" = (
 /obj/structure/stone_tile/block/cracked{
@@ -3874,11 +3868,6 @@
 /turf/open/indestructible/boss,
 /area/lavaland/surface/outdoors)
 "uM" = (
-/obj/machinery/door/window/westright{
-	dir = 4;
-	name = "Security Checkpoint";
-	req_access_txt = "1"
-	},
 /obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 4
 	},
@@ -4116,15 +4105,9 @@
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/sec)
 "wp" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/turf_decal/lumos/tile/yellow/half{
-	dir = 8
-	},
+/obj/item/kirbyplants/random,
 /turf/open/floor/plasteel,
-/area/xenoarch/eng)
+/area/xenoarch/arch)
 "ws" = (
 /obj/structure/fluff/drake_statue,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
@@ -4154,14 +4137,18 @@
 /turf/closed/mineral/random/labormineral/volcanic,
 /area/lavaland/surface/outdoors)
 "wF" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
+/obj/machinery/airalarm/unlocked{
+	pixel_y = 24
 	},
-/obj/effect/turf_decal/lumos/tile/yellow/half{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 6
+	},
+/obj/machinery/computer/turbine_computer{
+	id = "incineratorturbineL"
+	},
+/obj/effect/turf_decal/lumos/tile/yellow/fullcorner{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "wI" = (
@@ -4234,26 +4221,16 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "xo" = (
-/obj/machinery/airalarm/unlocked{
-	pixel_y = 24
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 6
-	},
-/obj/machinery/computer/turbine_computer{
-	id = "incineratorturbineL"
-	},
-/obj/effect/turf_decal/lumos/tile/yellow/fullcorner{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/eng)
-"xx" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/heater{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
+"xx" = (
+/obj/machinery/vending/tool,
+/obj/effect/turf_decal/lumos/tile/yellow/fulltile,
+/turf/open/floor/plasteel,
+/area/xenoarch/gen)
 "xy" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
@@ -4508,6 +4485,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
 	},
+/obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "yL" = (
@@ -4718,10 +4696,15 @@
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/sec)
 "zU" = (
-/obj/machinery/vending/tool,
-/obj/effect/turf_decal/lumos/tile/yellow/fulltile,
+/obj/effect/turf_decal/lumos/tile/purple/half{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
 /turf/open/floor/plasteel,
-/area/xenoarch/gen)
+/area/xenoarch/arch)
 "zW" = (
 /obj/structure/stone_tile/cracked{
 	dir = 8
@@ -4830,15 +4813,11 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/bot)
 "AT" = (
-/obj/effect/turf_decal/lumos/tile/purple/half{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/dark/hidden{
+	dir = 6
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
+/turf/open/floor/engine,
+/area/xenoarch/eng)
 "AU" = (
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
@@ -4956,10 +4935,11 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "BD" = (
-/obj/machinery/atmospherics/pipe/simple/dark/hidden{
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/machinery/atmospherics/pipe/simple/supply/visible/layer1{
 	dir = 6
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "BF" = (
 /obj/machinery/atmospherics/pipe/simple/dark/visible{
@@ -4968,11 +4948,11 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "BK" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/machinery/atmospherics/pipe/simple/supply/visible/layer1{
-	dir = 6
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4;
+	layer = 2.47
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/xenoarch/eng)
 "BS" = (
 /turf/closed/wall,
@@ -4996,14 +4976,19 @@
 /turf/open/floor/plasteel/stairs,
 /area/xenoarch/gen)
 "BZ" = (
-/obj/structure/chair/sofa/corp/right{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/structure/fireaxecabinet{
+	pixel_x = 32
 	},
-/obj/effect/turf_decal/lumos/tile/red/half{
-	dir = 8
+/obj/machinery/camera{
+	c_tag = "Xenoarchaeology Fourteen";
+	dir = 9
 	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/sec)
+/obj/effect/turf_decal/lumos/tile/yellow/half{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/eng)
 "Ca" = (
 /obj/structure/stone_tile/block/cracked{
 	dir = 1
@@ -5038,11 +5023,10 @@
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
 "Ct" = (
-/obj/machinery/atmospherics/pipe/layer_manifold{
-	dir = 4;
-	layer = 2.47
+/obj/machinery/door/poddoor/incinerator_atmos_main{
+	id = "atmos_incinerator_mainventL"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/engine,
 /area/xenoarch/eng)
 "Cx" = (
 /obj/structure/stone_tile/block/cracked{
@@ -5055,16 +5039,12 @@
 /turf/open/indestructible/boss,
 /area/lavaland/surface/outdoors)
 "CD" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/structure/fireaxecabinet{
-	pixel_x = 32
-	},
-/obj/machinery/camera{
-	c_tag = "Xenoarchaeology Fourteen";
-	dir = 9
-	},
-/obj/effect/turf_decal/lumos/tile/yellow/half{
+/obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
+	},
+/obj/machinery/atmospherics/components/binary/volume_pump/layer3,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
@@ -5088,11 +5068,17 @@
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/gen)
 "CJ" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
 /turf/open/floor/plasteel,
-/area/xenoarch/gen)
+/area/xenoarch/eng)
 "CK" = (
 /obj/item/reagent_containers/glass/bucket/wood,
 /obj/structure/stone_tile/block/cracked{
@@ -5149,34 +5135,12 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "CV" = (
-/obj/machinery/door/poddoor/incinerator_atmos_main{
-	id = "atmos_incinerator_mainventL"
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
 	},
-/turf/open/floor/engine,
-/area/xenoarch/eng)
+/turf/open/floor/plasteel,
+/area/xenoarch/gen)
 "CX" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/binary/volume_pump/layer3,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/eng)
-"CZ" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
-/obj/machinery/power/terminal{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/eng)
-"Db" = (
 /obj/machinery/camera{
 	c_tag = "Xenoarchaeology Four";
 	dir = 5
@@ -5186,15 +5150,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/gen)
-"Dc" = (
-/obj/machinery/quantumpad{
-	map_pad_id = "tostation";
-	map_pad_link_id = "toxenoarch"
-	},
-/obj/effect/turf_decal/lumos/tile/purple/fulltile,
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/arch)
-"Df" = (
+"CZ" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
@@ -5205,6 +5161,21 @@
 /obj/structure/closet/secure_closet/engineering_electrical,
 /turf/open/floor/plasteel,
 /area/xenoarch/gen)
+"Db" = (
+/turf/open/floor/engine,
+/area/xenoarch/eng)
+"Dc" = (
+/obj/machinery/quantumpad{
+	map_pad_id = "tostation";
+	map_pad_link_id = "toxenoarch"
+	},
+/obj/effect/turf_decal/lumos/tile/purple/fulltile,
+/turf/open/floor/plasteel/dark,
+/area/xenoarch/arch)
+"Df" = (
+/obj/machinery/atmospherics/pipe/manifold/purple/visible/layer3,
+/turf/open/floor/plasteel,
+/area/xenoarch/eng)
 "Dk" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -5227,7 +5198,10 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "Do" = (
-/turf/open/floor/engine,
+/obj/machinery/atmospherics/pipe/simple/purple/visible/layer3{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "Dp" = (
 /obj/structure/extinguisher_cabinet{
@@ -5241,7 +5215,13 @@
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/gen)
 "Du" = (
-/obj/machinery/atmospherics/pipe/manifold/purple/visible/layer3,
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 30
+	},
+/obj/effect/turf_decal/lumos/tile/yellow/half{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "Dv" = (
@@ -5497,6 +5477,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/structure/table,
 /obj/item/pipe_dispenser,
+/obj/item/inducer,
 /turf/open/floor/plasteel,
 /area/xenoarch/gen)
 "EX" = (
@@ -5530,11 +5511,11 @@
 /turf/closed/indestructible/riveted/boss,
 /area/lavaland/surface/outdoors)
 "Fv" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible/layer3{
-	dir = 10
-	},
+/obj/structure/table,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
 /turf/open/floor/plasteel,
-/area/xenoarch/eng)
+/area/xenoarch/gen)
 "Fw" = (
 /obj/machinery/light,
 /obj/structure/disposalpipe/segment{
@@ -5562,15 +5543,12 @@
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
 "FG" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 30
-	},
-/obj/effect/turf_decal/lumos/tile/yellow/half{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
+/obj/structure/closet/secure_closet/engineering_welding,
 /turf/open/floor/plasteel,
-/area/xenoarch/eng)
+/area/xenoarch/gen)
 "FI" = (
 /obj/machinery/light/small,
 /turf/open/floor/plating,
@@ -5607,11 +5585,12 @@
 /turf/closed/indestructible/riveted/boss,
 /area/lavaland/surface/outdoors)
 "FT" = (
-/obj/structure/table,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/metal/fifty,
+/obj/effect/turf_decal/tile/purple,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 30
+	},
 /turf/open/floor/plasteel,
-/area/xenoarch/gen)
+/area/xenoarch/arch)
 "FU" = (
 /turf/open/water,
 /area/lavaland/surface/outdoors)
@@ -5622,12 +5601,11 @@
 /turf/closed/indestructible/riveted/boss,
 /area/lavaland/surface/outdoors)
 "FW" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
+/obj/machinery/door/poddoor/incinerator_atmos_aux{
+	id = "atmos_incinerator_auxventL"
 	},
-/obj/structure/closet/secure_closet/engineering_welding,
-/turf/open/floor/plasteel,
-/area/xenoarch/gen)
+/turf/open/floor/engine,
+/area/xenoarch/eng)
 "FY" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/structure/table,
@@ -5826,9 +5804,6 @@
 "Ha" = (
 /obj/machinery/light,
 /obj/machinery/disposal/bin,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 6
-	},
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
@@ -5875,12 +5850,18 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "Hr" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 30
+/obj/machinery/atmospherics/pipe/simple/dark/visible,
+/obj/machinery/meter,
+/obj/effect/turf_decal/lumos/tile/yellow/half{
+	dir = 8
+	},
+/obj/item/radio/intercom{
+	dir = 8;
+	name = "Station Intercom (General)";
+	pixel_x = -28
 	},
 /turf/open/floor/plasteel,
-/area/xenoarch/arch)
+/area/xenoarch/eng)
 "Ht" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -5900,21 +5881,12 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "Hu" = (
-/obj/machinery/door/poddoor/incinerator_atmos_aux{
-	id = "atmos_incinerator_auxventL"
-	},
-/turf/open/floor/engine,
+/obj/machinery/atmospherics/pipe/simple/supply/visible/layer1,
+/turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "Hw" = (
-/obj/machinery/atmospherics/pipe/simple/dark/visible,
-/obj/machinery/meter,
-/obj/effect/turf_decal/lumos/tile/yellow/half{
-	dir = 8
-	},
-/obj/item/radio/intercom{
-	dir = 8;
-	name = "Station Intercom (General)";
-	pixel_x = -28
+/obj/machinery/atmospherics/components/binary/volume_pump/layer3{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
@@ -5946,12 +5918,15 @@
 /turf/open/floor/plasteel/white,
 /area/xenoarch/arch)
 "HL" = (
-/obj/machinery/atmospherics/pipe/simple/supply/visible/layer1,
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 9
+	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "HM" = (
-/obj/machinery/atmospherics/components/binary/volume_pump/layer3{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/effect/turf_decal/lumos/tile/yellow/half{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
@@ -5960,11 +5935,11 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "HQ" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 9
-	},
+/obj/structure/table,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
 /turf/open/floor/plasteel,
-/area/xenoarch/eng)
+/area/xenoarch/gen)
 "HS" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel,
@@ -5983,9 +5958,6 @@
 /turf/open/floor/plating,
 /area/xenoarch/sec)
 "Id" = (
-/obj/structure/chair/sofa/corp{
-	dir = 1
-	},
 /obj/effect/turf_decal/lumos/tile/red/half,
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/sec)
@@ -5998,12 +5970,14 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "If" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/effect/turf_decal/lumos/tile/yellow/half{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/xenoarch/eng)
+/area/xenoarch/gen)
 "Ig" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 2
@@ -6095,9 +6069,15 @@
 /turf/open/indestructible/boss,
 /area/ruin/unpowered/ash_walkers)
 "Iu" = (
-/obj/structure/table,
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/sec)
+/obj/machinery/atmospherics/components/binary/volume_pump,
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
+/obj/effect/turf_decal/lumos/tile/yellow/half{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/eng)
 "Iw" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -6160,11 +6140,12 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "IP" = (
-/obj/structure/table,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/glass/fifty,
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 6
+	},
+/obj/machinery/meter,
 /turf/open/floor/plasteel,
-/area/xenoarch/gen)
+/area/xenoarch/eng)
 "IS" = (
 /obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
@@ -6261,24 +6242,18 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "Ka" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/open/floor/plasteel,
-/area/xenoarch/gen)
+/area/xenoarch/eng)
 "Kc" = (
 /turf/open/floor/carpet,
 /area/xenoarch/gen)
 "Kd" = (
-/obj/machinery/atmospherics/components/binary/volume_pump,
-/obj/structure/sign/poster/official/random{
-	pixel_x = -32
-	},
-/obj/effect/turf_decal/lumos/tile/yellow/half{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
@@ -6439,10 +6414,14 @@
 /turf/open/floor/engine,
 /area/xenoarch/eng)
 "Lc" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 6
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/effect/turf_decal/lumos/tile/yellow/half{
+	dir = 4
 	},
-/obj/machinery/meter,
+/obj/machinery/status_display/evac{
+	layer = 4;
+	pixel_x = 32
+	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "Lg" = (
@@ -6455,9 +6434,17 @@
 /turf/open/floor/carpet,
 /area/xenoarch/gen)
 "Lo" = (
-/obj/structure/chair/sofa/corp,
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/sec)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/gen)
 "Lr" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -6488,10 +6475,13 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "Lw" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/machinery/meter,
+/obj/effect/turf_decal/lumos/tile/yellow/fullcorner{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "LB" = (
@@ -6599,9 +6589,13 @@
 /turf/open/indestructible/boss,
 /area/ruin/unpowered/ash_walkers)
 "Mf" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 10
+/obj/machinery/computer/atmos_control/tank/oxygen_tank{
+	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/lumos/tile/yellow/half,
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "Mg" = (
@@ -6609,14 +6603,13 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "Mi" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/effect/turf_decal/lumos/tile/yellow/half{
-	dir = 4
+/obj/machinery/computer/atmos_control/tank/nitrogen_tank{
+	dir = 1
 	},
-/obj/machinery/status_display/evac{
-	layer = 4;
-	pixel_x = 32
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 9
 	},
+/obj/effect/turf_decal/lumos/tile/yellow/half,
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "Mk" = (
@@ -6625,9 +6618,6 @@
 /turf/open/floor/plating,
 /area/xenoarch/gen)
 "Mm" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
@@ -6689,11 +6679,8 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/bot)
 "Nb" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
-	dir = 6
+	dir = 2
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
@@ -6738,24 +6725,14 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "Nn" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 8
-	},
-/obj/machinery/meter,
-/obj/effect/turf_decal/lumos/tile/yellow/fullcorner{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
+/obj/machinery/atmospherics/pipe/simple/dark/visible,
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/plating,
 /area/xenoarch/eng)
 "Nq" = (
-/obj/machinery/computer/atmos_control/tank/oxygen_tank{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/lumos/tile/yellow/half,
-/turf/open/floor/plasteel,
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/plating,
 /area/xenoarch/eng)
 "Nr" = (
 /obj/structure/stone_tile/surrounding_tile{
@@ -6809,15 +6786,12 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "NH" = (
-/obj/machinery/computer/atmos_control/tank/nitrogen_tank{
-	dir = 1
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 9
-	},
-/obj/effect/turf_decal/lumos/tile/yellow/half,
+/obj/machinery/autolathe,
 /turf/open/floor/plasteel,
-/area/xenoarch/eng)
+/area/xenoarch/gen)
 "NI" = (
 /obj/structure/stone_tile/block{
 	dir = 4
@@ -6965,14 +6939,9 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/gen)
 "OB" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/gen)
+/obj/machinery/atmospherics/pipe/simple/dark/visible,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "OC" = (
 /obj/structure/stone_tile/block{
 	dir = 1
@@ -6984,9 +6953,10 @@
 /turf/open/indestructible/boss,
 /area/ruin/unpowered/ash_walkers)
 "OF" = (
-/obj/machinery/atmospherics/pipe/simple/dark/visible,
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/nitrogen_output{
+	dir = 1
+	},
+/turf/open/floor/engine/air,
 /area/xenoarch/eng)
 "OH" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -7043,9 +7013,10 @@
 /turf/open/indestructible/boss,
 /area/lavaland/surface/outdoors)
 "OU" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/oxygen_output{
+	dir = 1
+	},
+/turf/open/floor/engine/o2,
 /area/xenoarch/eng)
 "OW" = (
 /obj/machinery/door/firedoor,
@@ -7055,15 +7026,17 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "Pb" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 10
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/nitrogen_output{
+	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/xenoarch/gen)
+/turf/open/floor/engine/n2,
+/area/xenoarch/eng)
 "Pc" = (
-/obj/machinery/atmospherics/pipe/simple/dark/visible,
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 4
+	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/area/xenoarch/eng)
 "Pd" = (
 /turf/open/lava/smooth/lava_land_surface,
 /area/lavaland/surface/outdoors)
@@ -7217,13 +7190,9 @@
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
 "Qi" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/nitrogen_output{
-	dir = 1
-	},
-/turf/open/floor/engine/air,
-/area/xenoarch/eng)
+/turf/closed/wall/r_wall,
+/area/space)
 "Qo" = (
-/obj/machinery/autolathe,
 /obj/effect/turf_decal/lumos/tile/yellow/fulltile,
 /obj/machinery/light{
 	dir = 1
@@ -7280,10 +7249,8 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "QS" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/oxygen_output{
-	dir = 1
-	},
-/turf/open/floor/engine/o2,
+/obj/machinery/light/small,
+/turf/open/floor/engine/air,
 /area/xenoarch/eng)
 "QV" = (
 /turf/closed/mineral/random/volcanic,
@@ -7317,10 +7284,9 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "Rj" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/nitrogen_output{
-	dir = 1
-	},
-/turf/open/floor/engine/n2,
+/obj/machinery/atmospherics/miner/oxygen,
+/obj/machinery/light/small,
+/turf/open/floor/engine/o2,
 /area/xenoarch/eng)
 "Rl" = (
 /obj/structure/stone_tile/block{
@@ -7390,10 +7356,9 @@
 /turf/open/indestructible/boss,
 /area/ruin/unpowered/ash_walkers)
 "RE" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on{
-	dir = 4
-	},
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/obj/machinery/atmospherics/miner/nitrogen,
+/obj/machinery/light/small,
+/turf/open/floor/engine/n2,
 /area/xenoarch/eng)
 "RF" = (
 /obj/machinery/door/airlock{
@@ -7463,9 +7428,6 @@
 	},
 /turf/closed/indestructible/riveted/boss,
 /area/ruin/unpowered/ash_walkers)
-"Si" = (
-/turf/closed/wall/r_wall,
-/area/space)
 "Sr" = (
 /obj/structure/stone_tile/block/cracked{
 	dir = 8
@@ -7552,10 +7514,6 @@
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
-"SL" = (
-/obj/machinery/light/small,
-/turf/open/floor/engine/air,
-/area/xenoarch/eng)
 "SO" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -7653,11 +7611,6 @@
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/open/floor/grass,
 /area/lavaland/surface/outdoors)
-"Th" = (
-/obj/machinery/atmospherics/miner/oxygen,
-/obj/machinery/light/small,
-/turf/open/floor/engine/o2,
-/area/xenoarch/eng)
 "Tk" = (
 /obj/structure/stone_tile/slab,
 /obj/structure/table/wood,
@@ -7688,13 +7641,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
-"Tw" = (
-/obj/structure/table,
-/obj/effect/turf_decal/lumos/tile/red/half{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/sec)
 "TD" = (
 /obj/structure/stone_tile/cracked,
 /obj/structure/stone_tile/block{
@@ -7896,14 +7842,6 @@
 	},
 /turf/open/floor/plating,
 /area/mining_level_access)
-"UW" = (
-/obj/structure/table,
-/obj/item/paper_bin{
-	pixel_y = 6
-	},
-/obj/item/pen,
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/sec)
 "UX" = (
 /obj/machinery/air_sensor{
 	pixel_x = -32;
@@ -7986,11 +7924,6 @@
 /obj/structure/flora/grass/jungle,
 /turf/open/floor/grass,
 /area/lavaland/surface/outdoors)
-"VG" = (
-/obj/machinery/atmospherics/miner/nitrogen,
-/obj/machinery/light/small,
-/turf/open/floor/engine/n2,
-/area/xenoarch/eng)
 "VJ" = (
 /obj/structure/flora/rock/pile/largejungle{
 	light_range = null
@@ -8038,13 +7971,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
-"Wy" = (
-/obj/structure/chair/sofa/corp/right,
-/obj/effect/turf_decal/lumos/tile/red/half{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/sec)
 "WD" = (
 /obj/structure/table/optable,
 /turf/open/floor/plasteel/white,
@@ -19406,10 +19332,10 @@ BS
 BS
 CT
 oc
-Tw
-BZ
-Wy
-Tw
+tJ
+tJ
+tJ
+tJ
 hp
 CT
 jn
@@ -19663,10 +19589,10 @@ BS
 Ix
 CT
 oU
-UW
-gV
-Lo
-UW
+qi
+qi
+qi
+qi
 Id
 CT
 jn
@@ -19920,10 +19846,10 @@ cZ
 jn
 CT
 rG
-Iu
-pE
-kF
-Iu
+qi
+qi
+qi
+qi
 ik
 CT
 jn
@@ -20197,7 +20123,7 @@ Mv
 as
 OM
 BS
-AU
+wp
 AU
 AU
 AU
@@ -21226,10 +21152,10 @@ ia
 uU
 ia
 ia
-AT
+zU
 ia
 rj
-Hr
+FT
 rj
 rj
 rj
@@ -21998,7 +21924,7 @@ Pd
 Pd
 Pd
 Ge
-CV
+Ct
 Ge
 Pd
 Pd
@@ -22768,9 +22694,9 @@ Pd
 Pd
 tN
 Ge
-BD
+AT
 rZ
-Do
+Db
 Ge
 Pd
 Pd
@@ -23028,7 +22954,7 @@ Ge
 Br
 cU
 UX
-Hu
+FW
 Pd
 Pd
 Pd
@@ -23804,7 +23730,7 @@ Ge
 Ge
 Ge
 Pd
-RE
+Pc
 Pd
 tN
 tN
@@ -24052,15 +23978,15 @@ tN
 tN
 tN
 Ge
-xo
+wF
 RW
 nf
 uT
-Hw
-Kd
+Hr
+Iu
+Lw
 Nn
-OF
-Pc
+OB
 BF
 Pd
 tN
@@ -24556,25 +24482,25 @@ pU
 iR
 pU
 hs
-fE
+fI
 iX
 ka
 iX
-mp
+mk
 Ge
 RK
 RK
-qy
-ui
+pD
+st
 dC
-BK
+BD
 mA
 zM
-HL
-HL
+Hu
+Hu
 GM
 DJ
-Qi
+OF
 yP
 yP
 Ge
@@ -24820,7 +24746,7 @@ eV
 mB
 Ge
 vU
-ps
+ok
 AZ
 lH
 CL
@@ -24833,7 +24759,7 @@ ct
 lH
 fG
 pW
-SL
+QS
 Ge
 tN
 tN
@@ -25070,7 +24996,7 @@ Ng
 cp
 XI
 hs
-fI
+gu
 eV
 eL
 eV
@@ -25082,12 +25008,12 @@ ZP
 DJ
 pn
 KL
-CX
-Du
+CD
+Df
 FB
-Lc
+IP
 Gs
-OU
+Nq
 gx
 yP
 yP
@@ -25590,19 +25516,19 @@ Rw
 eV
 kK
 Ge
-nx
-pD
-rr
-wp
+mp
+ps
+pE
+sw
 lf
-Ct
+BK
 Wu
-Fv
-HM
+Do
+Hw
 HF
 GM
 DJ
-QS
+OU
 Sv
 Sv
 Ge
@@ -25841,10 +25767,10 @@ ox
 Bc
 HP
 eA
-gu
+gV
 ja
 kD
-mg
+kW
 sT
 Ge
 jw
@@ -25857,11 +25783,11 @@ Wu
 FB
 FB
 Vd
-Nq
+Mf
 lH
 eh
 QX
-Th
+Rj
 Ge
 tN
 tN
@@ -26108,14 +26034,14 @@ jK
 Hq
 FB
 xl
-xx
+xo
 bA
-CZ
+CJ
 FB
 Ki
-Lw
+Ka
 fl
-ui
+st
 Om
 Sv
 Sv
@@ -26626,11 +26552,11 @@ Ki
 lw
 yR
 lw
-HQ
-Mf
+HL
+Kd
 GM
 DJ
-Rj
+Pb
 Hp
 Hp
 Ge
@@ -26872,12 +26798,12 @@ hs
 ha
 je
 eV
-mk
+mg
 im
 Ge
 Nu
 sL
-rC
+qy
 lw
 sc
 lw
@@ -26885,11 +26811,11 @@ Ue
 lw
 lw
 lw
-NH
+Mi
 lH
 aj
 vx
-VG
+RE
 Ge
 tN
 tN
@@ -27128,22 +27054,22 @@ gR
 hs
 pc
 Go
-kW
+kF
 Go
 SY
 Ge
 aE
 DS
 KJ
-wF
-BC
-CD
-tx
-FG
-If
-Mi
-YY
 ui
+BC
+BZ
+tx
+Du
+HM
+Lc
+YY
+st
 NL
 Hp
 Hp
@@ -27639,29 +27565,29 @@ ac
 MC
 MC
 MC
-fs
+fE
 ix
 js
 js
 js
 js
 js
-ok
+nx
 of
-st
+rr
 Ge
-zU
+xx
 Dw
-Db
-Dw
-Dw
+CX
 Dw
 Dw
-Pb
+Dw
+Dw
+NH
 zC
-Si
-Si
-Si
+Qi
+Qi
+Qi
 zC
 zC
 zC
@@ -28167,8 +28093,8 @@ Ge
 Qo
 Ox
 Ox
-FT
-IP
+Fv
+HQ
 Ox
 Ox
 FY
@@ -28422,12 +28348,12 @@ Pn
 en
 Ge
 zx
-Ox
-Ox
-Ox
-Ox
-Ox
-Ox
+CV
+CV
+CV
+CV
+CV
+CV
 ty
 zC
 xL
@@ -28679,12 +28605,12 @@ Pn
 en
 Ge
 rS
-CJ
-Df
-FW
-Ka
+CV
+CZ
+FG
+If
+Lo
 Nb
-OB
 Ha
 zC
 xL
@@ -28933,7 +28859,7 @@ Ym
 Ym
 Ym
 Pn
-sw
+rC
 Ge
 zC
 zC

--- a/_maps/map_files/Mining/Lavaland_Lumos.dmm
+++ b/_maps/map_files/Mining/Lavaland_Lumos.dmm
@@ -105,12 +105,10 @@
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
 "am" = (
-/obj/machinery/computer/rdconsole/core{
-	dir = 4
-	},
 /obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 8
 	},
+/obj/structure/table,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "an" = (
@@ -214,9 +212,11 @@
 /turf/open/floor/plating,
 /area/xenoarch/arch)
 "ax" = (
-/obj/machinery/rnd/production/protolathe/department/science,
 /obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 8
+	},
+/obj/machinery/computer/rdconsole/core{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
@@ -235,10 +235,7 @@
 /turf/open/lava/smooth/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "aA" = (
-/obj/effect/turf_decal/delivery,
-/obj/structure/closet/wardrobe/xenoarch,
-/obj/item/clothing/glasses/meson,
-/turf/open/floor/plasteel,
+/turf/closed/mineral/random/volcanic,
 /area/xenoarch/arch)
 "aB" = (
 /obj/item/radio/intercom{
@@ -246,10 +243,10 @@
 	name = "Station Intercom (General)";
 	pixel_x = 28
 	},
-/obj/structure/tank_dispenser/oxygen,
 /obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 4
 	},
+/obj/structure/tank_dispenser/oxygen,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "aC" = (
@@ -320,16 +317,14 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/yellow,
 /obj/structure/cable/yellow{
-	icon_state = "1-8"
+	icon_state = "0-8"
 	},
 /turf/open/floor/plating,
 /area/xenoarch/arch)
 "aK" = (
-/obj/machinery/suit_storage_unit/mining,
-/obj/effect/turf_decal/lumos/tile/purple/half{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
+/obj/structure/table,
+/obj/item/relic,
+/turf/open/floor/plating,
 /area/xenoarch/arch)
 "aL" = (
 /obj/machinery/light{
@@ -412,6 +407,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "aT" = (
@@ -425,9 +423,6 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/gen)
 "aU" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
@@ -446,8 +441,10 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "aW" = (
-/obj/structure/chair/office/dark,
-/turf/open/floor/plasteel,
+/obj/structure/frame/computer{
+	dir = 8
+	},
+/turf/open/floor/plating,
 /area/xenoarch/arch)
 "aX" = (
 /obj/structure/rack,
@@ -512,7 +509,7 @@
 	icon_state = "0-2"
 	},
 /obj/structure/cable/yellow{
-	icon_state = "2-8"
+	icon_state = "0-8"
 	},
 /turf/open/floor/plating,
 /area/xenoarch/arch)
@@ -534,7 +531,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "bi" = (
 /obj/structure/flora/ausbushes/lavendergrass,
@@ -558,6 +555,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/lumos/tile/purple/half,
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "bl" = (
@@ -595,6 +595,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/lumos/tile/purple/fulltile,
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "bq" = (
@@ -638,16 +641,18 @@
 /obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "bt" = (
+/obj/effect/turf_decal/lumos/tile/purple/half{
+	dir = 1
+	},
 /obj/structure/disposalpipe/segment{
-	dir = 9
+	dir = 10
 	},
-/obj/structure/sign/poster/official/random{
-	pixel_y = -32
-	},
-/obj/effect/turf_decal/lumos/tile/purple/half,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "bu" = (
@@ -665,14 +670,12 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/bot)
 "bv" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/structure/disposalpipe/junction/flip,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "bw" = (
@@ -839,9 +842,11 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "bP" = (
-/obj/machinery/bookbinder,
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/gen)
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "bQ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
@@ -1081,19 +1086,18 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "dn" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/structure/window/reinforced{
+/obj/effect/turf_decal/lumos/tile/red/checker{
 	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
 "do" = (
-/obj/machinery/hydroponics/constructable,
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
@@ -1630,9 +1634,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/structure/disposalpipe/junction/flip,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
@@ -2012,7 +2018,7 @@
 /obj/structure/disposalpipe/junction/flip{
 	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "iO" = (
 /obj/structure/stone_tile/slab,
@@ -2107,13 +2113,14 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "ju" = (
-/obj/structure/table,
-/obj/machinery/computer/libraryconsole,
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/gen)
+/obj/effect/turf_decal/delivery,
+/obj/structure/closet/wardrobe/xenoarch,
+/obj/item/clothing/glasses/meson,
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "jv" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/machinery/light/small{
@@ -2152,14 +2159,13 @@
 "jL" = (
 /obj/structure/table,
 /obj/item/clipboard,
-/obj/item/relic,
 /turf/open/floor/plating,
 /area/xenoarch/arch)
 "jN" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "jR" = (
 /obj/effect/turf_decal/stripes/line{
@@ -2312,7 +2318,7 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "kF" = (
 /obj/structure/chair/sofa/corp/left,
@@ -2335,10 +2341,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/bot)
-"kN" = (
-/obj/machinery/vending/snack/random,
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/gen)
 "kR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 1
@@ -2451,6 +2453,7 @@
 /turf/open/lava/smooth/lava_land_surface,
 /area/template_noop)
 "lu" = (
+/obj/effect/turf_decal/lumos/tile/blue/checker,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
@@ -2548,8 +2551,18 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/bot)
 "lP" = (
-/obj/structure/table,
-/obj/effect/turf_decal/lumos/tile/purple/fullcorner,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "lT" = (
@@ -2646,9 +2659,8 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "mq" = (
-/obj/structure/table,
-/obj/effect/turf_decal/lumos/tile/purple/half,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/lumos/tile/blue/fulltile,
+/turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
 "my" = (
 /obj/effect/turf_decal/tile/purple{
@@ -2666,7 +2678,6 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "mB" = (
-/obj/machinery/hydroponics/constructable,
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -2722,7 +2733,7 @@
 /turf/open/floor/plating,
 /area/xenoarch/arch)
 "mY" = (
-/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/lumos/tile/red/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
 "mZ" = (
@@ -2904,6 +2915,7 @@
 /obj/structure/table,
 /obj/machinery/light,
 /obj/effect/turf_decal/lumos/tile/purple/half,
+/obj/item/clipboard,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "nY" = (
@@ -3019,9 +3031,8 @@
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/sec)
 "oX" = (
-/obj/structure/bookcase/random,
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/gen)
+/turf/closed/wall,
+/area/lavaland/surface/outdoors)
 "pc" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/green{
@@ -3620,11 +3631,9 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "rX" = (
+/obj/effect/turf_decal/lumos/tile/red/checker,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
-	},
-/obj/structure/window/reinforced{
-	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
@@ -3742,10 +3751,10 @@
 /turf/open/floor/plasteel/elevatorshaft,
 /area/mining_level_access/lower)
 "sL" = (
-/obj/structure/disposalpipe/segment{
+/obj/effect/turf_decal/lumos/tile/purple/half,
+/obj/structure/disposalpipe/junction{
 	dir = 8
 	},
-/obj/effect/turf_decal/lumos/tile/purple/half,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "sP" = (
@@ -3799,7 +3808,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/carpet/red,
 /area/xenoarch/gen)
 "tc" = (
 /obj/structure/stone_tile/cracked{
@@ -3842,10 +3851,13 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "tr" = (
+/obj/structure/window/reinforced,
+/obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
-/obj/structure/window/reinforced,
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
 "tv" = (
@@ -4092,10 +4104,10 @@
 /turf/closed/wall/r_wall,
 /area/xenoarch/eng)
 "uU" = (
-/obj/structure/disposalpipe/junction{
-	dir = 8
-	},
 /obj/effect/turf_decal/lumos/tile/purple/half,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "uX" = (
@@ -4849,7 +4861,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "zl" = (
 /obj/structure/window/reinforced,
@@ -5022,13 +5034,12 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "AC" = (
-/obj/structure/table,
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
 /obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 1
 	},
+/obj/effect/turf_decal/delivery,
+/obj/structure/closet/wardrobe/xenoarch,
+/obj/item/clothing/glasses/meson,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "AD" = (
@@ -5046,12 +5057,10 @@
 	},
 /area/ruin/unpowered/ash_walkers)
 "AG" = (
+/obj/structure/window/reinforced,
+/obj/effect/turf_decal/lumos/tile/blue/checker,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
@@ -5092,11 +5101,11 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/bot)
 "AT" = (
+/obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
-	},
-/obj/structure/window/reinforced{
-	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
@@ -5178,11 +5187,12 @@
 /turf/open/indestructible/boss,
 /area/ruin/unpowered/ash_walkers)
 "Bl" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
 /obj/structure/window/reinforced{
 	dir = 1
+	},
+/obj/effect/turf_decal/lumos/tile/red/checker,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
@@ -5344,15 +5354,10 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "CI" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atm{
-	pixel_x = 30
-	},
+/obj/machinery/vending/cola/random,
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/gen)
 "CJ" = (
-/obj/structure/bookcase/random,
 /obj/machinery/light{
 	dir = 4
 	},
@@ -5514,16 +5519,13 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "Dt" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
+/obj/machinery/vending/snack/random,
+/turf/open/floor/plasteel/dark,
+/area/xenoarch/gen)
 "Du" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "Dv" = (
 /obj/structure/stone_tile/block/cracked{
@@ -5614,16 +5616,15 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "DW" = (
-/obj/structure/table,
 /obj/item/radio/intercom{
 	dir = 8;
 	name = "Station Intercom (General)";
 	pixel_x = -28
 	},
-/obj/item/strangerock,
 /obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 8
 	},
+/obj/machinery/rnd/production/protolathe/department/science,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "DX" = (
@@ -5681,7 +5682,6 @@
 /turf/open/floor/plating,
 /area/xenoarch/arch)
 "Eo" = (
-/obj/machinery/hydroponics/constructable,
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
@@ -5809,11 +5809,9 @@
 /area/xenoarch/gen)
 "Fw" = (
 /obj/machinery/light,
-/obj/structure/table,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/item/strangerock,
 /obj/effect/turf_decal/lumos/tile/purple/half,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
@@ -5822,7 +5820,7 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "FB" = (
 /turf/open/floor/plasteel,
@@ -5950,7 +5948,6 @@
 /area/xenoarch/bot)
 "Gq" = (
 /obj/structure/table,
-/obj/item/relic,
 /obj/effect/turf_decal/lumos/tile/purple/fullcorner{
 	dir = 1
 	},
@@ -6001,7 +5998,7 @@
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "Gy" = (
 /obj/machinery/atm{
@@ -6461,11 +6458,6 @@
 "IG" = (
 /turf/closed/wall/mineral/wood,
 /area/ruin/unpowered/ash_walkers)
-"IK" = (
-/obj/machinery/light,
-/obj/machinery/vending/cola/random,
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/gen)
 "IL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -6716,7 +6708,6 @@
 /turf/closed/wall/r_wall,
 /area/xenoarch/eng)
 "Kz" = (
-/obj/structure/bookcase/random,
 /obj/machinery/light{
 	dir = 8
 	},
@@ -6747,14 +6738,15 @@
 /turf/open/indestructible/boss,
 /area/ruin/unpowered/ash_walkers)
 "KG" = (
-/obj/structure/disposalpipe/trunk,
-/obj/machinery/disposal/bin,
 /obj/machinery/status_display/evac{
 	layer = 4;
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
@@ -7234,9 +7226,11 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "NQ" = (
-/obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/pen/fountain,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atm{
+	pixel_x = 30
+	},
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/gen)
 "NT" = (
@@ -7768,8 +7762,7 @@
 /turf/open/floor/plating,
 /area/xenoarch/eng)
 "QV" = (
-/obj/machinery/photocopier,
-/turf/open/floor/plasteel/dark,
+/turf/closed/mineral/random/volcanic,
 /area/xenoarch/gen)
 "QW" = (
 /obj/structure/frame,
@@ -7903,8 +7896,7 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "RF" = (
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/carpet/red,
 /area/xenoarch/gen)
 "RJ" = (
 /obj/item/pickaxe,
@@ -8099,7 +8091,7 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "SQ" = (
-/obj/machinery/vending/cola/random,
+/obj/machinery/light,
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/gen)
 "SS" = (
@@ -8167,6 +8159,9 @@
 /obj/item/strangerock,
 /obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 1
+	},
+/obj/machinery/newscaster{
+	pixel_y = 32
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
@@ -8252,6 +8247,9 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "TI" = (
+/obj/effect/turf_decal/lumos/tile/red/checker{
+	dir = 4
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
@@ -8325,7 +8323,6 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "Ug" = (
-/obj/structure/table,
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
@@ -8414,7 +8411,7 @@
 	c_tag = "Xenoarchaeology Ten";
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "Uz" = (
 /obj/effect/turf_decal/stripes/line{
@@ -8592,11 +8589,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/engine,
 /area/xenoarch/arch)
-"VW" = (
-/obj/structure/table,
-/obj/item/folder,
-/turf/open/floor/plasteel/dark,
-/area/xenoarch/gen)
 "Wa" = (
 /obj/machinery/door/poddoor/incinerator_atmos_main{
 	id = "atmos_incinerator_mainventL"
@@ -8834,10 +8826,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
-"Yc" = (
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "Yh" = (
 /obj/machinery/light{
 	dir = 1
@@ -8959,13 +8947,16 @@
 /turf/open/floor/plating,
 /area/xenoarch/eng)
 "YX" = (
-/obj/structure/table,
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
 	},
 /obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 1
 	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/disposal/bin,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "YY" = (
@@ -8984,10 +8975,6 @@
 "Za" = (
 /turf/closed/wall,
 /area/xenoarch/gen)
-"Zb" = (
-/obj/machinery/door/airlock/research/glass,
-/turf/open/floor/plating,
-/area/xenoarch/arch)
 "Ze" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/mechanical,
@@ -9023,9 +9010,6 @@
 /turf/open/floor/plating,
 /area/xenoarch/sec)
 "Zq" = (
-/obj/structure/chair/office/dark{
-	dir = 1
-	},
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -24
@@ -9066,9 +9050,6 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "ZF" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1
-	},
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
@@ -19371,13 +19352,13 @@ as
 KE
 BS
 vz
-vz
+mq
 zl
 fd
 yu
 zl
 fd
-vz
+mY
 vz
 BS
 DM
@@ -21945,9 +21926,9 @@ ia
 ia
 rj
 rj
-mY
-mY
-mY
+rj
+rj
+rj
 Uu
 Du
 tv
@@ -23709,24 +23690,24 @@ tN
 tN
 tN
 tN
+aA
+aA
+aA
+aA
+aA
 BS
-jn
-jn
-jn
-jn
-jn
-BS
+QW
 jn
 BS
 YX
 AU
-aA
-aA
+AU
+AU
 DP
-mq
+HP
 BS
 Ng
-UN
+lP
 sL
 BS
 Tz
@@ -23966,19 +23947,19 @@ tN
 tN
 tN
 tN
+aA
+aA
+aA
+aA
+aA
 BS
-jn
-jn
-jn
-jn
-jn
-BS
+aK
 jn
 ae
-Ng
-AU
-aA
-aA
+bt
+JR
+JR
+JR
 aR
 bk
 bp
@@ -24223,25 +24204,25 @@ tN
 tN
 tN
 tN
+aA
+aA
+aA
+aA
+aA
 BS
-Kl
 jn
-jn
-jn
-jn
-BS
 jn
 BS
 KG
-JR
-Dt
-Dt
+bP
+AU
+AU
 aU
 ZF
-LB
-hw
+BS
+Ng
 gQ
-bt
+XI
 BS
 fH
 PQ
@@ -24480,19 +24461,19 @@ tN
 tN
 tN
 tN
+aA
+aA
+aA
+aA
+aA
 BS
-jn
-jn
-jn
-jn
-jn
-BS
+aW
 jn
 BS
 AC
+ju
 AU
-Yc
-Yc
+AU
 AU
 Ug
 BS
@@ -24737,12 +24718,12 @@ tN
 tN
 tN
 tN
+aA
+aA
+aA
+aA
+aA
 BS
-jn
-jn
-jn
-jn
-jn
 BS
 dt
 BS
@@ -24750,7 +24731,7 @@ ag
 AU
 AU
 AU
-aW
+AU
 Fw
 LB
 hw
@@ -24994,21 +24975,21 @@ tN
 tN
 tN
 tN
-BS
-jn
-jn
-jn
-jn
-jn
+aA
+aA
+aA
+aA
+aA
+aA
 BS
 jn
 BS
 ah
 ap
 aB
-aK
-aK
-lP
+ia
+ia
+mc
 BS
 Xr
 KR
@@ -25251,12 +25232,12 @@ tN
 tN
 tN
 tN
-BS
-jn
-jn
-jn
-jn
-dt
+aA
+aA
+aA
+aA
+aA
+aA
 BS
 Oc
 BS
@@ -25508,12 +25489,12 @@ tN
 tN
 tN
 tN
-BS
-jn
-jn
-jn
-jn
-jn
+aA
+aA
+aA
+aA
+aA
+aA
 BS
 jn
 DI
@@ -25765,12 +25746,12 @@ tN
 tN
 tN
 tN
-BS
-jn
-jn
-jn
-jn
-jn
+aA
+aA
+aA
+aA
+aA
+aA
 BS
 jn
 jn
@@ -26022,12 +26003,12 @@ tN
 tN
 tN
 tN
-BS
-BS
-BS
-BS
-GY
-BS
+aA
+aA
+aA
+aA
+aA
+aA
 BS
 jn
 yr
@@ -26282,10 +26263,10 @@ tN
 tN
 tN
 tN
+aA
+aA
+aA
 BS
-jn
-jn
-jn
 jn
 kh
 BS
@@ -26539,8 +26520,8 @@ tN
 tN
 tN
 tN
-BS
-Oc
+aA
+aA
 BS
 BS
 BS
@@ -26796,8 +26777,8 @@ tN
 tN
 tN
 tN
-BS
-jn
+aA
+aA
 BS
 tB
 tB
@@ -27053,9 +27034,9 @@ tN
 tN
 tN
 tN
+aA
+aA
 BS
-jn
-Zb
 AU
 AU
 AU
@@ -27310,8 +27291,8 @@ tN
 tN
 tN
 tN
-BS
-BS
+aA
+aA
 BS
 bX
 zn
@@ -29155,7 +29136,7 @@ Mf
 co
 st
 Za
-pl
+DM
 DM
 DM
 DM
@@ -29674,7 +29655,7 @@ DM
 DM
 DM
 DM
-xe
+DM
 Za
 tN
 tN
@@ -30440,13 +30421,13 @@ Fq
 gu
 Nb
 Za
-pl
-DM
-DM
-DM
-DM
-DM
-Za
+QV
+QV
+QV
+QV
+QV
+QV
+QV
 tN
 tN
 tN
@@ -30689,21 +30670,21 @@ oI
 LV
 oI
 oI
-CI
 oI
+NQ
 my
 If
 If
 Df
 FW
-iC
-DM
-DM
-DM
-DM
-DM
-DM
 Za
+QV
+QV
+QV
+QV
+QV
+QV
+QV
 tN
 tN
 tN
@@ -30954,13 +30935,13 @@ Za
 Za
 Za
 Za
-DM
-DM
-DM
-DM
-DM
-DM
-Za
+QV
+QV
+QV
+QV
+QV
+QV
+QV
 tN
 tN
 tN
@@ -31205,19 +31186,19 @@ sB
 sB
 SQ
 Za
-oX
-oX
+sB
+sB
 Kz
-oX
-oX
+sB
+sB
 Za
-DM
-DM
-DM
-DM
-DM
-DM
-Za
+QV
+QV
+QV
+QV
+QV
+QV
+QV
 tN
 tN
 tN
@@ -31458,23 +31439,23 @@ Za
 Nx
 uX
 sl
+RF
+RF
+RF
+RF
+RF
 sB
 sB
-IK
+sB
+sB
 Za
-sB
-sB
-sB
-sB
-sB
-Za
-DM
-DM
-DM
-DM
-DM
-xe
-Za
+QV
+QV
+QV
+QV
+QV
+QV
+QV
 tN
 tN
 tN
@@ -31715,23 +31696,23 @@ Za
 YT
 WT
 sl
-sB
-sB
-sB
+RF
+RF
+RF
+RF
 RF
 sB
-bP
 sB
-NQ
-VW
+sB
+sB
 Za
-DM
-DM
-DM
-DM
-DM
-DM
-Za
+QV
+QV
+QV
+QV
+QV
+QV
+QV
 tN
 tN
 tN
@@ -31973,22 +31954,22 @@ Ob
 XJ
 gZ
 sZ
-sB
-sB
+RF
+RF
+RF
 RF
 sB
-QV
 sB
-ju
+sB
 Zq
 Za
-Za
-Za
-Za
-Za
-Za
-Za
-Za
+QV
+QV
+QV
+QV
+QV
+QV
+QV
 tN
 tN
 tN
@@ -32229,11 +32210,11 @@ Za
 bx
 uX
 sB
-sB
-sB
-kN
-Za
-sB
+RF
+RF
+RF
+RF
+RF
 sB
 sB
 sB
@@ -32487,14 +32468,14 @@ YT
 xI
 Ks
 mQ
-dV
-kN
+sB
+sB
 Za
-oX
-oX
+sB
+sB
 CJ
-oX
-oX
+sB
+sB
 Za
 tN
 tN
@@ -32744,8 +32725,8 @@ Za
 Za
 Za
 Za
-Za
-Za
+CI
+Dt
 Za
 Za
 Za
@@ -33000,10 +32981,10 @@ tN
 tN
 tN
 tN
-tN
-tN
-tN
-tN
+oX
+oX
+oX
+oX
 tN
 tN
 tN

--- a/_maps/map_files/Mining/Lavaland_Lumos.dmm
+++ b/_maps/map_files/Mining/Lavaland_Lumos.dmm
@@ -33,14 +33,11 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "ad" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
+	},
+/obj/effect/turf_decal/lumos/tile/purple/half{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/sec)
@@ -65,23 +62,16 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "ah" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
 /obj/machinery/suit_storage_unit/mining,
+/obj/effect/turf_decal/lumos/tile/purple/fullcorner{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "ai" = (
@@ -103,17 +93,23 @@
 /turf/open/floor/plating,
 /area/xenoarch/arch)
 "al" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
 /obj/structure/window/reinforced{
 	dir = 1
+	},
+/obj/effect/turf_decal/lumos/tile/purple/checker{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
 "am" = (
 /obj/machinery/computer/rdconsole/core{
 	dir = 4
+	},
+/obj/effect/turf_decal/lumos/tile/purple/half{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
@@ -132,14 +128,13 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "ap" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
 /obj/structure/sign/poster/official/random{
 	pixel_x = 32
 	},
 /obj/machinery/suit_storage_unit/mining,
+/obj/effect/turf_decal/lumos/tile/purple/half{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "aq" = (
@@ -150,14 +145,8 @@
 /obj/machinery/computer/security/mining{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/brown{
+/obj/effect/turf_decal/lumos/tile/brown/fullcorner{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
@@ -168,10 +157,7 @@
 /obj/machinery/camera{
 	c_tag = "Xenoarchaeology Sixteen"
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown{
+/obj/effect/turf_decal/lumos/tile/brown/half{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -189,16 +175,13 @@
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
 /obj/structure/rack,
 /obj/item/t_scanner/adv_mining_scanner/lesser,
 /obj/item/storage/bag/strangerock,
 /obj/item/gps/mining,
+/obj/effect/turf_decal/lumos/tile/brown/half{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "au" = (
@@ -207,12 +190,8 @@
 	pixel_y = 32
 	},
 /obj/machinery/suit_storage_unit/mining,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
+/obj/effect/turf_decal/lumos/tile/brown/fullcorner{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
@@ -236,6 +215,9 @@
 /area/xenoarch/arch)
 "ax" = (
 /obj/machinery/rnd/production/protolathe/department/science,
+/obj/effect/turf_decal/lumos/tile/purple/half{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "ay" = (
@@ -259,16 +241,15 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "aB" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
 /obj/item/radio/intercom{
 	dir = 8;
 	name = "Station Intercom (General)";
 	pixel_x = 28
 	},
 /obj/structure/tank_dispenser/oxygen,
+/obj/effect/turf_decal/lumos/tile/purple/half{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "aC" = (
@@ -283,11 +264,8 @@
 /obj/machinery/computer/shuttle/mining{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/brown{
+/obj/effect/turf_decal/lumos/tile/brown/half{
 	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
@@ -330,12 +308,11 @@
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/gen)
 "aI" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/lumos/tile/brown/half{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
@@ -348,11 +325,10 @@
 /turf/open/floor/plating,
 /area/xenoarch/arch)
 "aK" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
+/obj/machinery/suit_storage_unit/mining,
+/obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 4
 	},
-/obj/machinery/suit_storage_unit/mining,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "aL" = (
@@ -363,14 +339,11 @@
 	pixel_x = -32
 	},
 /obj/structure/table,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
 /obj/item/pipe_dispenser,
 /obj/item/construction/rcd,
+/obj/effect/turf_decal/lumos/tile/brown/half{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "aM" = (
@@ -418,10 +391,9 @@
 	},
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/disposal/bin,
-/obj/effect/turf_decal/tile/brown{
+/obj/effect/turf_decal/lumos/tile/brown/half{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/brown,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "aQ" = (
@@ -444,15 +416,12 @@
 /area/xenoarch/arch)
 "aT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/lumos/tile/purple/half,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/xenoarch/gen)
 "aU" = (
@@ -481,13 +450,10 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "aX" = (
-/obj/effect/turf_decal/tile/brown{
+/obj/structure/rack,
+/obj/effect/turf_decal/lumos/tile/brown/half{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/structure/rack,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "aY" = (
@@ -532,12 +498,11 @@
 /area/xenoarch/arch)
 "bd" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/lumos/tile/brown/half{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
@@ -590,54 +555,35 @@
 /turf/open/floor/plating,
 /area/xenoarch/arch)
 "bk" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/lumos/tile/purple/half,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "bl" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
 /obj/structure/rack,
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
 	},
 /obj/item/storage/firstaid/regular,
+/obj/effect/turf_decal/lumos/tile/brown/fullcorner{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "bm" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/lumos/tile/brown/half,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "bn" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown,
 /obj/structure/closet/emcloset/anchored,
+/obj/effect/turf_decal/lumos/tile/brown/half,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "bo" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown,
 /obj/structure/closet/secure_closet/miner,
+/obj/effect/turf_decal/lumos/tile/brown/fullcorner,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "bp" = (
@@ -648,6 +594,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/lumos/tile/purple/fulltile,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "bq" = (
@@ -667,6 +614,10 @@
 	name = "Mining Foreman Office";
 	req_access_txt = "48"
 	},
+/obj/effect/turf_decal/lumos/tile/brown/half{
+	dir = 1
+	},
+/obj/effect/turf_decal/lumos/tile/purple/half,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "br" = (
@@ -682,27 +633,21 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "bs" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/lumos/tile/purple/half{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "bt" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
 /obj/structure/sign/poster/official/random{
 	pixel_y = -32
 	},
+/obj/effect/turf_decal/lumos/tile/purple/half,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "bu" = (
@@ -822,13 +767,12 @@
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/eng)
 "bI" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
 /obj/machinery/camera{
 	c_tag = "Xenoarchaeology Eleven";
 	dir = 8
+	},
+/obj/effect/turf_decal/lumos/tile/purple/half{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
@@ -899,14 +843,11 @@
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/gen)
 "bQ" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
+	},
+/obj/effect/turf_decal/lumos/tile/purple/half{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
@@ -1062,10 +1003,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "cL" = (
@@ -1127,10 +1067,7 @@
 /area/xenoarch/arch)
 "di" = (
 /obj/machinery/light,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/lumos/tile/purple/half,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "dk" = (
@@ -1160,10 +1097,7 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/lumos/tile/purple/checker{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -1194,12 +1128,6 @@
 /turf/closed/mineral/random/high_chance/volcanic,
 /area/ruin/unpowered/ash_walkers)
 "dv" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
@@ -1212,6 +1140,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/effect/turf_decal/lumos/tile/red/half{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/sec)
 "dx" = (
@@ -1220,10 +1151,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/lumos/tile/purple/half,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "dC" = (
@@ -1319,17 +1247,14 @@
 /turf/open/floor/plating,
 /area/xenoarch/arch)
 "ec" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
+	},
+/obj/effect/turf_decal/lumos/tile/purple/half{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
@@ -1543,10 +1468,11 @@
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/gen)
 "fL" = (
+/obj/structure/window/reinforced,
+/obj/effect/turf_decal/lumos/tile/purple/checker,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
-/obj/structure/window/reinforced,
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
 "fM" = (
@@ -1555,14 +1481,10 @@
 	departmentType = 5;
 	pixel_y = 30
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/computer/security,
+/obj/effect/turf_decal/lumos/tile/red/fullcorner{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/sec)
 "fP" = (
@@ -1658,10 +1580,7 @@
 	c_tag = "Xenoarchaeology Seven";
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/lumos/tile/purple/half,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "gE" = (
@@ -1674,13 +1593,6 @@
 /obj/item/flashlight/lantern,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
-"gI" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple,
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "gL" = (
 /obj/structure/stone_tile/block/cracked{
 	dir = 8
@@ -1691,15 +1603,6 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "gN" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -1707,6 +1610,12 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/effect/turf_decal/lumos/tile/purple/half{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -1808,12 +1717,8 @@
 /obj/structure/chair/sofa/corp/right{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/lumos/tile/red/fullcorner{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/sec)
@@ -1836,13 +1741,10 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "hw" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
+/obj/structure/disposalpipe/segment{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
+/obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -1906,16 +1808,15 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "hP" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/lumos/tile/purple/half{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/xenoarch/sec)
 "hR" = (
@@ -1946,8 +1847,7 @@
 /turf/open/floor/plasteel/white,
 /area/xenoarch/arch)
 "ia" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -1973,14 +1873,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/lumos/tile/purple/half{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
@@ -2034,10 +1931,7 @@
 /obj/structure/chair/sofa/corp/left{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/red/half,
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/sec)
 "im" = (
@@ -2143,6 +2037,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/effect/turf_decal/lumos/tile/purple/fulltile,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "iS" = (
@@ -2150,14 +2045,11 @@
 /turf/open/floor/plating,
 /area/xenoarch/arch)
 "iT" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/machinery/airalarm{
 	dir = 1;
 	pixel_y = -22
 	},
+/obj/effect/turf_decal/lumos/tile/red/half,
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/sec)
 "iV" = (
@@ -2199,17 +2091,11 @@
 /turf/open/floor/plasteel/stairs,
 /area/xenoarch/gen)
 "jm" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
+	},
+/obj/effect/turf_decal/lumos/tile/yellow/fullcorner{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
@@ -2364,11 +2250,8 @@
 	pixel_y = 6
 	},
 /obj/item/pen,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/sec)
@@ -2394,13 +2277,9 @@
 	name = "Station Intercom (General)";
 	pixel_x = -28
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/lumos/tile/red/fullcorner{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/sec)
 "kv" = (
@@ -2440,14 +2319,11 @@
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/sec)
 "kI" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/lumos/tile/purple/half{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
@@ -2468,11 +2344,11 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/xenoarch/eng)
@@ -2551,13 +2427,10 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "lj" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 8
 	},
-/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/xenoarch/sec)
 "lm" = (
@@ -2599,8 +2472,7 @@
 	dir = 8
 	},
 /obj/machinery/portable_atmospherics/pump,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -2615,12 +2487,11 @@
 	dir = 8
 	},
 /obj/machinery/portable_atmospherics/scrubber,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
 /obj/structure/sign/poster/official/random{
 	pixel_x = 32
+	},
+/obj/effect/turf_decal/lumos/tile/yellow/half{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
@@ -2677,14 +2548,8 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/bot)
 "lP" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
 /obj/structure/table,
+/obj/effect/turf_decal/lumos/tile/purple/fullcorner,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "lT" = (
@@ -2719,30 +2584,17 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "mb" = (
-/obj/effect/turf_decal/tile/purple{
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "mc" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/lumos/tile/purple/fullcorner,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "mf" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple,
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
@@ -2754,6 +2606,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
+	},
+/obj/effect/turf_decal/lumos/tile/purple/half{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/sec)
@@ -2785,18 +2640,14 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "mq" = (
 /obj/structure/table,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/purple/half,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "my" = (
@@ -2841,16 +2692,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/gen)
-"mM" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "mQ" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 30
@@ -2873,13 +2714,7 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
+/obj/effect/turf_decal/lumos/tile/red/fullcorner,
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/sec)
 "mW" = (
@@ -2897,13 +2732,10 @@
 /turf/open/floor/plating,
 /area/xenoarch/arch)
 "nd" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 1
 	},
-/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "ne" = (
@@ -3071,10 +2903,7 @@
 "nW" = (
 /obj/structure/table,
 /obj/machinery/light,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/purple/half,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "nY" = (
@@ -3099,13 +2928,7 @@
 /area/ruin/unpowered/ash_walkers)
 "oc" = (
 /obj/structure/chair/sofa/corp/right,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/lumos/tile/red/fullcorner{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -3135,10 +2958,7 @@
 /area/xenoarch/eng)
 "ox" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -3150,10 +2970,7 @@
 /area/xenoarch/gen)
 "oJ" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/lumos/tile/purple/half,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "oL" = (
@@ -3173,10 +2990,7 @@
 /obj/machinery/atmospherics/components/binary/volume_pump{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -3199,11 +3013,8 @@
 /area/xenoarch/eng)
 "oU" = (
 /obj/structure/chair/sofa/corp,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/sec)
@@ -3381,25 +3192,21 @@
 /turf/open/floor/engine/air,
 /area/xenoarch/eng)
 "pX" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "pZ" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -3561,10 +3368,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/purple/half,
 /turf/open/floor/plasteel,
 /area/xenoarch/gen)
 "qH" = (
@@ -3574,17 +3378,14 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
 	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/gen)
@@ -3624,16 +3425,15 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 8
+	},
+/obj/effect/turf_decal/lumos/tile/red/half{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/sec)
@@ -3717,12 +3517,8 @@
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/gen)
 "rt" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/fullcorner{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
@@ -3766,11 +3562,8 @@
 	dir = 1
 	},
 /obj/structure/chair/sofa/corp/left,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/sec)
@@ -3813,7 +3606,6 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/vending/kink,
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/gen)
 "rT" = (
@@ -3900,10 +3692,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -3938,10 +3727,7 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/gen)
 "sA" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -3956,36 +3742,18 @@
 /turf/open/floor/plasteel/elevatorshaft,
 /area/mining_level_access/lower)
 "sL" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
-"sN" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
+/obj/effect/turf_decal/lumos/tile/purple/half,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "sP" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/firealarm{
 	pixel_y = 24
+	},
+/obj/effect/turf_decal/lumos/tile/red/half{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/sec)
@@ -4057,11 +3825,7 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "tl" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/lumos/tile/purple/fullcorner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -4114,11 +3878,10 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+/obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -4130,11 +3893,8 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "tJ" = (
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/sec)
@@ -4182,16 +3942,15 @@
 /turf/closed/indestructible/riveted/boss,
 /area/lavaland/surface/outdoors)
 "tZ" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /obj/machinery/light{
 	dir = 1
 	},
 /obj/machinery/airalarm{
 	pixel_y = 23
+	},
+/obj/effect/turf_decal/lumos/tile/purple/half{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
@@ -4226,9 +3985,11 @@
 /turf/closed/mineral/random/high_chance/volcanic,
 /area/lavaland/surface/outdoors)
 "um" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/engine,
-/area/xenoarch/gen)
+/obj/effect/turf_decal/lumos/tile/brown/half{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "up" = (
 /turf/closed/mineral/random/volcanic,
 /area/lavaland/surface/outdoors/unexplored)
@@ -4266,8 +4027,7 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -4285,12 +4045,8 @@
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
+/obj/effect/turf_decal/lumos/tile/purple/fullcorner{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
@@ -4320,8 +4076,7 @@
 	name = "Security Checkpoint";
 	req_access_txt = "1"
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -4337,13 +4092,10 @@
 /turf/closed/wall/r_wall,
 /area/xenoarch/eng)
 "uU" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
 /obj/structure/disposalpipe/junction{
 	dir = 8
 	},
+/obj/effect/turf_decal/lumos/tile/purple/half,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "uX" = (
@@ -4356,11 +4108,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
-"vg" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
+"vf" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/research/glass,
+/obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 8
 	},
+/obj/effect/turf_decal/lumos/tile/yellow/half{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
+"vg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
@@ -4368,6 +4127,7 @@
 	c_tag = "Xenoarchaeology Eight";
 	dir = 1
 	},
+/obj/effect/turf_decal/lumos/tile/purple/half,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "vi" = (
@@ -4473,10 +4233,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "vQ" = (
@@ -4504,12 +4263,8 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/effect/turf_decal/lumos/tile/red/fullcorner{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/sec)
@@ -4535,13 +4290,7 @@
 	dir = 8
 	},
 /obj/machinery/portable_atmospherics/pump,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
+/obj/effect/turf_decal/lumos/tile/yellow/fullcorner,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "wk" = (
@@ -4550,10 +4299,7 @@
 	dir = 1
 	},
 /obj/machinery/light,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/lumos/tile/red/half,
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/sec)
 "wp" = (
@@ -4576,14 +4322,11 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "wu" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/effect/turf_decal/lumos/tile/purple/half{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
@@ -4612,12 +4355,11 @@
 /obj/item/radio/off,
 /obj/item/crowbar,
 /obj/item/assembly/flash/handheld,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/lumos/tile/red/half{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/sec)
@@ -4723,12 +4465,8 @@
 	dir = 8
 	},
 /obj/machinery/portable_atmospherics/scrubber,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
+/obj/effect/turf_decal/lumos/tile/yellow/fullcorner{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
@@ -4815,10 +4553,7 @@
 /obj/machinery/atmospherics/components/binary/volume_pump{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -4913,13 +4648,12 @@
 /turf/open/floor/plating,
 /area/xenoarch/arch)
 "yt" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = 24
+	},
+/obj/effect/turf_decal/lumos/tile/red/half{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/sec)
@@ -4928,6 +4662,7 @@
 	map_pad_id = "tostation";
 	map_pad_link_id = "toxenoarch"
 	},
+/obj/effect/turf_decal/lumos/tile/purple/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
 "yv" = (
@@ -5060,10 +4795,9 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "yY" = (
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel,
 /area/xenoarch/sec)
 "za" = (
@@ -5102,10 +4836,7 @@
 	dir = 5
 	},
 /obj/machinery/light,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/yellow/half,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "zh" = (
@@ -5175,13 +4906,6 @@
 "zC" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/plasteel/white,
-/area/xenoarch/arch)
-"zF" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "zH" = (
 /obj/structure/stone_tile/surrounding_tile{
@@ -5298,15 +5022,12 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "AC" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
 /obj/structure/table,
 /obj/machinery/newscaster{
 	pixel_y = 32
+	},
+/obj/effect/turf_decal/lumos/tile/purple/half{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
@@ -5387,6 +5108,15 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel/stairs,
 /area/xenoarch/arch)
+"AY" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/lumos/tile/brown/half,
+/turf/open/floor/plasteel,
+/area/xenoarch/arch)
 "AZ" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/toxin_input,
 /turf/open/floor/engine/plasma,
@@ -5408,14 +5138,11 @@
 /area/xenoarch/arch)
 "Be" = (
 /obj/machinery/light,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/effect/turf_decal/lumos/tile/purple/half,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "Bf" = (
@@ -5529,10 +5256,7 @@
 /obj/structure/chair/sofa/corp/right{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -5710,6 +5434,16 @@
 /obj/machinery/disposal/bin,
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/gen)
+"Db" = (
+/obj/structure/window/reinforced,
+/obj/effect/turf_decal/lumos/tile/purple/checker{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/xenoarch/arch)
 "Dc" = (
 /obj/structure/rack,
 /obj/item/tank/internals/plasmaman,
@@ -5754,15 +5488,12 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "Dm" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
 /obj/machinery/status_display/evac{
 	layer = 4;
 	pixel_y = 32
+	},
+/obj/effect/turf_decal/lumos/tile/purple/half{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
@@ -5776,16 +5507,10 @@
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/gen)
 "Dp" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
 	},
+/obj/effect/turf_decal/lumos/tile/purple/fullcorner,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "Dt" = (
@@ -5810,6 +5535,16 @@
 /obj/structure/stone_tile,
 /turf/open/indestructible/boss,
 /area/ruin/unpowered/ash_walkers)
+"Dw" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/effect/turf_decal/lumos/tile/purple/checker,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/xenoarch/arch)
 "Dy" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -5880,18 +5615,15 @@
 /area/xenoarch/eng)
 "DW" = (
 /obj/structure/table,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
 /obj/item/radio/intercom{
 	dir = 8;
 	name = "Station Intercom (General)";
 	pixel_x = -28
 	},
 /obj/item/strangerock,
+/obj/effect/turf_decal/lumos/tile/purple/half{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "DX" = (
@@ -5919,10 +5651,6 @@
 /turf/open/floor/plating,
 /area/xenoarch/arch)
 "Ef" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple,
 /obj/machinery/door/firedoor,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -5930,6 +5658,9 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/lumos/tile/purple/half{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/xenoarch/sec)
 "El" = (
@@ -6025,14 +5756,8 @@
 /area/lavaland/surface/outdoors)
 "ET" = (
 /obj/structure/table,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/lumos/tile/purple/fullcorner{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
@@ -6084,15 +5809,12 @@
 /area/xenoarch/gen)
 "Fw" = (
 /obj/machinery/light,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
 /obj/structure/table,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
 /obj/item/strangerock,
+/obj/effect/turf_decal/lumos/tile/purple/half,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "Fy" = (
@@ -6131,13 +5853,10 @@
 /area/lavaland/surface/outdoors)
 "FK" = (
 /obj/machinery/light,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
+/obj/effect/turf_decal/lumos/tile/purple/half,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "FO" = (
@@ -6224,15 +5943,6 @@
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
-"Gm" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "Go" = (
 /obj/structure/chair/office/dark,
 /obj/effect/landmark/start/scientist,
@@ -6240,25 +5950,18 @@
 /area/xenoarch/bot)
 "Gq" = (
 /obj/structure/table,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
+/obj/item/relic,
+/obj/effect/turf_decal/lumos/tile/purple/fullcorner{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/item/relic,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "Gr" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
 /obj/machinery/firealarm{
 	pixel_y = 24
+	},
+/obj/effect/turf_decal/lumos/tile/purple/half{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
@@ -6301,14 +6004,11 @@
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
 "Gy" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
 /obj/machinery/atm{
 	pixel_y = 30
+	},
+/obj/effect/turf_decal/lumos/tile/purple/half{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
@@ -6441,18 +6141,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/sec)
-"Hj" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "Hl" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -6493,10 +6181,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -6587,10 +6274,7 @@
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/gen)
 "HP" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/lumos/tile/purple/half,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "HQ" = (
@@ -6611,14 +6295,11 @@
 /turf/open/floor/plasteel/white,
 /area/xenoarch/arch)
 "Ia" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
+	},
+/obj/effect/turf_decal/lumos/tile/purple/half{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
@@ -6630,10 +6311,7 @@
 /obj/structure/chair/sofa/corp{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/red/half,
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/sec)
 "Ie" = (
@@ -6835,15 +6513,6 @@
 /obj/item/spear/bonespear,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
-"IY" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "Jb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -6868,13 +6537,6 @@
 /turf/open/floor/plating,
 /area/xenoarch/arch)
 "Jh" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
 	},
@@ -6883,6 +6545,12 @@
 	},
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/lumos/tile/purple/half{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
@@ -6907,19 +6575,16 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/effect/turf_decal/lumos/tile/purple/half{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -6954,12 +6619,11 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "Ka" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 30
+	},
+/obj/effect/turf_decal/lumos/tile/purple/half{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
@@ -7083,17 +6747,14 @@
 /turf/open/indestructible/boss,
 /area/ruin/unpowered/ash_walkers)
 "KG" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/disposal/bin,
 /obj/machinery/status_display/evac{
 	layer = 4;
 	pixel_y = 32
+	},
+/obj/effect/turf_decal/lumos/tile/purple/half{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
@@ -7123,15 +6784,14 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/lumos/tile/purple/half{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
@@ -7164,18 +6824,6 @@
 /obj/structure/chair/sofa/corp,
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/sec)
-"Lq" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/xenoarch/arch)
 "Lr" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -7230,18 +6878,15 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
 /obj/machinery/light{
 	dir = 4
 	},
 /obj/machinery/airalarm{
 	dir = 8;
 	pixel_x = 24
+	},
+/obj/effect/turf_decal/lumos/tile/purple/half{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/gen)
@@ -7258,14 +6903,11 @@
 /turf/open/floor/plating,
 /area/mining_level_access)
 "LM" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
+	},
+/obj/effect/turf_decal/lumos/tile/purple/half{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
@@ -7344,11 +6986,10 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+/obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -7369,10 +7010,7 @@
 /turf/open/floor/plasteel/white,
 /area/xenoarch/arch)
 "My" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -7390,18 +7028,17 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "MC" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/lumos/tile/purple/half{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "ML" = (
@@ -7460,25 +7097,19 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "Ng" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "Nh" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
 	},
 /obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -7616,15 +7247,9 @@
 /area/xenoarch/arch)
 "NY" = (
 /obj/machinery/vending/wardrobe/sec_wardrobe,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable/yellow,
+/obj/effect/turf_decal/lumos/tile/red/fullcorner,
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/sec)
 "Ob" = (
@@ -7645,11 +7270,8 @@
 /obj/structure/chair/office/dark{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/sec)
@@ -7685,14 +7307,11 @@
 /turf/open/floor/engine/o2,
 /area/xenoarch/eng)
 "On" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
+	},
+/obj/effect/turf_decal/lumos/tile/purple/half{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/sec)
@@ -7831,11 +7450,10 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "OW" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "Pb" = (
@@ -7938,12 +7556,11 @@
 /turf/open/lava/smooth/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "PN" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
 /obj/structure/sign/poster/official/random{
 	pixel_x = 32
+	},
+/obj/effect/turf_decal/lumos/tile/purple/half{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
@@ -7998,16 +7615,13 @@
 /turf/open/floor/engine,
 /area/xenoarch/eng)
 "PZ" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
 /obj/item/radio/intercom{
 	dir = 8;
 	name = "Station Intercom (General)";
 	pixel_x = -28
+	},
+/obj/effect/turf_decal/lumos/tile/purple/half{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
@@ -8041,19 +7655,13 @@
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_y = 30
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/newscaster/security_unit{
 	pixel_x = -32
 	},
 /obj/machinery/computer/secure_data,
+/obj/effect/turf_decal/lumos/tile/red/fullcorner{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/sec)
 "Qf" = (
@@ -8131,14 +7739,13 @@
 /turf/open/floor/engine,
 /area/xenoarch/eng)
 "QM" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/closet/secure_closet/security_xenoarch,
+/obj/effect/turf_decal/lumos/tile/red/half{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/sec)
 "QR" = (
@@ -8194,14 +7801,11 @@
 /turf/open/floor/grass,
 /area/lavaland/surface/outdoors)
 "Rh" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
+	},
+/obj/effect/turf_decal/lumos/tile/purple/half{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
@@ -8421,11 +8025,8 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
@@ -8550,14 +8151,11 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/bot)
 "SZ" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
 /obj/machinery/airalarm{
 	pixel_y = 23
+	},
+/obj/effect/turf_decal/lumos/tile/purple/half{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
@@ -8566,13 +8164,10 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
+/obj/item/strangerock,
+/obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/item/strangerock,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "Td" = (
@@ -8620,23 +8215,14 @@
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/gen)
 "Tq" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/lumos/tile/purple/fullcorner{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "Tw" = (
 /obj/structure/table,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -8703,14 +8289,11 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "TR" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = 24
 	},
+/obj/effect/turf_decal/lumos/tile/purple/half,
 /turf/open/floor/plasteel,
 /area/xenoarch/gen)
 "TT" = (
@@ -8742,14 +8325,11 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
 "Ug" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
 /obj/structure/table,
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
+/obj/effect/turf_decal/lumos/tile/purple/half,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "Uh" = (
@@ -8948,10 +8528,7 @@
 	c_tag = "Xenoarchaeology Fifteen";
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -8967,10 +8544,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "Vs" = (
@@ -9064,10 +8640,7 @@
 /area/xenoarch/eng)
 "Wy" = (
 /obj/structure/chair/sofa/corp/right,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -9110,10 +8683,7 @@
 /obj/structure/table,
 /obj/machinery/plantgenes,
 /obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/lumos/tile/purple/checker{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -9163,23 +8733,16 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/computer/card,
+/obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/computer/card,
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/sec)
 "Xr" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
+/obj/effect/turf_decal/lumos/tile/purple/fullcorner{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "Xt" = (
@@ -9234,10 +8797,7 @@
 /obj/structure/sign/poster/official/random{
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/lumos/tile/purple/half,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "XJ" = (
@@ -9258,14 +8818,11 @@
 /area/xenoarch/arch)
 "XT" = (
 /obj/structure/table,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
+	},
+/obj/effect/turf_decal/lumos/tile/purple/half{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
@@ -9291,10 +8848,7 @@
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -9406,14 +8960,11 @@
 /area/xenoarch/eng)
 "YX" = (
 /obj/structure/table,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
+	},
+/obj/effect/turf_decal/lumos/tile/purple/half{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
@@ -9505,11 +9056,8 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/lumos/tile/yellow/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
@@ -9518,10 +9066,6 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "ZF" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
@@ -9535,6 +9079,7 @@
 	c_tag = "Xenoarchaeology Twelve";
 	dir = 1
 	},
+/obj/effect/turf_decal/lumos/tile/purple/half,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "ZP" = (
@@ -19571,9 +19116,9 @@ BS
 lu
 vz
 tr
-Bl
+Dw
 wO
-tr
+Db
 Bl
 vz
 TI
@@ -21867,23 +21412,23 @@ ad
 sA
 sA
 lj
-IY
+My
 PZ
 bQ
 Sy
 LM
 wu
 kI
-IY
+My
 mb
 Nh
-IY
+My
 ec
 eo
 Sy
-IY
+My
 Rh
-IY
+My
 AU
 Bf
 bh
@@ -22387,7 +21932,7 @@ rj
 PN
 ia
 ia
-gI
+ia
 ia
 OW
 bI
@@ -22398,7 +21943,7 @@ Ka
 mp
 ia
 ia
-ia
+rj
 rj
 mY
 mY
@@ -22640,7 +22185,7 @@ ku
 CT
 Ng
 UN
-zF
+HP
 BS
 BS
 BS
@@ -22897,7 +22442,7 @@ wk
 CT
 SZ
 UN
-zF
+HP
 BS
 zc
 zc
@@ -23154,7 +22699,7 @@ NY
 CT
 Dm
 UN
-zF
+HP
 BS
 Yh
 vz
@@ -23411,7 +22956,7 @@ CT
 CT
 Yj
 UN
-zF
+HP
 BS
 Qf
 Qf
@@ -24430,7 +23975,7 @@ jn
 BS
 jn
 ae
-Gm
+Ng
 AU
 aA
 aA
@@ -24726,7 +24271,7 @@ Za
 HQ
 co
 st
-um
+nJ
 Xt
 Tg
 SG
@@ -24951,9 +24496,9 @@ Yc
 AU
 Ug
 BS
-Hj
+Yj
 UN
-zF
+HP
 YC
 OQ
 OQ
@@ -24983,7 +24528,7 @@ Za
 HQ
 co
 st
-um
+nJ
 vi
 SG
 Tg
@@ -25240,7 +24785,7 @@ Za
 HQ
 co
 st
-um
+nJ
 SG
 vi
 SG
@@ -25465,7 +25010,7 @@ aK
 aK
 lP
 BS
-mM
+Xr
 KR
 Dp
 BS
@@ -25497,7 +25042,7 @@ Za
 HQ
 co
 st
-um
+nJ
 SG
 Tg
 SG
@@ -25754,7 +25299,7 @@ Za
 HQ
 co
 st
-um
+nJ
 Tg
 SG
 FU
@@ -25979,7 +25524,7 @@ aL
 aX
 bl
 yI
-Lq
+Tq
 ic
 tl
 hs
@@ -26011,7 +25556,7 @@ Za
 HQ
 co
 st
-um
+nJ
 vi
 SG
 FU
@@ -26230,7 +25775,7 @@ BS
 jn
 jn
 ak
-AU
+um
 aF
 aM
 AU
@@ -26268,7 +25813,7 @@ Za
 fI
 co
 st
-um
+nJ
 SG
 FU
 FU
@@ -26491,7 +26036,7 @@ ar
 AU
 aN
 Yb
-Yb
+AY
 bq
 sm
 Lv
@@ -26525,7 +26070,7 @@ Za
 Nq
 co
 st
-um
+nJ
 SG
 FU
 FU
@@ -26782,7 +26327,7 @@ Za
 pD
 co
 st
-um
+nJ
 SG
 FU
 FU
@@ -27039,7 +26584,7 @@ Za
 mg
 co
 st
-um
+nJ
 mk
 FU
 FU
@@ -27296,7 +26841,7 @@ Za
 HQ
 co
 st
-um
+nJ
 SG
 FU
 FU
@@ -27553,7 +27098,7 @@ Za
 HQ
 co
 st
-um
+nJ
 SG
 FU
 FU
@@ -27772,7 +27317,7 @@ bX
 zn
 AU
 Ac
-Gm
+Ng
 pq
 Tn
 rU
@@ -27810,7 +27355,7 @@ Za
 HQ
 co
 st
-um
+nJ
 Tg
 SG
 mk
@@ -28033,7 +27578,7 @@ Xr
 vP
 Vn
 cH
-gI
+ia
 lT
 Dy
 PW
@@ -28067,7 +27612,7 @@ Za
 HQ
 co
 st
-um
+nJ
 SG
 mk
 SG
@@ -28288,7 +27833,7 @@ af
 BS
 BS
 PA
-Ac
+vf
 IS
 BS
 BS
@@ -28808,7 +28353,7 @@ zg
 BS
 Gr
 gN
-sN
+LM
 hs
 hs
 hs


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/26664829/106660692-f1565000-6565-11eb-9c2b-ad6f55e5880c.png)

## About The Pull Request

Changes the layout of Xenoarch, omitting alot of superfluous or otherwise exploitable stuff.

## Why It's Good For The Game

Makes Xenoarchaeology's structure more efficient and sensible.

## Changelog
:cl:
tweak: Xenoarch
del: Xenoarch dorms
del: southern half of station
del: alot of EVA ware, chemistry machines, and other items that should only by trusted to the more secure station-side counterparts
/:cl: