### PR TITLE
Boxstation Med Changes (does trollface)

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation_Lumos.dmm
+++ b/_maps/map_files/BoxStation/BoxStation_Lumos.dmm
@@ -2431,6 +2431,7 @@
 	name = "Command Tool Storage";
 	req_access_txt = "19"
 	},
+/obj/effect/turf_decal/lumos/tile/blue/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
 "afQ" = (
@@ -7855,15 +7856,6 @@
 /obj/item/bedsheet/orange,
 /turf/open/floor/plasteel,
 /area/security/brig)
-"arE" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/mixing)
 "arF" = (
 /obj/machinery/atmospherics/pipe/simple/supplymain/hidden{
 	dir = 5
@@ -13441,6 +13433,9 @@
 "aFb" = (
 /obj/machinery/light/small{
 	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
@@ -32091,7 +32086,9 @@
 	name = "Medbay Storage";
 	req_access_txt = "5"
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/white/side{
+	dir = 1
+	},
 /area/medical/storage)
 "bAZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -36505,6 +36502,12 @@
 	luminosity = 2
 	},
 /area/science/test_area)
+"bLt" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/side,
+/area/science/research)
 "bLu" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -42313,7 +42316,9 @@
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
 /area/medical/sleeper)
 "caT" = (
 /obj/structure/disposalpipe/segment{
@@ -47426,13 +47431,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
-"cqc" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
 "cqn" = (
 /obj/structure/grille,
 /turf/open/floor/plating,
@@ -49563,6 +49561,7 @@
 	name = "Command Tool Storage";
 	req_access_txt = "19"
 	},
+/obj/effect/turf_decal/lumos/tile/blue/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
 "cyl" = (
@@ -51354,11 +51353,6 @@
 	},
 /turf/open/floor/carpet,
 /area/hallway/primary/central)
-"cRW" = (
-/turf/open/floor/plasteel/white/side{
-	dir = 10
-	},
-/area/science/research)
 "cSE" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -51926,6 +51920,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"dro" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "drE" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -52054,6 +52057,21 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/bar)
+"dBI" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "dCr" = (
 /obj/structure/pool/Rboard,
 /turf/open/floor/plasteel/yellowsiding{
@@ -52115,6 +52133,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
+"dJQ" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 8
+	},
+/area/science/research)
 "dKP" = (
 /turf/closed/wall,
 /area/maintenance/bar)
@@ -52135,12 +52161,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/medical/medbay/front_office)
-"dLn" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel/white,
-/area/science/mixing)
 "dLA" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
@@ -52231,12 +52251,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/quartermaster/miningdock)
-"dSn" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/science/mixing)
 "dTC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -52271,10 +52285,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/virology)
-"dWF" = (
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel/white,
-/area/science/mixing)
 "dWM" = (
 /obj/structure/table,
 /obj/machinery/recharger,
@@ -53137,6 +53147,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/teleporter)
+"ftm" = (
+/turf/open/floor/plasteel/white/side{
+	dir = 6
+	},
+/area/science/research)
 "ftE" = (
 /obj/item/radio/intercom{
 	pixel_y = 25
@@ -53242,17 +53257,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
-"fDa" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white/side{
-	dir = 8
-	},
-/area/science/xenobiology)
 "fDh" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
@@ -53658,14 +53662,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"ggL" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white/side{
-	dir = 8
-	},
-/area/science/research)
 "ghq" = (
 /obj/structure/lattice/catwalk,
 /obj/item/stack/marker_beacon{
@@ -53827,23 +53823,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"goP" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/violet/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white/side{
-	dir = 4
-	},
-/area/science/xenobiology)
 "gpD" = (
 /obj/machinery/light_switch{
 	pixel_y = 28
@@ -54168,23 +54147,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"gMw" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white/side{
-	dir = 4
-	},
-/area/science/research)
 "gMy" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -54654,14 +54616,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/medical/medbay/lobby)
-"hnu" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white/side{
-	dir = 8
-	},
-/area/science/research)
 "hnU" = (
 /obj/machinery/door/window/westleft{
 	base_state = "right";
@@ -55066,12 +55020,6 @@
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"hRP" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel/white,
-/area/science/mixing)
 "hSZ" = (
 /obj/structure/chair/comfy/brown{
 	dir = 1
@@ -55211,6 +55159,12 @@
 	},
 /turf/open/floor/plating,
 /area/security/processing)
+"ire" = (
+/obj/effect/turf_decal/trimline/purple/filled/line,
+/turf/open/floor/plasteel/white/side{
+	dir = 1
+	},
+/area/science/robotics/lab)
 "ism" = (
 /obj/item/reagent_containers/rag{
 	pixel_x = -4;
@@ -55232,11 +55186,6 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/aft)
-"isX" = (
-/turf/open/floor/plasteel/white/side{
-	dir = 4
-	},
-/area/science/research)
 "itK" = (
 /obj/structure/table,
 /obj/structure/light_construct{
@@ -55493,12 +55442,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"iMk" = (
-/obj/effect/turf_decal/trimline/purple/filled/line,
-/turf/open/floor/plasteel/white/side{
-	dir = 1
-	},
-/area/science/robotics/lab)
 "iMv" = (
 /obj/structure/table/glass,
 /obj/structure/bedsheetbin/towel,
@@ -55940,20 +55883,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/medical/medbay/front_office)
-"jmG" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white/side{
-	dir = 1
-	},
-/area/science/research)
 "jmH" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
@@ -56017,6 +55946,23 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/medical/medbay/lobby)
+"jrk" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/violet/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
+/area/science/xenobiology)
 "jsw" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -56242,6 +56188,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"jGw" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "jGW" = (
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/plasteel,
@@ -56313,21 +56265,6 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/exit)
-"jJe" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
 "jKC" = (
 /obj/item/clothing/under/misc/pj/blue,
 /obj/item/clothing/shoes/sneakers/white,
@@ -57011,12 +56948,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"kyx" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner,
-/turf/open/floor/plasteel/white/side{
-	dir = 9
-	},
-/area/science/robotics/lab)
 "kyB" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/westright{
@@ -57134,10 +57065,6 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"kKA" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
 "kKY" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/structure/closet,
@@ -57249,6 +57176,20 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"kTE" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 1
+	},
+/area/science/research)
 "kUA" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -57332,6 +57273,23 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/security/range)
+"lbk" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
+/area/science/research)
 "lcg" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /turf/open/floor/plating,
@@ -57395,6 +57353,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/art)
+"liX" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
+/area/science/research)
+"ljf" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "lmr" = (
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics)
@@ -57437,20 +57410,6 @@
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"lqM" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/machinery/disposal/bin,
-/obj/structure/window/reinforced,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/science/xenobiology)
 "lsk" = (
 /obj/structure/closet/wardrobe/white,
 /turf/open/floor/plasteel,
@@ -57601,14 +57560,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"lIu" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white/side{
-	dir = 4
-	},
-/area/science/xenobiology)
 "lII" = (
 /obj/structure/chair,
 /obj/structure/disposalpipe/segment{
@@ -57699,6 +57650,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"lPs" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/dark,
+/area/science/research)
 "lPB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -57870,6 +57825,14 @@
 	},
 /turf/open/floor/wood,
 /area/medical/psych)
+"mjC" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white/corner{
+	dir = 1
+	},
+/area/science/research)
 "mko" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
@@ -57908,6 +57871,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
+"mmm" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/lab)
 "mmR" = (
 /obj/structure/chair/comfy/black{
 	dir = 1
@@ -57921,14 +57890,6 @@
 /obj/item/target/syndicate,
 /turf/open/floor/plating,
 /area/security/range)
-"mok" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white/corner{
-	dir = 1
-	},
-/area/science/research)
 "moD" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/snacks/bluecherrycupcake{
@@ -58022,6 +57983,12 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
+"myj" = (
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel/white/side{
+	dir = 8
+	},
+/area/science/xenobiology)
 "mym" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -58046,6 +58013,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"myR" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 8
+	},
+/area/science/xenobiology)
 "myX" = (
 /obj/effect/turf_decal/lumos/tile/red/half,
 /turf/open/floor/plasteel,
@@ -58094,12 +58069,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"mGc" = (
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel/white/side{
-	dir = 8
-	},
-/area/science/xenobiology)
 "mGw" = (
 /obj/machinery/door/airlock/security{
 	name = "Labor Shuttle";
@@ -58137,12 +58106,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"mIx" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white/side,
-/area/science/research)
 "mJo" = (
 /obj/effect/spawner/blocker,
 /turf/open/floor/plating,
@@ -58587,12 +58550,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/starboard/fore)
-"npM" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/science/misc_lab)
 "nqe" = (
 /obj/effect/decal/cleanable/cobweb{
 	icon_state = "cobweb2"
@@ -58618,6 +58575,11 @@
 "nsA" = (
 /turf/closed/wall,
 /area/crew_quarters/abandoned_gambling_den)
+"nsW" = (
+/turf/open/floor/plasteel/white/side{
+	dir = 10
+	},
+/area/science/research)
 "nvk" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel/white,
@@ -58827,6 +58789,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
+"nHU" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/lab)
 "nIl" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -59127,6 +59095,14 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
+"nZO" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 8
+	},
+/area/science/research)
 "oax" = (
 /obj/machinery/light,
 /obj/structure/chair/comfy/brown{
@@ -59200,15 +59176,6 @@
 /obj/machinery/light/small,
 /turf/open/floor/plasteel/showroomfloor,
 /area/maintenance/bar)
-"odW" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
 "oem" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -59375,12 +59342,6 @@
 	dir = 8
 	},
 /area/science/xenobiology)
-"opo" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white/side,
-/area/science/research)
 "oqw" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 4
@@ -59551,20 +59512,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"oCW" = (
-/obj/machinery/atmospherics/pipe/simple/violet/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white/side{
-	dir = 4
-	},
-/area/science/xenobiology)
 "oDx" = (
 /obj/structure/rack,
 /obj/item/storage/box/zipties{
@@ -59602,12 +59549,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"oGm" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/science/lab)
 "oHe" = (
 /obj/structure/falsewall,
 /turf/open/floor/plating,
@@ -60361,6 +60302,12 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"pOc" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "pOj" = (
 /turf/closed/wall,
 /area/medical/medbay/central)
@@ -60375,12 +60322,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
-"pPx" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner,
-/turf/open/floor/plasteel/white/side{
-	dir = 8
-	},
-/area/science/research)
 "pPL" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
@@ -60410,6 +60351,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"pRF" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "pRY" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -60492,6 +60439,17 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
+"qbd" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 8
+	},
+/area/science/xenobiology)
 "qcs" = (
 /obj/structure/closet/secure_closet/freezer/cream_pie,
 /obj/effect/turf_decal/lumos/tile/blue/checker{
@@ -60608,6 +60566,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/medical/cryo)
+"qoQ" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/plasteel/white/side,
+/area/science/research)
 "qpg" = (
 /obj/structure/closet/secure_closet/chemical,
 /obj/machinery/light/small{
@@ -60671,7 +60637,9 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/white/side{
+	dir = 1
+	},
 /area/medical/medbay/front_office)
 "qsr" = (
 /obj/effect/turf_decal/tile/blue{
@@ -60736,6 +60704,10 @@
 	},
 /turf/open/floor/plating,
 /area/security/range)
+"qFg" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "qFB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -60896,6 +60868,15 @@
 	dir = 1
 	},
 /area/engine/atmos)
+"qRE" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "qTG" = (
 /obj/structure/table/wood,
 /obj/structure/mirror{
@@ -60986,6 +60967,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
+"raP" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "rcD" = (
 /obj/structure/sink{
 	dir = 8;
@@ -61030,6 +61017,12 @@
 "rfW" = (
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
+"rhp" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "rir" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -61083,12 +61076,6 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/hop)
-"rmP" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel/white,
-/area/science/mixing)
 "rmX" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/beer,
@@ -61340,6 +61327,11 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/range)
+"rLT" = (
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
+/area/science/research)
 "rNc" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -61427,6 +61419,20 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge/meeting_room)
+"rUz" = (
+/obj/machinery/atmospherics/pipe/simple/violet/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
+/area/science/xenobiology)
 "rVj" = (
 /obj/machinery/door/airlock/medical{
 	name = "Operating Theatre";
@@ -61439,15 +61445,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
-"rXi" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/mixing)
 "rXk" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -61622,6 +61619,12 @@
 	},
 /turf/open/floor/plating,
 /area/space/nearstation)
+"skb" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white/side,
+/area/science/research)
 "sks" = (
 /obj/effect/landmark/start/mime,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -62287,11 +62290,13 @@
 	dir = 8
 	},
 /area/crew_quarters/theatre)
-"tgF" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
+"tgw" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
 /area/science/xenobiology)
 "tgH" = (
 /obj/structure/filingcabinet/employment,
@@ -62386,12 +62391,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"tmu" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/lab)
 "tmO" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -62571,6 +62570,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"tzy" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner,
+/turf/open/floor/plasteel/white/side{
+	dir = 8
+	},
+/area/science/research)
 "tzQ" = (
 /obj/machinery/shower{
 	dir = 4
@@ -62684,22 +62689,6 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"tIJ" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white/side{
-	dir = 8
-	},
-/area/science/xenobiology)
-"tIY" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white/side{
-	dir = 4
-	},
-/area/science/research)
 "tJi" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -63156,6 +63145,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"utO" = (
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "uua" = (
 /obj/machinery/atmospherics/components/binary/valve,
 /turf/open/floor/plating,
@@ -64623,14 +64616,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
-"wtl" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/plasteel/white/side,
-/area/science/research)
 "wto" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
@@ -65026,11 +65011,6 @@
 /obj/item/coin/gold,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
-"xcF" = (
-/turf/open/floor/plasteel/white/side{
-	dir = 6
-	},
-/area/science/research)
 "xec" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -65252,6 +65232,15 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"xos" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "xqi" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -65275,6 +65264,12 @@
 /obj/effect/turf_decal/trimline/brown/filled/corner,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"xrv" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/science/misc_lab)
 "xrN" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel,
@@ -65449,10 +65444,20 @@
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"xLq" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/dark,
-/area/science/research)
+"xKK" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/disposal/bin,
+/obj/structure/window/reinforced,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
 "xLX" = (
 /obj/structure/lattice/catwalk,
 /obj/item/stack/marker_beacon{
@@ -65547,6 +65552,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
+"xTu" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner,
+/turf/open/floor/plasteel/white/side{
+	dir = 9
+	},
+/area/science/robotics/lab)
 "xTy" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -93900,7 +93911,7 @@ tJi
 gwf
 afP
 aFb
-aEZ
+jfk
 cyg
 aJp
 aKE
@@ -108580,7 +108591,7 @@ bht
 bsQ
 box
 btw
-jmG
+kTE
 byf
 bzt
 bAy
@@ -108837,7 +108848,7 @@ bsQ
 bsR
 box
 bvE
-jmG
+kTE
 byf
 bzw
 bAB
@@ -108849,7 +108860,7 @@ bEm
 bEm
 bJL
 bLa
-odW
+qRE
 aLt
 bPy
 bPA
@@ -109351,7 +109362,7 @@ cHZ
 cIf
 box
 btA
-jmG
+kTE
 byf
 bzy
 bAD
@@ -109371,17 +109382,17 @@ bQM
 cTZ
 mNi
 rcD
-lIu
-oCW
+tgw
+rUz
 mNi
 bRZ
-oCW
+rUz
 mNi
-lIu
-goP
+tgw
+jrk
 mNi
-lIu
-oCW
+tgw
+rUz
 ccQ
 bDb
 hYH
@@ -109608,7 +109619,7 @@ bqc
 bsS
 box
 bvE
-jmG
+kTE
 byf
 bzx
 bAC
@@ -109884,17 +109895,17 @@ cmk
 bQN
 eFW
 ooH
-tIJ
-mGc
+myR
+myj
 sbt
-tIJ
-mGc
+myR
+myj
 ooH
-fDa
-mGc
+qbd
+myj
 ooH
-tIJ
-mGc
+myR
+myj
 ooH
 mDa
 bDb
@@ -110122,7 +110133,7 @@ cIb
 bsT
 box
 btP
-jmG
+kTE
 byi
 bzz
 bAE
@@ -110135,11 +110146,11 @@ bIz
 bIz
 bJN
 bMl
-jJe
-kKA
+dBI
+qFg
 bPE
 bLe
-lqM
+xKK
 bTd
 bUg
 cKp
@@ -110379,7 +110390,7 @@ bqd
 biL
 box
 btS
-jmG
+kTE
 byi
 bwN
 bAG
@@ -110392,8 +110403,8 @@ bIB
 bIB
 bJN
 bMo
-jJe
-kKA
+dBI
+qFg
 bPH
 bJN
 bSa
@@ -110633,9 +110644,9 @@ blM
 qpj
 cHX
 cIc
-kyx
+xTu
 buj
-opo
+bLt
 bve
 byj
 bwM
@@ -110649,7 +110660,7 @@ bIA
 bIA
 bJN
 bMn
-jJe
+dBI
 bOz
 bPG
 bJN
@@ -110890,10 +110901,10 @@ bou
 cHT
 bou
 cId
-iMk
+ire
 bsw
 gOB
-jmG
+kTE
 byk
 bzD
 bxv
@@ -110907,7 +110918,7 @@ bIA
 bJN
 bMq
 chu
-cqc
+ljf
 bPJ
 cAc
 bEm
@@ -111149,8 +111160,8 @@ bpU
 brq
 bsW
 buj
-mIx
-jmG
+skb
+kTE
 byk
 bzC
 bAH
@@ -111164,7 +111175,7 @@ bGY
 bJN
 bMp
 bNp
-tgF
+pOc
 bPI
 cTY
 bEm
@@ -111407,7 +111418,7 @@ brs
 box
 box
 bvE
-jmG
+kTE
 byk
 byk
 byk
@@ -111663,20 +111674,20 @@ boM
 bzE
 bsX
 bsz
-xcF
+ftm
 bEf
 aIL
-isX
-isX
-isX
+rLT
+rLT
+rLT
 bDd
 bEq
 bDl
-gMw
+lbk
 bFQ
 bHc
 bHK
-tIY
+liX
 bID
 bOA
 bPK
@@ -111912,7 +111923,7 @@ dLA
 esZ
 bhB
 oMT
-xLq
+lPs
 aIe
 blX
 bow
@@ -112175,26 +112186,26 @@ bvx
 boz
 bpX
 bBD
-cRW
+nsW
 bsA
 bBD
 bBD
 brt
-ggL
+nZO
 bxF
 bzA
 bzZ
-pPx
-ggL
-ggL
-ggL
-hnu
+tzy
+nZO
+nZO
+nZO
+dJQ
 bHL
 bBD
 bBD
-mok
+mjC
 bPK
-npM
+xrv
 bWr
 bWr
 bWr
@@ -112956,9 +112967,9 @@ bxY
 bCh
 bvK
 bEv
-rmP
-arE
-hRP
+rhp
+dro
+jGw
 bJV
 bEC
 bMu
@@ -113196,7 +113207,7 @@ bdv
 aYV
 bgb
 bhC
-tmu
+nHU
 aIb
 blJ
 bno
@@ -113214,8 +113225,8 @@ bCg
 bvK
 bEu
 bHv
-dWF
-dLn
+utO
+raP
 bJU
 bEC
 bMt
@@ -113460,7 +113471,7 @@ blZ
 bnk
 bpo
 bqk
-wtl
+qoQ
 bsD
 bvK
 bxl
@@ -113713,7 +113724,7 @@ bhE
 bLI
 sKl
 blL
-oGm
+mmm
 bnh
 biU
 brx
@@ -114499,7 +114510,7 @@ chq
 fzX
 bEB
 bFW
-rXi
+xos
 tOq
 bNy
 bLi
@@ -115016,7 +115027,7 @@ bFX
 gvR
 bGF
 bKa
-dSn
+pRF
 bMA
 bNz
 bOI

--- a/_maps/map_files/BoxStation/BoxStation_Lumos.dmm
+++ b/_maps/map_files/BoxStation/BoxStation_Lumos.dmm
@@ -7855,6 +7855,15 @@
 /obj/item/bedsheet/orange,
 /turf/open/floor/plasteel,
 /area/security/brig)
+"arE" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "arF" = (
 /obj/machinery/atmospherics/pipe/simple/supplymain/hidden{
 	dir = 5
@@ -35785,6 +35794,7 @@
 	name = "Testing Lab";
 	req_access_txt = "47"
 	},
+/obj/effect/turf_decal/lumos/tile/purple/fulltile,
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
 "bJP" = (
@@ -38562,6 +38572,9 @@
 	dir = 4
 	},
 /obj/machinery/disposal/bin,
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
 "bQQ" = (
@@ -39398,10 +39411,9 @@
 /obj/machinery/atmospherics/pipe/simple/violet/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/effect/turf_decal/stripes/end{
+	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "bTe" = (
@@ -39419,9 +39431,6 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/violet/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/end{
 	dir = 4
 	},
 /turf/open/floor/engine,
@@ -40432,9 +40441,6 @@
 /obj/machinery/atmospherics/pipe/simple/violet/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/end{
-	dir = 8
-	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "bWm" = (
@@ -40451,10 +40457,9 @@
 /obj/machinery/atmospherics/pipe/simple/violet/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/effect/turf_decal/stripes/end{
+	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "bWn" = (
@@ -40475,9 +40480,6 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/violet/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/end{
 	dir = 4
 	},
 /turf/open/floor/engine,
@@ -42728,10 +42730,9 @@
 /obj/machinery/atmospherics/pipe/simple/violet/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/effect/turf_decal/stripes/end{
+	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "cbS" = (
@@ -42756,9 +42757,6 @@
 /obj/machinery/atmospherics/pipe/simple/violet/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/end{
-	dir = 8
-	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "cbU" = (
@@ -42776,9 +42774,6 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/violet/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/end{
 	dir = 4
 	},
 /turf/open/floor/engine,
@@ -44704,10 +44699,9 @@
 /obj/machinery/atmospherics/pipe/simple/violet/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/effect/turf_decal/stripes/end{
+	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "chs" = (
@@ -44728,9 +44722,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/violet/hidden{
 	dir = 4
-	},
-/obj/effect/turf_decal/stripes/end{
-	dir = 8
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
@@ -47435,6 +47426,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
+"cqc" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "cqn" = (
 /obj/structure/grille,
 /turf/open/floor/plating,
@@ -51356,18 +51354,9 @@
 	},
 /turf/open/floor/carpet,
 /area/hallway/primary/central)
-"cRa" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
+"cRW" = (
 /turf/open/floor/plasteel/white/side{
-	dir = 1
+	dir = 10
 	},
 /area/science/research)
 "cSE" = (
@@ -52146,6 +52135,12 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/medical/medbay/front_office)
+"dLn" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "dLA" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
@@ -52236,6 +52231,12 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/quartermaster/miningdock)
+"dSn" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "dTC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -52270,6 +52271,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/virology)
+"dWF" = (
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "dWM" = (
 /obj/structure/table,
 /obj/machinery/recharger,
@@ -52458,9 +52463,6 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/violet/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/end{
 	dir = 4
 	},
 /turf/open/floor/engine,
@@ -52827,6 +52829,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
 "eXi" = (
@@ -52852,37 +52857,11 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/entry)
-"eXT" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/mixing)
 "faw" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/white,
 /area/security/prison)
-"fax" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/violet/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white/side{
-	dir = 4
-	},
-/area/science/xenobiology)
 "fcn" = (
 /obj/structure/lattice,
 /turf/closed/wall/r_wall,
@@ -52954,12 +52933,6 @@
 	dir = 4
 	},
 /area/crew_quarters/theatre)
-"fgK" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner,
-/turf/open/floor/plasteel/white/side{
-	dir = 8
-	},
-/area/science/research)
 "fhl" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -53269,6 +53242,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
+"fDa" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 8
+	},
+/area/science/xenobiology)
 "fDh" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
@@ -53674,6 +53658,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"ggL" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 8
+	},
+/area/science/research)
 "ghq" = (
 /obj/structure/lattice/catwalk,
 /obj/item/stack/marker_beacon{
@@ -53719,12 +53711,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
-"gil" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel/white,
-/area/science/mixing)
 "gjc" = (
 /obj/item/radio/intercom{
 	pixel_y = 20
@@ -53841,6 +53827,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"goP" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/violet/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
+/area/science/xenobiology)
 "gpD" = (
 /obj/machinery/light_switch{
 	pixel_y = 28
@@ -54165,6 +54168,23 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"gMw" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
+/area/science/research)
 "gMy" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -54510,11 +54530,6 @@
 /obj/item/reagent_containers/food/snacks/cherrycupcake,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"hhh" = (
-/turf/open/floor/plasteel/white/side{
-	dir = 10
-	},
-/area/science/research)
 "hhi" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -54639,6 +54654,14 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/medical/medbay/lobby)
+"hnu" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 8
+	},
+/area/science/research)
 "hnU" = (
 /obj/machinery/door/window/westleft{
 	base_state = "right";
@@ -54796,12 +54819,6 @@
 	dir = 1
 	},
 /area/crew_quarters/fitness/pool)
-"hAI" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner,
-/turf/open/floor/plasteel/white/side{
-	dir = 9
-	},
-/area/science/robotics/lab)
 "hBA" = (
 /obj/structure/table,
 /obj/item/storage/firstaid/regular{
@@ -55037,12 +55054,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/chemistry)
-"hRp" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel/white,
-/area/science/mixing)
 "hRI" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -55055,6 +55066,12 @@
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"hRP" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "hSZ" = (
 /obj/structure/chair/comfy/brown{
 	dir = 1
@@ -55150,12 +55167,6 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"ilb" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/lab)
 "imH" = (
 /turf/open/floor/wood{
 	icon_state = "wood-broken3"
@@ -55221,6 +55232,11 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/aft)
+"isX" = (
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
+/area/science/research)
 "itK" = (
 /obj/structure/table,
 /obj/structure/light_construct{
@@ -55362,20 +55378,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"iBT" = (
-/obj/machinery/atmospherics/pipe/simple/violet/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white/side{
-	dir = 4
-	},
-/area/science/xenobiology)
 "iCM" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -55491,6 +55493,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"iMk" = (
+/obj/effect/turf_decal/trimline/purple/filled/line,
+/turf/open/floor/plasteel/white/side{
+	dir = 1
+	},
+/area/science/robotics/lab)
 "iMv" = (
 /obj/structure/table/glass,
 /obj/structure/bedsheetbin/towel,
@@ -55932,6 +55940,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/medical/medbay/front_office)
+"jmG" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 1
+	},
+/area/science/research)
 "jmH" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
@@ -56120,10 +56142,6 @@
 /obj/machinery/food_cart,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
-"jBa" = (
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel/white,
-/area/science/mixing)
 "jBi" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -56295,6 +56313,21 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/exit)
+"jJe" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "jKC" = (
 /obj/item/clothing/under/misc/pj/blue,
 /obj/item/clothing/shoes/sneakers/white,
@@ -56880,15 +56913,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
-"kqK" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/mixing)
 "ksE" = (
 /turf/closed/mineral/random/labormineral,
 /area/space/nearstation)
@@ -56987,11 +57011,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"kys" = (
+"kyx" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner,
 /turf/open/floor/plasteel/white/side{
-	dir = 6
+	dir = 9
 	},
-/area/science/research)
+/area/science/robotics/lab)
 "kyB" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/westright{
@@ -57008,14 +57033,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"kyN" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white/side{
-	dir = 4
-	},
-/area/science/research)
 "kze" = (
 /obj/effect/landmark/start/prisoner/prilate,
 /turf/open/floor/circuit/green,
@@ -57117,19 +57134,9 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"kIq" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/machinery/disposal/bin,
-/obj/structure/window/reinforced,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
+"kKA" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "kKY" = (
 /obj/effect/spawner/lootdrop/maintenance,
@@ -57430,6 +57437,20 @@
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"lqM" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/disposal/bin,
+/obj/structure/window/reinforced,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
 "lsk" = (
 /obj/structure/closet/wardrobe/white,
 /turf/open/floor/plasteel,
@@ -57508,12 +57529,6 @@
 /obj/structure/sign/nanotrasen,
 /turf/closed/wall,
 /area/science/explab)
-"lAO" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel/white,
-/area/science/mixing)
 "lCf" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -57586,6 +57601,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"lIu" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
+/area/science/xenobiology)
 "lII" = (
 /obj/structure/chair,
 /obj/structure/disposalpipe/segment{
@@ -57609,11 +57632,6 @@
 /obj/machinery/door/poddoor/incinerator_atmos_main,
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
-"lKu" = (
-/turf/open/floor/plasteel/white/side{
-	dir = 4
-	},
-/area/science/research)
 "lKA" = (
 /obj/structure/lattice,
 /obj/machinery/camera{
@@ -57880,15 +57898,6 @@
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/crew_quarters/toilet)
-"mlP" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
 "mmf" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -57912,6 +57921,14 @@
 /obj/item/target/syndicate,
 /turf/open/floor/plating,
 /area/security/range)
+"mok" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white/corner{
+	dir = 1
+	},
+/area/science/research)
 "moD" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/snacks/bluecherrycupcake{
@@ -58077,6 +58094,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"mGc" = (
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel/white/side{
+	dir = 8
+	},
+/area/science/xenobiology)
 "mGw" = (
 /obj/machinery/door/airlock/security{
 	name = "Labor Shuttle";
@@ -58114,6 +58137,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"mIx" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white/side,
+/area/science/research)
 "mJo" = (
 /obj/effect/spawner/blocker,
 /turf/open/floor/plating,
@@ -58157,14 +58186,6 @@
 	dir = 4
 	},
 /area/science/xenobiology)
-"mND" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white/side{
-	dir = 8
-	},
-/area/science/research)
 "mNE" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Custodial Maintenance";
@@ -58566,6 +58587,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/starboard/fore)
+"npM" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/science/misc_lab)
 "nqe" = (
 /obj/effect/decal/cleanable/cobweb{
 	icon_state = "cobweb2"
@@ -58910,12 +58937,6 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/bar)
-"nNG" = (
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel/white/side{
-	dir = 8
-	},
-/area/science/xenobiology)
 "nNS" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -59093,18 +59114,6 @@
 	},
 /turf/closed/wall,
 /area/maintenance/disposal/incinerator)
-"nYW" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/dark,
-/area/science/research)
-"nZb" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white/side{
-	dir = 8
-	},
-/area/science/xenobiology)
 "nZE" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/structure/cable{
@@ -59179,12 +59188,6 @@
 /obj/effect/turf_decal/lumos/tile/blue/half,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
-"odr" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white/side,
-/area/science/research)
 "odx" = (
 /obj/structure/sink{
 	dir = 4;
@@ -59197,6 +59200,15 @@
 /obj/machinery/light/small,
 /turf/open/floor/plasteel/showroomfloor,
 /area/maintenance/bar)
+"odW" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "oem" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -59363,6 +59375,12 @@
 	dir = 8
 	},
 /area/science/xenobiology)
+"opo" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/side,
+/area/science/research)
 "oqw" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 4
@@ -59533,6 +59551,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"oCW" = (
+/obj/machinery/atmospherics/pipe/simple/violet/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
+/area/science/xenobiology)
 "oDx" = (
 /obj/structure/rack,
 /obj/item/storage/box/zipties{
@@ -59570,6 +59602,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"oGm" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/lab)
 "oHe" = (
 /obj/structure/falsewall,
 /turf/open/floor/plating,
@@ -59594,13 +59632,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/explab)
-"oIl" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
 "oIJ" = (
 /obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 1
@@ -59904,23 +59935,6 @@
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/engine,
 /area/science/explab)
-"pjE" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white/side{
-	dir = 4
-	},
-/area/science/research)
 "pkF" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27;
@@ -60361,6 +60375,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
+"pPx" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner,
+/turf/open/floor/plasteel/white/side{
+	dir = 8
+	},
+/area/science/research)
 "pPL" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
@@ -60716,12 +60736,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/range)
-"qCM" = (
-/obj/effect/turf_decal/trimline/purple/filled/line,
-/turf/open/floor/plasteel/white/side{
-	dir = 1
-	},
-/area/science/robotics/lab)
 "qFB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -61016,10 +61030,6 @@
 "rfW" = (
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
-"rgk" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
 "rir" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -61073,6 +61083,12 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/hop)
+"rmP" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "rmX" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/beer,
@@ -61221,14 +61237,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"rCp" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white/side{
-	dir = 4
-	},
-/area/science/xenobiology)
 "rCF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -61290,14 +61298,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"rHY" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/plasteel/white/side,
-/area/science/research)
 "rIA" = (
 /obj/machinery/light{
 	dir = 8
@@ -61411,21 +61411,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"rSy" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
 "rTu" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -61454,6 +61439,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
+"rXi" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "rXk" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -61601,17 +61595,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/brig)
-"seU" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white/side{
-	dir = 8
-	},
-/area/science/xenobiology)
 "sfa" = (
 /obj/structure/filingcabinet,
 /obj/machinery/newscaster{
@@ -62304,6 +62287,12 @@
 	dir = 8
 	},
 /area/crew_quarters/theatre)
+"tgF" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "tgH" = (
 /obj/structure/filingcabinet/employment,
 /turf/open/floor/wood,
@@ -62397,6 +62386,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"tmu" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/lab)
 "tmO" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -62689,6 +62684,22 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"tIJ" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 8
+	},
+/area/science/xenobiology)
+"tIY" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
+/area/science/research)
 "tJi" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -63518,12 +63529,6 @@
 	dir = 1
 	},
 /area/ai_monitored/storage/eva)
-"vcK" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/science/mixing)
 "vcN" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -63754,9 +63759,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/violet/hidden{
 	dir = 4
-	},
-/obj/effect/turf_decal/stripes/end{
-	dir = 8
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
@@ -64106,12 +64108,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/cryopod)
-"vHk" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/science/lab)
 "vHz" = (
 /obj/structure/chair{
 	dir = 8
@@ -64320,12 +64316,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/medical/medbay/lobby)
-"wcy" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white/side,
-/area/science/research)
 "wcO" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
@@ -64522,9 +64512,6 @@
 /obj/machinery/atmospherics/pipe/simple/violet/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/end{
-	dir = 4
-	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "wlQ" = (
@@ -64636,6 +64623,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
+"wtl" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/plasteel/white/side,
+/area/science/research)
 "wto" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
@@ -64700,14 +64695,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"wyj" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white/side{
-	dir = 8
-	},
-/area/science/research)
 "wAj" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -65039,6 +65026,11 @@
 /obj/item/coin/gold,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
+"xcF" = (
+/turf/open/floor/plasteel/white/side{
+	dir = 6
+	},
+/area/science/research)
 "xec" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -65246,14 +65238,6 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/plasteel/grimy,
 /area/hallway/secondary/entry)
-"xmW" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white/corner{
-	dir = 1
-	},
-/area/science/research)
 "xnf" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -65465,6 +65449,10 @@
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"xLq" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/dark,
+/area/science/research)
 "xLX" = (
 /obj/structure/lattice/catwalk,
 /obj/item/stack/marker_beacon{
@@ -65759,12 +65747,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
-"ygZ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
 "yhz" = (
 /obj/structure/showcase/mecha/ripley,
 /obj/structure/window/reinforced,
@@ -108598,7 +108580,7 @@ bht
 bsQ
 box
 btw
-cRa
+jmG
 byf
 bzt
 bAy
@@ -108855,7 +108837,7 @@ bsQ
 bsR
 box
 bvE
-cRa
+jmG
 byf
 bzw
 bAB
@@ -108867,7 +108849,7 @@ bEm
 bEm
 bJL
 bLa
-mlP
+odW
 aLt
 bPy
 bPA
@@ -109369,7 +109351,7 @@ cHZ
 cIf
 box
 btA
-cRa
+jmG
 byf
 bzy
 bAD
@@ -109389,17 +109371,17 @@ bQM
 cTZ
 mNi
 rcD
-rCp
-iBT
+lIu
+oCW
 mNi
 bRZ
-iBT
+oCW
 mNi
-rCp
-fax
+lIu
+goP
 mNi
-rCp
-iBT
+lIu
+oCW
 ccQ
 bDb
 hYH
@@ -109626,7 +109608,7 @@ bqc
 bsS
 box
 bvE
-cRa
+jmG
 byf
 bzx
 bAC
@@ -109902,17 +109884,17 @@ cmk
 bQN
 eFW
 ooH
-nZb
-nNG
+tIJ
+mGc
 sbt
-nZb
-nNG
+tIJ
+mGc
 ooH
-seU
-nNG
+fDa
+mGc
 ooH
-nZb
-nNG
+tIJ
+mGc
 ooH
 mDa
 bDb
@@ -110140,7 +110122,7 @@ cIb
 bsT
 box
 btP
-cRa
+jmG
 byi
 bzz
 bAE
@@ -110153,11 +110135,11 @@ bIz
 bIz
 bJN
 bMl
-rSy
-rgk
+jJe
+kKA
 bPE
 bLe
-kIq
+lqM
 bTd
 bUg
 cKp
@@ -110397,7 +110379,7 @@ bqd
 biL
 box
 btS
-cRa
+jmG
 byi
 bwN
 bAG
@@ -110410,8 +110392,8 @@ bIB
 bIB
 bJN
 bMo
-rSy
-rgk
+jJe
+kKA
 bPH
 bJN
 bSa
@@ -110651,9 +110633,9 @@ blM
 qpj
 cHX
 cIc
-hAI
+kyx
 buj
-wcy
+opo
 bve
 byj
 bwM
@@ -110667,7 +110649,7 @@ bIA
 bIA
 bJN
 bMn
-rSy
+jJe
 bOz
 bPG
 bJN
@@ -110908,10 +110890,10 @@ bou
 cHT
 bou
 cId
-qCM
+iMk
 bsw
 gOB
-cRa
+jmG
 byk
 bzD
 bxv
@@ -110925,7 +110907,7 @@ bIA
 bJN
 bMq
 chu
-oIl
+cqc
 bPJ
 cAc
 bEm
@@ -111167,8 +111149,8 @@ bpU
 brq
 bsW
 buj
-odr
-cRa
+mIx
+jmG
 byk
 bzC
 bAH
@@ -111182,7 +111164,7 @@ bGY
 bJN
 bMp
 bNp
-ygZ
+tgF
 bPI
 cTY
 bEm
@@ -111425,7 +111407,7 @@ brs
 box
 box
 bvE
-cRa
+jmG
 byk
 byk
 byk
@@ -111681,20 +111663,20 @@ boM
 bzE
 bsX
 bsz
-kys
+xcF
 bEf
 aIL
-lKu
-lKu
-lKu
+isX
+isX
+isX
 bDd
 bEq
 bDl
-pjE
+gMw
 bFQ
 bHc
 bHK
-kyN
+tIY
 bID
 bOA
 bPK
@@ -111930,7 +111912,7 @@ dLA
 esZ
 bhB
 oMT
-nYW
+xLq
 aIe
 blX
 bow
@@ -112193,26 +112175,26 @@ bvx
 boz
 bpX
 bBD
-hhh
+cRW
 bsA
 bBD
 bBD
 brt
-mND
+ggL
 bxF
 bzA
 bzZ
-fgK
-mND
-mND
-mND
-wyj
+pPx
+ggL
+ggL
+ggL
+hnu
 bHL
 bBD
 bBD
-xmW
+mok
 bPK
-bWr
+npM
 bWr
 bWr
 bWr
@@ -112974,9 +112956,9 @@ bxY
 bCh
 bvK
 bEv
-hRp
-kqK
-lAO
+rmP
+arE
+hRP
 bJV
 bEC
 bMu
@@ -113214,7 +113196,7 @@ bdv
 aYV
 bgb
 bhC
-ilb
+tmu
 aIb
 blJ
 bno
@@ -113232,8 +113214,8 @@ bCg
 bvK
 bEu
 bHv
-jBa
-gil
+dWF
+dLn
 bJU
 bEC
 bMt
@@ -113478,7 +113460,7 @@ blZ
 bnk
 bpo
 bqk
-rHY
+wtl
 bsD
 bvK
 bxl
@@ -113731,7 +113713,7 @@ bhE
 bLI
 sKl
 blL
-vHk
+oGm
 bnh
 biU
 brx
@@ -114517,7 +114499,7 @@ chq
 fzX
 bEB
 bFW
-eXT
+rXi
 tOq
 bNy
 bLi
@@ -115034,7 +115016,7 @@ bFX
 gvR
 bGF
 bKa
-vcK
+dSn
 bMA
 bNz
 bOI

--- a/_maps/map_files/BoxStation/BoxStation_Lumos.dmm
+++ b/_maps/map_files/BoxStation/BoxStation_Lumos.dmm
@@ -27510,7 +27510,7 @@
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/window/eastright{
-	dir = 2;
+	dir = 1;
 	name = "Chemistry Desk";
 	req_access_txt = "33"
 	},
@@ -50838,18 +50838,6 @@
 /obj/machinery/vending/coffee,
 /turf/open/floor/wood,
 /area/bridge/meeting_room)
-"cXB" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/front_office)
 "cXU" = (
 /obj/effect/turf_decal/tile/red,
 /obj/machinery/light{
@@ -51115,7 +51103,7 @@
 	name = "chemistry shutters"
 	},
 /obj/machinery/door/window/eastright{
-	dir = 1;
+	dir = 2;
 	name = "Chemistry Desk";
 	req_access_txt = "33"
 	},
@@ -53043,6 +53031,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"gMh" = (
+/obj/structure/railing/corner,
+/turf/open/floor/plasteel/white,
+/area/medical/sleeper)
 "gMl" = (
 /obj/structure/table,
 /obj/structure/window/reinforced,
@@ -55103,10 +55095,6 @@
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/hallway/secondary/exit)
-"jPD" = (
-/obj/structure/railing/corner,
-/turf/open/floor/plasteel/white,
-/area/medical/sleeper)
 "jRp" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Medbay Storage";
@@ -55495,13 +55483,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
-"krh" = (
-/obj/machinery/door/firedoor,
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/open/floor/plasteel/stairs/right,
-/area/medical/sleeper)
 "ksE" = (
 /turf/closed/mineral/random/labormineral,
 /area/space/nearstation)
@@ -56745,6 +56726,13 @@
 /obj/effect/turf_decal/lumos/tile/blue/checker,
 /turf/open/floor/plasteel/dark,
 /area/blueshield)
+"mXH" = (
+/obj/machinery/door/firedoor,
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/plasteel/stairs/right,
+/area/medical/sleeper)
 "mYU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -57191,6 +57179,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics/cloning)
+"nMr" = (
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel/white,
+/area/medical/sleeper)
 "nMv" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Testing Lab Maintenance";
@@ -57285,6 +57277,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/circuit)
+"nRZ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/front_office)
 "nSt" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -57597,6 +57601,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
+"osJ" = (
+/obj/structure/railing/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/sleeper)
 "ouQ" = (
 /obj/machinery/light{
 	dir = 8;
@@ -59888,10 +59898,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"sJg" = (
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/white,
-/area/medical/sleeper)
 "sJk" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -59936,6 +59942,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
+"sKc" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/sleeper)
 "sKl" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -60682,15 +60697,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"tUz" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/railing/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/sleeper)
 "tXk" = (
 /obj/machinery/gulag_teleporter,
 /turf/open/floor/plasteel,
@@ -61230,12 +61236,6 @@
 	icon_state = "carpetsymbol"
 	},
 /area/crew_quarters/theatre)
-"uSr" = (
-/obj/structure/railing/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/sleeper)
 "uSC" = (
 /obj/machinery/pool/drain,
 /turf/open/pool,
@@ -99797,7 +99797,7 @@ bwG
 vwy
 bZR
 bZU
-tUz
+sKc
 bzW
 bGR
 bCT
@@ -100303,15 +100303,15 @@ uJi
 uJi
 uJi
 bpJ
-cXB
-sJg
+nRZ
+nMr
 wkm
 bNs
 ghS
 bVa
-jPD
-krh
-uSr
+gMh
+mXH
+osJ
 bCM
 bFv
 bFv

--- a/_maps/map_files/BoxStation/BoxStation_Lumos.dmm
+++ b/_maps/map_files/BoxStation/BoxStation_Lumos.dmm
@@ -36502,12 +36502,6 @@
 	luminosity = 2
 	},
 /area/science/test_area)
-"bLt" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white/side,
-/area/science/research)
 "bLu" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -37945,6 +37939,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"bPg" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "bPi" = (
 /obj/machinery/light{
 	dir = 4
@@ -39998,6 +39998,20 @@
 /obj/machinery/atmospherics/miner/n2o,
 /turf/open/floor/engine/n2o,
 /area/engine/atmos)
+"bUX" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 1
+	},
+/area/science/research)
 "bUY" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -51887,9 +51901,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
 /obj/structure/railing/corner{
 	dir = 1
 	},
@@ -51920,15 +51931,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"dro" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/mixing)
 "drE" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -52057,21 +52059,6 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/bar)
-"dBI" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
 "dCr" = (
 /obj/structure/pool/Rboard,
 /turf/open/floor/plasteel/yellowsiding{
@@ -52133,14 +52120,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
-"dJQ" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white/side{
-	dir = 8
-	},
-/area/science/research)
 "dKP" = (
 /turf/closed/wall,
 /area/maintenance/bar)
@@ -52255,9 +52234,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /obj/structure/railing/corner{
 	dir = 8
 	},
@@ -52276,6 +52252,12 @@
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/crew_quarters/toilet)
+"dTX" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/lab)
 "dVk" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 10
@@ -52555,6 +52537,11 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/hallway/secondary/entry)
+"eoW" = (
+/turf/open/floor/plasteel/white/side{
+	dir = 6
+	},
+/area/science/research)
 "epC" = (
 /obj/machinery/door/airlock{
 	desc = "To keep the station within regulations, space IKEA requires one storage cupboard for their Nanotrasen partnership to continue.";
@@ -52803,6 +52790,14 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"eTg" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/plasteel/white/side,
+/area/science/research)
 "eTo" = (
 /obj/machinery/holopad,
 /turf/open/floor/wood,
@@ -52943,6 +52938,21 @@
 	dir = 4
 	},
 /area/crew_quarters/theatre)
+"fhg" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "fhl" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -53147,11 +53157,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/teleporter)
-"ftm" = (
-/turf/open/floor/plasteel/white/side{
-	dir = 6
-	},
-/area/science/research)
 "ftE" = (
 /obj/item/radio/intercom{
 	pixel_y = 25
@@ -53309,6 +53314,12 @@
 /obj/item/watertank,
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"fHp" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white/side,
+/area/science/research)
 "fHG" = (
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
@@ -53769,6 +53780,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/medical/storage)
+"gle" = (
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "gli" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -53835,6 +53850,14 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/nuke_storage)
+"grQ" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 8
+	},
+/area/science/research)
 "grS" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -54383,17 +54406,11 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics)
 "hbs" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 1
 	},
-/obj/structure/railing/corner{
-	dir = 4
-	},
 /turf/open/floor/plasteel/white,
-/area/medical/sleeper)
+/area/science/lab)
 "hcb" = (
 /turf/open/floor/carpet,
 /area/crew_quarters/theatre)
@@ -54483,6 +54500,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal/incinerator)
+"hfH" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "hgO" = (
 /obj/structure/table,
 /obj/item/storage/pill_bottle/dice{
@@ -54557,9 +54583,6 @@
 	},
 /obj/structure/railing/corner{
 	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
@@ -55043,6 +55066,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"iae" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner,
+/turf/open/floor/plasteel/white/side{
+	dir = 9
+	},
+/area/science/robotics/lab)
 "idK" = (
 /obj/machinery/camera{
 	c_tag = "Firing Range";
@@ -55159,12 +55188,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/processing)
-"ire" = (
-/obj/effect/turf_decal/trimline/purple/filled/line,
-/turf/open/floor/plasteel/white/side{
-	dir = 1
-	},
-/area/science/robotics/lab)
 "ism" = (
 /obj/item/reagent_containers/rag{
 	pixel_x = -4;
@@ -55530,6 +55553,14 @@
 /obj/machinery/droneDispenser/preloaded,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"iQs" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
+/area/science/research)
 "iQR" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -55722,6 +55753,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"jer" = (
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel/white/side{
+	dir = 8
+	},
+/area/science/xenobiology)
 "jex" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -55832,6 +55869,12 @@
 /obj/item/coin/iron,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"jkZ" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "jlm" = (
 /obj/machinery/rnd/production/techfab/department/cargo,
 /turf/open/floor/plasteel,
@@ -55946,23 +55989,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/medical/medbay/lobby)
-"jrk" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/violet/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white/side{
-	dir = 4
-	},
-/area/science/xenobiology)
 "jsw" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -56188,12 +56214,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"jGw" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel/white,
-/area/science/mixing)
 "jGW" = (
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/plasteel,
@@ -56456,6 +56476,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"jSn" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner,
+/turf/open/floor/plasteel/white/side{
+	dir = 8
+	},
+/area/science/research)
 "jSC" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -56549,6 +56575,20 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"jWZ" = (
+/obj/machinery/atmospherics/pipe/simple/violet/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
+/area/science/xenobiology)
 "jYH" = (
 /obj/machinery/vending/cola/space_up,
 /turf/open/floor/plasteel/dark,
@@ -57065,6 +57105,12 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"kKB" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/science/misc_lab)
 "kKY" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/structure/closet,
@@ -57176,20 +57222,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"kTE" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white/side{
-	dir = 1
-	},
-/area/science/research)
 "kUA" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -57273,23 +57305,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/security/range)
-"lbk" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white/side{
-	dir = 4
-	},
-/area/science/research)
 "lcg" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /turf/open/floor/plating,
@@ -57317,6 +57332,12 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
+"lfG" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "lfJ" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -57353,21 +57374,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/art)
-"liX" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white/side{
-	dir = 4
-	},
-/area/science/research)
-"ljf" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
 "lmr" = (
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics)
@@ -57443,6 +57449,15 @@
 "lun" = (
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics/cloning)
+"luE" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "luQ" = (
 /obj/structure/lattice,
 /obj/structure/window/reinforced,
@@ -57526,6 +57541,12 @@
 	},
 /turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/captain)
+"lEq" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/side,
+/area/science/research)
 "lEt" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -57650,10 +57671,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"lPs" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/dark,
-/area/science/research)
 "lPB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -57825,14 +57842,6 @@
 	},
 /turf/open/floor/wood,
 /area/medical/psych)
-"mjC" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white/corner{
-	dir = 1
-	},
-/area/science/research)
 "mko" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
@@ -57861,6 +57870,17 @@
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/crew_quarters/toilet)
+"mlf" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 8
+	},
+/area/science/xenobiology)
 "mmf" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -57871,12 +57891,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
-"mmm" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/science/lab)
 "mmR" = (
 /obj/structure/chair/comfy/black{
 	dir = 1
@@ -57983,12 +57997,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
-"myj" = (
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel/white/side{
-	dir = 8
-	},
-/area/science/xenobiology)
 "mym" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -58013,14 +58021,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"myR" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white/side{
-	dir = 8
-	},
-/area/science/xenobiology)
 "myX" = (
 /obj/effect/turf_decal/lumos/tile/red/half,
 /turf/open/floor/plasteel,
@@ -58469,6 +58469,23 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"niG" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/violet/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
+/area/science/xenobiology)
 "niS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -58575,11 +58592,6 @@
 "nsA" = (
 /turf/closed/wall,
 /area/crew_quarters/abandoned_gambling_den)
-"nsW" = (
-/turf/open/floor/plasteel/white/side{
-	dir = 10
-	},
-/area/science/research)
 "nvk" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel/white,
@@ -58789,12 +58801,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
-"nHU" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/lab)
 "nIl" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -58823,6 +58829,11 @@
 /obj/structure/barricade/wooden/crude,
 /turf/open/floor/plasteel/showroomfloor,
 /area/maintenance/bar)
+"nKg" = (
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
+/area/science/research)
 "nKt" = (
 /obj/structure/table,
 /obj/item/screwdriver{
@@ -59095,14 +59106,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
-"nZO" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white/side{
-	dir = 8
-	},
-/area/science/research)
 "oax" = (
 /obj/machinery/light,
 /obj/structure/chair/comfy/brown{
@@ -59176,6 +59179,10 @@
 /obj/machinery/light/small,
 /turf/open/floor/plasteel/showroomfloor,
 /area/maintenance/bar)
+"odD" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/dark,
+/area/science/research)
 "oem" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -59373,6 +59380,11 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
+"orX" = (
+/turf/open/floor/plasteel/white/side{
+	dir = 10
+	},
+/area/science/research)
 "osJ" = (
 /obj/structure/railing/corner{
 	dir = 4
@@ -60033,6 +60045,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"pse" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
+/area/science/research)
 "pst" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -60302,12 +60331,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"pOc" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
 "pOj" = (
 /turf/closed/wall,
 /area/medical/medbay/central)
@@ -60351,12 +60374,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"pRF" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/science/mixing)
 "pRY" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -60439,17 +60456,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
-"qbd" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white/side{
-	dir = 8
-	},
-/area/science/xenobiology)
 "qcs" = (
 /obj/structure/closet/secure_closet/freezer/cream_pie,
 /obj/effect/turf_decal/lumos/tile/blue/checker{
@@ -60566,14 +60572,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/medical/cryo)
-"qoQ" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/plasteel/white/side,
-/area/science/research)
 "qpg" = (
 /obj/structure/closet/secure_closet/chemical,
 /obj/machinery/light/small{
@@ -60704,10 +60702,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/range)
-"qFg" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
 "qFB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -60736,6 +60730,10 @@
 /obj/structure/sign/warning/docking,
 /turf/open/floor/plating,
 /area/security/checkpoint/auxiliary)
+"qHA" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "qIw" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -60868,14 +60866,19 @@
 	dir = 1
 	},
 /area/engine/atmos)
-"qRE" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
+"qRZ" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/disposal/bin,
+/obj/structure/window/reinforced,
+/obj/machinery/light{
+	dir = 4
 	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/science/xenobiology)
 "qTG" = (
 /obj/structure/table/wood,
@@ -60967,12 +60970,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
-"raP" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel/white,
-/area/science/mixing)
 "rcD" = (
 /obj/structure/sink{
 	dir = 8;
@@ -61017,12 +61014,6 @@
 "rfW" = (
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
-"rhp" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel/white,
-/area/science/mixing)
 "rir" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -61327,11 +61318,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/range)
-"rLT" = (
-/turf/open/floor/plasteel/white/side{
-	dir = 4
-	},
-/area/science/research)
 "rNc" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -61419,20 +61405,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge/meeting_room)
-"rUz" = (
-/obj/machinery/atmospherics/pipe/simple/violet/hidden{
-	dir = 4
+"rTX" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 8
 	},
-/obj/effect/turf_decal/stripes/corner{
+/turf/open/floor/plasteel/white/corner{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white/side{
-	dir = 4
-	},
-/area/science/xenobiology)
+/area/science/research)
 "rVj" = (
 /obj/machinery/door/airlock/medical{
 	name = "Operating Theatre";
@@ -61567,6 +61547,15 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/grass,
 /area/medical/virology)
+"sdo" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "sea" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
@@ -61619,12 +61608,6 @@
 	},
 /turf/open/floor/plating,
 /area/space/nearstation)
-"skb" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white/side,
-/area/science/research)
 "sks" = (
 /obj/effect/landmark/start/mime,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -61903,6 +61886,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"sBT" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "sDf" = (
 /obj/machinery/camera{
 	c_tag = "Genetics";
@@ -62290,14 +62279,6 @@
 	dir = 8
 	},
 /area/crew_quarters/theatre)
-"tgw" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white/side{
-	dir = 4
-	},
-/area/science/xenobiology)
 "tgH" = (
 /obj/structure/filingcabinet/employment,
 /turf/open/floor/wood,
@@ -62570,12 +62551,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"tzy" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner,
-/turf/open/floor/plasteel/white/side{
-	dir = 8
-	},
-/area/science/research)
 "tzQ" = (
 /obj/machinery/shower{
 	dir = 4
@@ -63145,10 +63120,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"utO" = (
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel/white,
-/area/science/mixing)
 "uua" = (
 /obj/machinery/atmospherics/components/binary/valve,
 /turf/open/floor/plating,
@@ -63193,6 +63164,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
+"uyW" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
+/area/science/xenobiology)
 "uzs" = (
 /turf/open/floor/plasteel/yellowsiding{
 	dir = 4
@@ -63781,6 +63760,12 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
+"vsF" = (
+/obj/effect/turf_decal/trimline/purple/filled/line,
+/turf/open/floor/plasteel/white/side{
+	dir = 1
+	},
+/area/science/robotics/lab)
 "vsT" = (
 /obj/structure/chair/comfy/black{
 	dir = 8
@@ -64765,6 +64750,13 @@
 	},
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
+"wHB" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "wJs" = (
 /obj/machinery/computer/arcade,
 /turf/open/floor/plasteel,
@@ -65096,6 +65088,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
+"xgE" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 8
+	},
+/area/science/research)
 "xhj" = (
 /obj/effect/turf_decal/lumos/tile/purple/checker,
 /obj/effect/turf_decal/stripes/line{
@@ -65232,15 +65232,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"xos" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/mixing)
 "xqi" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -65264,12 +65255,6 @@
 /obj/effect/turf_decal/trimline/brown/filled/corner,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"xrv" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/science/misc_lab)
 "xrN" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel,
@@ -65444,20 +65429,12 @@
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"xKK" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 4
+"xJj" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
 	},
-/obj/machinery/disposal/bin,
-/obj/structure/window/reinforced,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/science/xenobiology)
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "xLX" = (
 /obj/structure/lattice/catwalk,
 /obj/item/stack/marker_beacon{
@@ -65552,12 +65529,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
-"xTu" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner,
-/turf/open/floor/plasteel/white/side{
-	dir = 9
-	},
-/area/science/robotics/lab)
 "xTy" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -65774,6 +65745,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"yhN" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 8
+	},
+/area/science/xenobiology)
 "ykU" = (
 /obj/structure/table/wood,
 /turf/open/floor/plating{
@@ -101399,7 +101378,7 @@ bug
 bDT
 vPb
 hdo
-hbs
+bNZ
 bCG
 bBc
 xNE
@@ -108591,7 +108570,7 @@ bht
 bsQ
 box
 btw
-kTE
+bUX
 byf
 bzt
 bAy
@@ -108848,7 +108827,7 @@ bsQ
 bsR
 box
 bvE
-kTE
+bUX
 byf
 bzw
 bAB
@@ -108860,7 +108839,7 @@ bEm
 bEm
 bJL
 bLa
-qRE
+luE
 aLt
 bPy
 bPA
@@ -109362,7 +109341,7 @@ cHZ
 cIf
 box
 btA
-kTE
+bUX
 byf
 bzy
 bAD
@@ -109382,17 +109361,17 @@ bQM
 cTZ
 mNi
 rcD
-tgw
-rUz
+uyW
+jWZ
 mNi
 bRZ
-rUz
+jWZ
 mNi
-tgw
-jrk
+uyW
+niG
 mNi
-tgw
-rUz
+uyW
+jWZ
 ccQ
 bDb
 hYH
@@ -109619,7 +109598,7 @@ bqc
 bsS
 box
 bvE
-kTE
+bUX
 byf
 bzx
 bAC
@@ -109895,17 +109874,17 @@ cmk
 bQN
 eFW
 ooH
-myR
-myj
+yhN
+jer
 sbt
-myR
-myj
+yhN
+jer
 ooH
-qbd
-myj
+mlf
+jer
 ooH
-myR
-myj
+yhN
+jer
 ooH
 mDa
 bDb
@@ -110133,7 +110112,7 @@ cIb
 bsT
 box
 btP
-kTE
+bUX
 byi
 bzz
 bAE
@@ -110146,11 +110125,11 @@ bIz
 bIz
 bJN
 bMl
-dBI
-qFg
+fhg
+qHA
 bPE
 bLe
-xKK
+qRZ
 bTd
 bUg
 cKp
@@ -110390,7 +110369,7 @@ bqd
 biL
 box
 btS
-kTE
+bUX
 byi
 bwN
 bAG
@@ -110403,8 +110382,8 @@ bIB
 bIB
 bJN
 bMo
-dBI
-qFg
+fhg
+qHA
 bPH
 bJN
 bSa
@@ -110644,9 +110623,9 @@ blM
 qpj
 cHX
 cIc
-xTu
+iae
 buj
-bLt
+lEq
 bve
 byj
 bwM
@@ -110660,7 +110639,7 @@ bIA
 bIA
 bJN
 bMn
-dBI
+fhg
 bOz
 bPG
 bJN
@@ -110901,10 +110880,10 @@ bou
 cHT
 bou
 cId
-ire
+vsF
 bsw
 gOB
-kTE
+bUX
 byk
 bzD
 bxv
@@ -110918,7 +110897,7 @@ bIA
 bJN
 bMq
 chu
-ljf
+wHB
 bPJ
 cAc
 bEm
@@ -111160,8 +111139,8 @@ bpU
 brq
 bsW
 buj
-skb
-kTE
+fHp
+bUX
 byk
 bzC
 bAH
@@ -111175,7 +111154,7 @@ bGY
 bJN
 bMp
 bNp
-pOc
+bPg
 bPI
 cTY
 bEm
@@ -111418,7 +111397,7 @@ brs
 box
 box
 bvE
-kTE
+bUX
 byk
 byk
 byk
@@ -111674,20 +111653,20 @@ boM
 bzE
 bsX
 bsz
-ftm
+eoW
 bEf
 aIL
-rLT
-rLT
-rLT
+nKg
+nKg
+nKg
 bDd
 bEq
 bDl
-lbk
+pse
 bFQ
 bHc
 bHK
-liX
+iQs
 bID
 bOA
 bPK
@@ -111923,7 +111902,7 @@ dLA
 esZ
 bhB
 oMT
-lPs
+odD
 aIe
 blX
 bow
@@ -112186,26 +112165,26 @@ bvx
 boz
 bpX
 bBD
-nsW
+orX
 bsA
 bBD
 bBD
 brt
-nZO
+xgE
 bxF
 bzA
 bzZ
-tzy
-nZO
-nZO
-nZO
-dJQ
+jSn
+xgE
+xgE
+xgE
+grQ
 bHL
 bBD
 bBD
-mjC
+rTX
 bPK
-xrv
+kKB
 bWr
 bWr
 bWr
@@ -112967,9 +112946,9 @@ bxY
 bCh
 bvK
 bEv
-rhp
-dro
-jGw
+lfG
+sdo
+xJj
 bJV
 bEC
 bMu
@@ -113207,7 +113186,7 @@ bdv
 aYV
 bgb
 bhC
-nHU
+hbs
 aIb
 blJ
 bno
@@ -113225,8 +113204,8 @@ bCg
 bvK
 bEu
 bHv
-utO
-raP
+gle
+sBT
 bJU
 bEC
 bMt
@@ -113471,7 +113450,7 @@ blZ
 bnk
 bpo
 bqk
-qoQ
+eTg
 bsD
 bvK
 bxl
@@ -113724,7 +113703,7 @@ bhE
 bLI
 sKl
 blL
-mmm
+dTX
 bnh
 biU
 brx
@@ -114510,7 +114489,7 @@ chq
 fzX
 bEB
 bFW
-xos
+hfH
 tOq
 bNy
 bLi
@@ -115027,7 +115006,7 @@ bFX
 gvR
 bGF
 bKa
-pRF
+jkZ
 bMA
 bNz
 bOI

--- a/_maps/map_files/BoxStation/BoxStation_Lumos.dmm
+++ b/_maps/map_files/BoxStation/BoxStation_Lumos.dmm
@@ -15597,7 +15597,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aKG" = (
-/obj/machinery/vending/snack/random,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
 "aKH" = (
@@ -17659,6 +17662,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"aQn" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/mob/living/carbon/monkey,
+/turf/open/floor/grass,
+/area/medical/genetics)
 "aQp" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -18627,7 +18638,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/medical/medbay/front_office)
 "aSP" = (
 /obj/machinery/smartfridge,
@@ -23905,11 +23916,10 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/item/storage/firstaid/regular,
 /obj/effect/turf_decal/lumos/tile/blue/checker{
 	dir = 4
 	},
-/obj/structure/table/glass,
+/obj/machinery/vending/coffee,
 /turf/open/floor/plasteel/cafeteria,
 /area/medical/medbay/lobby)
 "bhe" = (
@@ -25336,13 +25346,11 @@
 	},
 /area/space/nearstation)
 "bli" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/lumos/tile/blue/checker{
-	dir = 4
+/obj/structure/sign/poster/contraband/lusty_xenomorph{
+	pixel_x = 32
 	},
-/obj/structure/reagent_dispensers/water_cooler,
-/turf/open/floor/plasteel/cafeteria,
-/area/medical/medbay/lobby)
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "blj" = (
 /obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 8
@@ -26501,7 +26509,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/medical/medbay/front_office)
 "boo" = (
 /obj/machinery/door/firedoor,
@@ -27037,8 +27045,12 @@
 /obj/machinery/airalarm{
 	pixel_y = 23
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
-/turf/open/floor/plasteel/white,
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/floor/plasteel/stairs/right{
+	dir = 4
+	},
 /area/medical/medbay/front_office)
 "bpH" = (
 /obj/structure/cable{
@@ -27048,7 +27060,10 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
-/turf/open/floor/plasteel/white,
+/obj/structure/railing/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/medical/medbay/front_office)
 "bpI" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -27063,7 +27078,7 @@
 	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/medical/medbay/front_office)
 "bpJ" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
@@ -27081,7 +27096,7 @@
 /obj/machinery/vending/medical{
 	pixel_x = -2
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/medical/medbay/front_office)
 "bpL" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
@@ -27090,13 +27105,16 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/medical/medbay/front_office)
 "bpM" = (
 /obj/effect/turf_decal/lumos/tile/blue/checker{
 	dir = 4
 	},
 /obj/effect/turf_decal/bot,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/cafeteria,
 /area/medical/medbay/lobby)
 "bpN" = (
@@ -27484,6 +27502,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/delivery,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/cafeteria,
 /area/medical/medbay/lobby)
 "bqS" = (
@@ -27542,9 +27563,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
 /obj/machinery/camera{
 	c_tag = "Upper East Medical Hallway";
 	dir = 1;
@@ -27553,7 +27571,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/medical/medbay/front_office)
 "bre" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -27566,7 +27588,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/medical/medbay/front_office)
 "brj" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -27851,8 +27873,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
 "brX" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk,
+/obj/machinery/holopad,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "brZ" = (
@@ -27964,19 +27985,25 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bsr" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
+/obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
 	},
-/turf/open/floor/plasteel/white,
-/area/medical/sleeper)
+/obj/machinery/vending/snack/random,
+/turf/open/floor/plasteel/cafeteria,
+/area/medical/medbay/lobby)
 "bss" = (
-/obj/machinery/door/airlock/medical{
-	name = "Medbay Reception";
-	req_access_txt = "5"
+/obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
 	},
-/obj/effect/turf_decal/lumos/tile/blue/fulltile,
-/turf/open/floor/plasteel/white,
-/area/medical/sleeper)
+/obj/machinery/requests_console{
+	department = "Medbay";
+	departmentType = 1;
+	name = "Medbay RC";
+	pixel_y = 28
+	},
+/obj/structure/closet/secure_closet/medical1,
+/turf/open/floor/plasteel/cafeteria,
+/area/medical/medbay/front_office)
 "bst" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -27991,11 +28018,11 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
 "bsv" = (
-/obj/machinery/computer/scan_consolenew,
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
+/mob/living/carbon/monkey,
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/grass,
 /area/medical/genetics)
 "bsw" = (
 /obj/machinery/door/airlock/research{
@@ -28010,7 +28037,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/medical/medbay/front_office)
 "bsy" = (
 /obj/structure/table/reinforced,
@@ -28163,25 +28190,17 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "bsN" = (
-/obj/machinery/computer/med_data{
-	dir = 1
-	},
-/obj/machinery/camera{
-	c_tag = "Medical Reception Desk";
-	dir = 4;
-	network = list("ss13","medbay")
-	},
-/obj/machinery/light/small,
-/obj/machinery/button/door{
-	desc = "A remote control switch for the medbay foyer.";
-	id = "MedbayFoyer";
-	name = "Medbay Doors Control";
-	normaldoorcontrol = 1;
-	pixel_x = -24;
-	req_access_txt = "5"
-	},
 /obj/effect/turf_decal/lumos/tile/blue/checker{
 	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/medical/medbay/front_office)
@@ -28566,9 +28585,6 @@
 	},
 /area/science/research)
 "btR" = (
-/obj/structure/bed/roller,
-/obj/effect/turf_decal/bot,
-/obj/machinery/iv_drip,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 4
 	},
@@ -28578,6 +28594,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/turf_decal/bot,
+/obj/structure/bed/roller,
+/obj/machinery/iv_drip,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "btS" = (
@@ -28589,6 +28608,12 @@
 "btT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
+	},
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -28674,26 +28699,23 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics/cloning)
 "bug" = (
-/obj/machinery/computer/crew{
-	dir = 1
-	},
-/obj/machinery/requests_console{
-	department = "Medbay";
-	departmentType = 1;
-	name = "Medbay RC";
-	pixel_x = 30
-	},
 /obj/effect/turf_decal/lumos/tile/blue/checker{
 	dir = 4
+	},
+/obj/machinery/computer/crew{
+	dir = 1
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/medical/medbay/front_office)
 "bui" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+/obj/effect/turf_decal/lumos/tile/blue/checker{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
+/obj/item/kirbyplants{
+	icon_state = "plant-22"
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/medical/medbay/lobby)
 "buj" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "robotics2";
@@ -28703,31 +28725,37 @@
 /turf/open/floor/plating,
 /area/science/robotics/lab)
 "bul" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics)
 "bum" = (
+/obj/machinery/light{
+	light_color = "#e8eaff"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
+/mob/living/carbon/monkey,
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/grass,
 /area/medical/genetics)
 "bun" = (
-/obj/machinery/door/airlock/research{
-	name = "Genetics Research Access";
-	req_access_txt = "9"
+/obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
-/area/medical/genetics)
+/obj/structure/reagent_dispensers/water_cooler,
+/turf/open/floor/plasteel/cafeteria,
+/area/medical/medbay/lobby)
 "buo" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -28751,28 +28779,20 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "buq" = (
-/obj/machinery/power/apc/auto_name/south,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "0-4"
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics)
 "bur" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics/cloning)
@@ -28789,17 +28809,14 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "but" = (
-/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
+	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
+/mob/living/carbon/monkey,
+/turf/open/floor/grass,
 /area/medical/genetics)
 "buu" = (
 /obj/structure/cable{
@@ -29150,10 +29167,13 @@
 /area/science/research)
 "bvh" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -27
+	pixel_x = -25
 	},
 /obj/effect/turf_decal/lumos/tile/blue/checker{
 	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 8
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/medical/medbay/front_office)
@@ -29165,42 +29185,24 @@
 /obj/effect/turf_decal/lumos/tile/red/fulltile,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
-"bvl" = (
-/obj/machinery/holopad,
-/obj/structure/disposalpipe/segment,
+"bvp" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
-"bvo" = (
-/obj/machinery/vending/wardrobe/gene_wardrobe,
-/obj/effect/turf_decal/trimline/purple/filled/line,
-/turf/open/floor/plasteel/dark,
-/area/medical/genetics)
-"bvp" = (
-/obj/machinery/camera{
-	c_tag = "Genetics";
-	dir = 8;
-	network = list("ss13","medbay")
-	},
-/obj/structure/closet/secure_closet/medical1,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics)
 "bvs" = (
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
+	},
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics/cloning)
 "bvw" = (
@@ -29540,27 +29542,29 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bww" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner,
-/obj/machinery/camera{
-	c_tag = "Chemistry";
-	dir = 1;
-	network = list("ss13","medbay")
-	},
+/obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bwx" = (
-/obj/machinery/chem_heater,
-/obj/machinery/light{
-	dir = 8
+/obj/structure/closet/secure_closet/chemical,
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -23
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bwy" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
@@ -29574,20 +29578,21 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/front_office)
 "bwA" = (
-/obj/machinery/chem_heater,
-/obj/machinery/light{
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bwB" = (
-/obj/structure/table/glass,
-/obj/item/storage/box/syringes,
-/obj/item/clothing/glasses/science{
-	pixel_x = 2;
-	pixel_y = 4
-	},
-/obj/item/clothing/glasses/science,
 /obj/item/radio/intercom{
 	dir = 8;
 	name = "Station Intercom (General)";
@@ -29597,32 +29602,46 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner,
+/obj/structure/table/glass,
+/obj/item/storage/box/syringes,
+/obj/item/clothing/glasses/science{
+	pixel_x = 2;
+	pixel_y = 4
+	},
+/obj/item/clothing/glasses/science{
+	pixel_x = 2;
+	pixel_y = 4
+	},
+/obj/item/clothing/glasses/science,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bwD" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
+/obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
 	},
-/obj/structure/mirror{
-	pixel_x = -28
+/obj/structure/chair{
+	dir = 8
 	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/medical/medbay/lobby)
+"bwE" = (
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 8
+	},
+/obj/machinery/chem_master,
 /obj/machinery/camera{
-	c_tag = "Sleeper";
-	dir = 4;
+	c_tag = "Chemistry";
+	dir = 1;
 	network = list("ss13","medbay")
 	},
-/turf/open/floor/plasteel/white,
-/area/medical/sleeper)
-"bwE" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bwF" = (
@@ -29642,6 +29661,9 @@
 "bwG" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
@@ -29833,18 +29855,15 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
 "bwZ" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/window/eastright{
-	dir = 1;
-	name = "Chemistry Desk";
-	req_access_txt = "33"
+/obj/effect/turf_decal/lumos/tile/yellow/fulltile,
+/obj/machinery/door/airlock/medical/glass{
+	name = "Chemistry Lab";
+	req_access_txt = "5; 33"
 	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "chemsh";
-	name = "chemistry shutters"
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bxb" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
@@ -29856,18 +29875,13 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/medical/medbay/lobby)
 "bxc" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Chemistry Lab";
-	req_access_txt = "5; 33"
+/obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
+/obj/structure/table/glass,
+/obj/item/storage/firstaid/regular,
+/turf/open/floor/plasteel/cafeteria,
+/area/medical/medbay/lobby)
 "bxe" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -29888,7 +29902,11 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/white,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
 /area/medical/medbay/front_office)
 "bxg" = (
 /obj/structure/reagent_dispensers/watertank,
@@ -30112,12 +30130,17 @@
 	},
 /area/hallway/secondary/exit)
 "bxL" = (
-/obj/machinery/camera{
-	c_tag = "Central Hallway South-East";
+/obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
+	},
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/turf/open/floor/plasteel/cafeteria,
+/area/medical/medbay/lobby)
 "bxM" = (
 /obj/structure/chair/office/dark,
 /obj/effect/landmark/event_spawn,
@@ -30133,7 +30156,10 @@
 /area/medical/genetics/cloning)
 "bxO" = (
 /obj/structure/disposalpipe/segment{
-	dir = 5
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
@@ -30625,73 +30651,73 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
 "byY" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/sleeper)
-"byZ" = (
-/obj/machinery/door/window/eastleft{
-	name = "Medical Delivery";
-	req_access_txt = "5"
-	},
-/obj/effect/turf_decal/delivery,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/medical/sleeper)
-"bza" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
-"bzb" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/disposalpipe/segment{
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/machinery/door/window/eastright{
+	dir = 2;
+	name = "Chemistry Storage";
+	req_access_txt = "33"
+	},
+/turf/open/floor/plasteel,
+/area/medical/chemistry)
+"byZ" = (
+/obj/structure/window/reinforced,
+/obj/machinery/requests_console{
+	department = "Medbay";
+	departmentType = 1;
+	name = "Medbay RC";
+	pixel_x = -30
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 4
 	},
+/obj/machinery/vending/wardrobe/chem_wardrobe,
+/turf/open/floor/plasteel,
+/area/medical/chemistry)
+"bza" = (
+/obj/structure/chair/office/light,
+/obj/effect/landmark/start/chemist,
 /turf/open/floor/plasteel/white,
-/area/medical/sleeper)
+/area/medical/chemistry)
+"bzb" = (
+/obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
+	},
+/obj/structure/table/glass,
+/obj/item/reagent_containers/food/drinks/soda_cans/starkist{
+	pixel_x = 5;
+	pixel_y = 7
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/medical/medbay/lobby)
 "bzc" = (
 /obj/machinery/light{
 	dir = 8;
 	light_color = "#e8eaff"
 	},
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
 	},
-/mob/living/carbon/monkey,
-/turf/open/floor/grass,
+/turf/open/floor/plasteel/dark,
 /area/medical/genetics)
 "bze" = (
-/obj/structure/closet/wardrobe/chemistry_white,
-/obj/machinery/light/small{
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 1
 	},
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
-"bzf" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/railing/corner{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/medical/sleeper)
 "bzh" = (
 /obj/machinery/sleeper{
@@ -30735,27 +30761,29 @@
 	dir = 8;
 	light_color = "#e8eaff"
 	},
-/obj/machinery/computer/scan_consolenew,
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
-	},
 /obj/machinery/airalarm{
 	pixel_y = 23
+	},
+/obj/structure/closet/secure_closet/medical1,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics)
 "bzm" = (
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
 	},
-/mob/living/carbon/monkey,
-/turf/open/floor/grass,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
 /area/medical/genetics)
 "bzn" = (
-/obj/machinery/dna_scannernew,
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
+/obj/machinery/computer/scan_consolenew,
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics)
 "bzq" = (
@@ -30902,24 +30930,17 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bzH" = (
-/obj/machinery/requests_console{
-	department = "Medbay";
-	departmentType = 1;
-	name = "Medbay RC";
-	pixel_x = -30
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/structure/cable{
-	icon_state = "2-4"
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/sleeper)
+/turf/open/floor/plasteel,
+/area/medical/storage)
 "bzJ" = (
 /obj/machinery/computer/mecha{
 	dir = 8
@@ -30930,16 +30951,14 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/hor)
 "bzK" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/door/airlock/medical/glass{
+	name = "Medbay Storage";
+	req_access_txt = "5"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/effect/turf_decal/lumos/tile/blue/fulltile,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "bzL" = (
@@ -31042,12 +31061,11 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "bzW" = (
@@ -31188,22 +31206,9 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "bAl" = (
-/obj/structure/table/glass,
-/obj/item/grenade/chem_grenade,
-/obj/item/grenade/chem_grenade,
-/obj/item/grenade/chem_grenade,
-/obj/item/grenade/chem_grenade,
-/obj/item/screwdriver{
-	pixel_x = -2;
-	pixel_y = 6
-	},
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
+/obj/machinery/chem_dispenser,
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
@@ -31292,7 +31297,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/obj/structure/railing/corner,
+/turf/open/floor/plasteel,
 /area/medical/medbay/front_office)
 "bAw" = (
 /turf/open/floor/plating,
@@ -31528,18 +31534,17 @@
 /turf/open/floor/plasteel,
 /area/janitor)
 "bAW" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Medbay Storage";
-	req_access_txt = "5"
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/lumos/tile/blue/fulltile,
-/turf/open/floor/plasteel/white,
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#c1caff"
+	},
+/turf/open/floor/plasteel,
 /area/medical/storage)
 "bAZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -31551,18 +31556,22 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "bBb" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/medical/storage)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
+	},
+/obj/structure/table/glass,
+/turf/open/floor/plasteel/cafeteria,
+/area/medical/medbay/lobby)
 "bBc" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/storage)
-"bBd" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
-/turf/open/floor/plasteel/dark,
-/area/medical/genetics)
 "bBf" = (
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_x = 30
@@ -31655,13 +31664,15 @@
 /turf/open/floor/plasteel,
 /area/medical/cryo)
 "bBn" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/medical/cryo)
+/obj/structure/railing/corner,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/sleeper)
 "bBp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -31746,9 +31757,13 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bBy" = (
-/obj/machinery/light,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/disposalpipe/junction/flip{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -31759,20 +31774,18 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/sign/poster/contraband/space_up{
-	pixel_y = -32
-	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bBA" = (
 /obj/structure/cable{
-	icon_state = "2-4"
+	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/junction/flip{
-	dir = 8
+/obj/structure/sign/poster/contraband/space_up{
+	pixel_y = -32
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bBB" = (
@@ -31829,10 +31842,21 @@
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "bBL" = (
-/obj/structure/table,
+/obj/structure/table{
+	pixel_y = -5
+	},
 /obj/item/stack/packageWrap,
 /obj/item/stack/packageWrap,
 /obj/item/pen,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bBM" = (
@@ -31842,17 +31866,9 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "bBN" = (
-/obj/machinery/door/window/eastright{
-	dir = 1;
-	name = "Monkey Pen";
-	req_access_txt = "9"
-	},
-/mob/living/carbon/monkey,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/grass,
+/obj/structure/chair/office/light,
+/obj/effect/landmark/start/geneticist,
+/turf/open/floor/plasteel/dark,
 /area/medical/genetics)
 "bBO" = (
 /obj/structure/cable{
@@ -31864,16 +31880,20 @@
 	req_access_txt = "5; 68"
 	},
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/lumos/tile/blue/fulltile,
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "bBP" = (
-/obj/machinery/door/window/eastright{
-	dir = 2;
-	name = "Chemistry Storage";
-	req_access_txt = "33"
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 1
 	},
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/floor/plasteel/stairs/left,
+/area/medical/sleeper)
 "bBQ" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/delivery,
@@ -32156,80 +32176,74 @@
 /turf/open/floor/plasteel,
 /area/gateway)
 "bCz" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
+/obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/table/glass,
+/obj/item/paper_bin{
+	pixel_y = 4
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plating,
-/area/maintenance/aft)
+/obj/item/pen,
+/turf/open/floor/plasteel/cafeteria,
+/area/medical/medbay/lobby)
 "bCA" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 5
 	},
-/obj/machinery/disposal/bin,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
 "bCB" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Surgery Maintenance";
-	req_access_txt = "45"
-	},
-/obj/structure/disposalpipe/segment{
+/obj/effect/turf_decal/lumos/tile/blue/checker{
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/table/glass,
+/obj/item/reagent_containers/food/snacks/grown/apple{
+	pixel_x = 2;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/medical/medbay/lobby)
+"bCE" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/medical/storage)
-"bCE" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
+/obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/medical/storage)
 "bCF" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
+	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
+	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
+	dir = 6
 	},
-/obj/machinery/airalarm{
-	pixel_y = 23
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
-/turf/open/floor/plasteel/white,
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/effect/landmark/start/medical_doctor,
+/turf/open/floor/plasteel,
 /area/medical/storage)
 "bCG" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
@@ -32248,61 +32262,100 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
+	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/closet/crate/freezer/blood,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 10
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/obj/structure/table,
+/obj/item/storage/belt/medical{
+	pixel_y = 2
+	},
+/obj/item/storage/belt/medical{
+	pixel_y = 2
+	},
+/obj/item/storage/belt/medical{
+	pixel_y = 2
+	},
+/obj/item/clothing/neck/stethoscope,
+/turf/open/floor/plasteel,
 /area/medical/storage)
 "bCJ" = (
 /obj/machinery/rnd/production/techfab/department/medical,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/white,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/medical/storage)
 "bCK" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/white,
+/obj/structure/closet/l3closet,
+/turf/open/floor/plasteel,
 /area/medical/storage)
 "bCL" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "bCM" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "bCN" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
+/obj/machinery/door/firedoor,
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/floor/plasteel/stairs/left{
+	dir = 8
+	},
 /area/medical/cryo)
 "bCO" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
-/area/medical/cryo)
+/obj/structure/railing/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/sleeper)
 "bCQ" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -32342,29 +32395,36 @@
 	dir = 1
 	},
 /obj/structure/cable{
-	icon_state = "2-8"
+	icon_state = "0-2"
 	},
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 14
-	},
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/machinery/power/apc/auto_name/north,
+/turf/open/floor/plasteel,
 /area/medical/storage)
 "bCT" = (
-/obj/structure/bed,
-/obj/item/bedsheet/medical,
-/obj/machinery/iv_drip,
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
 	},
+/obj/structure/table,
+/obj/item/soap/nanotrasen,
+/obj/item/soap/nanotrasen,
+/obj/item/folder/white,
+/obj/item/gun/syringe,
+/obj/item/reagent_containers/dropper,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "bCU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
+	},
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -32388,10 +32448,16 @@
 /area/medical/surgery)
 "bCZ" = (
 /obj/machinery/limbgrower,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "bDa" = (
 /obj/structure/table/optable,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "bDb" = (
@@ -32571,32 +32637,43 @@
 	},
 /area/hallway/secondary/exit)
 "bDA" = (
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
+"bDB" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
+	},
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/grille/broken,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/maintenance/aft)
-"bDB" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/storage)
-"bDD" = (
-/obj/effect/landmark/start/medical_doctor,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/medical/storage)
 "bDE" = (
-/obj/machinery/power/apc/auto_name/east,
-/obj/structure/cable,
-/turf/open/floor/plasteel/white,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/medical/storage)
 "bDG" = (
 /obj/machinery/door/firedoor,
@@ -32694,11 +32771,11 @@
 /turf/open/floor/plasteel,
 /area/janitor)
 "bDO" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/sign/poster/contraband/hacking_guide{
-	pixel_y = 32
+	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
@@ -32714,20 +32791,23 @@
 /turf/open/floor/plasteel,
 /area/janitor)
 "bDQ" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plating,
-/area/maintenance/aft)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/medical/medbay/lobby)
 "bDS" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/backpack/duffelbag/med/surgery,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "bDT" = (
@@ -32764,19 +32844,22 @@
 /turf/open/floor/plasteel/white,
 /area/science/storage)
 "bDZ" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Medbay Storage";
-	req_access_txt = "5"
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "chemsh";
+	name = "chemistry shutters"
 	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/lumos/tile/blue/fulltile,
-/turf/open/floor/plasteel/white,
-/area/medical/storage)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/medical/chemistry)
 "bEa" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/obj/machinery/door/firedoor,
+/obj/structure/railing,
+/turf/open/floor/plasteel/stairs/right{
+	dir = 8
+	},
 /area/medical/cryo)
 "bEb" = (
 /obj/structure/cable{
@@ -32792,9 +32875,11 @@
 /turf/open/floor/plasteel/white,
 /area/science/storage)
 "bEd" = (
-/obj/effect/landmark/start/paramedic,
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/railing/corner{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/medical/cryo)
@@ -32806,6 +32891,10 @@
 	pixel_x = -26;
 	pixel_y = 6;
 	req_access_txt = "33"
+	},
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
@@ -32840,6 +32929,11 @@
 /turf/open/floor/plasteel/white,
 /area/science/storage)
 "bEh" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics/cloning)
 "bEj" = (
@@ -33256,6 +33350,9 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "bFm" = (
@@ -33303,36 +33400,33 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bFt" = (
-/obj/effect/landmark/start/paramedic,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/medical/storage)
 "bFu" = (
-/obj/structure/table,
-/obj/item/storage/belt/medical{
-	pixel_y = 2
-	},
-/obj/item/storage/belt/medical{
-	pixel_y = 2
-	},
-/obj/item/storage/belt/medical{
-	pixel_y = 2
-	},
-/obj/item/clothing/neck/stethoscope,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/disposalpipe/segment{
+	dir = 9
 	},
-/turf/open/floor/plasteel/white,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
 /area/medical/storage)
 "bFv" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8
-	},
+/obj/structure/bed/roller,
+/obj/effect/turf_decal/bot,
+/obj/machinery/iv_drip,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "bFw" = (
@@ -33354,14 +33448,9 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/spawner/structure/window/hollow/directional{
-	dir = 6
-	},
+/obj/effect/spawner/structure/window/hollow/directional,
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"bFy" = (
-/turf/open/floor/plasteel/white,
-/area/medical/storage)
 "bFz" = (
 /obj/structure/table,
 /obj/item/storage/firstaid/toxin{
@@ -33409,27 +33498,7 @@
 /turf/open/floor/wood,
 /area/hallway/primary/central)
 "bFD" = (
-/obj/structure/table/glass{
-	layer = 3
-	},
-/obj/item/storage/box/beakers{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/storage/box/beakers{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/dropper,
-/obj/item/reagent_containers/dropper,
-/obj/machinery/button/door{
-	id = "chemsh";
-	name = "Chemistry Shutters";
-	pixel_y = 8;
-	req_access_txt = "33"
-	},
+/obj/machinery/chem_heater,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bFE" = (
@@ -33446,7 +33515,7 @@
 /obj/item/storage/box/gloves,
 /obj/item/reagent_containers/spray/cleaner,
 /obj/machinery/light,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/medical/storage)
 "bFH" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -33474,14 +33543,14 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/bed/roller,
-/obj/effect/turf_decal/bot,
-/obj/machinery/iv_drip,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
+/obj/effect/turf_decal/bot,
+/obj/structure/bed/roller,
+/obj/machinery/iv_drip,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bFK" = (
@@ -33491,7 +33560,7 @@
 /obj/item/storage/box/medipens,
 /obj/item/storage/box/gloves,
 /obj/item/reagent_containers/spray/cleaner,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/medical/storage)
 "bFL" = (
 /obj/machinery/power/apc/auto_name/east,
@@ -33790,6 +33859,15 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
+	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "bGI" = (
@@ -33800,9 +33878,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
+/obj/structure/grille/broken,
+/obj/item/assembly/mousetrap/armed,
+/turf/open/floor/plating,
 /area/maintenance/aft)
 "bGK" = (
 /obj/structure/cable{
@@ -33881,9 +33959,12 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "bGR" = (
-/obj/structure/bed,
-/obj/item/bedsheet/medical,
-/obj/machinery/iv_drip,
+/obj/structure/table,
+/obj/structure/bedsheetbin{
+	pixel_x = 2
+	},
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/clothing/mask/muzzle,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "bGV" = (
@@ -33913,6 +33994,10 @@
 "bGZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "bHb" = (
@@ -33921,7 +34006,7 @@
 	pixel_x = 14
 	},
 /obj/effect/landmark/start/medical_doctor,
-/obj/effect/turf_decal/lumos/tile/blue/half,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "bHc" = (
@@ -34396,21 +34481,37 @@
 "bIi" = (
 /obj/machinery/power/apc/auto_name/south,
 /obj/structure/cable,
-/obj/machinery/camera{
-	c_tag = "Treatment Center";
-	dir = 1;
-	network = list("ss13","medbay")
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "bIj" = (
-/obj/machinery/vending/medical{
-	pixel_x = -2
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "bIk" = (
-/obj/structure/closet/wardrobe/pjs,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "bIl" = (
@@ -34418,13 +34519,23 @@
 	dir = 1;
 	pixel_y = -22
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Treatment Center";
+	dir = 1;
+	network = list("ss13","medbay")
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "bIo" = (
-/obj/machinery/chem_dispenser/apothecary,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
-	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bIp" = (
@@ -34921,9 +35032,13 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bJG" = (
-/obj/structure/window/reinforced,
-/mob/living/carbon/monkey,
-/turf/open/floor/grass,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 10
+	},
+/obj/item/kirbyplants{
+	icon_state = "plant-10"
+	},
+/turf/open/floor/plasteel/dark,
 /area/medical/genetics)
 "bJH" = (
 /obj/structure/cable{
@@ -35014,7 +35129,7 @@
 "bJP" = (
 /obj/structure/falsewall/reinforced,
 /turf/open/floor/plating,
-/area/maintenance/aft)
+/area/medical/medbay/central)
 "bJT" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/plasteel/white,
@@ -35411,11 +35526,23 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "bKQ" = (
-/obj/structure/disposalpipe/junction/flip{
-	dir = 8
+/obj/structure/table/glass{
+	layer = 3
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/obj/item/storage/box/beakers{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/storage/box/beakers{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/dropper,
+/obj/item/reagent_containers/dropper,
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "bKR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
@@ -40604,8 +40731,23 @@
 	c_tag = "Medbay Cryogenics";
 	network = list("ss13","medbay")
 	},
-/obj/item/reagent_containers/glass/beaker/cryoxadone,
-/obj/item/reagent_containers/glass/beaker/cryoxadone,
+/obj/item/reagent_containers/glass/beaker/cryoxadone{
+	pixel_x = -5;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/glass/beaker/cryoxadone{
+	pixel_x = -5;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/glass/beaker/cryoxadone{
+	pixel_x = 5;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/glass/beaker/cryoxadone{
+	pixel_x = 5;
+	pixel_y = 2
+	},
+/obj/structure/railing/corner,
 /turf/open/floor/plasteel,
 /area/medical/cryo)
 "bZc" = (
@@ -45635,7 +45777,12 @@
 /turf/closed/wall,
 /area/maintenance/aft)
 "cnE" = (
-/obj/effect/spawner/structure/window/hollow,
+/obj/structure/sign/poster/contraband/hacking_guide{
+	pixel_y = 32
+	},
+/obj/effect/spawner/structure/window/hollow/directional{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "cnF" = (
@@ -45823,23 +45970,11 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "col" = (
-/obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=4";
-	dir = 4;
-	freq = 1400;
-	location = "Medbay"
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
 	},
-/obj/structure/plasticflaps/opaque,
-/obj/effect/turf_decal/bot,
-/obj/machinery/door/poddoor/preopen{
-	id = "cmoofficesh1";
-	name = "biohazard containment door"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/medical/medbay/central)
+/turf/open/floor/plasteel/white,
+/area/medical/sleeper)
 "con" = (
 /turf/open/pool,
 /area/crew_quarters/fitness/pool)
@@ -46213,20 +46348,40 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /obj/structure/disposalpipe/segment{
-	dir = 9
+	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/closet/crate/freezer/surplus_limbs,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
+/obj/machinery/airalarm{
+	pixel_y = 23
 	},
-/turf/open/floor/plasteel/white,
+/obj/structure/table,
+/obj/item/storage/box/beakers{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/storage/box/syringes,
+/obj/item/reagent_containers/glass/bottle/morphine{
+	pixel_x = 8;
+	pixel_y = -3
+	},
+/obj/item/reagent_containers/glass/bottle/epinephrine{
+	pixel_x = 7;
+	pixel_y = -3
+	},
+/obj/item/reagent_containers/syringe{
+	pixel_x = 6;
+	pixel_y = -3
+	},
+/turf/open/floor/plasteel,
 /area/medical/storage)
 "cpI" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -48760,21 +48915,10 @@
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "cAg" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
+/obj/structure/sign/poster/contraband/lusty_xenomorph{
+	pixel_x = 32
 	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
-	},
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
+/turf/open/floor/plating,
 /area/maintenance/aft)
 "cAh" = (
 /obj/structure/cable{
@@ -49100,9 +49244,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/bed/roller,
-/obj/effect/turf_decal/bot,
-/obj/machinery/iv_drip,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "cBn" = (
@@ -49414,30 +49555,13 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
 "cCp" = (
-/obj/structure/table,
-/obj/item/storage/box/beakers{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/storage/box/syringes,
-/obj/item/reagent_containers/glass/bottle/epinephrine{
-	pixel_x = 7;
-	pixel_y = -3
-	},
-/obj/item/reagent_containers/glass/bottle/morphine{
-	pixel_x = 8;
-	pixel_y = -3
-	},
-/obj/item/reagent_containers/syringe{
-	pixel_x = 6;
-	pixel_y = -3
-	},
 /obj/machinery/camera{
 	c_tag = "Medical Storage";
 	dir = 1;
 	network = list("ss13","medbay")
 	},
-/turf/open/floor/plasteel/white,
+/obj/structure/closet/crate/freezer/blood,
+/turf/open/floor/plasteel,
 /area/medical/storage)
 "cCq" = (
 /obj/machinery/deepfryer,
@@ -50581,6 +50705,12 @@
 /obj/effect/turf_decal/lumos/tile/blue/checker{
 	dir = 4
 	},
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
 /turf/open/floor/plasteel/cafeteria,
 /area/medical/medbay/lobby)
 "cZe" = (
@@ -50590,11 +50720,15 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "cZP" = (
-/obj/structure/closet/secure_closet/medical1,
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = -24
 	},
+/obj/machinery/shower{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/lumos/shower,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "daA" = (
@@ -50742,6 +50876,18 @@
 /obj/effect/turf_decal/lumos/tile/green/fulltile,
 /turf/open/floor/plasteel,
 /area/security/brig)
+"dng" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/sleeper)
 "dqb" = (
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/pool)
@@ -50755,6 +50901,12 @@
 "dra" = (
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -50771,18 +50923,6 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/toilet)
-"duL" = (
-/obj/structure/table,
-/obj/structure/bedsheetbin{
-	pixel_x = 2
-	},
-/obj/item/clothing/suit/straight_jacket,
-/obj/item/clothing/mask/muzzle,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/sleeper)
 "dvc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
@@ -50801,6 +50941,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"dwA" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "chemsh";
+	name = "chemistry shutters"
+	},
+/obj/machinery/door/window/eastright{
+	dir = 1;
+	name = "Chemistry Desk";
+	req_access_txt = "33"
+	},
+/turf/open/floor/plating,
+/area/medical/chemistry)
 "dxe" = (
 /obj/structure/window,
 /obj/structure/window{
@@ -50902,10 +51056,10 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "dIj" = (
+/obj/effect/landmark/start/geneticist,
 /obj/structure/chair/office/light{
 	dir = 1
 	},
-/obj/effect/landmark/start/geneticist,
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics)
 "dIP" = (
@@ -50976,6 +51130,10 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/obj/effect/landmark/start/paramedic,
 /turf/open/floor/plasteel,
 /area/medical/cryo)
 "dOq" = (
@@ -51010,6 +51168,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
+"dTC" = (
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/turf/open/floor/plasteel/white,
+/area/medical/sleeper)
 "dTI" = (
 /obj/machinery/light/small,
 /obj/machinery/camera{
@@ -51121,6 +51291,9 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "ecI" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics)
 "edA" = (
@@ -51206,6 +51379,12 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"eiE" = (
+/obj/machinery/computer/med_data{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/sleeper)
 "ejm" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
@@ -51233,11 +51412,7 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
 "elf" = (
-/obj/structure/table/glass,
-/obj/machinery/reagentgrinder,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
-	},
+/obj/structure/closet/wardrobe/chemistry_white,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "elh" = (
@@ -51251,7 +51426,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/medical/medbay/front_office)
 "emL" = (
 /obj/machinery/plate_chute/outputchute{
@@ -51354,7 +51529,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "eBX" = (
-/obj/machinery/vending/cola/space_up,
+/obj/machinery/vending/snack/random,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
 "eCr" = (
@@ -51430,14 +51605,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"eJa" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
-	},
-/area/maintenance/aft)
 "eMs" = (
 /obj/structure/rack,
 /obj/machinery/light/small{
@@ -51502,8 +51669,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "eSO" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk,
+/obj/structure/closet/wardrobe/pjs,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "eTo" = (
@@ -51668,6 +51834,9 @@
 "fmv" = (
 /obj/structure/table/reinforced,
 /obj/item/wrench/medical,
+/obj/structure/railing/corner{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/medical/cryo)
 "fmR" = (
@@ -51915,12 +52084,10 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "fGa" = (
-/obj/structure/table,
-/obj/item/folder/white,
-/obj/item/gun/syringe,
-/obj/item/reagent_containers/dropper,
-/obj/item/soap/nanotrasen,
-/obj/item/soap/nanotrasen,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "fGf" = (
@@ -52071,6 +52238,21 @@
 /obj/item/bedsheet/orange,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
+"fXw" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/medical/genetics/cloning)
 "fYb" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 6
@@ -52131,6 +52313,12 @@
 /obj/effect/turf_decal/lumos/tile/blue/checker{
 	dir = 4
 	},
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
 /turf/open/floor/plasteel/cafeteria,
 /area/medical/medbay/lobby)
 "gcF" = (
@@ -52169,6 +52357,16 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"gfo" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/mob/living/carbon/monkey,
+/obj/machinery/door/window/eastright{
+	dir = 8;
+	name = "Monkey Pen";
+	req_access_txt = "9"
+	},
+/turf/open/floor/grass,
+/area/medical/genetics)
 "gfr" = (
 /obj/structure/chair/sofa/corp/left,
 /turf/open/floor/plating,
@@ -52202,6 +52400,9 @@
 "ghS" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
+	},
+/mob/living/simple_animal/bot/cleanbot{
+	name = "Dr. Blow-His-Load"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
@@ -52279,11 +52480,11 @@
 /turf/open/floor/engine,
 /area/science/storage)
 "gkD" = (
-/obj/effect/landmark/start/medical_doctor,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
 	},
-/turf/open/floor/plasteel/white,
+/obj/effect/landmark/start/paramedic,
+/turf/open/floor/plasteel,
 /area/medical/storage)
 "gli" = (
 /obj/structure/disposalpipe/trunk{
@@ -52320,7 +52521,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/medical/medbay/front_office)
 "gpD" = (
 /obj/machinery/light_switch{
@@ -52338,10 +52539,23 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
+/turf/open/floor/plating,
 /area/maintenance/aft)
+"guI" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel/dark,
+/area/medical/genetics)
 "guS" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -52514,14 +52728,24 @@
 	},
 /turf/open/space,
 /area/maintenance/disposal/incinerator)
+"gHt" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/sleeper)
 "gHV" = (
 /obj/effect/turf_decal/lumos/tile/blue/checker{
 	dir = 4
 	},
-/obj/structure/chair{
-	dir = 1
+/obj/structure/table/glass,
+/obj/item/reagent_containers/rag{
+	pixel_x = -4;
+	pixel_y = 8
 	},
-/obj/structure/window/reinforced,
 /turf/open/floor/plasteel/cafeteria,
 /area/medical/medbay/lobby)
 "gIC" = (
@@ -52716,7 +52940,10 @@
 /area/space/nearstation)
 "gXv" = (
 /obj/machinery/vending/medical{
-	pixel_x = -2
+	pixel_y = -6
+	},
+/obj/structure/window/reinforced{
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -52741,7 +52968,7 @@
 /area/ai_monitored/storage/eva)
 "gZG" = (
 /obj/machinery/holopad,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/medical/storage)
 "gZQ" = (
 /obj/machinery/door/airlock/security/glass{
@@ -52762,8 +52989,12 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 5
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
@@ -52783,23 +53014,33 @@
 /turf/open/floor/grass,
 /area/medical/virology)
 "hbh" = (
-/obj/effect/turf_decal/lumos/tile/blue/checker{
+/obj/machinery/vending/wardrobe/gene_wardrobe,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/medical/genetics)
+"hbs" = (
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/table/glass,
-/obj/item/paper_bin{
-	pixel_y = 4
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/obj/item/pen,
-/turf/open/floor/plasteel/cafeteria,
-/area/medical/medbay/lobby)
+/obj/structure/railing/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/sleeper)
 "hcb" = (
 /turf/open/floor/carpet,
 /area/crew_quarters/theatre)
 "hdo" = (
-/obj/structure/window/reinforced,
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/plasteel/stairs/right,
+/area/medical/sleeper)
 "hdv" = (
 /obj/structure/table/glass,
 /obj/item/folder/white,
@@ -52901,6 +53142,23 @@
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
+"hjD" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/sleeper)
 "hjK" = (
 /obj/machinery/atmospherics/pipe/simple/violet/hidden{
 	dir = 4
@@ -53107,6 +53365,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"hzu" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/vending/wardrobe/medi_wardrobe,
+/turf/open/floor/plasteel,
+/area/medical/storage)
 "hzK" = (
 /turf/open/floor/plasteel/yellowsiding/corner{
 	dir = 1
@@ -53153,7 +53422,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "hFP" = (
-/obj/machinery/chem_master,
+/obj/structure/table/glass,
+/obj/item/stack/sheet/mineral/plasma,
+/obj/item/stack/sheet/mineral/plasma,
+/obj/item/reagent_containers/glass/bottle/epinephrine,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "hGH" = (
@@ -53446,12 +53718,19 @@
 	},
 /turf/open/floor/plating,
 /area/security/processing)
-"iso" = (
-/obj/structure/window,
-/obj/structure/grille/broken,
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
+"ism" = (
+/obj/structure/sign/poster/contraband/busty_backdoor_xeno_babes_6{
+	pixel_y = 30
 	},
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/semen,
+/turf/open/floor/plating,
+/area/maintenance/aft)
+"iso" = (
+/obj/structure/grille/broken,
+/turf/open/floor/plating,
 /area/maintenance/aft)
 "itK" = (
 /obj/structure/table,
@@ -53471,10 +53750,10 @@
 /turf/open/floor/plating,
 /area/security/range)
 "ium" = (
-/obj/effect/spawner/structure/window/hollow/middle,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
+/obj/structure/window,
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
 /area/maintenance/aft)
 "iuv" = (
 /obj/structure/table/wood,
@@ -53786,6 +54065,25 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"iWI" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Surgery Maintenance";
+	req_access_txt = "45"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/medical/storage)
 "iYb" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -53900,8 +54198,7 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "jex" = (
-/obj/effect/landmark/start/paramedic,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/medical/storage)
 "jez" = (
 /obj/effect/landmark/blobstart,
@@ -54027,7 +54324,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/medical/medbay/front_office)
 "jmH" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -54063,13 +54360,14 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "jqu" = (
-/obj/item/kirbyplants{
-	icon_state = "plant-22"
-	},
 /obj/machinery/light{
 	dir = 8
 	},
 /obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
+	},
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
@@ -54211,11 +54509,11 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "jEH" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 6
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics)
@@ -54389,6 +54687,39 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/pool)
+"jMR" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 6
+	},
+/obj/machinery/power/apc/auto_name/south,
+/obj/structure/cable,
+/obj/structure/table,
+/obj/item/storage/box/disks{
+	pixel_x = -1;
+	pixel_y = 3
+	},
+/obj/item/storage/box/disks{
+	pixel_x = -1;
+	pixel_y = 3
+	},
+/obj/item/storage/pill_bottle/mannitol{
+	pixel_x = -8;
+	pixel_y = 9
+	},
+/obj/item/storage/pill_bottle/mannitol{
+	pixel_x = -8;
+	pixel_y = 9
+	},
+/obj/item/storage/pill_bottle/mutadone{
+	pixel_x = -8;
+	pixel_y = -9
+	},
+/obj/item/storage/pill_bottle/mutadone{
+	pixel_x = -8;
+	pixel_y = -9
+	},
+/turf/open/floor/plasteel/dark,
+/area/medical/genetics)
 "jNn" = (
 /obj/machinery/light/small,
 /obj/structure/chair/comfy/black{
@@ -54434,6 +54765,18 @@
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/hallway/secondary/exit)
+"jRp" = (
+/obj/machinery/door/airlock/medical/glass{
+	name = "Medbay Storage";
+	req_access_txt = "5"
+	},
+/obj/effect/turf_decal/lumos/tile/blue/fulltile,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel/white,
+/area/medical/storage)
 "jRq" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -54446,11 +54789,11 @@
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "jSb" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 9
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
@@ -54492,34 +54835,10 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/medical/medbay/lobby)
 "jTX" = (
-/obj/structure/table,
-/obj/item/storage/pill_bottle/mannitol{
-	pixel_x = -8;
-	pixel_y = 9
-	},
-/obj/item/storage/pill_bottle/mannitol{
-	pixel_x = -8;
-	pixel_y = 9
-	},
-/obj/item/storage/pill_bottle/mutadone{
-	pixel_x = -8;
-	pixel_y = -9
-	},
-/obj/item/storage/pill_bottle/mutadone{
-	pixel_x = -8;
-	pixel_y = -9
-	},
-/obj/item/storage/box/disks{
-	pixel_x = -1;
-	pixel_y = 3
-	},
-/obj/item/storage/box/disks{
-	pixel_x = -1;
-	pixel_y = 3
-	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
+/obj/machinery/dna_scannernew,
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics)
 "jUb" = (
@@ -54564,6 +54883,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"jYH" = (
+/obj/machinery/vending/cola/space_up,
+/turf/open/floor/plasteel/dark,
+/area/hallway/primary/central)
 "jYL" = (
 /turf/closed/wall/r_wall,
 /area/crew_quarters/heads/hor)
@@ -54656,6 +54979,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"kep" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "ker" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -54685,6 +55014,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/railing/corner,
 /turf/open/floor/plasteel,
 /area/medical/cryo)
 "kgH" = (
@@ -54728,6 +55058,7 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
+/obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "kkH" = (
@@ -54806,6 +55137,12 @@
 "ktA" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "ktD" = (
@@ -55224,9 +55561,6 @@
 /turf/open/floor/plasteel,
 /area/storage/art)
 "lmr" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics)
 "lnk" = (
@@ -55265,9 +55599,6 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "lsG" = (
-/obj/structure/chair{
-	dir = 1
-	},
 /obj/structure/window/reinforced,
 /obj/effect/turf_decal/lumos/tile/blue/checker{
 	dir = 4
@@ -55294,9 +55625,6 @@
 /turf/open/floor/plasteel,
 /area/storage/art)
 "lun" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/shower{
 	dir = 4
 	},
@@ -55402,6 +55730,18 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"lJx" = (
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -23
+	},
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
+	},
+/obj/machinery/chem_master,
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "lJS" = (
 /obj/machinery/door/poddoor/incinerator_atmos_main,
 /turf/open/floor/engine/vacuum,
@@ -55440,7 +55780,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/medical/medbay/front_office)
 "lPr" = (
 /obj/item/kirbyplants{
@@ -55470,6 +55810,18 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/explab)
+"lRG" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/floor/plasteel/stairs/right{
+	dir = 4
+	},
+/area/medical/cryo)
 "lRY" = (
 /obj/structure/barricade/wooden{
 	max_integrity = 10;
@@ -55560,14 +55912,9 @@
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
 "mfY" = (
-/obj/machinery/chem_master,
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -23
-	},
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
+/obj/effect/landmark/start/medical_doctor,
+/obj/structure/chair/office/light{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -55697,6 +56044,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"mww" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/medical/genetics)
 "mwV" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 9
@@ -55781,6 +56137,14 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
+"mEb" = (
+/obj/structure/railing/corner,
+/obj/effect/turf_decal/stripes/corner,
+/obj/machinery/vending/medical{
+	pixel_x = -2
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/sleeper)
 "mGw" = (
 /obj/machinery/door/airlock/security{
 	name = "Labor Shuttle";
@@ -55805,10 +56169,11 @@
 /obj/effect/turf_decal/lumos/tile/blue/checker{
 	dir = 4
 	},
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/structure/table/glass,
+/obj/item/reagent_containers/food/drinks/soda_cans/dr_gibb{
+	pixel_x = -3;
+	pixel_y = 2
 	},
-/obj/structure/chair,
 /turf/open/floor/plasteel/cafeteria,
 /area/medical/medbay/lobby)
 "mHU" = (
@@ -55830,8 +56195,20 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/effect/landmark/start/paramedic,
 /turf/open/floor/plasteel,
 /area/medical/cryo)
+"mLy" = (
+/obj/machinery/door/window/eastleft{
+	name = "Medical Delivery";
+	req_access_txt = "5"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/medical/medbay/front_office)
 "mNi" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -55927,17 +56304,12 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "mSs" = (
-/obj/structure/table/glass,
-/obj/item/reagent_containers/glass/beaker/cryoxadone{
-	pixel_x = 7;
-	pixel_y = 1
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/obj/item/reagent_containers/glass/beaker/cryoxadone{
-	pixel_x = 7;
-	pixel_y = 1
-	},
-/turf/open/floor/plasteel,
-/area/medical/cryo)
+/mob/living/carbon/monkey,
+/turf/open/floor/grass,
+/area/medical/genetics)
 "mTG" = (
 /obj/effect/turf_decal/lumos/tile/bar/checker,
 /obj/structure/table,
@@ -56013,16 +56385,15 @@
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
 	dir = 1
 	},
+/obj/structure/railing/corner{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/medical/cryo)
 "nac" = (
-/obj/structure/closet/secure_closet/chemical,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
@@ -56154,8 +56525,10 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "nmw" = (
@@ -56204,22 +56577,20 @@
 /turf/closed/wall,
 /area/crew_quarters/abandoned_gambling_den)
 "nvk" = (
-/obj/machinery/shower{
-	dir = 4
-	},
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -22
-	},
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/lumos/shower,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel/white,
-/area/medical/sleeper)
+/area/medical/chemistry)
 "nws" = (
 /obj/machinery/power/apc/auto_name/south,
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
+"nwT" = (
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "nwW" = (
 /obj/structure/trash_pile,
 /turf/open/floor/plating,
@@ -56374,6 +56745,23 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/hallway/secondary/entry)
+"nIl" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/research{
+	name = "Genetics Research Access";
+	req_access_txt = "9"
+	},
+/obj/effect/turf_decal/lumos/tile/purple/fulltile,
+/turf/open/floor/plasteel/dark,
+/area/medical/genetics)
 "nIB" = (
 /obj/machinery/door/airlock{
 	id_tag = "barbath";
@@ -56428,6 +56816,14 @@
 	},
 /turf/open/floor/plating,
 /area/science/explab)
+"nMS" = (
+/obj/item/reagent_containers/rag{
+	pixel_x = -4;
+	pixel_y = 8
+	},
+/obj/structure/table,
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "nNF" = (
 /obj/structure/chair/comfy/black,
 /turf/open/floor/plating{
@@ -56799,12 +57195,28 @@
 	},
 /turf/open/floor/wood,
 /area/hallway/primary/central)
+"ouR" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/medical/genetics)
+"ovf" = (
+/obj/machinery/atmospherics/components/unary/cryo_cell,
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/medical/cryo)
 "owO" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 10
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/structure/railing/corner{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/medical/cryo)
@@ -56825,6 +57237,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"oyD" = (
+/obj/machinery/door/airlock/medical/glass{
+	name = "Chemistry Lab";
+	req_access_txt = "5; 33"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/lumos/tile/yellow/fulltile,
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "oyN" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
@@ -56835,6 +57264,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/pool)
+"ozX" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/sleeper)
 "oAw" = (
 /obj/structure/window{
 	dir = 1
@@ -56937,17 +57375,19 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/crew_quarters/dorms)
 "oJp" = (
-/obj/structure/table/glass,
-/obj/item/stack/cable_coil/random,
-/obj/item/stack/cable_coil/random,
-/obj/item/stack/sheet/mineral/plasma,
-/obj/item/stack/sheet/mineral/plasma,
-/obj/item/reagent_containers/glass/bottle/epinephrine,
 /obj/machinery/requests_console{
 	department = "Chemistry";
 	departmentType = 2;
 	pixel_x = 30;
 	receive_ore_updates = 1
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 4
+	},
+/obj/structure/table/glass,
+/obj/machinery/reagentgrinder{
+	pixel_x = -5;
+	pixel_y = 9
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
@@ -57044,6 +57484,19 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/structure/railing/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/sleeper)
+"oTQ" = (
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "oTZ" = (
@@ -57101,7 +57554,9 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "oXc" = (
-/obj/effect/landmark/start/chemist,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "oZc" = (
@@ -57420,9 +57875,23 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
 "pHl" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/open/floor/plasteel,
-/area/medical/cryo)
+/obj/structure/table/glass,
+/obj/item/grenade/chem_grenade,
+/obj/item/grenade/chem_grenade,
+/obj/item/grenade/chem_grenade,
+/obj/item/grenade/chem_grenade,
+/obj/item/screwdriver{
+	pixel_x = -2;
+	pixel_y = 6
+	},
+/obj/item/stack/cable_coil/random,
+/obj/item/stack/cable_coil/random,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 25
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner,
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "pHO" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/structure/sign/poster/contraband/fun_police{
@@ -57461,6 +57930,9 @@
 	},
 /obj/effect/turf_decal/loading_area{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/medical/medbay/lobby)
@@ -57586,7 +58058,7 @@
 	dir = 8;
 	pixel_x = -14
 	},
-/obj/effect/turf_decal/lumos/tile/blue/half,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "pTB" = (
@@ -57710,6 +58182,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "qje" = (
@@ -57718,6 +58193,11 @@
 	},
 /turf/closed/wall,
 /area/quartermaster/miningdock)
+"qjn" = (
+/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/machinery/dna_scannernew,
+/turf/open/floor/plasteel/dark,
+/area/medical/genetics)
 "qkG" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -57751,7 +58231,6 @@
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 1
 	},
-/obj/effect/landmark/start/paramedic,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -57808,6 +58287,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
+"qsa" = (
+/obj/machinery/door/airlock/medical{
+	name = "Medbay Reception";
+	req_access_txt = "5"
+	},
+/obj/effect/turf_decal/lumos/tile/blue/fulltile,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/front_office)
 "qsr" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -57824,6 +58316,12 @@
 /obj/structure/grille/broken,
 /turf/open/space/basic,
 /area/space/nearstation)
+"qvm" = (
+/obj/structure/disposalpipe/junction/flip{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "qxq" = (
 /turf/closed/wall,
 /area/security/range)
@@ -57840,6 +58338,15 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/lumos/tile/blue/checker{
 	dir = 4
+	},
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/medical/medbay/lobby)
@@ -57932,15 +58439,11 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "qLn" = (
-/obj/machinery/computer/med_data{
-	dir = 4
+/obj/machinery/door/airlock/medical{
+	name = "Medbay Reception";
+	req_access_txt = "5"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/blue/fulltile,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "qLR" = (
@@ -57956,7 +58459,6 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/crew_quarters/dorms)
 "qMv" = (
-/obj/effect/landmark/start/medical_doctor,
 /obj/structure/chair/office/light{
 	dir = 8
 	},
@@ -58052,6 +58554,18 @@
 /obj/structure/disposalpipe/broken,
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"qZC" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/medical/genetics/cloning)
 "qZF" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating,
@@ -58180,17 +58694,11 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "rpr" = (
-/mob/living/simple_animal/bot/cleanbot{
-	name = "C.L.E.A.N."
+/obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/white,
-/area/medical/sleeper)
+/turf/open/floor/plasteel/cafeteria,
+/area/medical/medbay/front_office)
 "rqf" = (
 /obj/machinery/light{
 	dir = 1
@@ -58304,6 +58812,21 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"rCF" = (
+/obj/effect/turf_decal/lumos/tile/blue/fulltile,
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/door/airlock/medical/glass{
+	name = "Medbay Storage";
+	req_access_txt = "5"
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/storage)
 "rCT" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -58312,11 +58835,16 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/railing,
+/turf/open/floor/plasteel/stairs/left{
+	dir = 4
+	},
 /area/medical/medbay/front_office)
 "rDu" = (
 /obj/effect/turf_decal/stripes/line{
@@ -58397,6 +58925,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"rOu" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "rOV" = (
 /obj/machinery/camera{
 	c_tag = "Port Hallway 2"
@@ -58488,6 +59028,9 @@
 /obj/effect/turf_decal/lumos/tile/blue/checker{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
 /turf/open/floor/plasteel/cafeteria,
 /area/medical/medbay/lobby)
 "rYg" = (
@@ -58518,6 +59061,24 @@
 /obj/effect/turf_decal/lumos/tile/blue/fulltile,
 /turf/open/floor/plasteel,
 /area/security/brig)
+"sak" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/door/poddoor/preopen{
+	id = "cmoofficesh1";
+	name = "biohazard containment door"
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=4";
+	dir = 4;
+	freq = 1400;
+	location = "Medbay"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/plasticflaps/opaque,
+/turf/open/floor/plasteel,
+/area/medical/medbay/front_office)
 "sax" = (
 /obj/machinery/requests_console{
 	department = "Theatre";
@@ -58541,6 +59102,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"sbS" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
+	},
+/obj/machinery/chem_dispenser/apothecary,
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "scf" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
@@ -58612,6 +59180,9 @@
 /area/security/checkpoint/medical)
 "sgD" = (
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -58851,6 +59422,17 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"sDf" = (
+/obj/machinery/camera{
+	c_tag = "Genetics";
+	dir = 8;
+	network = list("ss13","medbay")
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/medical/genetics)
 "sEi" = (
 /obj/machinery/vr_sleeper{
 	dir = 1
@@ -59139,7 +59721,12 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "tbz" = (
-/obj/machinery/bloodbankgen,
+/obj/machinery/bloodbankgen{
+	pixel_y = -5
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "tbP" = (
@@ -59203,6 +59790,18 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"tjt" = (
+/obj/structure/closet/secure_closet/medical3,
+/obj/item/sensor_device,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/item/storage/box/medipens,
+/obj/item/storage/box/gloves,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/medical/storage)
 "tkB" = (
 /obj/effect/turf_decal/lumos/tile/blue/half,
 /turf/open/floor/plasteel,
@@ -59229,8 +59828,20 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/medical/medbay/lobby)
 "tmf" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics/cloning)
@@ -59291,7 +59902,6 @@
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
 	},
-/obj/effect/landmark/start/paramedic,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -59454,16 +60064,21 @@
 /turf/open/floor/plating,
 /area/maintenance/bar)
 "tFr" = (
-/obj/structure/table,
-/obj/item/storage/box/rxglasses{
-	pixel_x = 3;
-	pixel_y = 3
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
 	},
-/obj/item/storage/box/bodybags,
-/obj/item/pen,
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel/dark,
-/area/medical/genetics/cloning)
+/turf/open/floor/plasteel/white,
+/area/medical/sleeper)
+"tFs" = (
+/obj/structure/bed,
+/obj/item/bedsheet/medical,
+/obj/item/bedsheet/medical,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/iv_drip,
+/turf/open/floor/plasteel/white,
+/area/medical/sleeper)
 "tFO" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 9
@@ -59952,8 +60567,8 @@
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
 "uzZ" = (
-/obj/machinery/vending/wardrobe/medi_wardrobe,
-/turf/open/floor/plasteel/white,
+/obj/structure/closet/crate/freezer/surplus_limbs,
+/turf/open/floor/plasteel,
 /area/medical/storage)
 "uAH" = (
 /turf/open/floor/plasteel/yellowsiding/corner{
@@ -60019,6 +60634,15 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
+"uHT" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/sleeper)
 "uIO" = (
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
@@ -60060,6 +60684,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/closed/wall/r_wall,
 /area/ai_monitored/nuke_storage)
+"uPz" = (
+/obj/effect/landmark/start/medical_doctor,
+/turf/open/floor/plasteel,
+/area/medical/storage)
 "uPT" = (
 /obj/machinery/button/door/incinerator_vent_atmos_aux{
 	pixel_x = 6;
@@ -60146,7 +60774,16 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/light,
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/structure/table,
+/obj/item/storage/box/rxglasses{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/box/bodybags,
+/obj/item/pen,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics/cloning)
 "uZJ" = (
@@ -60344,6 +60981,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"vnc" = (
+/obj/structure/bed,
+/obj/item/bedsheet/medical,
+/obj/machinery/iv_drip,
+/turf/open/floor/plasteel/white,
+/area/medical/sleeper)
 "vnI" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -60475,11 +61118,26 @@
 /obj/effect/turf_decal/lumos/tile/blue/checker{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
+/obj/structure/disposalpipe/junction{
+	dir = 8
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/medical/medbay/lobby)
+"vwy" = (
+/obj/machinery/camera{
+	c_tag = "Sleeper";
+	dir = 4;
+	network = list("ss13","medbay")
+	},
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -22
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/sleeper)
 "vxA" = (
 /obj/machinery/door/airlock/external{
 	name = "Escape Pod Three"
@@ -60532,9 +61190,15 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 10
+	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "vyH" = (
@@ -60783,9 +61447,21 @@
 /turf/open/floor/wood,
 /area/hallway/primary/central)
 "vPb" = (
-/obj/machinery/vending/wardrobe/chem_wardrobe,
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/obj/structure/sink{
+	pixel_y = 28
+	},
+/obj/structure/mirror{
+	pixel_y = 34
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/railing/corner,
+/turf/open/floor/plasteel,
+/area/medical/sleeper)
 "vPs" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -60895,6 +61571,28 @@
 /obj/structure/fans/tiny/invisible,
 /turf/open/space/basic,
 /area/space)
+"weI" = (
+/obj/effect/turf_decal/lumos/tile/blue/checker{
+	dir = 4
+	},
+/obj/machinery/computer/med_data{
+	dir = 1
+	},
+/obj/machinery/button/door{
+	desc = "A remote control switch for the medbay foyer.";
+	id = "MedbayFoyer";
+	name = "Medbay Doors Control";
+	normaldoorcontrol = 1;
+	pixel_y = -24;
+	req_access_txt = "5"
+	},
+/obj/machinery/camera{
+	c_tag = "Medical Reception Desk";
+	dir = 1;
+	network = list("ss13","medbay")
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/medical/medbay/front_office)
 "weM" = (
 /obj/structure/table,
 /obj/item/nanite_remote,
@@ -61009,6 +61707,16 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"wlQ" = (
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/railing,
+/turf/open/floor/plasteel/stairs/left{
+	dir = 4
+	},
+/area/medical/cryo)
 "wor" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1;
@@ -61405,6 +62113,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
+"wZB" = (
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/sleeper)
 "wZI" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -61716,9 +62440,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/bed/roller,
-/obj/effect/turf_decal/bot,
-/obj/machinery/iv_drip,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -61816,6 +62537,19 @@
 /obj/machinery/vending/wardrobe/curator_wardrobe,
 /turf/open/floor/carpet,
 /area/library)
+"xFf" = (
+/obj/structure/bed,
+/obj/item/bedsheet/medical,
+/obj/item/bedsheet/medical,
+/obj/machinery/iv_drip,
+/obj/structure/railing/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/sleeper)
 "xFF" = (
 /obj/machinery/light_switch{
 	pixel_x = 28
@@ -61845,22 +62579,18 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "xMz" = (
-/obj/structure/window/reinforced,
-/mob/living/carbon/monkey,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/machinery/computer/scan_consolenew{
 	dir = 1
 	},
-/turf/open/floor/grass,
+/turf/open/floor/plasteel/dark,
 /area/medical/genetics)
 "xNE" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/closet/l3closet,
-/turf/open/floor/plasteel/white,
+/obj/effect/landmark/start/paramedic,
+/turf/open/floor/plasteel,
 /area/medical/storage)
 "xOj" = (
 /obj/structure/sign/poster/contraband/eat{
@@ -62106,6 +62836,13 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/bar)
+"ymc" = (
+/obj/machinery/camera{
+	c_tag = "Central Hallway South-East";
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 
 (1,1,1) = {"
 cNd
@@ -93863,7 +94600,7 @@ buY
 viG
 qNZ
 aJq
-aXf
+bBu
 bCv
 bDP
 bCv
@@ -94119,9 +94856,9 @@ buX
 buX
 viG
 qNZ
-aJq
+iTU
 bBy
-bzs
+rOu
 bDO
 bFl
 bGH
@@ -94376,11 +95113,11 @@ buZ
 fUj
 bqH
 wgq
-iTU
+bkV
 bBA
-bCz
-bDQ
-rkg
+bzs
+bzs
+nwT
 vyA
 rkg
 qGe
@@ -94635,7 +95372,7 @@ bqH
 aJq
 wES
 bBz
-bzs
+jYH
 bzs
 cnE
 bGJ
@@ -94894,8 +95631,8 @@ kPj
 bBB
 eBX
 bzs
-bAw
-eJa
+ism
+grS
 iso
 bJA
 bKG
@@ -95148,10 +95885,10 @@ aJq
 aJq
 aJq
 bAj
-aXf
+qvm
 aKG
 bzs
-jCL
+nMS
 grS
 ium
 bGQ
@@ -95401,13 +96138,13 @@ bpC
 aJq
 aJq
 aJq
+ymc
 aJq
-bxL
 aRt
 xWV
-bKQ
+aXh
 bCA
-bzs
+kep
 cAg
 bDA
 bFx
@@ -95657,16 +96394,16 @@ bfH
 bfG
 bAp
 bAp
+bqV
+bAp
+bqV
 bAp
 bAp
 bAp
-bAp
-bAp
-col
-pOj
+sak
 kpr
-bCB
 kpr
+iWI
 kpr
 kpr
 caU
@@ -95905,7 +96642,7 @@ bcq
 bfS
 bfG
 bha
-hbh
+wbE
 wbE
 wbE
 tle
@@ -95920,8 +96657,8 @@ elf
 bwB
 bAp
 byZ
-bDT
-bDW
+mLy
+hzu
 bCF
 bDB
 bFB
@@ -96161,26 +96898,26 @@ aYV
 aYV
 tkB
 bfH
+bsr
 wbE
-wbE
-wbE
-wbE
+bwD
+bwD
 cYz
-wbE
+bwD
 hmk
 bqP
 bqS
 bLX
 mxZ
-bui
-oXc
+mxZ
+mxZ
 bww
 bwZ
 byY
 bzH
 bAW
 bCE
-bFy
+jex
 bFz
 kpr
 caU
@@ -96418,24 +97155,24 @@ aYV
 aYV
 tkB
 bfH
-wbE
+bui
 wbE
 gHV
 mHy
-tle
-wbE
+bBb
+bCz
 lsG
 bpM
 bqT
 bFD
 brX
 nac
-bvl
+bFD
 bwE
-bxc
-bzb
+bAp
+bDT
 bzK
-bBb
+bDW
 cpG
 gkD
 bId
@@ -96677,21 +97414,21 @@ tkB
 brB
 wbE
 wbE
-gHV
-mHy
+wbE
+wbE
 bvw
 bxb
 lsG
 bqP
-bqS
-bLX
-mxZ
+bDZ
+bKQ
+nvk
 bwy
 oXc
 bza
-bqT
+dwA
 jSb
-bCG
+ozX
 bBc
 bCH
 bFt
@@ -96934,21 +97671,21 @@ tkB
 brB
 wbE
 wbE
-gHV
-mHy
+wbE
+wbE
 bvy
 bxT
 lsG
 bpM
 bqV
 hFP
-kXT
+pHl
 bwA
 oJp
 bAl
-bAp
-bNZ
-bCG
+bqT
+gHt
+oTQ
 bBc
 bCJ
 gZG
@@ -97189,24 +97926,24 @@ aYV
 aYV
 bgY
 bfH
+bui
 wbE
-wbE
-gHV
-mHy
-tle
-wbE
+bxc
+bzb
+bBb
+bCB
 lsG
 pIg
 bAp
 bAp
 bAp
-bAp
+oyD
 bAp
 bAp
 bAp
 oTJ
-bCG
-bBc
+wZB
+rCF
 bFu
 jex
 uzZ
@@ -97446,26 +98183,26 @@ aYV
 aYV
 tkB
 bfH
+bun
 wbE
-wbE
-wbE
-wbE
+bxL
+bxL
 gcj
 qBa
-qBa
+bDQ
 rYa
 bsy
 tvj
 bvh
 bsN
-bAp
+qsa
 bze
 bBP
-bNZ
-bCG
+hjD
+dTC
 bBc
 xNE
-bDD
+jex
 bFK
 kpr
 caU
@@ -97704,7 +98441,7 @@ aYV
 bet
 bfG
 bhe
-bli
+xrW
 xrW
 xrW
 jTe
@@ -97715,14 +98452,14 @@ bqX
 ssm
 dLb
 bug
-bAp
+ejD
 vPb
 hdo
-bNZ
+hbs
 bCG
-bDZ
+bBc
 bCK
-bFy
+uPz
 bFF
 kpr
 caU
@@ -97970,17 +98707,17 @@ eMx
 bpO
 bDT
 bss
+rpr
+weI
 bDT
 bDT
 bDT
-bDT
-bDT
-bNZ
+dng
 bzU
 bDW
 bCS
 bDE
-bFK
+tjt
 kpr
 caU
 bzs
@@ -98225,18 +98962,18 @@ qrm
 svE
 hhi
 iHI
+bDT
 bAs
-bsr
 qLn
-bwD
-nvk
+bAs
+bDT
 cZP
 bAs
 bNZ
 bCQ
 bDW
-bDW
-bDW
+bBc
+jRp
 bDW
 kpr
 caU
@@ -98483,17 +99220,17 @@ boi
 bpw
 iwg
 bxQ
-wkm
-wkm
+col
+tFr
 bwG
-wkm
+vwy
 wkm
 bxQ
 bNZ
 bzW
 bGR
 bCT
-bGR
+uHT
 bIj
 xvR
 caU
@@ -98741,7 +99478,7 @@ bpv
 eyW
 bAr
 bBK
-rpr
+bBK
 bwF
 bBK
 bBK
@@ -98749,7 +99486,7 @@ bBQ
 bOk
 bzV
 nlV
-bzf
+nlV
 hap
 bIi
 xvR
@@ -99005,8 +99742,8 @@ wkm
 bxQ
 wkm
 bCM
-wkm
-ghS
+bFv
+bFv
 bFv
 bIl
 xvR
@@ -99253,10 +99990,10 @@ rlS
 iIj
 jHZ
 mta
-bAs
+bDT
 bxS
 bxS
-wkm
+eiE
 bxS
 bzh
 bAs
@@ -99264,7 +100001,7 @@ eSO
 bCL
 bxO
 fGa
-duL
+fGa
 bIk
 xvR
 caU
@@ -99517,12 +100254,12 @@ bxV
 bxV
 bTk
 bTk
-oBB
+mEb
 bCO
 bBn
-oBB
-nko
-xvR
+xFf
+tFs
+vnc
 xvR
 bUZ
 bna
@@ -99743,7 +100480,7 @@ aGL
 aIg
 aJH
 aKR
-aKR
+bli
 aWd
 aOP
 aJI
@@ -99774,15 +100511,15 @@ bwJ
 bxU
 bzi
 bTk
-mSs
+oBB
 bCN
 bEa
-pHl
+oBB
 nko
-bAw
+xtF
 bJP
-bZO
-bAw
+xtF
+caK
 afF
 bNd
 bNd
@@ -100031,13 +100768,13 @@ hrb
 lzG
 mTO
 bTk
-hfj
+ovf
 dOd
 bEd
 fmv
 nko
-xtF
-xtF
+sbS
+lJx
 xtF
 xtF
 xtF
@@ -101060,8 +101797,8 @@ bxX
 bTk
 bTk
 oBB
-bCO
-bBn
+lRG
+wlQ
 oBB
 bGV
 bIr
@@ -101312,8 +102049,8 @@ gok
 tXq
 bzl
 ecI
+mww
 ecI
-bvo
 bzc
 bJG
 bBL
@@ -101825,11 +102562,11 @@ aSO
 gok
 brj
 jTX
-bBd
+lmr
 bul
 bvp
 bzm
-bJG
+qjn
 tbz
 tjo
 bBw
@@ -102081,12 +102818,12 @@ bfL
 bpH
 bAt
 brj
-bzn
-dIj
+hbh
+ouR
 buq
-tXq
-nTb
-nTb
+sDf
+guI
+jMR
 bFO
 bFO
 bFO
@@ -102339,11 +103076,11 @@ bpG
 rCT
 tXq
 bsv
-ecI
+gfo
 bum
-bun
-bEh
-tFr
+tXq
+nIl
+brj
 bFO
 bCY
 kaR
@@ -102595,11 +103332,11 @@ bpE
 bxf
 brc
 tXq
-brj
-brj
+mSs
+aQn
 but
 tXq
-bEh
+fXw
 uYb
 bFO
 bCZ
@@ -103113,7 +103850,7 @@ bsK
 oem
 bvs
 bEh
-bEh
+qZC
 gdi
 bFO
 bDa

--- a/_maps/map_files/BoxStation/BoxStation_Lumos.dmm
+++ b/_maps/map_files/BoxStation/BoxStation_Lumos.dmm
@@ -17667,6 +17667,9 @@
 "aQn" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /mob/living/carbon/monkey,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
 /turf/open/floor/grass,
 /area/medical/genetics)
 "aQp" = (
@@ -26498,9 +26501,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/front_office)
 "bop" = (
@@ -27510,7 +27510,7 @@
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/window/eastright{
-	dir = 1;
+	dir = 2;
 	name = "Chemistry Desk";
 	req_access_txt = "33"
 	},
@@ -27545,7 +27545,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/front_office)
 "bqX" = (
@@ -28701,9 +28700,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics/cloning)
 "bug" = (
@@ -28803,9 +28799,6 @@
 	dir = 5
 	},
 /obj/effect/turf_decal/stripes/line,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics/cloning)
 "bus" = (
@@ -28825,6 +28818,9 @@
 	dir = 9
 	},
 /mob/living/carbon/monkey,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
 /turf/open/floor/grass,
 /area/medical/genetics)
 "buu" = (
@@ -29658,8 +29654,20 @@
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
 	},
-/obj/machinery/chem_master,
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
+/obj/structure/table/glass,
+/obj/item/storage/box/beakers{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/storage/box/beakers{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/dropper,
+/obj/item/reagent_containers/dropper,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bwF" = (
@@ -31042,9 +31050,6 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "bzU" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
-	},
 /obj/machinery/airalarm{
 	dir = 1;
 	pixel_y = -22
@@ -31852,19 +31857,10 @@
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "bBL" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/railing/corner{
-	dir = 8
-	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/obj/machinery/bloodbankgen{
-	pixel_x = 7;
-	pixel_y = -5
-	},
+/obj/machinery/bloodbankgen,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bBM" = (
@@ -32230,21 +32226,16 @@
 /obj/machinery/airalarm{
 	pixel_y = 32
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
 	},
-/obj/structure/sink{
-	pixel_x = 8;
-	pixel_y = 26
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/effect/landmark/start/medical_doctor,
+/obj/machinery/vending/wardrobe/chem_wardrobe,
 /turf/open/floor/plasteel,
 /area/medical/storage)
 "bCG" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
@@ -33481,6 +33472,7 @@
 	dir = 4;
 	pixel_x = -24
 	},
+/obj/effect/turf_decal/lumos/shower,
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
 "bFC" = (
@@ -34580,6 +34572,10 @@
 /obj/effect/spawner/structure/window,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "orsh";
+	name = "operating room shutters"
+	},
 /turf/open/floor/plating,
 /area/medical/surgery)
 "bIv" = (
@@ -35062,8 +35058,10 @@
 	dir = 10
 	},
 /obj/item/kirbyplants{
-	icon_state = "plant-10"
+	icon_state = "plant-10";
+	pixel_y = 6
 	},
+/obj/structure/window/reinforced,
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics)
 "bJH" = (
@@ -35162,6 +35160,7 @@
 /area/science/research)
 "bJU" = (
 /obj/machinery/vending/wardrobe/science_wardrobe,
+/obj/machinery/light,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "bJV" = (
@@ -35425,6 +35424,7 @@
 /area/construction)
 "bKB" = (
 /obj/machinery/door/window/northleft{
+	dir = 2;
 	name = "Virology Desk";
 	req_access_txt = "39"
 	},
@@ -35571,7 +35571,23 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "bKQ" = (
-/obj/machinery/vending/wardrobe/chem_wardrobe,
+/obj/structure/table/glass,
+/obj/machinery/reagentgrinder{
+	pixel_x = -8;
+	pixel_y = 6
+	},
+/obj/item/stack/sheet/mineral/plasma{
+	pixel_x = 5;
+	pixel_y = 4
+	},
+/obj/item/stack/sheet/mineral/plasma{
+	pixel_x = 5;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/glass/bottle/epinephrine{
+	pixel_x = 10;
+	pixel_y = -1
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bKR" = (
@@ -36016,14 +36032,12 @@
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
 "bMc" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/mob/living/carbon/monkey,
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/front_office)
+/turf/open/floor/grass,
+/area/medical/genetics)
 "bMd" = (
 /obj/machinery/airalarm{
 	dir = 1;
@@ -36440,9 +36454,19 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/virology)
 "bNi" = (
-/obj/machinery/chem_master,
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 1
+	},
+/obj/structure/table/glass,
+/obj/item/grenade/chem_grenade,
+/obj/item/grenade/chem_grenade,
+/obj/item/grenade/chem_grenade,
+/obj/item/grenade/chem_grenade,
+/obj/item/stack/cable_coil/random,
+/obj/item/stack/cable_coil/random,
+/obj/item/screwdriver{
+	pixel_x = -2;
+	pixel_y = 6
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
@@ -36571,6 +36595,10 @@
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#c1caff"
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
@@ -39050,6 +39078,10 @@
 /obj/machinery/atmospherics/components/unary/thermomachine/heater{
 	dir = 8
 	},
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#c1caff"
+	},
 /turf/open/floor/engine,
 /area/science/mixing)
 "bUs" = (
@@ -40863,28 +40895,12 @@
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "bZa" = (
-/obj/structure/table/glass,
 /obj/machinery/camera{
 	c_tag = "Medbay Cryogenics";
 	network = list("ss13","medbay")
 	},
-/obj/item/reagent_containers/glass/beaker/cryoxadone{
-	pixel_x = -5;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/glass/beaker/cryoxadone{
-	pixel_x = -5;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/glass/beaker/cryoxadone{
-	pixel_x = 5;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/glass/beaker/cryoxadone{
-	pixel_x = 5;
-	pixel_y = 2
-	},
 /obj/structure/railing/corner,
+/obj/machinery/atmospherics/components/unary/cryo_cell,
 /turf/open/floor/plasteel,
 /area/medical/cryo)
 "bZc" = (
@@ -51098,12 +51114,8 @@
 "dwA" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "chemsh";
-	name = "chemistry shutters"
-	},
 /obj/machinery/door/window/eastright{
-	dir = 2;
+	dir = 1;
 	name = "Chemistry Desk";
 	req_access_txt = "33"
 	},
@@ -51326,7 +51338,6 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "dTC" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
@@ -51335,6 +51346,12 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/railing/corner{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
@@ -51573,20 +51590,10 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
 "elf" = (
-/obj/structure/table/glass,
-/obj/item/grenade/chem_grenade,
-/obj/item/grenade/chem_grenade,
-/obj/item/grenade/chem_grenade,
-/obj/item/grenade/chem_grenade,
-/obj/item/stack/cable_coil/random,
-/obj/item/stack/cable_coil/random,
-/obj/item/screwdriver{
-	pixel_x = -2;
-	pixel_y = 6
-	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
+/obj/structure/closet/wardrobe/chemistry_white,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "elh" = (
@@ -51695,6 +51702,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/front_office)
+"ezb" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/obj/structure/railing/corner,
+/turf/open/floor/plasteel/white,
+/area/medical/sleeper)
 "ezF" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
@@ -52003,6 +52017,16 @@
 /obj/structure/closet/radiation,
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
+"fky" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
+	},
+/turf/open/floor/engine,
+/area/science/mixing)
 "flc" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
 	dir = 8
@@ -52029,11 +52053,11 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
 "fmv" = (
-/obj/structure/table/reinforced,
 /obj/item/wrench/medical,
 /obj/structure/railing/corner{
 	dir = 1
 	},
+/obj/structure/table/glass,
 /turf/open/floor/plasteel,
 /area/medical/cryo)
 "fmR" = (
@@ -52811,6 +52835,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"gvR" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "gvX" = (
 /turf/open/floor/plasteel/yellowsiding,
 /area/crew_quarters/fitness/pool)
@@ -52957,8 +52987,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 1
+	},
+/obj/structure/railing/corner{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
@@ -53168,12 +53201,7 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "gXv" = (
-/obj/machinery/vending/medical{
-	pixel_y = -6
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
+/obj/machinery/vending/medical,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "gXE" = (
@@ -53327,7 +53355,23 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "hfj" = (
-/obj/machinery/atmospherics/components/unary/cryo_cell,
+/obj/structure/table/glass,
+/obj/item/reagent_containers/glass/beaker/cryoxadone{
+	pixel_x = -5;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/glass/beaker/cryoxadone{
+	pixel_x = -5;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/glass/beaker/cryoxadone{
+	pixel_x = 5;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/glass/beaker/cryoxadone{
+	pixel_x = 5;
+	pixel_y = 2
+	},
 /turf/open/floor/plasteel,
 /area/medical/cryo)
 "hfp" = (
@@ -53405,11 +53449,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /obj/structure/railing/corner{
 	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
@@ -53680,27 +53724,12 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "hFP" = (
-/obj/structure/table/glass,
-/obj/item/stack/sheet/mineral/plasma{
-	pixel_x = 5;
-	pixel_y = 4
-	},
-/obj/item/stack/sheet/mineral/plasma{
-	pixel_x = 5;
-	pixel_y = 4
-	},
-/obj/item/reagent_containers/glass/bottle/epinephrine{
-	pixel_x = 10;
-	pixel_y = -1
-	},
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 23
 	},
-/obj/machinery/reagentgrinder{
-	pixel_x = -8;
-	pixel_y = 6
-	},
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "hGH" = (
@@ -53743,18 +53772,15 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/front_office)
 "hKk" = (
-/obj/structure/table,
 /obj/machinery/cell_charger,
 /obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
+/obj/structure/table/glass,
 /turf/open/floor/plasteel,
 /area/medical/cryo)
 "hKs" = (
@@ -53845,12 +53871,9 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "hRa" = (
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
-	},
-/turf/open/floor/engine,
-/area/science/mixing)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/medical/chemistry)
 "hRI" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -54188,6 +54211,10 @@
 /area/hallway/secondary/entry)
 "iFz" = (
 /obj/effect/spawner/structure/window,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "orsh";
+	name = "operating room shutters"
+	},
 /turf/open/floor/plating,
 /area/medical/surgery)
 "iHI" = (
@@ -54517,6 +54544,7 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/plasteel,
 /area/medical/storage)
 "jez" = (
@@ -55495,6 +55523,12 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
 	},
+/obj/machinery/button/door{
+	id = "orsh";
+	name = "Operating Room Shutters";
+	pixel_x = 26;
+	req_access_txt = "5"
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "ktD" = (
@@ -55803,10 +55837,10 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "kXT" = (
-/obj/structure/closet/wardrobe/chemistry_white,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
+/obj/machinery/chem_master,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "kYk" = (
@@ -56559,8 +56593,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/landmark/start/paramedic,
-/obj/machinery/atmospherics/pipe/manifold/general/hidden,
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/medical/cryo)
 "mLy" = (
@@ -57174,9 +57209,6 @@
 /area/hydroponics)
 "nLL" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics/cloning)
 "nMr" = (
@@ -57344,6 +57376,12 @@
 /obj/effect/turf_decal/lumos/tile/yellow/fulltile,
 /turf/open/floor/plasteel,
 /area/security/brig)
+"nXg" = (
+/obj/structure/railing,
+/turf/open/floor/plasteel/stairs/left{
+	dir = 4
+	},
+/area/medical/sleeper)
 "nXT" = (
 /turf/open/floor/wood{
 	icon_state = "wood-broken4"
@@ -57638,8 +57676,8 @@
 /obj/structure/railing/corner{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/general/hidden{
-	dir = 10
+/obj/machinery/atmospherics/pipe/manifold/general/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/medical/cryo)
@@ -57814,20 +57852,8 @@
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 4
 	},
-/obj/structure/table/glass,
-/obj/item/storage/box/beakers{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/storage/box/beakers{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/dropper,
-/obj/item/reagent_containers/dropper,
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
+/obj/machinery/chem_master,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "oKh" = (
@@ -57923,16 +57949,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/structure/railing/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/structure/railing{
 	dir = 1
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/stairs/right{
+	dir = 4
+	},
 /area/medical/sleeper)
 "oTQ" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
@@ -58337,8 +58359,7 @@
 	pixel_x = 25
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "pHO" = (
@@ -58645,6 +58666,7 @@
 "qjn" = (
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/machinery/dna_scannernew,
+/obj/structure/window/reinforced,
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics)
 "qkG" = (
@@ -60164,12 +60186,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "tbz" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/table{
-	pixel_y = -5
-	},
+/obj/structure/table,
 /obj/item/stack/packageWrap,
 /obj/item/stack/packageWrap,
 /obj/item/pen,
@@ -63148,6 +63165,7 @@
 /obj/machinery/computer/scan_consolenew{
 	dir = 1
 	},
+/obj/structure/window/reinforced,
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics)
 "xNE" = (
@@ -98254,9 +98272,9 @@ pHl
 bwA
 oJp
 bAl
-bqV
+hRa
 gHt
-oTQ
+ezb
 bBc
 bCJ
 gZG
@@ -98513,8 +98531,8 @@ bAp
 bAp
 bAp
 oTJ
-oTQ
-bBc
+nXg
+bDW
 xNE
 rCF
 uzZ
@@ -102101,7 +102119,7 @@ uJi
 uJi
 uJi
 uJi
-bMc
+bol
 bqW
 bTk
 iZB
@@ -103903,7 +103921,7 @@ bpE
 bxf
 brc
 tXq
-mSs
+bMc
 aQn
 but
 tXq
@@ -112147,8 +112165,8 @@ bOH
 wkN
 vzp
 vzp
-hRa
-vzp
+jAg
+fky
 bEs
 mRe
 oHU
@@ -112651,7 +112669,7 @@ cfy
 fzX
 bED
 bFX
-bFU
+gvR
 bGF
 bKa
 bFU

--- a/_maps/map_files/BoxStation/BoxStation_Lumos.dmm
+++ b/_maps/map_files/BoxStation/BoxStation_Lumos.dmm
@@ -12788,6 +12788,9 @@
 	pixel_x = -4;
 	pixel_y = 13
 	},
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 8
+	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/hor)
 "aDI" = (
@@ -14730,6 +14733,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "aIc" = (
@@ -14749,7 +14754,11 @@
 	dir = 10
 	},
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/research)
 "aIf" = (
 /obj/structure/disposalpipe/segment,
@@ -14970,7 +14979,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/white/side{
-	dir = 5
+	dir = 4
 	},
 /area/science/research)
 "aIM" = (
@@ -15966,7 +15975,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/science/storage)
 "aLd" = (
 /obj/structure/table,
@@ -16097,6 +16106,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "aLu" = (
@@ -21797,6 +21807,7 @@
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/green/filled/corner,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bam" = (
@@ -22223,6 +22234,7 @@
 	name = "Hydroponics";
 	req_access_txt = "35"
 	},
+/obj/effect/turf_decal/lumos/tile/green/fulltile,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bbD" = (
@@ -23067,7 +23079,7 @@
 /area/maintenance/aft)
 "bdQ" = (
 /obj/machinery/vending/assist,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/science/mixing)
 "bdR" = (
 /obj/structure/cable{
@@ -23877,10 +23889,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
 "bfR" = (
 /obj/structure/table/reinforced,
@@ -23917,13 +23932,13 @@
 /obj/item/kirbyplants{
 	icon_state = "plant-13"
 	},
-/obj/effect/turf_decal/lumos/tile/purple/fullcorner{
-	dir = 1
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bfX" = (
-/obj/effect/turf_decal/lumos/tile/purple/half,
+/obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bfY" = (
@@ -23931,26 +23946,28 @@
 	name = "Station Intercom (General)";
 	pixel_y = -29
 	},
-/obj/effect/turf_decal/lumos/tile/purple/half,
+/obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bfZ" = (
 /obj/structure/sign/warning/securearea{
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/lumos/tile/purple/half,
+/obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bga" = (
 /obj/machinery/light,
-/obj/effect/turf_decal/lumos/tile/purple/half,
+/obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bgb" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-10"
 	},
-/obj/effect/turf_decal/lumos/tile/purple/fullcorner,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 6
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bgc" = (
@@ -24078,14 +24095,17 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "bgy" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
@@ -24437,7 +24457,10 @@
 	req_access_txt = "47"
 	},
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/stripes/end{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/research)
 "bhC" = (
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -24607,6 +24630,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "bhW" = (
@@ -24648,11 +24677,11 @@
 	name = "Station Intercom (General)";
 	pixel_x = 29
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 4
-	},
 /obj/structure/disposalpipe/trunk{
 	dir = 8
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 6
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
@@ -24835,7 +24864,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/dark,
 /area/science/research)
 "biS" = (
 /obj/machinery/camera{
@@ -24848,7 +24877,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/dark,
 /area/science/research)
 "biT" = (
 /obj/structure/disposalpipe/segment{
@@ -24857,8 +24886,8 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "biU" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 9
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
@@ -24887,8 +24916,8 @@
 	pixel_y = 24;
 	req_access_txt = "47"
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
@@ -25311,7 +25340,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/dark,
 /area/science/research)
 "bke" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -25343,9 +25372,7 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 4
-	},
+/obj/effect/turf_decal/lumos/tile/purple/fulltile,
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "bkj" = (
@@ -25432,7 +25459,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/dark,
 /area/science/research)
 "bkr" = (
 /obj/machinery/shower{
@@ -25444,7 +25471,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/dark,
 /area/science/research)
 "bks" = (
 /obj/machinery/requests_console{
@@ -25454,9 +25481,8 @@
 	pixel_x = -30;
 	receive_ore_updates = 1
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 8
-	},
+/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "bkv" = (
@@ -25938,30 +25964,24 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/dark,
 /area/science/research)
 "blI" = (
 /obj/machinery/rnd/destructive_analyzer,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /turf/open/floor/plasteel,
 /area/science/lab)
 "blJ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /obj/machinery/rnd/production/protolathe/department/science,
 /turf/open/floor/plasteel,
 /area/science/lab)
 "blK" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /turf/open/floor/plasteel,
 /area/science/lab)
 "blL" = (
 /obj/machinery/holopad,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "blM" = (
@@ -26058,7 +26078,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/stripes/end,
+/turf/open/floor/plasteel/dark,
 /area/science/research)
 "blY" = (
 /obj/structure/closet/emcloset,
@@ -26072,6 +26093,9 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "bma" = (
@@ -26091,9 +26115,7 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 4
-	},
+/obj/effect/turf_decal/lumos/tile/purple/fulltile,
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "bmf" = (
@@ -26445,11 +26467,17 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "bnh" = (
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
@@ -26501,6 +26529,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
 	},
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 1
+	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "bnl" = (
@@ -26527,9 +26558,7 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 4
-	},
+/obj/effect/turf_decal/lumos/tile/purple/fulltile,
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "bnn" = (
@@ -26978,12 +27007,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/science/research)
-"boA" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/lab)
 "boB" = (
 /turf/closed/wall,
 /area/science/lab)
@@ -27067,6 +27090,9 @@
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
 "boM" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 8
+	},
 /turf/open/floor/plasteel/white/corner,
 /area/science/research)
 "boN" = (
@@ -27309,7 +27335,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 4
+	dir = 5
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
@@ -27600,9 +27626,6 @@
 /obj/item/disk/tech_disk,
 /obj/item/disk/design_disk,
 /obj/item/disk/design_disk,
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 8
-	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "bqa" = (
@@ -27644,7 +27667,9 @@
 	id = "rnd2";
 	name = "research lab shutters"
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/white/side{
+	dir = 1
+	},
 /area/science/lab)
 "bqg" = (
 /obj/structure/rack,
@@ -27690,7 +27715,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/white/side{
+	dir = 1
+	},
 /area/science/lab)
 "bql" = (
 /obj/machinery/conveyor{
@@ -28051,8 +28078,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
 	},
+/obj/effect/turf_decal/trimline/purple/filled/corner,
 /turf/open/floor/plasteel/white/side{
-	dir = 9
+	dir = 8
 	},
 /area/science/research)
 "brv" = (
@@ -28421,7 +28449,8 @@
 	name = "Robotics Lab";
 	req_access_txt = "29"
 	},
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/lumos/tile/purple/fulltile,
+/turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "bsx" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
@@ -28452,7 +28481,7 @@
 	pixel_x = -32
 	},
 /turf/open/floor/plasteel/white/side{
-	dir = 5
+	dir = 4
 	},
 /area/science/research)
 "bsA" = (
@@ -28472,7 +28501,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/white/side{
+	dir = 1
+	},
 /area/science/research)
 "bsE" = (
 /obj/structure/cable{
@@ -28489,7 +28520,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
 /area/science/circuit)
 "bsF" = (
 /obj/structure/cable{
@@ -28648,14 +28681,22 @@
 /area/quartermaster/office)
 "bsW" = (
 /obj/machinery/vending/wardrobe/robo_wardrobe,
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 5
+	},
 /area/science/robotics/lab)
 "bsX" = (
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 1
+	},
 /turf/open/floor/plasteel/white/side{
-	dir = 5
+	dir = 4
 	},
 /area/science/research)
 "bsY" = (
@@ -28675,13 +28716,13 @@
 /obj/machinery/camera{
 	c_tag = "Research Division North"
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/white/side,
 /area/science/research)
 "btb" = (
 /obj/structure/noticeboard{
 	pixel_y = 32
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/white/side,
 /area/science/research)
 "btd" = (
 /obj/effect/turf_decal/stripes/line{
@@ -28693,7 +28734,9 @@
 /obj/item/kirbyplants{
 	icon_state = "plant-16"
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/white/corner{
+	dir = 8
+	},
 /area/science/research)
 "btj" = (
 /obj/machinery/vending/assist,
@@ -28822,7 +28865,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/white/side,
 /area/science/research)
 "bty" = (
 /obj/structure/chair{
@@ -28842,7 +28885,7 @@
 /obj/machinery/camera{
 	c_tag = "Research Division West"
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/white/side,
 /area/science/research)
 "btB" = (
 /obj/machinery/computer/bounty{
@@ -28976,12 +29019,7 @@
 	pixel_x = -5;
 	pixel_y = 30
 	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
-"btQ" = (
-/turf/open/floor/plasteel/white/side{
-	dir = 10
-	},
+/turf/open/floor/plasteel/white/side,
 /area/science/research)
 "btR" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
@@ -29002,7 +29040,7 @@
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/white/side,
 /area/science/research)
 "btT" = (
 /obj/structure/railing/corner{
@@ -29016,9 +29054,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"btU" = (
-/turf/open/floor/plasteel/white,
-/area/science/research)
 "btV" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -29176,7 +29211,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/white/side{
+	dir = 1
+	},
 /area/science/research)
 "bup" = (
 /obj/machinery/light,
@@ -29189,7 +29226,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/white/side{
+	dir = 1
+	},
 /area/science/research)
 "buq" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -29219,7 +29258,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/white/corner{
+	dir = 1
+	},
 /area/science/research)
 "but" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -29483,7 +29524,9 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/white/corner{
+	dir = 4
+	},
 /area/science/research)
 "buV" = (
 /obj/effect/turf_decal/stripes/line{
@@ -29540,7 +29583,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/white/side{
+	dir = 1
+	},
 /area/science/research)
 "bvc" = (
 /obj/structure/cable{
@@ -29553,7 +29598,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/white/side{
+	dir = 1
+	},
 /area/science/research)
 "bve" = (
 /obj/structure/cable{
@@ -29568,7 +29615,9 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/white/side{
+	dir = 1
+	},
 /area/science/research)
 "bvg" = (
 /obj/structure/cable{
@@ -29695,9 +29744,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "bvE" = (
-/turf/open/floor/plasteel/white/side{
-	dir = 6
-	},
+/turf/open/floor/plasteel/white/side,
 /area/science/research)
 "bvF" = (
 /obj/machinery/requests_console{
@@ -30555,8 +30602,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white/side{
-	dir = 9
+	dir = 8
 	},
 /area/science/research)
 "bxG" = (
@@ -30632,6 +30682,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/hor)
 "bxQ" = (
@@ -30698,6 +30751,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/turf_decal/lumos/tile/purple/fulltile,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/hor)
 "bxX" = (
@@ -30801,7 +30855,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/security/checkpoint/science)
 "byk" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -31330,8 +31384,11 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white/side{
-	dir = 9
+	dir = 8
 	},
 /area/science/research)
 "bzB" = (
@@ -31371,8 +31428,11 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science)
 "bzE" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel/white/side{
-	dir = 5
+	dir = 4
 	},
 /area/science/research)
 "bzF" = (
@@ -31543,8 +31603,11 @@
 /area/medical/sleeper)
 "bzZ" = (
 /obj/machinery/door/firedoor/heavy,
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white/side{
-	dir = 9
+	dir = 8
 	},
 /area/science/research)
 "bAa" = (
@@ -32286,7 +32349,7 @@
 /area/hallway/primary/central)
 "bBD" = (
 /turf/open/floor/plasteel/white/side{
-	dir = 9
+	dir = 8
 	},
 /area/science/research)
 "bBE" = (
@@ -32303,11 +32366,10 @@
 "bBF" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/item/storage/firstaid/toxin,
-/obj/effect/turf_decal/stripes/line,
 /obj/machinery/airalarm/unlocked{
 	pixel_y = 24
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/science/mixing)
 "bBI" = (
 /obj/machinery/airalarm{
@@ -32488,6 +32550,9 @@
 	},
 /obj/structure/table,
 /obj/machinery/photocopier/faxmachine,
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 1
+	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/hor)
 "bCg" = (
@@ -32856,7 +32921,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/science/storage)
 "bCY" = (
 /obj/structure/closet/secure_closet/medical2,
@@ -32909,7 +32974,7 @@
 	pixel_x = -22
 	},
 /turf/open/floor/plasteel/white/side{
-	dir = 5
+	dir = 4
 	},
 /area/science/research)
 "bDe" = (
@@ -32926,7 +32991,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/science/storage)
 "bDi" = (
 /obj/structure/sign/warning/docking{
@@ -32939,7 +33004,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/science/storage)
 "bDk" = (
 /obj/structure/table,
@@ -32962,8 +33027,11 @@
 	dir = 4;
 	pixel_x = -24
 	},
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 8
+	},
 /turf/open/floor/plasteel/white/side{
-	dir = 5
+	dir = 4
 	},
 /area/science/research)
 "bDm" = (
@@ -32974,8 +33042,8 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bDn" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
+/obj/effect/turf_decal/stripes/end{
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
@@ -33313,7 +33381,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/science/storage)
 "bDZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -33349,7 +33417,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/science/storage)
 "bEd" = (
 /obj/structure/disposalpipe/segment{
@@ -33407,7 +33475,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/stripes/end{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/science/storage)
 "bEh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -33462,7 +33533,7 @@
 	icon_state = "0-4"
 	},
 /turf/open/floor/plasteel/white/side{
-	dir = 5
+	dir = 4
 	},
 /area/science/research)
 "bEr" = (
@@ -33482,31 +33553,29 @@
 /area/science/mixing)
 "bEt" = (
 /obj/machinery/vending/coffee,
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/trimline/purple/filled/line,
+/turf/open/floor/plasteel,
 /area/science/research)
 "bEu" = (
 /obj/structure/closet/bombcloset,
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/science/mixing)
 "bEv" = (
 /obj/structure/closet/bombcloset,
 /obj/machinery/light_switch{
 	pixel_y = 28
 	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/science/mixing)
 "bEw" = (
 /obj/machinery/portable_atmospherics/canister,
 /obj/item/radio/intercom{
 	pixel_y = 25
 	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/science/mixing)
 "bEx" = (
 /obj/machinery/portable_atmospherics/canister,
@@ -33520,21 +33589,23 @@
 	c_tag = "Toxins Lab West";
 	network = list("ss13","rd")
 	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/science/mixing)
 "bEy" = (
 /obj/machinery/portable_atmospherics/pump,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/science/mixing)
 "bEz" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "bEA" = (
@@ -33639,16 +33710,17 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "bEO" = (
 /obj/structure/sign/warning/securearea{
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 8
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "bEQ" = (
 /obj/effect/landmark/start/shaft_miner,
@@ -34025,7 +34097,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/science/storage)
 "bFJ" = (
 /obj/structure/cable{
@@ -34085,20 +34157,22 @@
 /obj/structure/sign/warning/nosmoking{
 	pixel_x = -32
 	},
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 1
+	},
 /turf/open/floor/plasteel/white/side{
-	dir = 5
+	dir = 4
 	},
 /area/science/research)
 "bFS" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
+/obj/effect/turf_decal/stripes/end,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "bFT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "bFU" = (
@@ -34113,11 +34187,17 @@
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 5
 	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "bFX" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 9
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
@@ -34142,7 +34222,7 @@
 /obj/machinery/doppler_array/research/science{
 	dir = 4
 	},
-/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/box,
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "bGe" = (
@@ -34168,7 +34248,7 @@
 "bGk" = (
 /obj/structure/chair/stool,
 /obj/effect/landmark/start/scientist,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/science/mixing)
 "bGl" = (
 /obj/item/assembly/prox_sensor{
@@ -34187,7 +34267,7 @@
 	pixel_y = 2
 	},
 /obj/structure/table/reinforced,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/science/mixing)
 "bGn" = (
 /obj/structure/closet/secure_closet/miner,
@@ -34277,7 +34357,7 @@
 	},
 /obj/item/analyzer,
 /obj/machinery/atmospherics/pipe/layer_manifold,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/science/mixing)
 "bGA" = (
 /obj/machinery/holopad,
@@ -34319,6 +34399,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/turf_decal/stripes/end{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "bGD" = (
@@ -34349,6 +34432,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "bGG" = (
@@ -34361,7 +34448,7 @@
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "bGH" = (
 /obj/structure/cable{
@@ -34395,28 +34482,28 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "bGL" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "bGN" = (
 /obj/structure/cable{
@@ -34539,7 +34626,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/white/side{
-	dir = 5
+	dir = 4
 	},
 /area/science/research)
 "bHd" = (
@@ -34564,7 +34651,7 @@
 	network = list("ss13","rd")
 	},
 /obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/science/storage)
 "bHf" = (
 /obj/structure/showcase/cyborg/old{
@@ -34611,6 +34698,10 @@
 	name = "Toxins Lab";
 	req_access_txt = "7"
 	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "bHo" = (
@@ -34646,8 +34737,8 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/purple/filled/corner,
+/turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "bHt" = (
 /obj/effect/landmark/event_spawn,
@@ -34661,13 +34752,16 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel/white,
 /area/science/mixing)
 "bHv" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/white,
 /area/science/mixing)
 "bHw" = (
 /obj/item/target,
@@ -34777,7 +34871,7 @@
 	},
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plasteel/white/side{
-	dir = 5
+	dir = 4
 	},
 /area/science/research)
 "bHL" = (
@@ -34787,7 +34881,7 @@
 	},
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plasteel/white/side{
-	dir = 9
+	dir = 8
 	},
 /area/science/research)
 "bHM" = (
@@ -34982,6 +35076,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "bIi" = (
@@ -35085,6 +35182,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "bIu" = (
@@ -35101,6 +35199,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
 	},
+/obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "bIw" = (
@@ -35139,7 +35238,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/science/storage)
 "bID" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -35148,8 +35247,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel/white/side{
-	dir = 5
+	dir = 4
 	},
 /area/science/research)
 "bIE" = (
@@ -35228,14 +35330,14 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/science/xenobiology)
 "bIP" = (
 /obj/structure/chair/office/dark{
 	dir = 8
 	},
 /obj/effect/landmark/start/scientist,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/science/xenobiology)
 "bIQ" = (
 /obj/structure/cable{
@@ -35270,7 +35372,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/stripes/end{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/science/mixing)
 "bIT" = (
 /obj/effect/spawner/structure/window,
@@ -35280,11 +35385,11 @@
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "bIU" = (
-/obj/effect/turf_decal/stripes/corner,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 9
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/white,
 /area/science/mixing)
 "bIV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -35293,11 +35398,15 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/white,
 /area/science/mixing)
 "bIW" = (
 /obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/white,
 /area/science/mixing)
 "bIX" = (
 /obj/structure/sign/warning/securearea{
@@ -35419,6 +35528,7 @@
 /turf/open/floor/plating,
 /area/storage/tech)
 "bJo" = (
+/obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/plasteel/white/side{
 	dir = 1
 	},
@@ -35683,18 +35793,21 @@
 /area/medical/medbay/central)
 "bJT" = (
 /obj/machinery/vending/cigarette,
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
 /area/science/research)
 "bJU" = (
 /obj/machinery/vending/wardrobe/science_wardrobe,
 /obj/machinery/light,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/science/mixing)
 "bJV" = (
 /obj/structure/closet/l3closet/scientist{
 	pixel_x = -2
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/science/mixing)
 "bJW" = (
 /obj/item/transfer_valve{
@@ -35719,7 +35832,7 @@
 	receive_ore_updates = 1
 	},
 /obj/structure/table/reinforced,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/science/mixing)
 "bJX" = (
 /obj/item/assembly/signaler{
@@ -35738,11 +35851,11 @@
 	pixel_y = -2
 	},
 /obj/structure/table/reinforced,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/science/mixing)
 "bJY" = (
 /obj/structure/tank_dispenser,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/science/mixing)
 "bJZ" = (
 /obj/item/assembly/timer{
@@ -35760,7 +35873,7 @@
 /obj/item/assembly/timer,
 /obj/structure/table/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/science/mixing)
 "bKa" = (
 /obj/machinery/power/apc{
@@ -35770,6 +35883,9 @@
 	pixel_x = 26
 	},
 /obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "bKb" = (
@@ -35779,23 +35895,23 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "bKc" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "bKd" = (
 /obj/machinery/camera{
 	c_tag = "Toxins Launch Room Access";
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "bKe" = (
 /obj/effect/spawner/structure/window,
@@ -36194,7 +36310,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "bKX" = (
@@ -36213,9 +36328,6 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "bKY" = (
@@ -36226,7 +36338,6 @@
 	plane = -4
 	},
 /obj/structure/table/reinforced,
-/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "bKZ" = (
@@ -36237,9 +36348,6 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "bLa" = (
@@ -36247,14 +36355,15 @@
 	name = "Test Chamber";
 	req_access_txt = "55"
 	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/stripes/end{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "bLb" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "bLc" = (
@@ -36264,7 +36373,6 @@
 /obj/item/clothing/glasses/science,
 /obj/item/clothing/glasses/science,
 /obj/structure/table,
-/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "bLd" = (
@@ -36318,6 +36426,9 @@
 "bLi" = (
 /obj/structure/sign/warning/nosmoking{
 	pixel_x = -32
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
@@ -36642,6 +36753,9 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "bMh" = (
@@ -36649,19 +36763,27 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "bMi" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "bMk" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "bMl" = (
-/obj/effect/turf_decal/stripes/line,
 /obj/structure/table/glass,
 /obj/item/storage/box/syringes{
 	pixel_y = 5
@@ -36678,9 +36800,6 @@
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "bMn" = (
@@ -36689,7 +36808,6 @@
 	desc = "Used to grind things up into raw materials and liquids.";
 	pixel_y = 5
 	},
-/obj/effect/turf_decal/stripes/line,
 /obj/item/stack/sheet/mineral/plasma{
 	pixel_y = 4
 	},
@@ -36708,7 +36826,6 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "bMo" = (
-/obj/effect/turf_decal/stripes/line,
 /obj/machinery/chem_master,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
@@ -36716,12 +36833,10 @@
 /obj/machinery/light_switch{
 	pixel_y = 28
 	},
-/obj/effect/turf_decal/stripes/line,
 /obj/machinery/monkey_recycler,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "bMq" = (
-/obj/effect/turf_decal/stripes/line,
 /obj/structure/table/glass,
 /obj/item/clothing/glasses/science,
 /obj/item/clothing/gloves/color/latex,
@@ -36776,9 +36891,6 @@
 	dir = 4;
 	name = "mix to port"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "bMz" = (
@@ -36798,8 +36910,8 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
+/obj/effect/turf_decal/stripes/end{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
@@ -37077,6 +37189,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "bNo" = (
@@ -37089,6 +37204,9 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 1
 	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "bNp" = (
@@ -37097,6 +37215,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
@@ -37110,6 +37232,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/end{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -37134,11 +37259,11 @@
 /turf/open/floor/engine,
 /area/science/mixing)
 "bNx" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
-/area/science/mixing)
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "bNy" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -37161,6 +37286,9 @@
 /obj/machinery/light{
 	dir = 4;
 	light_color = "#c1caff"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
@@ -37539,6 +37667,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "bOy" = (
@@ -37551,12 +37682,17 @@
 /area/science/misc_lab)
 "bOz" = (
 /obj/structure/chair/stool,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "bOA" = (
 /obj/item/kirbyplants,
-/turf/open/floor/plasteel/white/side{
+/obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 1
+	},
+/obj/effect/turf_decal/trimline/purple/filled/corner,
+/turf/open/floor/plasteel/white/corner{
+	dir = 4
 	},
 /area/science/research)
 "bOB" = (
@@ -37610,9 +37746,6 @@
 	dir = 4;
 	name = "port to mix"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "bOH" = (
@@ -37637,9 +37770,7 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
+/obj/effect/turf_decal/stripes/end,
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "bOJ" = (
@@ -37911,9 +38042,6 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "bPy" = (
@@ -37921,15 +38049,12 @@
 /obj/structure/chair/office/dark{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/science/xenobiology)
 "bPz" = (
 /obj/machinery/light,
 /obj/structure/disposalpipe/segment{
 	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
 	},
 /obj/machinery/smartfridge/extract/preloaded,
 /turf/open/floor/plasteel,
@@ -37937,9 +38062,6 @@
 "bPA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
 	},
 /obj/structure/table/glass,
 /obj/item/storage/box/monkeycubes,
@@ -37960,9 +38082,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -37981,12 +38100,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "bPE" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
 	dir = 8
 	},
@@ -38009,9 +38128,6 @@
 	pixel_y = -29
 	},
 /obj/machinery/light,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
@@ -38023,24 +38139,15 @@
 	pixel_y = -30;
 	receive_ore_updates = 1
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /obj/machinery/portable_atmospherics/canister/bz,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "bPI" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /obj/structure/closet/l3closet/scientist,
 /obj/item/extinguisher,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "bPJ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /obj/structure/closet/l3closet/scientist,
 /obj/item/extinguisher,
 /obj/structure/cable{
@@ -38422,18 +38529,16 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "bQM" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/structure/sign/warning/biohazard{
+	pixel_x = -30
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "bQN" = (
@@ -38443,11 +38548,10 @@
 	dir = 8;
 	network = list("ss13","rd")
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/general/visible,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "bQO" = (
@@ -38918,7 +39022,12 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
 /area/science/xenobiology)
 "bSa" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -39257,7 +39366,6 @@
 /area/medical/virology)
 "bTa" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/sign/warning/biohazard,
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "bTb" = (
@@ -39287,12 +39395,13 @@
 	name = "Containment Pen";
 	req_access_txt = "55"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/violet/hidden{
 	dir = 4
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "bTe" = (
@@ -39305,14 +39414,14 @@
 	id = "xenobio5";
 	name = "containment blast door"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/violet/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/end{
 	dir = 4
 	},
 /turf/open/floor/engine,
@@ -40316,15 +40425,15 @@
 	id = "xenobio1";
 	name = "containment blast door"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/violet/hidden{
 	dir = 4
+	},
+/obj/effect/turf_decal/stripes/end{
+	dir = 8
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
@@ -40336,15 +40445,16 @@
 	name = "Containment Pen";
 	req_access_txt = "55"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/violet/hidden{
 	dir = 4
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "bWn" = (
@@ -40357,9 +40467,6 @@
 	id = "xenobio6";
 	name = "containment blast door"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
@@ -40368,6 +40475,9 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/violet/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/end{
 	dir = 4
 	},
 /turf/open/floor/engine,
@@ -42612,15 +42722,16 @@
 	name = "Containment Pen";
 	req_access_txt = "55"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/violet/hidden{
 	dir = 4
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "cbS" = (
@@ -42635,9 +42746,6 @@
 	id = "xenobio3";
 	name = "containment blast door"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -42647,6 +42755,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/violet/hidden{
 	dir = 4
+	},
+/obj/effect/turf_decal/stripes/end{
+	dir = 8
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
@@ -42660,14 +42771,14 @@
 	id = "xenobio8";
 	name = "containment blast door"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/violet/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/end{
 	dir = 4
 	},
 /turf/open/floor/engine,
@@ -43042,7 +43153,13 @@
 	dir = 1;
 	network = list("ss13","rd")
 	},
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/purple/filled/corner,
+/turf/open/floor/plasteel/white/corner{
+	dir = 4
+	},
 /area/science/xenobiology)
 "ccR" = (
 /obj/machinery/portable_atmospherics/pump,
@@ -43337,11 +43454,11 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "cdN" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 5
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
 	},
-/turf/open/floor/plasteel/white,
-/area/science/lab)
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "cdQ" = (
 /obj/structure/closet/emcloset,
 /obj/effect/decal/cleanable/cobweb,
@@ -44372,14 +44489,17 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
 "cgU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -44581,12 +44701,13 @@
 	name = "Containment Pen";
 	req_access_txt = "55"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/violet/hidden{
 	dir = 4
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "chs" = (
@@ -44601,15 +44722,15 @@
 	id = "xenobio4";
 	name = "containment blast door"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/violet/hidden{
 	dir = 4
+	},
+/obj/effect/turf_decal/stripes/end{
+	dir = 8
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
@@ -44623,6 +44744,9 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "chu" = (
@@ -44634,6 +44758,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
@@ -45043,7 +45170,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 8
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
@@ -45361,7 +45488,7 @@
 /obj/machinery/computer/camera_advanced/xenobio{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/science/xenobiology)
 "cjC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -45574,7 +45701,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/white/corner,
 /area/science/research)
 "ckf" = (
 /obj/machinery/atmospherics/pipe/simple/dark/visible{
@@ -45627,7 +45754,10 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/trimline/purple/filled/line,
+/turf/open/floor/plasteel/white/side{
+	dir = 1
+	},
 /area/science/xenobiology)
 "cko" = (
 /obj/structure/table/glass,
@@ -45956,7 +46086,7 @@
 /area/maintenance/aft)
 "clp" = (
 /obj/machinery/processor/slime,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/science/xenobiology)
 "cls" = (
 /obj/machinery/power/apc/auto_name/north,
@@ -46223,6 +46353,9 @@
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 6
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "cmo" = (
@@ -46235,9 +46368,6 @@
 	dir = 1
 	},
 /obj/structure/reagent_dispensers/water_cooler,
-/obj/effect/turf_decal/lumos/tile/purple/fullcorner{
-	dir = 4
-	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "cmv" = (
@@ -46422,9 +46552,6 @@
 	dir = 1
 	},
 /obj/machinery/vending/coffee,
-/obj/effect/turf_decal/lumos/tile/purple/fullcorner{
-	dir = 8
-	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "cng" = (
@@ -46684,11 +46811,11 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
 "cnR" = (
 /obj/structure/cable{
@@ -46706,9 +46833,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
-	dir = 4
+	dir = 5
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
 "cnU" = (
 /obj/structure/cable{
@@ -46836,7 +46963,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
 "cow" = (
 /obj/structure/cable/yellow{
@@ -46851,7 +46978,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
 "cox" = (
 /obj/effect/turf_decal/stripes/line{
@@ -46866,20 +46993,21 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
 "coy" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
 "coz" = (
 /obj/structure/cable/yellow{
@@ -46894,20 +47022,23 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
 "coA" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
 "coB" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -46920,30 +47051,34 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
 "coC" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
 "coH" = (
 /obj/structure/cable/yellow{
@@ -47057,14 +47192,14 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
 "cpk" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
 "cpl" = (
 /obj/structure/cable{
@@ -47076,7 +47211,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
 "cpm" = (
 /obj/machinery/airalarm{
@@ -47086,21 +47221,21 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
 "cpn" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
 "cpo" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
 "cpp" = (
 /obj/machinery/door/firedoor,
@@ -47109,9 +47244,9 @@
 	pixel_y = -22
 	},
 /obj/effect/turf_decal/stripes/line{
-	dir = 4
+	dir = 6
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
 "cpq" = (
 /obj/structure/sign/warning/electricshock{
@@ -47237,7 +47372,7 @@
 	},
 /obj/structure/table,
 /obj/item/stock_parts/cell/high/plus,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
 "cpT" = (
 /obj/item/radio/intercom{
@@ -47248,7 +47383,7 @@
 	dir = 6
 	},
 /obj/structure/closet/secure_closet/engineering_electrical,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
 "cpU" = (
 /obj/structure/cable{
@@ -47258,8 +47393,11 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
 "cpV" = (
 /obj/machinery/camera{
@@ -47454,24 +47592,6 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/engine/engineering)
-"cri" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/turf_decal/lumos/tile/purple/fullcorner{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
 "crj" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -47658,7 +47778,8 @@
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/atmospherics/pipe/simple/violet/hidden,
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/lumos/tile/purple/fulltile,
+/turf/open/floor/plasteel/white/side,
 /area/science/xenobiology)
 "csl" = (
 /obj/structure/transit_tube/curved{
@@ -47688,19 +47809,6 @@
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
-"csy" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/turf_decal/lumos/tile/purple/fullcorner,
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
 "csD" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -49653,7 +49761,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/violet/hidden,
 /obj/machinery/holopad,
-/obj/effect/turf_decal/lumos/tile/purple/half{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -49694,6 +49802,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/purple/filled/corner,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "czW" = (
@@ -49709,9 +49821,11 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "czX" = (
-/obj/structure/sign/warning/biohazard,
-/turf/closed/wall/r_wall,
-/area/science/xenobiology)
+/obj/effect/turf_decal/trimline/green/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "cAc" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -50208,11 +50322,11 @@
 	pixel_y = 24
 	},
 /obj/effect/landmark/event_spawn,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
 /area/science/mixing)
 "cBB" = (
 /obj/effect/landmark/event_spawn,
@@ -50271,7 +50385,10 @@
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white/side,
 /area/science/xenobiology)
 "cBH" = (
 /obj/structure/cable{
@@ -50321,7 +50438,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/effect/turf_decal/lumos/tile/purple/half,
+/obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "cBO" = (
@@ -50746,7 +50863,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
 /area/science/robotics/lab)
 "cHL" = (
 /obj/machinery/mech_bay_recharge_port{
@@ -51237,6 +51356,20 @@
 	},
 /turf/open/floor/carpet,
 /area/hallway/primary/central)
+"cRa" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 1
+	},
+/area/science/research)
 "cSE" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -51560,9 +51693,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
-	dir = 8
+	dir = 9
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/white/corner,
 /area/science/xenobiology)
 "cVb" = (
 /turf/closed/wall,
@@ -52282,7 +52415,7 @@
 	pixel_y = 32;
 	req_access_txt = "7"
 	},
-/obj/effect/turf_decal/lumos/tile/purple/half{
+/obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -52320,14 +52453,14 @@
 	id = "xenobio7";
 	name = "containment blast door"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/violet/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/end{
 	dir = 4
 	},
 /turf/open/floor/engine,
@@ -52426,8 +52559,8 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "esZ" = (
-/obj/effect/turf_decal/lumos/tile/purple/half,
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "evt" = (
@@ -52567,7 +52700,13 @@
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 9
 	},
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel/white/corner{
+	dir = 8
+	},
 /area/science/xenobiology)
 "eIF" = (
 /obj/structure/window/reinforced{
@@ -52713,11 +52852,37 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/entry)
+"eXT" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "faw" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/white,
 /area/security/prison)
+"fax" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/violet/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
+/area/science/xenobiology)
 "fcn" = (
 /obj/structure/lattice,
 /turf/closed/wall/r_wall,
@@ -52789,6 +52954,12 @@
 	dir = 4
 	},
 /area/crew_quarters/theatre)
+"fgK" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner,
+/turf/open/floor/plasteel/white/side{
+	dir = 8
+	},
+/area/science/research)
 "fhl" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -53548,6 +53719,12 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
+"gil" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "gjc" = (
 /obj/item/radio/intercom{
 	pixel_y = 20
@@ -53736,6 +53913,9 @@
 /area/hallway/secondary/exit)
 "gvR" = (
 /obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -54013,6 +54193,9 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "gOB" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel/white/side,
 /area/science/research)
 "gOZ" = (
@@ -54327,6 +54510,11 @@
 /obj/item/reagent_containers/food/snacks/cherrycupcake,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"hhh" = (
+/turf/open/floor/plasteel/white/side{
+	dir = 10
+	},
+/area/science/research)
 "hhi" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -54608,6 +54796,12 @@
 	dir = 1
 	},
 /area/crew_quarters/fitness/pool)
+"hAI" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner,
+/turf/open/floor/plasteel/white/side{
+	dir = 9
+	},
+/area/science/robotics/lab)
 "hBA" = (
 /obj/structure/table,
 /obj/item/storage/firstaid/regular{
@@ -54843,6 +55037,12 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/chemistry)
+"hRp" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "hRI" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -54873,8 +55073,8 @@
 /obj/structure/sink{
 	pixel_y = 28
 	},
-/obj/effect/turf_decal/lumos/tile/purple/half{
-	dir = 1
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
@@ -54950,6 +55150,12 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"ilb" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/lab)
 "imH" = (
 /turf/open/floor/wood{
 	icon_state = "wood-broken3"
@@ -55156,6 +55362,20 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"iBT" = (
+/obj/machinery/atmospherics/pipe/simple/violet/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
+/area/science/xenobiology)
 "iCM" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -55900,6 +56120,10 @@
 /obj/machinery/food_cart,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"jBa" = (
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "jBi" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -56113,7 +56337,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/stripes/end,
+/turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
 "jLH" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -56655,6 +56880,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
+"kqK" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "ksE" = (
 /turf/closed/mineral/random/labormineral,
 /area/space/nearstation)
@@ -56692,13 +56926,13 @@
 /obj/machinery/power/smes{
 	charge = 5e+006
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/stripes/end{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
 "ktS" = (
 /turf/open/space/basic,
@@ -56753,6 +56987,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"kys" = (
+/turf/open/floor/plasteel/white/side{
+	dir = 6
+	},
+/area/science/research)
 "kyB" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/westright{
@@ -56769,6 +57008,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"kyN" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
+/area/science/research)
 "kze" = (
 /obj/effect/landmark/start/prisoner/prilate,
 /turf/open/floor/circuit/green,
@@ -56870,6 +57117,20 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"kIq" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/disposal/bin,
+/obj/structure/window/reinforced,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
 "kKY" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/structure/closet,
@@ -57247,6 +57508,12 @@
 /obj/structure/sign/nanotrasen,
 /turf/closed/wall,
 /area/science/explab)
+"lAO" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "lCf" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -57342,6 +57609,11 @@
 /obj/machinery/door/poddoor/incinerator_atmos_main,
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
+"lKu" = (
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
+/area/science/research)
 "lKA" = (
 /obj/structure/lattice,
 /obj/machinery/camera{
@@ -57608,6 +57880,15 @@
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/crew_quarters/toilet)
+"mlP" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "mmf" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -57769,7 +58050,15 @@
 /obj/machinery/shower{
 	dir = 1
 	},
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white/corner{
+	dir = 1
+	},
 /area/science/xenobiology)
 "mDb" = (
 /obj/structure/disposalpipe/segment{
@@ -57861,11 +58150,21 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "mNi" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
+/area/science/xenobiology)
+"mND" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
+/area/science/research)
 "mNE" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Custodial Maintenance";
@@ -57899,6 +58198,12 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
 "mPd" = (
@@ -58605,6 +58910,12 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/bar)
+"nNG" = (
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel/white/side{
+	dir = 8
+	},
+/area/science/xenobiology)
 "nNS" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -58782,6 +59093,18 @@
 	},
 /turf/closed/wall,
 /area/maintenance/disposal/incinerator)
+"nYW" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/dark,
+/area/science/research)
+"nZb" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 8
+	},
+/area/science/xenobiology)
 "nZE" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/structure/cable{
@@ -58814,6 +59137,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
 	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "ocl" = (
@@ -58855,6 +59179,12 @@
 /obj/effect/turf_decal/lumos/tile/blue/half,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"odr" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white/side,
+/area/science/research)
 "odx" = (
 /obj/structure/sink{
 	dir = 4;
@@ -59025,7 +59355,13 @@
 /obj/machinery/atmospherics/pipe/simple/violet/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 8
+	},
 /area/science/xenobiology)
 "oqw" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
@@ -59056,7 +59392,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
 "osJ" = (
 /obj/structure/railing/corner{
@@ -59258,6 +59594,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/explab)
+"oIl" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "oIJ" = (
 /obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 1
@@ -59317,7 +59660,13 @@
 /area/security/processing)
 "oMT" = (
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/research)
 "oMZ" = (
 /obj/structure/closet/secure_closet/brig,
@@ -59453,6 +59802,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "oWe" = (
@@ -59553,6 +59904,23 @@
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/engine,
 /area/science/explab)
+"pjE" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
+/area/science/research)
 "pkF" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27;
@@ -59601,7 +59969,7 @@
 /obj/structure/chair{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/white,
 /area/science/mixing)
 "pod" = (
 /obj/structure/closet,
@@ -59758,7 +60126,7 @@
 	},
 /obj/effect/turf_decal/lumos/tile/red/fulltile,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/white/side,
 /area/science/robotics/lab)
 "puh" = (
 /obj/machinery/light/small,
@@ -59952,9 +60320,6 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "pLh" = (
-/obj/effect/turf_decal/lumos/tile/purple/half{
-	dir = 1
-	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "pLn" = (
@@ -60351,6 +60716,12 @@
 	},
 /turf/open/floor/plating,
 /area/security/range)
+"qCM" = (
+/obj/effect/turf_decal/trimline/purple/filled/line,
+/turf/open/floor/plasteel/white/side{
+	dir = 1
+	},
+/area/science/robotics/lab)
 "qFB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -60607,7 +60978,12 @@
 	pixel_x = -12;
 	pixel_y = 2
 	},
-/turf/open/floor/plasteel/white,
+/obj/structure/sign/warning/biohazard{
+	pixel_x = -30
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
 /area/science/xenobiology)
 "rdG" = (
 /obj/machinery/hydroponics/constructable,
@@ -60640,6 +61016,10 @@
 "rfW" = (
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
+"rgk" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "rir" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -60762,7 +61142,7 @@
 /obj/machinery/camera{
 	c_tag = "Bar Backroom"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
 "rtC" = (
 /obj/structure/disposalpipe/segment{
@@ -60780,6 +61160,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "ruF" = (
@@ -60839,6 +61220,14 @@
 	dir = 8
 	},
 /turf/open/floor/engine,
+/area/science/xenobiology)
+"rCp" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
 /area/science/xenobiology)
 "rCF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -60901,6 +61290,14 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"rHY" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/plasteel/white/side,
+/area/science/research)
 "rIA" = (
 /obj/machinery/light{
 	dir = 8
@@ -60955,7 +61352,7 @@
 /obj/structure/chair{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/white,
 /area/science/mixing)
 "rOu" = (
 /obj/machinery/door/airlock/maintenance{
@@ -61014,6 +61411,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"rSy" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "rTu" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -61057,7 +61469,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
 "rYa" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -61130,7 +61542,13 @@
 /obj/machinery/atmospherics/pipe/simple/violet/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 8
+	},
 /area/science/xenobiology)
 "sbS" = (
 /obj/structure/extinguisher_cabinet{
@@ -61183,6 +61601,17 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/brig)
+"seU" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 8
+	},
+/area/science/xenobiology)
 "sfa" = (
 /obj/structure/filingcabinet,
 /obj/machinery/newscaster{
@@ -61324,6 +61753,7 @@
 /obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/green/filled/line,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "ssP" = (
@@ -61591,6 +62021,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/purple/filled/corner,
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "sLa" = (
@@ -62303,7 +62734,10 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/stripes/end{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
 "tJS" = (
 /obj/effect/spawner/lootdrop/keg,
@@ -62345,6 +62779,9 @@
 "tOq" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
@@ -62393,6 +62830,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "tXk" = (
@@ -62488,7 +62926,10 @@
 	icon_state = "1-4"
 	},
 /obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
 "uha" = (
 /obj/effect/turf_decal/stripes/line{
@@ -62990,7 +63431,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/science/storage)
 "uXb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -63077,6 +63518,12 @@
 	dir = 1
 	},
 /area/ai_monitored/storage/eva)
+"vcK" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "vcN" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -63262,7 +63709,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
 "voh" = (
 /obj/machinery/computer/secure_data{
@@ -63301,15 +63748,15 @@
 	id = "xenobio2";
 	name = "containment blast door"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/violet/hidden{
 	dir = 4
+	},
+/obj/effect/turf_decal/stripes/end{
+	dir = 8
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
@@ -63644,7 +64091,10 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
 "vHj" = (
 /obj/machinery/door/airlock/public/glass{
@@ -63656,6 +64106,12 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/cryopod)
+"vHk" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/lab)
 "vHz" = (
 /obj/structure/chair{
 	dir = 8
@@ -63796,7 +64252,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/effect/turf_decal/lumos/tile/purple/half,
+/obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "vVw" = (
@@ -63864,6 +64320,12 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/medical/medbay/lobby)
+"wcy" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/side,
+/area/science/research)
 "wcO" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
@@ -64053,14 +64515,14 @@
 	id = "xenobio9";
 	name = "containment blast door"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/violet/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/end{
 	dir = 4
 	},
 /turf/open/floor/engine,
@@ -64238,6 +64700,14 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"wyj" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 8
+	},
+/area/science/research)
 "wAj" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -64423,14 +64893,14 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "wUg" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
 /obj/machinery/airalarm{
 	dir = 4;
 	pixel_x = -22
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/stripes/end{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
 "wUV" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
@@ -64652,7 +65122,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
 "xhj" = (
 /obj/effect/turf_decal/lumos/tile/purple/checker,
@@ -64675,12 +65145,15 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
 "xhV" = (
 /obj/structure/cable{
@@ -64773,6 +65246,14 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/plasteel/grimy,
 /area/hallway/secondary/entry)
+"xmW" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white/corner{
+	dir = 1
+	},
+/area/science/research)
 "xnf" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -65236,8 +65717,8 @@
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "ydD" = (
-/obj/effect/turf_decal/bot,
 /obj/machinery/suit_storage_unit/rd,
+/obj/effect/turf_decal/box,
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "yfq" = (
@@ -65278,6 +65759,12 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
+"ygZ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "yhz" = (
 /obj/structure/showcase/mecha/ripley,
 /obj/structure/window/reinforced,
@@ -105269,7 +105756,7 @@ xmk
 aYP
 bal
 bam
-aYV
+bNx
 aYV
 aYV
 bfL
@@ -105526,7 +106013,7 @@ aVI
 aYO
 ssB
 bbB
-aYV
+cdN
 aYV
 aYV
 bfL
@@ -105781,9 +106268,9 @@ nLw
 aVK
 kmw
 gBu
-aRJ
+mPk
 bbB
-aYV
+cdN
 aYV
 aYV
 bpE
@@ -106040,7 +106527,7 @@ mPk
 aYQ
 bam
 bam
-aYV
+czX
 aYV
 aYV
 byX
@@ -106296,7 +106783,7 @@ bne
 mPk
 aYQ
 bam
-aYV
+bNx
 aYV
 aYV
 brz
@@ -106553,7 +107040,7 @@ aRJ
 ofU
 aYR
 ban
-aYV
+cdN
 aYV
 aYV
 bez
@@ -106810,7 +107297,7 @@ aXo
 aXo
 iLJ
 bap
-aYV
+czX
 aYV
 aYV
 beB
@@ -108111,7 +108598,7 @@ bht
 bsQ
 box
 btw
-bus
+cRa
 byf
 bzt
 bAy
@@ -108367,8 +108854,8 @@ boL
 bsQ
 bsR
 box
-btU
-bus
+bvE
+cRa
 byf
 bzw
 bAB
@@ -108380,7 +108867,7 @@ bEm
 bEm
 bJL
 bLa
-bMi
+mlP
 aLt
 bPy
 bPA
@@ -108402,7 +108889,7 @@ chs
 iYb
 bDb
 cmq
-cri
+cBN
 iQR
 aaa
 aaa
@@ -108624,7 +109111,7 @@ boG
 bqa
 cIe
 box
-btU
+bvE
 bvb
 byh
 bzv
@@ -108641,7 +109128,7 @@ bMi
 aLt
 bIO
 bPB
-czX
+bDb
 bRV
 bTa
 bDb
@@ -108882,7 +109369,7 @@ cHZ
 cIf
 box
 btA
-bus
+cRa
 byf
 bzy
 bAD
@@ -108902,17 +109389,17 @@ bQM
 cTZ
 mNi
 rcD
-bMi
-ooH
-bMi
+rCp
+iBT
+mNi
 bRZ
-ooH
-bMi
-bMi
-sbt
-bMi
-bMi
-ooH
+iBT
+mNi
+rCp
+fax
+mNi
+rCp
+iBT
 ccQ
 bDb
 hYH
@@ -109138,8 +109625,8 @@ bpR
 bqc
 bsS
 box
-btU
-bus
+bvE
+cRa
 byf
 bzx
 bAC
@@ -109395,7 +109882,7 @@ cHV
 cIa
 stF
 box
-btU
+bvE
 bvc
 byf
 byf
@@ -109415,17 +109902,17 @@ cmk
 bQN
 eFW
 ooH
-bMi
-bMi
+nZb
+nNG
 sbt
-bMi
-bMi
+nZb
+nNG
 ooH
-bRZ
-bMi
+seU
+nNG
 ooH
-bMi
-bMi
+nZb
+nNG
 ooH
 mDa
 bDb
@@ -109653,7 +110140,7 @@ cIb
 bsT
 box
 btP
-bus
+cRa
 byi
 bzz
 bAE
@@ -109666,11 +110153,11 @@ bIz
 bIz
 bJN
 bMl
-aLt
-bMi
+rSy
+rgk
 bPE
 bLe
-bRY
+kIq
 bTd
 bUg
 cKp
@@ -109910,7 +110397,7 @@ bqd
 biL
 box
 btS
-bus
+cRa
 byi
 bwN
 bAG
@@ -109923,8 +110410,8 @@ bIB
 bIB
 bJN
 bMo
-aLt
-bMi
+rSy
+rgk
 bPH
 bJN
 bSa
@@ -109944,7 +110431,7 @@ wld
 kve
 bDb
 cnf
-csy
+vUP
 iQR
 aaa
 aaa
@@ -110164,9 +110651,9 @@ blM
 qpj
 cHX
 cIc
-biL
+hAI
 buj
-btQ
+wcy
 bve
 byj
 bwM
@@ -110180,7 +110667,7 @@ bIA
 bIA
 bJN
 bMn
-aLt
+rSy
 bOz
 bPG
 bJN
@@ -110421,10 +110908,10 @@ bou
 cHT
 bou
 cId
-biL
+qCM
 bsw
 gOB
-bus
+cRa
 byk
 bzD
 bxv
@@ -110438,7 +110925,7 @@ bIA
 bJN
 bMq
 chu
-bMk
+oIl
 bPJ
 cAc
 bEm
@@ -110680,8 +111167,8 @@ bpU
 brq
 bsW
 buj
-bvE
-bus
+odr
+cRa
 byk
 bzC
 bAH
@@ -110695,7 +111182,7 @@ bGY
 bJN
 bMp
 bNp
-bMi
+ygZ
 bPI
 cTY
 bEm
@@ -110937,8 +111424,8 @@ bpW
 brs
 box
 box
-btU
-bus
+bvE
+cRa
 byk
 byk
 byk
@@ -111194,20 +111681,20 @@ boM
 bzE
 bsX
 bsz
-bzE
+kys
 bEf
 aIL
-bzE
-bzE
-bzE
+lKu
+lKu
+lKu
 bDd
 bEq
 bDl
-bEf
+pjE
 bFQ
 bHc
 bHK
-bzE
+kyN
 bID
 bOA
 bPK
@@ -111443,7 +111930,7 @@ dLA
 esZ
 bhB
 oMT
-oMT
+nYW
 aIe
 blX
 bow
@@ -111706,24 +112193,24 @@ bvx
 boz
 bpX
 bBD
-bBD
+hhh
 bsA
 bBD
 bBD
 brt
-bBD
+mND
 bxF
 bzA
 bzZ
-bBD
-bBD
-bBD
-bBD
-bBD
+fgK
+mND
+mND
+mND
+wyj
 bHL
 bBD
 bBD
-bJo
+xmW
 bPK
 bWr
 bWr
@@ -112474,10 +112961,10 @@ biV
 oVo
 blK
 bnp
-boA
+ciE
 boQ
 brx
-btQ
+bvE
 buo
 bvK
 bxj
@@ -112487,9 +112974,9 @@ bxY
 bCh
 bvK
 bEv
-bFU
-bFU
-bFU
+hRp
+kqK
+lAO
 bJV
 bEC
 bMu
@@ -112727,14 +113214,14 @@ bdv
 aYV
 bgb
 bhC
-bLI
+ilb
 aIb
 blJ
 bno
 bnf
 biW
 bqf
-btU
+bvE
 buo
 bvK
 bxi
@@ -112744,9 +113231,9 @@ aKt
 bCg
 bvK
 bEu
-bFU
-bFU
-bFU
+bHv
+jBa
+gil
 bJU
 bEC
 bMt
@@ -112991,7 +113478,7 @@ blZ
 bnk
 bpo
 bqk
-aJX
+rHY
 bsD
 bvK
 bxl
@@ -113001,8 +113488,8 @@ bya
 bCj
 bvK
 bEx
-bFU
-bFU
+bHv
+bIW
 bGl
 bJX
 bEC
@@ -113244,9 +113731,9 @@ bhE
 bLI
 sKl
 blL
-biW
+vHk
 bnh
-biW
+biU
 brx
 bvE
 bup
@@ -113258,7 +113745,7 @@ bxZ
 bCi
 bvK
 bEw
-bFU
+bHv
 bEL
 bGk
 bJW
@@ -113498,7 +113985,7 @@ bdy
 beI
 bgc
 bhF
-cdN
+bLI
 bib
 bki
 bma
@@ -113515,7 +114002,7 @@ byb
 aGs
 bvK
 bBF
-bFU
+bHv
 oce
 bGz
 bJZ
@@ -113772,7 +114259,7 @@ jYL
 jYL
 jYL
 bEy
-bFU
+bHv
 bFT
 bdQ
 bJY
@@ -114030,9 +114517,9 @@ chq
 fzX
 bEB
 bFW
-bFT
+eXT
 tOq
-bFU
+bNy
 bLi
 bMz
 bNy
@@ -114292,7 +114779,7 @@ bGA
 bFU
 bFU
 bMy
-bNx
+bFU
 bOG
 wkN
 uoB
@@ -114547,7 +115034,7 @@ bFX
 gvR
 bGF
 bKa
-bFU
+vcK
 bMA
 bNz
 bOI

--- a/_maps/map_files/BoxStation/BoxStation_Lumos.dmm
+++ b/_maps/map_files/BoxStation/BoxStation_Lumos.dmm
@@ -26915,7 +26915,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/white/side{
+	dir = 8
+	},
 /area/medical/medbay/front_office)
 "bop" = (
 /obj/structure/cable{
@@ -31509,6 +31511,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/hor)
+"bzO" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner,
+/turf/open/floor/plasteel/white/side{
+	dir = 8
+	},
+/area/science/research)
 "bzP" = (
 /obj/machinery/computer/cargo{
 	dir = 4
@@ -51677,6 +51685,12 @@
 "cVb" = (
 /turf/closed/wall,
 /area/hallway/secondary/service)
+"cVp" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "cVs" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/wood,
@@ -51998,12 +52012,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"dyR" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
 "dzi" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
@@ -52074,12 +52082,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"dEN" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel/white,
-/area/science/mixing)
 "dFX" = (
 /turf/closed/wall,
 /area/crew_quarters/fitness/pool)
@@ -52168,11 +52170,6 @@
 /obj/item/clothing/under/color/grey,
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
-"dNK" = (
-/turf/open/floor/plasteel/white/side{
-	dir = 10
-	},
-/area/science/research)
 "dOd" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -52314,14 +52311,6 @@
 "dXP" = (
 /turf/closed/wall/r_wall,
 /area/security/range)
-"dYj" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white/side{
-	dir = 8
-	},
-/area/science/research)
 "dZo" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -52556,6 +52545,14 @@
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"euK" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 8
+	},
+/area/science/xenobiology)
 "evt" = (
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
@@ -52701,6 +52698,23 @@
 	dir = 8
 	},
 /area/science/xenobiology)
+"eIh" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/violet/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
+/area/science/xenobiology)
 "eIF" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -52794,13 +52808,6 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
-"eVj" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
 "eVC" = (
 /obj/effect/spawner/structure/window,
 /obj/machinery/door/firedoor,
@@ -52832,12 +52839,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
-"eWm" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/science/lab)
 "eXi" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/mechanical,
@@ -53545,12 +53546,6 @@
 /obj/item/storage/box/lights/mixed,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
-"gch" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/science/misc_lab)
 "gcj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 10
@@ -54149,10 +54144,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
-"gNf" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/dark,
-/area/science/research)
 "gNC" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -54706,6 +54697,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"huZ" = (
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "hvd" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -54747,6 +54742,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"hyp" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/disposal/bin,
+/obj/structure/window/reinforced,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
 "hzu" = (
 /obj/machinery/vending/wardrobe/medi_wardrobe,
 /obj/structure/disposalpipe/segment{
@@ -54878,7 +54887,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/white/side{
+	dir = 8
+	},
 /area/medical/medbay/front_office)
 "hKk" = (
 /obj/machinery/cell_charger,
@@ -54972,6 +54983,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"hMT" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "hOv" = (
 /obj/structure/table/wood/fancy,
 /obj/item/reagent_containers/food/snacks/burger/plain,
@@ -55372,6 +55392,12 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"iFv" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "iFz" = (
 /obj/effect/spawner/structure/window,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -55550,17 +55576,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"iUr" = (
-/turf/open/floor/plasteel/white/side{
-	dir = 4
-	},
-/area/science/research)
 "iUL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"iUN" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/side,
+/area/science/research)
 "iVQ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -56380,6 +56407,11 @@
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/hallway/secondary/exit)
+"jQt" = (
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
+/area/science/research)
 "jRp" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Medbay Storage";
@@ -57004,14 +57036,16 @@
 /obj/effect/turf_decal/lumos/tile/red/checker,
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
-"kEL" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
 "kEY" = (
 /obj/effect/landmark/stationroom/box/engine,
 /turf/open/space/basic,
 /area/space)
+"kFN" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner,
+/turf/open/floor/plasteel/white/side{
+	dir = 9
+	},
+/area/science/robotics/lab)
 "kGl" = (
 /obj/machinery/door/window/northleft{
 	name = "Brig Operations";
@@ -57050,6 +57084,15 @@
 /obj/machinery/computer/prisoner/gulag_teleporter_computer,
 /turf/open/floor/plasteel,
 /area/security/prison)
+"kNd" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "kNv" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -57334,12 +57377,6 @@
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"lrg" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner,
-/turf/open/floor/plasteel/white/side{
-	dir = 9
-	},
-/area/science/robotics/lab)
 "lsk" = (
 /obj/structure/closet/wardrobe/white,
 /turf/open/floor/plasteel,
@@ -57565,6 +57602,12 @@
 "lOi" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/starboard/aft)
+"lOR" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/science/misc_lab)
 "lOY" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-10"
@@ -57574,17 +57617,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/medical/medbay/front_office)
-"lPe" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white/side{
-	dir = 8
-	},
-/area/science/xenobiology)
 "lPr" = (
 /obj/item/kirbyplants{
 	icon_state = "applebush"
@@ -57613,15 +57645,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/explab)
-"lRn" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/mixing)
 "lRG" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -57751,6 +57774,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/pool)
+"mgH" = (
+/turf/open/floor/plasteel/white/side{
+	dir = 10
+	},
+/area/science/research)
 "mgP" = (
 /obj/structure/closet/secure_closet/personal/patient,
 /obj/machinery/camera{
@@ -57879,12 +57907,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/front_office)
-"mtQ" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white/side,
-/area/science/research)
 "mvt" = (
 /obj/machinery/airalarm{
 	dir = 1;
@@ -57949,6 +57971,12 @@
 /obj/effect/turf_decal/lumos/tile/red/half,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
+"mzi" = (
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel/white/side{
+	dir = 8
+	},
+/area/science/xenobiology)
 "mAH" = (
 /obj/machinery/atmospherics/components/unary/tank/air{
 	dir = 8
@@ -57985,6 +58013,12 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/medical/surgery)
+"mDE" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "mEb" = (
 /obj/structure/railing/corner,
 /obj/effect/turf_decal/stripes/corner,
@@ -58695,6 +58729,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/hallway/secondary/entry)
+"nGU" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "nHh" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 4
@@ -58728,6 +58768,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics)
+"nIv" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
+/area/science/research)
 "nIB" = (
 /obj/machinery/door/airlock{
 	id_tag = "barbath";
@@ -59316,6 +59364,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/medical/cryo)
+"owS" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 8
+	},
+/area/science/research)
 "oxm" = (
 /obj/structure/window{
 	dir = 1
@@ -59705,14 +59761,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
-"oXI" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white/corner{
-	dir = 1
-	},
-/area/science/research)
 "oZc" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -59750,14 +59798,12 @@
 /obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"pcz" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 4
-	},
+"pdX" = (
+/obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/plasteel/white/side{
-	dir = 8
+	dir = 1
 	},
-/area/science/research)
+/area/science/robotics/lab)
 "pek" = (
 /obj/machinery/door/airlock/external{
 	name = "Labor Camp Shuttle Airlock"
@@ -59912,6 +59958,13 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/medical/virology)
+"ppw" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "pqe" = (
 /obj/structure/chair/sofa,
 /obj/structure/window{
@@ -60075,6 +60128,11 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
+"pDh" = (
+/turf/open/floor/plasteel/white/side{
+	dir = 6
+	},
+/area/science/research)
 "pEn" = (
 /obj/machinery/light_switch{
 	pixel_x = -20
@@ -60237,12 +60295,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
-"pPI" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel/white,
-/area/science/mixing)
 "pPL" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
@@ -60544,21 +60596,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
-"quh" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
 "qus" = (
 /obj/effect/turf_decal/trimline/red/filled/corner,
 /turf/open/floor/plasteel,
@@ -60574,26 +60611,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"qwk" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/violet/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white/side{
-	dir = 4
-	},
-/area/science/xenobiology)
 "qxq" = (
 /turf/closed/wall,
 /area/security/range)
+"qxX" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white/side,
+/area/science/research)
 "qyb" = (
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating,
@@ -60792,6 +60818,20 @@
 	dir = 1
 	},
 /area/engine/atmos)
+"qQt" = (
+/obj/machinery/atmospherics/pipe/simple/violet/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
+/area/science/xenobiology)
 "qTG" = (
 /obj/structure/table/wood,
 /obj/structure/mirror{
@@ -60941,12 +60981,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
-"rjG" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel/white,
-/area/science/mixing)
 "rjQ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
@@ -61047,6 +61081,14 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
+"rsC" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/plasteel/white/side,
+/area/science/research)
 "rtl" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -61182,12 +61224,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
-"rFJ" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white/side,
-/area/science/research)
 "rGq" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -61515,6 +61551,10 @@
 	},
 /turf/open/floor/plating,
 /area/space/nearstation)
+"sjo" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/dark,
+/area/science/research)
 "sks" = (
 /obj/effect/landmark/start/mime,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -61579,20 +61619,6 @@
 /obj/effect/turf_decal/lumos/tile/red/fulltile,
 /turf/open/floor/plasteel,
 /area/security/brig)
-"soC" = (
-/obj/machinery/atmospherics/pipe/simple/violet/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white/side{
-	dir = 4
-	},
-/area/science/xenobiology)
 "sqc" = (
 /obj/structure/table,
 /obj/machinery/recharger{
@@ -61807,12 +61833,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
-"sBL" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/science/mixing)
 "sDf" = (
 /obj/machinery/camera{
 	c_tag = "Genetics";
@@ -61826,14 +61846,6 @@
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics)
-"sEc" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white/side{
-	dir = 4
-	},
-/area/science/research)
 "sEi" = (
 /obj/machinery/vr_sleeper{
 	dir = 1
@@ -62137,6 +62149,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
+"sYH" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "sYR" = (
 /obj/structure/table/wood,
 /obj/item/instrument/guitar{
@@ -62528,6 +62546,14 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
+"tEu" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 8
+	},
+/area/science/research)
 "tFc" = (
 /obj/machinery/power/apc{
 	areastring = "/area/storage/art";
@@ -62851,6 +62877,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
+"uhx" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white/corner{
+	dir = 1
+	},
+/area/science/research)
 "uhX" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -62966,14 +63000,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/mixing)
-"uoD" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white/side{
-	dir = 4
-	},
-/area/science/xenobiology)
 "uoG" = (
 /obj/machinery/power/apc{
 	areastring = "/area/security/detectives_office";
@@ -63017,14 +63043,6 @@
 "uqP" = (
 /obj/machinery/atmospherics/pipe/simple/violet/hidden,
 /turf/closed/wall,
-/area/science/xenobiology)
-"urt" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white/side{
-	dir = 8
-	},
 /area/science/xenobiology)
 "usv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -63088,10 +63106,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/brig)
-"uwt" = (
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel/white,
-/area/science/mixing)
 "uxY" = (
 /obj/effect/turf_decal/trimline/white/filled/corner{
 	dir = 4
@@ -63332,23 +63346,6 @@
 /obj/structure/window/reinforced,
 /turf/open/space,
 /area/space/nearstation)
-"uUN" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white/side{
-	dir = 4
-	},
-/area/science/research)
 "uVS" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -63524,6 +63521,12 @@
 /obj/item/target,
 /turf/open/floor/plating,
 /area/security/range)
+"veC" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/lab)
 "vfe" = (
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
@@ -64012,20 +64015,6 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"vET" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/machinery/disposal/bin,
-/obj/structure/window/reinforced,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/science/xenobiology)
 "vEZ" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
@@ -64110,6 +64099,15 @@
 /obj/structure/closet/secure_closet/medical1,
 /turf/open/floor/plasteel/cafeteria,
 /area/medical/virology)
+"vMX" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "vNi" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 5
@@ -64168,12 +64166,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"vRE" = (
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel/white/side{
-	dir = 8
-	},
-/area/science/xenobiology)
 "vUK" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "bridge blast";
@@ -64398,7 +64390,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/pool)
-"wiA" = (
+"wiN" = (
+/obj/structure/rack,
+/obj/item/stack/sheet/metal/twenty,
+/obj/item/stack/sheet/rglass{
+	amount = 50
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"wiW" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -64412,14 +64412,6 @@
 	dir = 1
 	},
 /area/science/research)
-"wiN" = (
-/obj/structure/rack,
-/obj/item/stack/sheet/metal/twenty,
-/obj/item/stack/sheet/rglass{
-	amount = 50
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
 "wjo" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -64488,12 +64480,6 @@
 	dir = 4
 	},
 /area/medical/cryo)
-"wnq" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner,
-/turf/open/floor/plasteel/white/side{
-	dir = 8
-	},
-/area/science/research)
 "wor" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1;
@@ -64691,6 +64677,14 @@
 	},
 /turf/open/floor/plating,
 /area/security/main)
+"wBV" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
+/area/science/xenobiology)
 "wCv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -64706,6 +64700,10 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
+"wEc" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "wES" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -64817,15 +64815,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"wRa" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/mixing)
 "wRn" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible/layer1{
 	dir = 4
@@ -64860,15 +64849,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
-"wUh" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
 "wUV" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
@@ -65091,14 +65071,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
-"xgJ" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/plasteel/white/side,
-/area/science/research)
 "xhj" = (
 /obj/effect/turf_decal/lumos/tile/purple/checker,
 /obj/effect/turf_decal/stripes/line{
@@ -65235,12 +65207,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"xpE" = (
-/obj/effect/turf_decal/trimline/purple/filled/line,
-/turf/open/floor/plasteel/white/side{
-	dir = 1
-	},
-/area/science/robotics/lab)
 "xqi" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -65335,6 +65301,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"xCx" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
+/area/science/research)
 "xDh" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
@@ -65366,6 +65349,21 @@
 "xDQ" = (
 /turf/open/floor/plasteel,
 /area/security/processing)
+"xDR" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "xEu" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
@@ -65478,6 +65476,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"xOs" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 8
+	},
+/area/science/xenobiology)
 "xOA" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -65637,11 +65646,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/pool)
-"yal" = (
-/turf/open/floor/plasteel/white/side{
-	dir = 6
-	},
-/area/science/research)
 "ybX" = (
 /obj/structure/chair/office/light,
 /obj/structure/cable{
@@ -108570,7 +108574,7 @@ bht
 bsQ
 box
 btw
-wiA
+wiW
 byf
 bzt
 bAy
@@ -108827,7 +108831,7 @@ bsQ
 bsR
 box
 bvE
-wiA
+wiW
 byf
 bzw
 bAB
@@ -108839,7 +108843,7 @@ bEm
 bEm
 bJL
 bLa
-wUh
+vMX
 aLt
 bPy
 bPA
@@ -109341,7 +109345,7 @@ cHZ
 cIf
 box
 btA
-wiA
+wiW
 byf
 bzy
 bAD
@@ -109361,17 +109365,17 @@ bQM
 cTZ
 mNi
 rcD
-uoD
-soC
+wBV
+qQt
 mNi
 bRZ
-soC
+qQt
 mNi
-uoD
-qwk
+wBV
+eIh
 mNi
-uoD
-soC
+wBV
+qQt
 ccQ
 bDb
 hYH
@@ -109598,7 +109602,7 @@ bqc
 bsS
 box
 bvE
-wiA
+wiW
 byf
 bzx
 bAC
@@ -109874,17 +109878,17 @@ cmk
 bQN
 eFW
 ooH
-urt
-vRE
+euK
+mzi
 sbt
-urt
-vRE
+euK
+mzi
 ooH
-lPe
-vRE
+xOs
+mzi
 ooH
-urt
-vRE
+euK
+mzi
 ooH
 mDa
 bDb
@@ -110112,7 +110116,7 @@ cIb
 bsT
 box
 btP
-wiA
+wiW
 byi
 bzz
 bAE
@@ -110125,11 +110129,11 @@ bIz
 bIz
 bJN
 bMl
-quh
-kEL
+xDR
+wEc
 bPE
 bLe
-vET
+hyp
 bTd
 bUg
 cKp
@@ -110369,7 +110373,7 @@ bqd
 biL
 box
 btS
-wiA
+wiW
 byi
 bwN
 bAG
@@ -110382,8 +110386,8 @@ bIB
 bIB
 bJN
 bMo
-quh
-kEL
+xDR
+wEc
 bPH
 bJN
 bSa
@@ -110623,9 +110627,9 @@ blM
 qpj
 cHX
 cIc
-lrg
+kFN
 buj
-mtQ
+iUN
 bve
 byj
 bwM
@@ -110639,7 +110643,7 @@ bIA
 bIA
 bJN
 bMn
-quh
+xDR
 bOz
 bPG
 bJN
@@ -110880,10 +110884,10 @@ bou
 cHT
 bou
 cId
-xpE
+pdX
 bsw
 gOB
-wiA
+wiW
 byk
 bzD
 bxv
@@ -110897,7 +110901,7 @@ bIA
 bJN
 bMq
 chu
-eVj
+ppw
 bPJ
 cAc
 bEm
@@ -111139,8 +111143,8 @@ bpU
 brq
 bsW
 buj
-rFJ
-wiA
+qxX
+wiW
 byk
 bzC
 bAH
@@ -111154,7 +111158,7 @@ bGY
 bJN
 bMp
 bNp
-dyR
+sYH
 bPI
 cTY
 bEm
@@ -111397,7 +111401,7 @@ brs
 box
 box
 bvE
-wiA
+wiW
 byk
 byk
 byk
@@ -111653,20 +111657,20 @@ boM
 bzE
 bsX
 bsz
-yal
+pDh
 bEf
 aIL
-iUr
-iUr
-iUr
+jQt
+jQt
+jQt
 bDd
 bEq
 bDl
-uUN
+xCx
 bFQ
 bHc
 bHK
-sEc
+nIv
 bID
 bOA
 bPK
@@ -111902,7 +111906,7 @@ dLA
 esZ
 bhB
 oMT
-gNf
+sjo
 aIe
 blX
 bow
@@ -112165,26 +112169,26 @@ bvx
 boz
 bpX
 bBD
-dNK
+mgH
 bsA
 bBD
 bBD
 brt
-pcz
+tEu
 bxF
 bzA
 bzZ
-wnq
-pcz
-pcz
-pcz
-dYj
+bzO
+tEu
+tEu
+tEu
+owS
 bHL
 bBD
 bBD
-oXI
+uhx
 bPK
-gch
+lOR
 bWr
 bWr
 bWr
@@ -112946,9 +112950,9 @@ bxY
 bCh
 bvK
 bEv
-pPI
-wRa
-rjG
+cVp
+hMT
+iFv
 bJV
 bEC
 bMu
@@ -113204,8 +113208,8 @@ bCg
 bvK
 bEu
 bHv
-uwt
-dEN
+huZ
+mDE
 bJU
 bEC
 bMt
@@ -113450,7 +113454,7 @@ blZ
 bnk
 bpo
 bqk
-xgJ
+rsC
 bsD
 bvK
 bxl
@@ -113703,7 +113707,7 @@ bhE
 bLI
 sKl
 blL
-eWm
+veC
 bnh
 biU
 brx
@@ -114489,7 +114493,7 @@ chq
 fzX
 bEB
 bFW
-lRn
+kNd
 tOq
 bNy
 bLi
@@ -115006,7 +115010,7 @@ bFX
 gvR
 bGF
 bKa
-sBL
+nGU
 bMA
 bNz
 bOI

--- a/_maps/map_files/BoxStation/BoxStation_Lumos.dmm
+++ b/_maps/map_files/BoxStation/BoxStation_Lumos.dmm
@@ -50838,6 +50838,18 @@
 /obj/machinery/vending/coffee,
 /turf/open/floor/wood,
 /area/bridge/meeting_room)
+"cXB" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/front_office)
 "cXU" = (
 /obj/effect/turf_decal/tile/red,
 /obj/machinery/light{
@@ -55091,6 +55103,10 @@
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/hallway/secondary/exit)
+"jPD" = (
+/obj/structure/railing/corner,
+/turf/open/floor/plasteel/white,
+/area/medical/sleeper)
 "jRp" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Medbay Storage";
@@ -55479,6 +55495,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
+"krh" = (
+/obj/machinery/door/firedoor,
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/plasteel/stairs/right,
+/area/medical/sleeper)
 "ksE" = (
 /turf/closed/mineral/random/labormineral,
 /area/space/nearstation)
@@ -56245,10 +56268,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
-"maQ" = (
-/obj/structure/railing/corner,
-/turf/open/floor/plasteel/white,
-/area/medical/sleeper)
 "mbU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -58607,13 +58626,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
-"qiE" = (
-/obj/machinery/door/firedoor,
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/open/floor/plasteel/stairs/right,
-/area/medical/sleeper)
 "qje" = (
 /obj/structure/sign/mining{
 	pixel_y = 7
@@ -59876,6 +59888,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"sJg" = (
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel/white,
+/area/medical/sleeper)
 "sJk" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -60666,6 +60682,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"tUz" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/sleeper)
 "tXk" = (
 /obj/machinery/gulag_teleporter,
 /turf/open/floor/plasteel,
@@ -60959,15 +60984,6 @@
 "uuh" = (
 /turf/open/floor/carpet/black,
 /area/maintenance/bar)
-"uuF" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/railing/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/sleeper)
 "uve" = (
 /obj/structure/table,
 /obj/item/coin/silver,
@@ -61214,6 +61230,12 @@
 	icon_state = "carpetsymbol"
 	},
 /area/crew_quarters/theatre)
+"uSr" = (
+/obj/structure/railing/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/sleeper)
 "uSC" = (
 /obj/machinery/pool/drain,
 /turf/open/pool,
@@ -61466,10 +61488,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"vls" = (
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/white,
-/area/medical/sleeper)
 "vlZ" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/stripes/corner{
@@ -62196,12 +62214,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/wood,
 /area/medical/psych)
-"wjC" = (
-/obj/structure/railing/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/sleeper)
 "wkj" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
@@ -63289,18 +63301,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/pool)
-"yaO" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/front_office)
 "ybX" = (
 /obj/structure/chair/office/light,
 /obj/structure/cable{
@@ -99797,7 +99797,7 @@ bwG
 vwy
 bZR
 bZU
-uuF
+tUz
 bzW
 bGR
 bCT
@@ -100303,15 +100303,15 @@ uJi
 uJi
 uJi
 bpJ
-yaO
-vls
+cXB
+sJg
 wkm
 bNs
 ghS
 bVa
-maQ
-qiE
-wjC
+jPD
+krh
+uSr
 bCM
 bFv
 bFv

--- a/_maps/map_files/BoxStation/BoxStation_Lumos.dmm
+++ b/_maps/map_files/BoxStation/BoxStation_Lumos.dmm
@@ -17665,9 +17665,6 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aQn" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /mob/living/carbon/monkey,
 /turf/open/floor/grass,
@@ -23957,12 +23954,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
-"bhm" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/medical/morgue)
 "bhp" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
@@ -25387,9 +25378,6 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
 "blo" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
 /obj/machinery/light/small,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
@@ -26970,10 +26958,13 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/structure/disposalpipe/junction/yjunction,
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 1
 	},
-/obj/structure/disposalpipe/junction/yjunction,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/front_office)
 "bpw" = (
@@ -26985,12 +26976,13 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/front_office)
 "bpy" = (
@@ -27077,14 +27069,14 @@
 /turf/open/floor/plasteel,
 /area/medical/medbay/front_office)
 "bpJ" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/front_office)
@@ -28036,13 +28028,6 @@
 /obj/structure/bed/dogbed/runtime,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
-"bsv" = (
-/mob/living/carbon/monkey,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/grass,
-/area/medical/genetics)
 "bsw" = (
 /obj/machinery/door/airlock/research{
 	name = "Robotics Lab";
@@ -28716,6 +28701,9 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics/cloning)
 "bug" = (
@@ -28764,9 +28752,6 @@
 	dir = 4
 	},
 /mob/living/carbon/monkey,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
 /turf/open/floor/grass,
 /area/medical/genetics)
 "bun" = (
@@ -28808,6 +28793,9 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics)
 "bur" = (
@@ -28815,6 +28803,9 @@
 	dir = 5
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics/cloning)
 "bus" = (
@@ -28830,9 +28821,6 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "but" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 9
 	},
@@ -30208,8 +30196,10 @@
 /area/crew_quarters/heads/hor)
 "bxQ" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "bxS" = (
 /obj/machinery/sleeper{
@@ -30749,6 +30739,9 @@
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
+	},
+/obj/structure/railing/corner{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
@@ -31292,14 +31285,13 @@
 /area/medical/chemistry)
 "bAr" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "bAs" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -31670,12 +31662,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bBm" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 6
-	},
-/obj/machinery/holopad,
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/medical/cryo)
@@ -31861,12 +31852,6 @@
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "bBL" = (
-/obj/structure/table{
-	pixel_y = -5
-	},
-/obj/item/stack/packageWrap,
-/obj/item/stack/packageWrap,
-/obj/item/pen,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -31875,6 +31860,10 @@
 	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
+	},
+/obj/machinery/bloodbankgen{
+	pixel_x = 7;
+	pixel_y = -5
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -31915,14 +31904,13 @@
 /area/medical/sleeper)
 "bBQ" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/stairs,
 /area/medical/sleeper)
 "bBR" = (
 /obj/structure/reagent_dispensers/fueltank,
@@ -32898,6 +32886,7 @@
 /obj/structure/railing/corner{
 	dir = 8
 	},
+/obj/machinery/holopad,
 /turf/open/floor/plasteel,
 /area/medical/cryo)
 "bEe" = (
@@ -34542,13 +34531,14 @@
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "bIo" = (
+/obj/machinery/chem_dispenser/apothecary,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bIp" = (
-/obj/machinery/holopad,
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
+/obj/machinery/chem_heater,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bIr" = (
@@ -36775,6 +36765,9 @@
 /area/engine/atmos)
 "bNZ" = (
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/railing/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -41189,6 +41182,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/structure/railing/corner{
+	dir = 8
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "bZS" = (
@@ -41215,11 +41211,13 @@
 /area/maintenance/aft)
 "bZU" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/floor/plasteel/stairs/left,
 /area/medical/sleeper)
 "bZV" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -44422,9 +44420,6 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "ciI" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
 "ciL" = (
@@ -45297,7 +45292,7 @@
 "cls" = (
 /obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable{
-	icon_state = "0-8"
+	icon_state = "0-2"
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
@@ -50765,6 +50760,9 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
 "cTM" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
 "cTO" = (
@@ -50881,6 +50879,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/lumos/shower,
+/obj/structure/railing/corner,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "daA" = (
@@ -51282,9 +51281,6 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "dOd" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 5
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -51292,6 +51288,9 @@
 	dir = 1
 	},
 /obj/effect/landmark/start/paramedic,
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	dir = 5
+	},
 /turf/open/floor/plasteel,
 /area/medical/cryo)
 "dOq" = (
@@ -51691,6 +51690,9 @@
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/front_office)
 "ezF" = (
@@ -51739,15 +51741,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"eCY" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 1
-	},
-/obj/structure/chair/stool{
-	pixel_y = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/medical/virology)
 "eDf" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -51863,6 +51856,9 @@
 /area/maintenance/starboard/aft)
 "eSO" = (
 /obj/structure/closet/wardrobe/pjs,
+/obj/structure/railing/corner{
+	dir = 1
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "eTo" = (
@@ -51976,10 +51972,6 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
-"feB" = (
-/obj/structure/table,
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
 "feE" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -52024,6 +52016,14 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"flA" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/snacks/grown/strawberry{
+	pixel_x = -5;
+	pixel_y = 10
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "flE" = (
 /obj/structure/closet/crate/wooden/fish_learning,
 /turf/open/floor/plasteel/showroomfloor,
@@ -52256,29 +52256,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/crew_quarters/abandoned_gambling_den)
-"fCm" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 1
-	},
-/obj/structure/table/glass,
-/obj/item/book/manual/wiki/infections{
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/item/reagent_containers/dropper{
-	pixel_x = -3;
-	pixel_y = -2
-	},
-/obj/item/hand_labeler{
-	pixel_x = -6;
-	pixel_y = 6
-	},
-/obj/item/reagent_containers/syringe/antiviral{
-	pixel_x = -5;
-	pixel_y = -3
-	},
-/turf/open/floor/plasteel/dark,
-/area/medical/virology)
 "fCx" = (
 /obj/machinery/button/door{
 	id = "holoprivacy";
@@ -52458,6 +52435,13 @@
 /obj/item/bedsheet/orange,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
+"fVz" = (
+/obj/machinery/door/airlock/atmos/abandoned{
+	name = "Atmospherics Maintenance";
+	req_access_txt = "12;24"
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "fXw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -52553,6 +52537,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"gcI" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 10
+	},
+/obj/effect/landmark/start/virologist,
+/obj/structure/chair/office/light,
+/turf/open/floor/plasteel/dark,
+/area/medical/virology)
 "gdi" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -31
@@ -52583,11 +52575,6 @@
 "gfo" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /mob/living/carbon/monkey,
-/obj/machinery/door/window/eastright{
-	dir = 8;
-	name = "Monkey Pen";
-	req_access_txt = "9"
-	},
 /turf/open/floor/grass,
 /area/medical/genetics)
 "gfr" = (
@@ -53001,14 +52988,6 @@
 	},
 /turf/open/floor/plating,
 /area/space/nearstation)
-"gIV" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/snacks/grown/strawberry{
-	pixel_x = -5;
-	pixel_y = 10
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
 "gJi" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
@@ -53067,15 +53046,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
-"gMZ" = (
-/obj/effect/turf_decal/trimline/green/filled/corner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/medical/virology)
 "gNC" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -53295,6 +53265,9 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 5
 	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics)
 "hbs" = (
@@ -53379,9 +53352,6 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "hhi" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -53393,10 +53363,13 @@
 	pixel_y = 24;
 	req_access_txt = "5"
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -54100,6 +54073,9 @@
 "iwg" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/front_office)
 "iwm" = (
@@ -54211,15 +54187,13 @@
 /turf/open/floor/plating,
 /area/medical/surgery)
 "iHI" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/turf_decal/lumos/tile/blue/fulltile,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/front_office)
 "iIj" = (
@@ -54367,6 +54341,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"iUL" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "iVQ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -55238,19 +55218,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"jWP" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "jYH" = (
 /obj/machinery/vending/cola/space_up,
 /turf/open/floor/plasteel/dark,
@@ -55386,13 +55353,13 @@
 /turf/open/floor/plating,
 /area/storage/tech)
 "kfQ" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/structure/railing/corner,
+/obj/machinery/atmospherics/pipe/manifold/general/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/medical/cryo)
 "kgH" = (
@@ -55515,14 +55482,6 @@
 "ksE" = (
 /turf/closed/mineral/random/labormineral,
 /area/space/nearstation)
-"ksS" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 10
-	},
-/obj/effect/landmark/start/virologist,
-/obj/structure/chair/office/light,
-/turf/open/floor/plasteel/dark,
-/area/medical/virology)
 "ktA" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/backpack/duffelbag/med/surgery,
@@ -55680,12 +55639,6 @@
 /obj/effect/turf_decal/lumos/tile/red/checker,
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
-"kEG" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
 "kEY" = (
 /obj/effect/landmark/stationroom/box/engine,
 /turf/open/space/basic,
@@ -55825,12 +55778,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"kTU" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "kUA" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -56038,6 +55985,21 @@
 /obj/machinery/atmospherics/pipe/simple/dark/visible,
 /turf/open/space,
 /area/space/nearstation)
+"lvi" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "lvU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -56139,7 +56101,7 @@
 	dir = 8;
 	light_color = "#e8eaff"
 	},
-/obj/machinery/chem_master,
+/obj/machinery/holopad,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "lJS" = (
@@ -56173,15 +56135,6 @@
 "lOi" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/starboard/aft)
-"lOk" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/machinery/atmospherics/components/unary/tank/air{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "lOY" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-10"
@@ -56292,6 +56245,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
+"maQ" = (
+/obj/structure/railing/corner,
+/turf/open/floor/plasteel/white,
+/area/medical/sleeper)
 "mbU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -56323,7 +56280,7 @@
 "mfY" = (
 /obj/effect/landmark/start/medical_doctor,
 /obj/structure/chair/office/light{
-	dir = 8
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -56355,6 +56312,9 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"mio" = (
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "mjr" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/med_data/laptop{
@@ -56472,7 +56432,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
-/obj/machinery/chem_heater,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "mxZ" = (
@@ -56597,11 +56556,11 @@
 /turf/open/floor/wood,
 /area/maintenance/bar)
 "mKc" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/effect/landmark/start/paramedic,
+/obj/machinery/atmospherics/pipe/manifold/general/hidden,
 /turf/open/floor/plasteel,
 /area/medical/cryo)
 "mLy" = (
@@ -56708,9 +56667,6 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "mSs" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
 /mob/living/carbon/monkey,
 /turf/open/floor/grass,
 /area/medical/genetics)
@@ -57211,6 +57167,9 @@
 /area/hydroponics)
 "nLL" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics/cloning)
 "nMv" = (
@@ -57336,6 +57295,16 @@
 /obj/structure/sign/warning/fire,
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
+"nVd" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "nVk" = (
 /obj/machinery/door/window/brigdoor/security/cell{
 	id = "Cell 3";
@@ -57474,6 +57443,15 @@
 	},
 /turf/open/floor/plating,
 /area/engine/atmos)
+"oeF" = (
+/obj/effect/turf_decal/trimline/green/filled/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/medical/virology)
 "ofU" = (
 /obj/structure/chair/comfy/black{
 	dir = 4
@@ -57611,6 +57589,10 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
+/obj/machinery/door/window/eastright{
+	name = "Monkey Pen";
+	req_access_txt = "9"
+	},
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics)
 "ovf" = (
@@ -57621,14 +57603,14 @@
 /turf/open/floor/plasteel,
 /area/medical/cryo)
 "owO" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 10
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/structure/railing/corner{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/medical/cryo)
@@ -57927,6 +57909,12 @@
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"oTS" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "oTZ" = (
 /obj/machinery/portable_atmospherics/scrubber/huge,
 /obj/effect/turf_decal/stripes/line,
@@ -58619,6 +58607,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
+"qiE" = (
+/obj/machinery/door/firedoor,
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/plasteel/stairs/right,
+/area/medical/sleeper)
 "qje" = (
 /obj/structure/sign/mining{
 	pixel_y = 7
@@ -58660,11 +58655,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "qor" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/general/hidden{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/medical/cryo)
@@ -58758,16 +58753,6 @@
 "qxq" = (
 /turf/closed/wall,
 /area/security/range)
-"qxG" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/machinery/portable_atmospherics/canister/air,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "qyb" = (
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating,
@@ -58847,6 +58832,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/cryopod)
+"qIF" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/closed/wall/r_wall,
+/area/medical/virology)
 "qJr" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -58903,9 +58892,6 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/crew_quarters/dorms)
 "qMv" = (
-/obj/structure/chair/office/light{
-	dir = 8
-	},
 /obj/machinery/camera{
 	c_tag = "Apothecary";
 	dir = 1;
@@ -59529,7 +59515,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
 	},
-/obj/machinery/chem_dispenser/apothecary,
+/obj/machinery/chem_master,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "scf" = (
@@ -59733,9 +59719,6 @@
 	},
 /turf/open/floor/plating,
 /area/blueshield)
-"ssW" = (
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
 "ssX" = (
 /obj/machinery/button/door{
 	id = "xenobio1";
@@ -60150,12 +60133,16 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "tbz" = (
-/obj/machinery/bloodbankgen{
-	pixel_y = -5
-	},
 /obj/structure/window/reinforced{
 	dir = 1
 	},
+/obj/structure/table{
+	pixel_y = -5
+	},
+/obj/item/stack/packageWrap,
+/obj/item/stack/packageWrap,
+/obj/item/pen,
+/obj/item/pen,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "tbP" = (
@@ -60346,14 +60333,14 @@
 /turf/open/floor/plasteel,
 /area/security/courtroom)
 "tss" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/medical/cryo)
@@ -60529,11 +60516,6 @@
 /obj/machinery/iv_drip,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"tFv" = (
-/obj/structure/closet/secure_closet/personal/patient,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
 "tFO" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 9
@@ -60836,6 +60818,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"ulT" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/machinery/atmospherics/components/unary/tank/air{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "umE" = (
 /obj/machinery/button/door{
 	id = "xenobio3";
@@ -60968,6 +60959,15 @@
 "uuh" = (
 /turf/open/floor/carpet/black,
 /area/maintenance/bar)
+"uuF" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/sleeper)
 "uve" = (
 /obj/structure/table,
 /obj/item/coin/silver,
@@ -61006,7 +61006,7 @@
 	dir = 6
 	},
 /obj/structure/cable{
-	icon_state = "2-8"
+	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
@@ -61084,6 +61084,11 @@
 	},
 /turf/open/space,
 /area/solar/port/fore)
+"uDP" = (
+/obj/structure/closet/secure_closet/personal/patient,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "uEx" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "PoolShut";
@@ -61461,6 +61466,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"vls" = (
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel/white,
+/area/medical/sleeper)
 "vlZ" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/stripes/corner{
@@ -61628,6 +61637,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"vwF" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
+	},
+/obj/structure/chair/stool{
+	pixel_y = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/medical/virology)
 "vxA" = (
 /obj/machinery/door/airlock/external{
 	name = "Escape Pod Three"
@@ -61706,6 +61724,10 @@
 	},
 /turf/open/floor/engine,
 /area/science/mixing)
+"vzG" = (
+/obj/structure/table,
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "vzO" = (
 /obj/machinery/door/window/southright,
 /obj/machinery/door/window/northright,
@@ -62174,6 +62196,35 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/wood,
 /area/medical/psych)
+"wjC" = (
+/obj/structure/railing/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/sleeper)
+"wkj" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
+	},
+/obj/structure/table/glass,
+/obj/item/book/manual/wiki/infections{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/dropper{
+	pixel_x = -3;
+	pixel_y = -2
+	},
+/obj/item/hand_labeler{
+	pixel_x = -6;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/syringe/antiviral{
+	pixel_x = -5;
+	pixel_y = -3
+	},
+/turf/open/floor/plasteel/dark,
+/area/medical/virology)
 "wkm" = (
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
@@ -62311,13 +62362,6 @@
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
-"wuc" = (
-/obj/machinery/door/airlock/atmos/abandoned{
-	name = "Atmospherics Maintenance";
-	req_access_txt = "12;24"
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "wuH" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -62506,6 +62550,19 @@
 	},
 /turf/open/pool,
 /area/crew_quarters/fitness/pool)
+"wQp" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "wRn" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible/layer1{
 	dir = 4
@@ -62563,21 +62620,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
-"wVO" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "wVV" = (
 /obj/machinery/light{
 	dir = 1
@@ -62956,10 +62998,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"xAp" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/closed/wall/r_wall,
-/area/medical/virology)
 "xBk" = (
 /obj/machinery/light{
 	dir = 4;
@@ -63251,6 +63289,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/pool)
+"yaO" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/front_office)
 "ybX" = (
 /obj/structure/chair/office/light,
 /obj/structure/cable{
@@ -99747,7 +99797,7 @@ bwG
 vwy
 bZR
 bZU
-bNZ
+uuF
 bzW
 bGR
 bCT
@@ -100253,15 +100303,15 @@ uJi
 uJi
 uJi
 bpJ
-mta
-bxQ
+yaO
+vls
 wkm
 bNs
 ghS
 bVa
-wkm
-bxQ
-wkm
+maQ
+qiE
+wjC
 bCM
 bFv
 bFv
@@ -102591,9 +102641,9 @@ bNd
 bST
 bJD
 bKB
-eCY
-gMZ
-ksS
+vwF
+oeF
+gcI
 bYX
 bNd
 ccK
@@ -102848,7 +102898,7 @@ bRP
 bSW
 bMH
 bRQ
-fCm
+wkj
 bWZ
 bYd
 bYY
@@ -103596,7 +103646,7 @@ bfL
 bpG
 rCT
 tXq
-bsv
+mSs
 gfo
 bum
 tXq
@@ -103620,9 +103670,9 @@ bIR
 bMJ
 bNj
 bNW
-kEG
-tFv
-xAp
+oTS
+uDP
+qIF
 bZQ
 caP
 bzs
@@ -103878,11 +103928,11 @@ bKz
 bKC
 bKM
 bXc
-gIV
+flA
 bNd
 bZS
 caR
-wuc
+fVz
 bGP
 bHd
 ceL
@@ -104101,7 +104151,7 @@ aYV
 aYV
 aYV
 byX
-bhm
+ciI
 ciI
 ciI
 ciI
@@ -104137,8 +104187,8 @@ bWj
 bWj
 bNd
 bNd
-lOk
-qxG
+ulT
+nVd
 bzs
 bGP
 bHd
@@ -104391,7 +104441,7 @@ bJC
 tla
 bKC
 bKM
-ssW
+mio
 bYe
 bNd
 bzs
@@ -104649,13 +104699,13 @@ bMJ
 bNl
 bNW
 bXd
-feB
+vzG
 bNd
 bZT
-wVO
+lvi
 bDO
-jWP
-kTU
+wQp
+iUL
 bzs
 cfq
 bAw

--- a/_maps/map_files/BoxStation/BoxStation_Lumos.dmm
+++ b/_maps/map_files/BoxStation/BoxStation_Lumos.dmm
@@ -22517,8 +22517,8 @@
 /turf/open/floor/wood,
 /area/medical/psych)
 "bds" = (
-/obj/effect/turf_decal/lumos/tile/red/half,
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bdt" = (
@@ -23016,7 +23016,7 @@
 /area/quartermaster/warehouse)
 "beE" = (
 /obj/machinery/light,
-/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/trimline/red/filled/corner,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "beG" = (
@@ -23837,7 +23837,7 @@
 /obj/machinery/computer/security{
 	dir = 8
 	},
-/obj/effect/turf_decal/lumos/tile/red/half{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -23993,7 +23993,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/lumos/tile/red/fullcorner{
+/obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -24003,8 +24003,8 @@
 	pixel_y = 28
 	},
 /obj/machinery/rnd/production/circuit_imprinter,
-/obj/effect/turf_decal/lumos/tile/red/fullcorner{
-	dir = 8
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
@@ -24413,11 +24413,11 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "biN" = (
-/obj/effect/turf_decal/lumos/tile/red/half{
+/obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 1
 	},
-/turf/open/floor/plasteel/white,
-/area/science/robotics/lab)
+/turf/open/floor/plasteel/dark,
+/area/medical/morgue)
 "biO" = (
 /obj/machinery/camera{
 	c_tag = "Robotics Lab";
@@ -24436,23 +24436,14 @@
 	pixel_y = 5
 	},
 /obj/item/reagent_containers/glass/beaker/large,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
 "biP" = (
 /obj/structure/filingcabinet/chestdrawer,
-/obj/effect/turf_decal/lumos/tile/red/fullcorner{
-	dir = 8
-	},
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
 "biQ" = (
 /obj/structure/chair/stool,
-/obj/effect/turf_decal/lumos/tile/red/half{
-	dir = 1
-	},
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
 "biR" = (
@@ -24917,7 +24908,7 @@
 /obj/machinery/recharger{
 	pixel_y = 4
 	},
-/obj/effect/turf_decal/lumos/tile/red/half{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -25044,10 +25035,6 @@
 	pixel_x = 32
 	},
 /obj/machinery/aug_manipulator,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
 "bkp" = (
@@ -25349,7 +25336,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "blj" = (
-/obj/effect/turf_decal/lumos/tile/red/half{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -25362,11 +25349,11 @@
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_x = 30
 	},
-/obj/effect/turf_decal/lumos/tile/red/half{
-	dir = 4
-	},
 /obj/structure/chair{
 	dir = 8
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
@@ -25491,9 +25478,6 @@
 	pixel_x = -31;
 	receive_ore_updates = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
 "blz" = (
@@ -25502,9 +25486,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/lumos/tile/red/half{
-	dir = 8
-	},
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
 "blA" = (
@@ -25955,8 +25936,8 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/lumos/tile/red/half,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
 "bmO" = (
@@ -28345,6 +28326,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 9
+	},
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics)
 "bto" = (
@@ -28353,6 +28337,9 @@
 	},
 /obj/machinery/light/small{
 	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics)
@@ -28892,6 +28879,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics)
 "buz" = (
@@ -28953,6 +28943,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/turf_decal/lumos/tile/purple/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics/cloning)
 "buH" = (
@@ -28972,6 +28963,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/turf_decal/lumos/tile/blue/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/science/research)
 "buI" = (
@@ -29001,6 +28993,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -29040,11 +29035,17 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
 "buT" = (
-/obj/effect/turf_decal/trimline/white/filled/line{
-	dir = 1
+/obj/machinery/door/firedoor/heavy,
+/obj/machinery/door/poddoor/preopen{
+	id = "Biohazard";
+	name = "biohazard containment door"
 	},
-/turf/open/floor/plasteel/dark,
-/area/medical/morgue)
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "buU" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -29061,7 +29062,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/effect/turf_decal/lumos/tile/blue/half{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -29241,6 +29242,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 10
+	},
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics)
 "bvA" = (
@@ -29253,6 +29257,9 @@
 	dir = 8;
 	network = list("ss13","medbay");
 	pixel_y = -22
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics)
@@ -30191,17 +30198,18 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/hor)
 "bxQ" = (
-/obj/machinery/door/firedoor/heavy,
-/obj/machinery/door/poddoor/preopen{
-	id = "Biohazard";
-	name = "biohazard containment door"
+/obj/machinery/door/airlock/medical/glass{
+	id_tag = "GeneticsDoor";
+	name = "Genetics";
+	req_access_txt = "5; 68"
 	},
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/lumos/tile/blue/half{
-	dir = 8
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/lumos/tile/blue/fulltile,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
+/turf/open/floor/plasteel/dark,
+/area/medical/surgery)
 "bxS" = (
 /obj/machinery/sleeper{
 	dir = 8
@@ -31870,17 +31878,14 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics)
 "bBO" = (
-/obj/machinery/door/airlock/medical/glass{
-	id_tag = "GeneticsDoor";
-	name = "Genetics";
-	req_access_txt = "5; 68"
+/obj/machinery/door/airlock/maintenance{
+	name = "Surgery Maintenance";
+	req_access_txt = "45"
 	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/lumos/tile/blue/fulltile,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plating,
 /area/medical/surgery)
 "bBP" = (
 /obj/structure/disposalpipe/segment,
@@ -37084,11 +37089,16 @@
 /turf/open/floor/plating,
 /area/science/test_area)
 "bOL" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/disposalpipe/sorting/mail{
+	sortType = 9
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "bOM" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -43583,8 +43593,8 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/effect/turf_decal/lumos/tile/red/fullcorner{
-	dir = 4
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
@@ -50120,7 +50130,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -50158,7 +50168,7 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "cHZ" = (
-/obj/effect/turf_decal/lumos/tile/blue/half{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -50197,7 +50207,7 @@
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
 "cIf" = (
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -53085,10 +53095,10 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "gMy" = (
-/obj/effect/turf_decal/lumos/tile/red/half{
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
 "gNC" = (
@@ -53422,6 +53432,9 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/front_office)
 "hiG" = (
@@ -53622,14 +53635,8 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
 "hvD" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Surgery Maintenance";
-	req_access_txt = "45"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
+/obj/machinery/smartfridge/organ,
+/turf/closed/wall,
 /area/medical/surgery)
 "hwJ" = (
 /obj/structure/cable{
@@ -53708,7 +53715,7 @@
 /obj/item/radio/intercom{
 	pixel_x = 25
 	},
-/obj/effect/turf_decal/lumos/tile/red/half{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -53998,7 +54005,7 @@
 /area/hallway/secondary/exit)
 "ipA" = (
 /obj/structure/table,
-/obj/effect/turf_decal/lumos/tile/red/half{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -54146,17 +54153,6 @@
 /obj/structure/frame/machine,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"izA" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/disposalpipe/sorting/mail{
-	sortType = 9
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "iBi" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -57810,10 +57806,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"oDx" = (
-/obj/machinery/smartfridge/organ,
-/turf/closed/wall,
-/area/medical/surgery)
 "oEP" = (
 /obj/machinery/status_display/evac,
 /turf/closed/wall,
@@ -58769,8 +58761,8 @@
 "qrm" = (
 /obj/structure/closet/secure_closet/security/med,
 /obj/item/book/manual/wiki/security_space_law,
-/obj/effect/turf_decal/lumos/tile/red/fullcorner{
-	dir = 1
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
@@ -59629,8 +59621,8 @@
 /obj/machinery/camera{
 	c_tag = "Security Post - Medbay"
 	},
-/obj/effect/turf_decal/lumos/tile/red/fullcorner{
-	dir = 8
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
@@ -62657,7 +62649,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/effect/turf_decal/lumos/tile/red/half{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -63150,9 +63142,11 @@
 /obj/machinery/light_switch{
 	pixel_x = 28
 	},
-/obj/effect/turf_decal/lumos/tile/red/fullcorner,
 /obj/structure/chair{
 	dir = 8
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
@@ -102895,7 +102889,7 @@ aYV
 aYV
 bqN
 omm
-buT
+biN
 qVZ
 nQv
 hvd
@@ -103428,7 +103422,7 @@ bFO
 bFO
 bFO
 rVj
-oDx
+hvD
 bFO
 bFO
 jyt
@@ -104452,7 +104446,7 @@ bvs
 bEh
 qZC
 gdi
-bBO
+bxQ
 bDa
 sgD
 scf
@@ -104967,7 +104961,7 @@ bvA
 nTb
 nTb
 bFO
-hvD
+bBO
 bFO
 bFO
 bFO
@@ -105224,7 +105218,7 @@ bvz
 bdO
 bna
 bna
-izA
+bOL
 bna
 cbL
 cbL
@@ -105989,7 +105983,7 @@ boE
 bsQ
 bsQ
 box
-bxQ
+buT
 buU
 byf
 bzu
@@ -107776,7 +107770,7 @@ vsT
 aFu
 aYV
 bck
-bOL
+uTE
 bfV
 bhw
 cHM
@@ -108293,7 +108287,7 @@ bck
 aYV
 bfW
 bhy
-biN
+biL
 biL
 bni
 blM

--- a/_maps/map_files/BoxStation/BoxStation_Lumos.dmm
+++ b/_maps/map_files/BoxStation/BoxStation_Lumos.dmm
@@ -22968,7 +22968,8 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
 "bey" = (
-/turf/open/floor/plasteel/white/corner,
+/obj/effect/turf_decal/trimline/white/filled/corner,
+/turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bez" = (
 /obj/machinery/power/apc{
@@ -26027,9 +26028,10 @@
 /area/crew_quarters/kitchen)
 "bmX" = (
 /obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/white/corner{
+/obj/effect/turf_decal/trimline/white/filled/corner{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bna" = (
 /obj/structure/disposalpipe/segment,
@@ -26272,9 +26274,6 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "bnH" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -26962,9 +26961,6 @@
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6
-	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/front_office)
 "bpw" = (
@@ -26982,7 +26978,6 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/front_office)
 "bpy" = (
@@ -27075,9 +27070,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 9
-	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/front_office)
 "bpK" = (
@@ -27494,7 +27487,8 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bqN" = (
-/turf/open/floor/plasteel/white/side,
+/obj/effect/turf_decal/trimline/white/filled/line,
+/turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bqP" = (
 /obj/effect/turf_decal/lumos/tile/blue/checker{
@@ -28311,29 +28305,26 @@
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
 "btk" = (
-/obj/structure/closet/wardrobe,
-/obj/item/clothing/under/dress/flower,
-/obj/item/clothing/under/dress/blacktango,
-/obj/item/clothing/suit/wornshirt/polychromic,
-/obj/item/clothing/under/misc/pj/red,
-/obj/item/clothing/under/misc/pj/blue,
-/obj/item/clothing/under/misc/polyjumpsuit,
-/obj/item/clothing/under/misc/polyjumpsuit,
-/obj/item/clothing/under/misc/polyjumpsuit,
-/obj/item/clothing/under/misc/staffassistant,
-/obj/item/clothing/under/misc/staffassistant,
-/obj/item/clothing/under/misc/staffassistant,
-/obj/machinery/camera{
-	c_tag = "Cloning";
-	network = list("ss13","medbay")
+/obj/machinery/shower{
+	pixel_x = 3;
+	pixel_y = 20
 	},
-/obj/machinery/airalarm{
-	pixel_y = 23
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
+/obj/effect/turf_decal/lumos/shower{
+	pixel_x = 3;
+	pixel_y = 2
 	},
-/turf/open/floor/plasteel/dark,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/door/window/northleft{
+	dir = 2;
+	name = "Shower Door"
+	},
+/obj/structure/curtain,
+/turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
 "btl" = (
 /obj/structure/cable{
@@ -28354,7 +28345,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/dark,
 /area/medical/genetics)
 "bto" = (
 /obj/structure/sign/warning/securearea{
@@ -28363,7 +28354,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/dark,
 /area/medical/genetics)
 "btp" = (
 /turf/open/floor/plating,
@@ -28429,9 +28420,6 @@
 "btw" = (
 /obj/machinery/light{
 	dir = 1
-	},
-/obj/effect/turf_decal/lumos/tile/blue/half{
-	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
@@ -28625,11 +28613,11 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "btV" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/front_office)
@@ -28694,11 +28682,24 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
 "buf" = (
-/obj/structure/sink{
-	pixel_y = 28
+/obj/machinery/airalarm{
+	pixel_y = 23
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#cee5d2"
+	},
+/obj/structure/table,
+/obj/item/storage/box/rxglasses{
+	pixel_x = 3;
+	pixel_y = 7
+	},
+/obj/item/pen{
+	pixel_x = -8;
+	pixel_y = -3
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics/cloning)
@@ -28738,9 +28739,6 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics)
 "bum" = (
-/obj/machinery/light{
-	light_color = "#e8eaff"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
 	},
@@ -28748,6 +28746,9 @@
 	dir = 4
 	},
 /mob/living/carbon/monkey,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
 /turf/open/floor/grass,
 /area/medical/genetics)
 "bun" = (
@@ -28789,16 +28790,12 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics)
 "bur" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 5
 	},
-/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics/cloning)
 "bus" = (
@@ -28863,9 +28860,6 @@
 /turf/open/floor/plasteel,
 /area/science/circuit)
 "bux" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -28873,6 +28867,12 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -28892,7 +28892,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/dark,
 /area/medical/genetics)
 "buz" = (
 /obj/structure/cable{
@@ -28953,7 +28953,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/dark,
 /area/medical/genetics/cloning)
 "buH" = (
 /obj/machinery/door/airlock/research{
@@ -28972,7 +28972,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/dark,
 /area/science/research)
 "buI" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -29003,7 +29003,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/dark,
 /area/medical/genetics)
 "buM" = (
 /obj/machinery/keycard_auth{
@@ -29040,20 +29040,11 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
 "buT" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/effect/turf_decal/trimline/white/filled/line{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/turf_decal/lumos/tile/blue/half{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
+/turf/open/floor/plasteel/dark,
+/area/medical/morgue)
 "buU" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -29070,7 +29061,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/lumos/tile/blue/half{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/science/research)
 "buV" = (
 /obj/effect/turf_decal/stripes/line{
@@ -29127,7 +29121,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/plasteel/median/whitetodark,
+/turf/open/floor/plasteel/white,
 /area/science/research)
 "bvc" = (
 /obj/structure/cable{
@@ -29208,8 +29202,8 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics/cloning)
@@ -29247,7 +29241,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/dark,
 /area/medical/genetics)
 "bvA" = (
 /obj/structure/sign/warning/securearea,
@@ -29260,7 +29254,7 @@
 	network = list("ss13","medbay");
 	pixel_y = -22
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/dark,
 /area/medical/genetics)
 "bvD" = (
 /obj/structure/cable{
@@ -29562,12 +29556,6 @@
 	dir = 4;
 	pixel_x = -23
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 1
-	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bwy" = (
@@ -29632,9 +29620,6 @@
 	c_tag = "Chemistry";
 	dir = 1;
 	network = list("ss13","medbay")
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
@@ -30176,6 +30161,9 @@
 /area/security/checkpoint/auxiliary)
 "bxN" = (
 /obj/machinery/clonepod,
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics/cloning)
 "bxO" = (
@@ -30203,12 +30191,17 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/hor)
 "bxQ" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
+/obj/machinery/door/firedoor/heavy,
+/obj/machinery/door/poddoor/preopen{
+	id = "Biohazard";
+	name = "biohazard containment door"
+	},
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/lumos/tile/blue/half{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
-/area/medical/sleeper)
+/area/science/research)
 "bxS" = (
 /obj/machinery/sleeper{
 	dir = 8
@@ -30972,9 +30965,11 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/hor)
 "bzK" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
@@ -31220,9 +31215,6 @@
 /obj/machinery/chem_dispenser,
 /obj/machinery/light{
 	dir = 4
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 6
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
@@ -31861,6 +31853,9 @@
 	dir = 1
 	},
 /obj/machinery/bloodbankgen,
+/obj/structure/railing/corner{
+	dir = 8
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bBM" = (
@@ -31875,9 +31870,6 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics)
 "bBO" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = "GeneticsDoor";
 	name = "Genetics";
@@ -31885,7 +31877,10 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/lumos/tile/blue/fulltile,
-/turf/open/floor/plasteel/white,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
 /area/medical/surgery)
 "bBP" = (
 /obj/structure/disposalpipe/segment,
@@ -32208,17 +32203,14 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/medical/medbay/lobby)
 "bCE" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/medical/storage)
@@ -32226,13 +32218,13 @@
 /obj/machinery/airalarm{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/vending/wardrobe/chem_wardrobe,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/medical/storage)
 "bCG" = (
@@ -32248,9 +32240,6 @@
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "bCH" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
 /obj/structure/table,
 /obj/item/storage/box/beakers{
 	pixel_x = 2;
@@ -32273,9 +32262,6 @@
 /area/medical/storage)
 "bCJ" = (
 /obj/machinery/rnd/production/techfab/department/medical,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
 /turf/open/floor/plasteel,
 /area/medical/storage)
 "bCL" = (
@@ -32343,15 +32329,9 @@
 	name = "Station Intercom (Medbay)";
 	pixel_x = -30
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
-	},
 /obj/machinery/light{
 	dir = 8;
 	light_color = "#e8eaff"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -32359,9 +32339,6 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bCS" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
@@ -32409,24 +32386,38 @@
 /obj/item/tank/internals/anesthetic,
 /obj/item/tank/internals/anesthetic,
 /obj/item/tank/internals/anesthetic,
-/obj/item/tank/internals/anesthetic,
-/obj/item/reagent_containers/medspray/sterilizine,
-/obj/item/reagent_containers/medspray/sterilizine,
-/turf/open/floor/plasteel/white,
+/obj/item/clothing/mask/breath/medical,
+/obj/item/clothing/mask/breath/medical,
+/obj/item/clothing/mask/breath/medical,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/showroomfloor,
 /area/medical/surgery)
 "bCZ" = (
-/obj/machinery/limbgrower,
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4
+/obj/machinery/airalarm{
+	pixel_y = 20
 	},
-/turf/open/floor/plasteel/white,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/closet/crate/freezer/surplus_limbs,
+/turf/open/floor/plasteel/showroomfloor,
 /area/medical/surgery)
 "bDa" = (
-/obj/structure/table/optable,
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/showroomfloor,
 /area/medical/surgery)
 "bDb" = (
 /turf/closed/wall/r_wall,
@@ -32620,6 +32611,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
 /area/medical/storage)
 "bDB" = (
@@ -32682,12 +32674,6 @@
 	dir = 8;
 	network = list("ss13","medbay")
 	},
-/obj/machinery/requests_console{
-	department = "Medbay";
-	departmentType = 1;
-	name = "Medbay RC";
-	pixel_x = 28
-	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
 	},
@@ -32697,7 +32683,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bDJ" = (
@@ -32796,10 +32781,11 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner,
-/obj/machinery/light{
-	dir = 8
+/obj/item/reagent_containers/medspray/sterilizine{
+	pixel_x = -9;
+	pixel_y = 13
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/showroomfloor,
 /area/medical/surgery)
 "bDT" = (
 /turf/closed/wall,
@@ -32815,6 +32801,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/turf_decal/lumos/tile/blue/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics/cloning)
 "bDW" = (
@@ -32892,12 +32879,9 @@
 	dir = 8;
 	light_color = "#e8eaff"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 4
-	},
 /obj/machinery/chem_dispenser,
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
@@ -32937,20 +32921,15 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics/cloning)
-"bEj" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/surgery)
 "bEl" = (
-/obj/effect/landmark/start/medical_doctor,
-/turf/open/floor/plasteel/white,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/showroomfloor,
 /area/medical/surgery)
 "bEm" = (
 /turf/open/floor/engine,
@@ -33439,6 +33418,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bFx" = (
@@ -33453,7 +33433,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/medical/storage)
 "bFz" = (
 /obj/effect/turf_decal/stripes/line{
@@ -33490,8 +33470,18 @@
 "bFE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/effect/turf_decal/lumos/tile/blue/fulltile,
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/obj/machinery/limbgrower,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/showroomfloor,
 /area/medical/surgery)
 "bFF" = (
 /obj/structure/table,
@@ -33519,7 +33509,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/showroomfloor,
 /area/medical/surgery)
 "bFI" = (
 /obj/machinery/airalarm{
@@ -33574,15 +33564,16 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bFN" = (
 /obj/machinery/computer/operating{
 	dir = 4
 	},
-/obj/effect/turf_decal/lumos/tile/blue/fulltile,
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/showroomfloor,
 /area/medical/surgery)
 "bFO" = (
 /turf/closed/wall,
@@ -33992,10 +33983,10 @@
 /area/maintenance/aft)
 "bGX" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -34011,7 +34002,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/showroomfloor,
 /area/medical/surgery)
 "bHb" = (
 /obj/structure/sink{
@@ -34020,7 +34011,7 @@
 	},
 /obj/effect/landmark/start/medical_doctor,
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/showroomfloor,
 /area/medical/surgery)
 "bHc" = (
 /obj/structure/extinguisher_cabinet{
@@ -34388,7 +34379,6 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bIc" = (
-/obj/structure/closet/crate/freezer/surplus_limbs,
 /turf/open/floor/plasteel,
 /area/medical/storage)
 "bId" = (
@@ -34431,8 +34421,10 @@
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/effect/turf_decal/lumos/tile/green/fulltile,
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/stripes/end{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
 /area/medical/virology)
 "bIg" = (
 /obj/structure/cable{
@@ -34524,14 +34516,14 @@
 /area/medical/sleeper)
 "bIo" = (
 /obj/machinery/chem_dispenser/apothecary,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/medical/medbay/central)
 "bIp" = (
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
 /obj/machinery/chem_heater,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/medical/medbay/central)
 "bIr" = (
 /obj/machinery/smartfridge/chemistry/preloaded,
@@ -34587,7 +34579,7 @@
 "bIw" = (
 /obj/structure/table/optable,
 /obj/effect/turf_decal/lumos/tile/blue/fulltile,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/showroomfloor,
 /area/medical/surgery)
 "bIx" = (
 /obj/structure/sign/warning/electricshock,
@@ -35551,7 +35543,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bKP" = (
@@ -35602,6 +35596,9 @@
 	},
 /obj/structure/chair{
 	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/surgery)
@@ -35741,7 +35738,10 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel/dark,
 /area/medical/virology)
 "bLg" = (
@@ -35982,7 +35982,7 @@
 	dir = 8;
 	light_color = "#e8eaff"
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/medical/medbay/central)
 "bLV" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -35997,7 +35997,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/medical/medbay/central)
 "bLW" = (
 /obj/machinery/firealarm{
@@ -36006,7 +36006,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/medical/medbay/central)
 "bLX" = (
 /obj/structure/chair/office/light{
@@ -36454,9 +36454,6 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/virology)
 "bNi" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 1
-	},
 /obj/structure/table/glass,
 /obj/item/grenade/chem_grenade,
 /obj/item/grenade/chem_grenade,
@@ -36467,6 +36464,9 @@
 /obj/item/screwdriver{
 	pixel_x = -2;
 	pixel_y = 6
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
@@ -37283,6 +37283,9 @@
 /area/medical/virology)
 "bPp" = (
 /obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/white/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -38244,10 +38247,8 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/effect/turf_decal/lumos/tile/green/checker{
-	dir = 4
-	},
-/turf/open/floor/plasteel/cafeteria,
+/obj/effect/turf_decal/stripes/end,
+/turf/open/floor/plasteel/dark,
 /area/medical/virology)
 "bRQ" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -46508,9 +46509,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "cpG" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
 /obj/machinery/requests_console{
 	department = "Medbay";
 	departmentType = 1;
@@ -46532,6 +46530,9 @@
 /obj/machinery/light{
 	dir = 1;
 	light_color = "#cee5d2"
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/medical/storage)
@@ -49408,6 +49409,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "cBn" = (
@@ -50260,8 +50262,12 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "cKu" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk,
+/obj/machinery/camera{
+	c_tag = "Cloning";
+	dir = 9;
+	network = list("ss13","medbay")
+	},
+/obj/effect/turf_decal/trimline/purple/filled/corner,
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics/cloning)
 "cKz" = (
@@ -51341,18 +51347,14 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 5
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /obj/structure/railing/corner{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "dTI" = (
@@ -51590,9 +51592,6 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
 "elf" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
 /obj/structure/closet/wardrobe/chemistry_white,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
@@ -51673,7 +51672,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/medical/medbay/central)
 "exP" = (
 /obj/item/kirbyplants{
@@ -51697,16 +51696,16 @@
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/front_office)
 "ezb" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
-	},
 /obj/structure/railing/corner,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "ezF" = (
@@ -52477,10 +52476,10 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 9
-	},
-/obj/effect/turf_decal/stripes/corner{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics/cloning)
@@ -52570,10 +52569,10 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/virology)
 "gdi" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -31
-	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics/cloning)
 "gdQ" = (
@@ -52599,6 +52598,11 @@
 "gfo" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /mob/living/carbon/monkey,
+/obj/machinery/door/window/eastright{
+	dir = 8;
+	name = "Monkey Pen";
+	req_access_txt = "9"
+	},
 /turf/open/floor/grass,
 /area/medical/genetics)
 "gfr" = (
@@ -52803,6 +52807,9 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics)
 "guS" = (
@@ -52993,6 +53000,7 @@
 /obj/structure/railing/corner{
 	dir = 4
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "gHV" = (
@@ -53297,9 +53305,6 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 5
 	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics)
 "hbs" = (
@@ -53415,10 +53420,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10
-	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 4
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/front_office)
@@ -53620,7 +53622,6 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
 "hvD" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/airlock/maintenance{
 	name = "Surgery Maintenance";
 	req_access_txt = "45"
@@ -53937,15 +53938,13 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/front_office)
 "iiQ" = (
@@ -54057,11 +54056,14 @@
 /turf/open/floor/plating,
 /area/security/range)
 "ium" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -54100,9 +54102,6 @@
 "iwg" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 9
-	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/front_office)
 "iwm" = (
@@ -54162,6 +54161,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "iCM" = (
@@ -54224,7 +54224,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/effect/turf_decal/lumos/tile/blue/fulltile,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/front_office)
 "iIj" = (
@@ -54410,6 +54412,9 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/medical/storage)
 "iYb" = (
@@ -54801,6 +54806,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/medical/surgery)
 "jAg" = (
@@ -54946,14 +54954,14 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "jHZ" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/front_office)
@@ -55145,15 +55153,16 @@
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
 "jRq" = (
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/machinery/computer/operating{
 	dir = 8
 	},
-/obj/effect/turf_decal/lumos/tile/blue/fulltile,
-/turf/open/floor/plasteel/white,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/showroomfloor,
 /area/medical/surgery)
 "jSb" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -55280,7 +55289,11 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
+/obj/machinery/power/apc/auto_name/west,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plasteel/showroomfloor,
 /area/medical/surgery)
 "kbi" = (
 /obj/machinery/light/small{
@@ -55429,17 +55442,19 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
 "kiG" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
 /obj/structure/table/reinforced,
-/obj/item/storage/backpack/duffelbag/med/surgery,
-/obj/machinery/power/apc/auto_name/east,
-/obj/structure/cable{
-	icon_state = "0-8"
+/obj/item/storage/box/bodybags{
+	pixel_x = 4;
+	pixel_y = 2
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/obj/machinery/light{
-	dir = 4
+/obj/item/pen{
+	pixel_x = -9;
+	pixel_y = -4
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/showroomfloor,
 /area/medical/surgery)
 "kkH" = (
 /obj/machinery/suit_storage_unit/cmo,
@@ -55518,9 +55533,6 @@
 /obj/structure/table/reinforced,
 /obj/item/storage/backpack/duffelbag/med/surgery,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
 	},
 /obj/machinery/button/door{
@@ -55529,7 +55541,16 @@
 	pixel_x = 26;
 	req_access_txt = "5"
 	},
-/turf/open/floor/plasteel/white,
+/obj/machinery/camera{
+	c_tag = "Operating Room";
+	dir = 8;
+	network = list("ss13","medbay")
+	},
+/obj/item/reagent_containers/medspray/sterilizine{
+	pixel_x = -9;
+	pixel_y = 13
+	},
+/turf/open/floor/plasteel/showroomfloor,
 /area/medical/surgery)
 "ktD" = (
 /obj/machinery/camera{
@@ -55837,9 +55858,6 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "kXT" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
 /obj/machinery/chem_master,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
@@ -55879,6 +55897,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/medical/surgery)
 "laq" = (
@@ -55907,7 +55928,7 @@
 	pixel_x = -23
 	},
 /obj/structure/table,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/medical/medbay/central)
 "lfJ" = (
 /obj/machinery/light/small{
@@ -56011,11 +56032,7 @@
 /turf/open/floor/plasteel,
 /area/storage/art)
 "lun" = (
-/obj/machinery/shower{
-	dir = 4
-	},
-/obj/effect/turf_decal/lumos/shower,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/dark,
 /area/medical/genetics/cloning)
 "luQ" = (
 /obj/structure/lattice,
@@ -56140,7 +56157,7 @@
 	light_color = "#e8eaff"
 	},
 /obj/machinery/holopad,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/medical/medbay/central)
 "lJS" = (
 /obj/machinery/door/poddoor/incinerator_atmos_main,
@@ -56316,7 +56333,7 @@
 /obj/structure/chair/office/light{
 	dir = 1
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/medical/medbay/central)
 "mgf" = (
 /obj/machinery/light{
@@ -56344,7 +56361,7 @@
 	dir = 1;
 	network = list("ss13","medbay")
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/medical/medbay/central)
 "mio" = (
 /turf/open/floor/plasteel/white,
@@ -56463,10 +56480,8 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "mxv" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/turf/open/floor/plasteel,
 /area/medical/medbay/central)
 "mxZ" = (
 /turf/open/floor/plasteel/white,
@@ -56526,15 +56541,13 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "mDb" = (
-/obj/machinery/computer/operating{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/camera{
-	c_tag = "Operating Room";
-	dir = 8;
-	network = list("ss13","medbay")
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/showroomfloor,
 /area/medical/surgery)
 "mEb" = (
 /obj/structure/railing/corner,
@@ -56605,6 +56618,7 @@
 /obj/item/kirbyplants{
 	icon_state = "plant-22"
 	},
+/obj/machinery/light,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "mNi" = (
@@ -56703,6 +56717,9 @@
 /area/crew_quarters/heads/captain)
 "mSs" = (
 /mob/living/carbon/monkey,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
 /turf/open/floor/grass,
 /area/medical/genetics)
 "mTG" = (
@@ -56748,6 +56765,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/surgery)
@@ -57162,6 +57182,9 @@
 	req_access_txt = "9"
 	},
 /obj/effect/turf_decal/lumos/tile/purple/fulltile,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics)
 "nIB" = (
@@ -57236,6 +57259,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/medical/surgery)
 "nNF" = (
@@ -57249,8 +57275,11 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/virology)
@@ -57313,12 +57342,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/front_office)
 "nSt" = (
@@ -57378,6 +57402,12 @@
 /area/security/brig)
 "nXg" = (
 /obj/structure/railing,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel/stairs/left{
 	dir = 4
 	},
@@ -57578,6 +57608,10 @@
 	name = "Morgue";
 	req_access_txt = "5;6;22"
 	},
+/obj/effect/turf_decal/trimline/white/filled/line,
+/obj/effect/turf_decal/trimline/white/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "omY" = (
@@ -57656,10 +57690,6 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
-/obj/machinery/door/window/eastright{
-	name = "Monkey Pen";
-	req_access_txt = "9"
-	},
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics)
 "ovf" = (
@@ -57726,7 +57756,6 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/pool)
 "ozX" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -57738,6 +57767,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "2-8"
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 2
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
@@ -57779,19 +57811,9 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "oDx" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel/median/whitetodark/corner{
-	dir = 8
-	},
-/area/science/research)
+/obj/machinery/smartfridge/organ,
+/turf/closed/wall,
+/area/medical/surgery)
 "oEP" = (
 /obj/machinery/status_display/evac,
 /turf/closed/wall,
@@ -57852,7 +57874,6 @@
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner,
 /obj/machinery/chem_master,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
@@ -57957,7 +57978,9 @@
 	},
 /area/medical/sleeper)
 "oTQ" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "oTS" = (
@@ -58246,6 +58269,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/front_office)
 "ptM" = (
@@ -58528,8 +58552,9 @@
 	dir = 8;
 	pixel_x = -14
 	},
+/obj/effect/landmark/start/medical_doctor,
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/showroomfloor,
 /area/medical/surgery)
 "pTB" = (
 /obj/structure/lattice/catwalk,
@@ -58563,18 +58588,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
-"pUF" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel/median/whitetodark/corner,
-/area/science/research)
 "pWM" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -58649,13 +58662,16 @@
 /turf/open/floor/plating,
 /area/library)
 "qif" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/showroomfloor,
 /area/medical/surgery)
 "qje" = (
 /obj/structure/sign/mining{
@@ -58944,7 +58960,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/medical/medbay/central)
 "qNZ" = (
 /obj/effect/turf_decal/stripes/line{
@@ -58998,16 +59014,6 @@
 /obj/machinery/atmospherics/components/binary/valve,
 /turf/open/floor/engine,
 /area/science/mixing)
-"qVv" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 14
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/surgery)
 "qVP" = (
 /obj/effect/spawner/blocker,
 /turf/open/floor/plating,
@@ -59038,8 +59044,8 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
+/obj/structure/disposalpipe/segment{
+	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics/cloning)
@@ -59240,10 +59246,10 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -31
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -59560,16 +59566,13 @@
 	pixel_x = -27
 	},
 /obj/machinery/chem_master,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/medical/medbay/central)
 "scf" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/showroomfloor,
 /area/medical/surgery)
 "sci" = (
 /turf/open/floor/plasteel/dark,
@@ -59632,13 +59635,7 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
 "sgD" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/showroomfloor,
 /area/medical/surgery)
 "shR" = (
 /obj/effect/turf_decal/stripes/line{
@@ -59884,6 +59881,8 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk,
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics)
 "sEi" = (
@@ -60090,8 +60089,8 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
 	},
-/obj/structure/disposalpipe/junction/yjunction{
-	dir = 4
+/obj/structure/disposalpipe/segment{
+	dir = 5
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -60191,6 +60190,13 @@
 /obj/item/stack/packageWrap,
 /obj/item/pen,
 /obj/item/pen,
+/obj/machinery/requests_console{
+	department = "Medbay";
+	departmentType = 1;
+	name = "Medbay RC";
+	pixel_x = 28;
+	pixel_y = -11
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "tbP" = (
@@ -60315,11 +60321,8 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/effect/turf_decal/trimline/purple/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics/cloning)
@@ -60331,7 +60334,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "tmO" = (
@@ -60353,12 +60355,16 @@
 /area/hallway/secondary/exit)
 "tpc" = (
 /obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -31
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/machinery/light,
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics/cloning)
 "tqg" = (
@@ -60519,7 +60525,9 @@
 	pixel_y = -30
 	},
 /obj/machinery/dna_scannernew,
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics/cloning)
 "tCa" = (
@@ -60683,9 +60691,9 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 9
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/showroomfloor,
 /area/medical/surgery)
 "tRB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -61304,16 +61312,18 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/machinery/light,
-/obj/structure/table,
-/obj/item/storage/box/rxglasses{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/box/bodybags,
-/obj/item/pen,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10
+/obj/structure/closet/wardrobe,
+/obj/item/clothing/suit/wornshirt/polychromic,
+/obj/item/clothing/under/misc/pj/red,
+/obj/item/clothing/under/misc/pj/blue,
+/obj/item/clothing/under/misc/polyjumpsuit,
+/obj/item/clothing/under/misc/polyjumpsuit,
+/obj/item/clothing/under/misc/polyjumpsuit,
+/obj/item/clothing/under/misc/staffassistant,
+/obj/item/clothing/under/misc/staffassistant,
+/obj/item/clothing/under/misc/staffassistant,
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics/cloning)
@@ -61411,10 +61421,7 @@
 	dir = 10
 	},
 /obj/machinery/holopad,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/showroomfloor,
 /area/medical/surgery)
 "vda" = (
 /obj/effect/turf_decal/stripes/line{
@@ -61449,7 +61456,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/medical/medbay/central)
 "vhb" = (
 /obj/structure/window{
@@ -62204,6 +62211,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/medical/surgery)
 "wig" = (
@@ -62371,6 +62381,9 @@
 "wsu" = (
 /obj/machinery/airalarm{
 	pixel_y = 23
+	},
+/obj/effect/turf_decal/trimline/white/filled/corner{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
@@ -63025,6 +63038,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "xBk" = (
@@ -63169,9 +63183,6 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics)
 "xNE" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
 /obj/structure/closet/secure_closet/medical3,
 /obj/item/storage/box/gloves,
 /obj/item/storage/box/medipens,
@@ -99808,7 +99819,7 @@ bmL
 boi
 bpw
 iwg
-bxQ
+nMr
 col
 tFr
 bwG
@@ -102884,7 +102895,7 @@ aYV
 aYV
 bqN
 omm
-qVZ
+buT
 qVZ
 nQv
 hvd
@@ -103417,7 +103428,7 @@ bFO
 bFO
 bFO
 rVj
-bFO
+oDx
 bFO
 bFO
 jyt
@@ -104184,9 +104195,9 @@ bur
 lun
 tmf
 tpc
-bBO
+bFO
 qif
-bEj
+sgD
 vcY
 bGZ
 bFE
@@ -104441,9 +104452,9 @@ bvs
 bEh
 qZC
 gdi
-bFO
+bBO
 bDa
-qVv
+sgD
 scf
 bHb
 bIw
@@ -104956,9 +104967,9 @@ bvA
 nTb
 nTb
 bFO
-bFO
-bFO
 hvD
+bFO
+bFO
 bFO
 bFO
 bFO
@@ -105213,9 +105224,9 @@ bvz
 bdO
 bna
 bna
-bna
-bna
 izA
+bna
+cbL
 cbL
 bna
 bna
@@ -105978,7 +105989,7 @@ boE
 bsQ
 bsQ
 box
-boz
+bxQ
 buU
 byf
 bzu
@@ -106236,7 +106247,7 @@ bht
 bsQ
 box
 btw
-buT
+bus
 byf
 bzt
 bAy
@@ -106493,7 +106504,7 @@ bsQ
 bsR
 box
 btU
-pUF
+bus
 byf
 bzw
 bAB
@@ -107007,7 +107018,7 @@ cHZ
 cIf
 box
 btA
-oDx
+bus
 byf
 bzy
 bAD

--- a/_maps/map_files/BoxStation/BoxStation_Lumos.dmm
+++ b/_maps/map_files/BoxStation/BoxStation_Lumos.dmm
@@ -199,11 +199,11 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aaK" = (
-/obj/structure/closet/secure_closet/security/sec{
-	anchored = 1
+/obj/effect/turf_decal/trimline/red/line{
+	dir = 1
 	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/trimline/red/line,
+/turf/open/floor/plasteel,
 /area/security/main)
 "aaL" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -291,7 +291,6 @@
 /turf/open/floor/circuit/green,
 /area/security/prison)
 "aaY" = (
-/obj/effect/turf_decal/bot,
 /obj/structure/closet/crate/secure/weapon{
 	desc = "A secure clothing crate.";
 	name = "formal uniform crate";
@@ -318,6 +317,7 @@
 /obj/item/clothing/head/beret/sec/navyofficer,
 /obj/item/clothing/head/beret/sec/navywarden,
 /obj/item/clothing/head/beret/sec/navyhos,
+/obj/effect/turf_decal/lumos/tile/red/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "aaZ" = (
@@ -403,19 +403,8 @@
 /turf/open/floor/circuit/green,
 /area/security/prison)
 "abk" = (
-/obj/effect/turf_decal/lumos/tile/red/half{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/main)
-"abm" = (
-/turf/open/floor/plasteel/dark,
-/area/security/main)
-"abn" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/closet/secure_closet/security/sec{
-	anchored = 1
-	},
+/obj/machinery/vending/wardrobe/sec_wardrobe,
+/obj/effect/turf_decal/lumos/tile/red/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "abo" = (
@@ -552,37 +541,32 @@
 /turf/open/space/basic,
 /area/ai_monitored/security/armory)
 "abH" = (
-/obj/effect/turf_decal/bot,
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/structure/closet/secure_closet/security/sec{
-	anchored = 1
+/obj/effect/turf_decal/trimline/red/line,
+/obj/effect/turf_decal/trimline/red/line{
+	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel,
 /area/security/main)
 "abI" = (
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "2-8"
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "abJ" = (
-/obj/machinery/vending/wardrobe/sec_wardrobe,
-/obj/effect/turf_decal/bot,
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/lumos/loading_area,
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
 /area/security/main)
 "abK" = (
 /obj/structure/trash_pile,
@@ -607,28 +591,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"abN" = (
-/obj/effect/landmark/secequipment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
-	},
-/obj/effect/turf_decal/lumos/tile/red/half{
-	dir = 8
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel/dark,
-/area/security/main)
 "abO" = (
-/turf/open/floor/plasteel/showroomfloor,
+/obj/machinery/vending/security,
+/obj/effect/turf_decal/lumos/tile/red/fulltile,
+/turf/open/floor/plasteel/dark,
 /area/security/main)
 "abP" = (
 /obj/effect/landmark/start/security_officer,
 /obj/structure/sign/plaques/golden{
 	pixel_y = 32
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
@@ -639,10 +610,13 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
 "abR" = (
-/obj/machinery/vending/security,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel/dark,
-/area/security/main)
+/obj/structure/chair/stool,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/red/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "abS" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel,
@@ -677,7 +651,15 @@
 	dir = 4;
 	pixel_x = -26
 	},
-/turf/open/floor/plasteel/showroomfloor,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/corner{
+	dir = 8
+	},
 /area/security/main)
 "abW" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -758,14 +740,6 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "ack" = (
-/obj/structure/table/reinforced,
-/obj/item/grenade/barrier{
-	pixel_x = 4
-	},
-/obj/item/grenade/barrier,
-/obj/item/grenade/barrier{
-	pixel_x = -4
-	},
 /obj/machinery/power/apc/highcap/five_k{
 	areastring = "/area/ai_monitored/security/armory";
 	dir = 8;
@@ -778,51 +752,31 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
+/obj/effect/turf_decal/trimline/blue/line,
+/obj/effect/turf_decal/trimline/red/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "acl" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/end{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/blue/line,
+/obj/effect/turf_decal/trimline/red/line{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "acm" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/lumos/tile/red/half{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
-"acn" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
 	},
 /obj/effect/turf_decal/stripes/corner{
-	dir = 1
+	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/lumos/tile/red/half{
+/obj/effect/turf_decal/trimline/blue/line,
+/obj/effect/turf_decal/trimline/red/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -834,14 +788,14 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/lumos/tile/red/half{
-	dir = 1
-	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "acq" = (
 /obj/machinery/firealarm{
 	pixel_y = 24
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
@@ -970,6 +924,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "acI" = (
@@ -1001,6 +958,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "acL" = (
@@ -1019,6 +977,10 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "acN" = (
@@ -1026,12 +988,13 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "acO" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/lumos/tile/red/half{
-	dir = 8
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
 /area/security/main)
 "acP" = (
 /obj/machinery/light{
@@ -1040,7 +1003,9 @@
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_x = 30
 	},
-/turf/open/floor/plasteel/dark,
+/obj/structure/table/reinforced,
+/obj/machinery/recharger,
+/turf/open/floor/plasteel,
 /area/security/main)
 "acQ" = (
 /obj/structure/table/wood,
@@ -1181,11 +1146,15 @@
 /turf/open/floor/plating,
 /area/ai_monitored/security/armory)
 "adh" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/corner,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
@@ -1208,45 +1177,36 @@
 	dir = 4;
 	light_color = "#c1caff"
 	},
-/obj/effect/turf_decal/lumos/tile/red/half{
-	dir = 4
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 5
 	},
-/obj/effect/turf_decal/lumos/tile/neutral/half{
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 8
 	},
-/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
-"adj" = (
-/obj/machinery/recharger,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/structure/table/reinforced,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/main)
 "adk" = (
-/obj/machinery/recharger,
-/obj/structure/table/reinforced,
-/turf/open/floor/plasteel/showroomfloor,
+/obj/effect/turf_decal/trimline/red/filled/corner,
+/turf/open/floor/plasteel,
 /area/security/main)
 "adl" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/lumos/tile/red/fullcorner{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/plasteel,
 /area/security/main)
 "adm" = (
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_x = 29
 	},
-/obj/effect/landmark/secequipment,
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/lumos/tile/red/half,
-/turf/open/floor/plasteel/dark,
+/obj/structure/table/reinforced,
+/obj/machinery/recharger,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/security/main)
 "adn" = (
 /obj/structure/chair{
@@ -1445,7 +1405,7 @@
 	c_tag = "Brig EVA Storage";
 	dir = 4
 	},
-/obj/effect/turf_decal/lumos/tile/red/half{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -1460,7 +1420,10 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/lumos/tile/red/half{
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -1504,13 +1467,13 @@
 	pixel_y = -3
 	},
 /obj/structure/window/reinforced,
-/obj/effect/turf_decal/lumos/tile/red/half{
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/lumos/tile/neutral/half{
+/obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "adQ" = (
@@ -1634,6 +1597,7 @@
 	req_access_txt = "2"
 	},
 /obj/machinery/atmospherics/pipe/simple/general/hidden,
+/obj/effect/turf_decal/trimline/red/filled/corner,
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
 "aee" = (
@@ -1649,8 +1613,8 @@
 "aef" = (
 /obj/structure/table,
 /obj/item/restraints/handcuffs,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 9
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -1743,9 +1707,6 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 5
-	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aes" = (
@@ -1765,18 +1726,9 @@
 	req_access_txt = "1"
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/lumos/tile/red/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "aeu" = (
@@ -1794,20 +1746,15 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "aev" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
+/obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/effect/turf_decal/trimline/red/line{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/security/brig)
+/area/security/prison)
 "aew" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -1817,8 +1764,11 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
-/obj/effect/turf_decal/lumos/tile/red/half{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -1870,16 +1820,12 @@
 /obj/item/stack/packageWrap,
 /obj/item/stack/packageWrap,
 /obj/item/hand_labeler,
-/obj/effect/turf_decal/lumos/tile/red/fulltile,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
+/obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel,
 /area/security/main)
 "aeB" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk,
-/obj/effect/turf_decal/lumos/tile/red/fulltile,
+/obj/machinery/recharge_station,
 /turf/open/floor/plasteel,
 /area/security/main)
 "aeC" = (
@@ -1902,13 +1848,13 @@
 /area/crew_quarters/heads/hos)
 "aeE" = (
 /obj/structure/closet/secure_closet/lethalshots,
-/obj/effect/turf_decal/lumos/tile/neutral/half{
-	dir = 4
-	},
-/obj/effect/turf_decal/lumos/tile/blue/half{
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "aeF" = (
@@ -1919,7 +1865,9 @@
 /obj/item/storage/box/firingpins{
 	pixel_x = -3
 	},
-/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 9
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "aeG" = (
@@ -1988,6 +1936,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
 "aeL" = (
@@ -2002,9 +1953,6 @@
 "aeM" = (
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -2033,7 +1981,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/lumos/tile/red/fulltile,
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
+	},
 /area/security/execution/transfer)
 "aeP" = (
 /obj/machinery/airalarm{
@@ -2044,9 +1995,6 @@
 	},
 /obj/structure/cable{
 	icon_state = "2-4"
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -2064,25 +2012,19 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aeS" = (
-/obj/structure/closet/secure_closet/brig,
-/obj/item/radio/headset{
-	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
-	name = "prisoner headset";
-	prison_radio = 1
+/obj/structure/chair/stool,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/green/line,
 /turf/open/floor/plasteel,
-/area/security/brig)
+/area/security/prison)
 "aeT" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
-/obj/effect/turf_decal/trimline/red/filled/corner,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aeU" = (
@@ -2091,9 +2033,6 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -2119,47 +2058,46 @@
 	pixel_x = -3
 	},
 /obj/item/storage/lockbox/loyalty,
-/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "aeX" = (
-/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
-/obj/structure/window/reinforced{
-	dir = 4;
-	layer = 2.9
+/obj/structure/closet/secure_closet/contraband/armory,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "aeY" = (
-/obj/vehicle/ridden/secway,
-/obj/item/key/security,
-/obj/effect/turf_decal/lumos/tile/blue/fullcorner{
-	dir = 4
+/obj/structure/window/reinforced,
+/obj/effect/turf_decal/bot,
+/obj/machinery/flasher/portable,
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "aeZ" = (
-/obj/structure/rack,
-/obj/item/gun/energy/ionrifle,
-/obj/item/gun/energy/temperature/security,
-/obj/item/clothing/suit/armor/laserproof,
 /obj/machinery/airalarm{
 	pixel_y = 23
 	},
-/obj/effect/turf_decal/lumos/tile/blue/half{
-	dir = 1
-	},
-/obj/effect/turf_decal/lumos/tile/neutral/half,
-/obj/effect/turf_decal/delivery,
+/obj/structure/window/reinforced,
+/obj/effect/turf_decal/bot,
+/obj/machinery/flasher/portable,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "afa" = (
 /obj/item/radio/intercom{
 	pixel_y = 25
 	},
-/obj/effect/landmark/start/assistant,
 /obj/structure/chair/sofa/right,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
@@ -2167,26 +2105,23 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
-/obj/effect/turf_decal/lumos/tile/red/half{
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/corner,
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "afc" = (
-/obj/structure/closet/secure_closet/contraband/armory,
-/obj/effect/turf_decal/lumos/tile/blue/fullcorner{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
-"afd" = (
-/obj/structure/rack,
-/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
-/obj/effect/turf_decal/bot,
+/obj/machinery/door/window/westleft{
+	dir = 2;
+	name = "Armory Flash Storage";
+	req_one_access_txt = "4; 1"
+	},
+/obj/machinery/flasher/portable,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "afe" = (
@@ -2196,16 +2131,19 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
 	},
-/obj/effect/turf_decal/lumos/tile/red/half{
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "aff" = (
 /obj/effect/landmark/start/security_officer,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 9
-	},
 /turf/open/floor/plasteel,
 /area/security/main)
 "afh" = (
@@ -2238,30 +2176,36 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/main)
 "afk" = (
 /obj/effect/landmark/start/security_officer,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
 "afl" = (
-/obj/effect/turf_decal/lumos/tile/red/fulltile,
 /obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
 "afm" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 5
+/obj/effect/turf_decal/trimline/green/filled/corner{
+	dir = 4
 	},
+/obj/effect/turf_decal/trimline/green/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/green/line,
 /turf/open/floor/plasteel,
-/area/security/main)
+/area/security/prison)
 "afn" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -2283,9 +2227,11 @@
 	},
 /obj/effect/landmark/start/security_officer,
 /obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 9
+	dir = 8
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
+	},
 /area/security/main)
 "afs" = (
 /obj/item/storage/secure/safe/HoS{
@@ -2339,6 +2285,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
 "afy" = (
@@ -2346,12 +2295,10 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "afz" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 1
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 10
-	},
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "afA" = (
@@ -2369,9 +2316,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 6
-	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "afC" = (
@@ -2387,13 +2331,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "afD" = (
 /obj/effect/landmark/start/security_officer,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
@@ -2401,6 +2344,7 @@
 /obj/structure/chair/sofa/left{
 	dir = 1
 	},
+/obj/structure/window/reinforced,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "afF" = (
@@ -2408,29 +2352,18 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "afH" = (
-/obj/structure/table/glass,
-/obj/item/reagent_containers/glass/bottle/charcoal{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/glass/bottle/epinephrine{
-	pixel_x = -2;
-	pixel_y = -2
-	},
-/obj/item/reagent_containers/syringe{
-	name = "steel point"
-	},
 /obj/machinery/airalarm{
 	dir = 4;
 	pixel_x = -22
 	},
-/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
+/obj/structure/closet/secure_closet/brig_phys,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "afI" = (
-/obj/effect/turf_decal/lumos/tile/red/half{
-	dir = 4
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 9
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/brig)
 "afJ" = (
@@ -2438,7 +2371,9 @@
 	pixel_x = 1;
 	pixel_y = -27
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "afK" = (
@@ -2453,12 +2388,18 @@
 	dir = 8;
 	pixel_x = 24
 	},
+/obj/item/reagent_containers/glass/bottle/charcoal{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/glass/bottle/epinephrine{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/obj/item/reagent_containers/syringe{
+	name = "steel point"
+	},
 /obj/structure/table/glass,
-/obj/item/reagent_containers/blood,
-/obj/item/reagent_containers/spray/cleaner,
-/obj/item/storage/box/bodybags,
-/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
-/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "afM" = (
@@ -2518,7 +2459,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/lumos/tile/red/fulltile,
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
 /area/security/brig)
 "afT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -2527,8 +2471,11 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
 	},
-/obj/effect/turf_decal/lumos/tile/red/half{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -2539,10 +2486,10 @@
 /obj/structure/table,
 /obj/item/restraints/handcuffs,
 /obj/item/assembly/timer,
+/obj/effect/turf_decal/trimline/red/filled/corner,
 /turf/open/floor/plasteel,
 /area/security/main)
 "afW" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
@@ -2553,6 +2500,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/holopad,
+/obj/effect/turf_decal/lumos/tile/red/fulltile,
 /turf/open/floor/plasteel,
 /area/security/main)
 "afY" = (
@@ -2569,23 +2518,30 @@
 	pixel_y = 10
 	},
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/security/main)
 "aga" = (
 /obj/structure/sign/warning/pods{
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/lumos/tile/red/fulltile,
-/obj/machinery/recharge_station,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/disposal/bin,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
 "agb" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
@@ -2639,29 +2595,19 @@
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
 "agi" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security/glass{
-	name = "Prison Wing";
-	req_access_txt = "2"
+/obj/effect/turf_decal/lumos/loading_area,
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/lumos/tile/red/fulltile,
-/turf/open/floor/plasteel,
-/area/security/brig)
+/area/security/main)
 "agj" = (
 /turf/closed/wall,
 /area/security/brig)
 "agk" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security/glass{
-	name = "Prison Wing";
-	req_access_txt = "2"
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/lumos/tile/red/fulltile,
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "agl" = (
@@ -2700,10 +2646,16 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "agp" = (
-/obj/structure/table,
-/obj/item/book/manual/wiki/security_space_law,
-/obj/item/book/manual/wiki/security_space_law,
-/turf/open/floor/plasteel,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
 /area/security/brig)
 "agq" = (
 /obj/effect/turf_decal/delivery,
@@ -2716,7 +2668,15 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/plasteel/showroomfloor,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
+	},
 /area/security/main)
 "agt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -2764,7 +2724,7 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "agx" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -2788,13 +2748,13 @@
 /obj/item/storage/box/rubbershot,
 /obj/item/storage/box/rubbershot,
 /obj/item/storage/box/rubbershot,
-/obj/effect/turf_decal/lumos/tile/neutral/half{
-	dir = 4
-	},
-/obj/effect/turf_decal/lumos/tile/blue/half{
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "agA" = (
@@ -2803,18 +2763,17 @@
 	departmentType = 5;
 	pixel_y = 30
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
 /turf/open/floor/plasteel,
 /area/security/main)
 "agB" = (
 /obj/structure/table,
 /obj/item/assembly/flash/handheld,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/security/main)
 "agC" = (
-/obj/machinery/holopad,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -2824,6 +2783,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/red/filled,
 /turf/open/floor/plasteel,
 /area/security/main)
 "agD" = (
@@ -2848,6 +2808,9 @@
 	pixel_y = -10
 	},
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/security/main)
 "agF" = (
@@ -2871,9 +2834,6 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
 /obj/effect/turf_decal/lumos/loading_area/corner,
 /turf/open/floor/plasteel,
 /area/security/main)
@@ -2884,21 +2844,32 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/lumos/tile/red/half{
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "agJ" = (
-/obj/machinery/flasher/portable,
-/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
-/obj/effect/turf_decal/bot,
+/obj/structure/table/reinforced,
+/obj/item/grenade/barrier{
+	pixel_x = 4
+	},
+/obj/item/grenade/barrier,
+/obj/item/grenade/barrier{
+	pixel_x = -4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "agK" = (
-/obj/machinery/flasher/portable,
-/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
-/obj/effect/turf_decal/delivery,
+/obj/vehicle/ridden/secway,
+/obj/item/key/security,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "agL" = (
@@ -2908,17 +2879,11 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "agM" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
 /obj/machinery/power/apc{
 	areastring = "/area/security/brig";
 	dir = 1;
 	name = "Brig APC";
 	pixel_y = 24
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -2926,8 +2891,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "0-2"
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -2947,24 +2912,13 @@
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
 /obj/effect/turf_decal/lumos/tile/red/fulltile,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "agP" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 9
-	},
+/obj/machinery/holopad,
 /turf/open/floor/plasteel,
-/area/security/brig)
+/area/security/main)
 "agQ" = (
 /obj/machinery/light{
 	light_color = "#cee5d2"
@@ -2972,17 +2926,19 @@
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "agR" = (
-/obj/effect/turf_decal/loading_area{
-	dir = 4;
-	pixel_x = -3
-	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "agS" = (
+/obj/effect/turf_decal/trimline/neutral/filled/corner,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "agU" = (
 /obj/machinery/holopad,
+/obj/effect/turf_decal/trimline/neutral/filled/line,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "agV" = (
@@ -3019,21 +2975,30 @@
 	pixel_y = -26;
 	req_access_txt = "3"
 	},
-/obj/effect/turf_decal/delivery,
 /obj/machinery/door/poddoor/shutters/window{
 	id = "armory2"
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "agY" = (
-/obj/structure/table/glass,
-/obj/item/storage/box/bodybags,
-/obj/item/reagent_containers/spray/cleaner,
+/obj/item/storage/box/bodybags{
+	pixel_x = 5;
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_x = 9
+	},
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/item/reagent_containers/blood,
-/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
+/obj/item/reagent_containers/blood{
+	pixel_x = -8;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_x = 2
+	},
+/obj/structure/table/wood,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "agZ" = (
@@ -3049,14 +3014,18 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "ahb" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/brig)
 "ahc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
@@ -3064,11 +3033,17 @@
 /obj/structure/table,
 /obj/item/book/manual/wiki/security_space_law,
 /obj/item/book/manual/wiki/security_space_law,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/security/main)
 "ahe" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
@@ -3081,6 +3056,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/lumos/tile/red/fulltile,
 /turf/open/floor/plasteel,
 /area/security/main)
 "ahg" = (
@@ -3110,6 +3086,9 @@
 	dir = 4;
 	sortType = 8
 	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/security/main)
 "ahi" = (
@@ -3119,9 +3098,6 @@
 	},
 /obj/effect/turf_decal/loading_area{
 	dir = 8
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
@@ -3177,24 +3153,32 @@
 	c_tag = "Armory Motion Sensor";
 	dir = 4
 	},
-/obj/effect/turf_decal/lumos/tile/neutral/half{
-	dir = 4
-	},
-/obj/effect/turf_decal/lumos/tile/blue/half{
-	dir = 8
-	},
 /obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/corner,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "ahn" = (
 /turf/closed/wall,
 /area/maintenance/fore/secondary)
 "aho" = (
-/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "ahp" = (
-/obj/effect/turf_decal/lumos/tile/red/half,
+/obj/structure/rack,
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "ahq" = (
@@ -3234,8 +3218,6 @@
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
 /obj/machinery/iv_drip,
-/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
-/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "ahv" = (
@@ -3256,8 +3238,11 @@
 /turf/open/floor/plating,
 /area/security/brig)
 "ahy" = (
-/obj/effect/turf_decal/lumos/tile/red/half{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -3281,13 +3266,13 @@
 /obj/item/radio/intercom{
 	pixel_x = -30
 	},
-/obj/effect/turf_decal/lumos/tile/neutral/half{
-	dir = 4
-	},
-/obj/effect/turf_decal/lumos/tile/blue/half{
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "ahB" = (
@@ -3322,22 +3307,20 @@
 /turf/open/floor/plasteel,
 /area/security/processing)
 "ahE" = (
-/obj/structure/closet/secure_closet/brig,
-/obj/item/radio/headset{
-	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
-	name = "prisoner headset";
-	prison_radio = 1
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "ahG" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/door/window/westright{
 	name = "Brig Operations";
 	req_one_access_txt = "4; 1"
 	},
-/obj/effect/turf_decal/lumos/tile/red/half{
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -3348,6 +3331,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
@@ -3366,6 +3352,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
@@ -3397,12 +3386,10 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
 /obj/effect/turf_decal/lumos/loading_area/corner{
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/red/filled/corner,
 /turf/open/floor/plasteel,
 /area/security/main)
 "ahP" = (
@@ -3438,13 +3425,13 @@
 	dir = 1;
 	pixel_y = 1
 	},
-/obj/effect/turf_decal/lumos/tile/red/half{
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/lumos/tile/neutral/half{
+/obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "ahS" = (
@@ -3452,9 +3439,12 @@
 	c_tag = "Brig Infirmary";
 	dir = 4
 	},
-/obj/structure/closet/secure_closet/brig_phys,
-/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
-/obj/effect/turf_decal/bot,
+/obj/structure/table/wood,
+/obj/machinery/computer/med_data/laptop{
+	dir = 4;
+	pixel_x = 2;
+	pixel_y = 3
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "ahU" = (
@@ -3470,6 +3460,7 @@
 /obj/machinery/computer/security/labor{
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/red/filled/corner,
 /turf/open/floor/plasteel,
 /area/security/processing)
 "ahW" = (
@@ -3511,17 +3502,20 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -26
 	},
-/obj/effect/turf_decal/lumos/tile/neutral/half{
-	dir = 4
-	},
-/obj/effect/turf_decal/lumos/tile/blue/half{
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "ahX" = (
-/obj/effect/turf_decal/lumos/tile/red/half{
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -3534,13 +3528,21 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "ahZ" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
+	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/brig)
 "aia" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/security/main)
 "aib" = (
@@ -3569,9 +3571,11 @@
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "aid" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
-/obj/effect/turf_decal/lumos/tile/red/half{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/brig)
@@ -3579,44 +3583,27 @@
 /obj/structure/bed,
 /obj/machinery/iv_drip,
 /obj/item/bedsheet/medical,
-/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "aig" = (
-/obj/structure/table,
-/obj/item/clothing/mask/gas/sechailer{
-	pixel_x = -3;
-	pixel_y = 3
+/obj/machinery/computer/secure_data{
+	dir = 4
 	},
-/obj/item/clothing/mask/gas/sechailer,
-/obj/item/clothing/mask/gas/sechailer{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/storage/toolbox/electrical{
-	pixel_x = -2;
-	pixel_y = 2
-	},
-/obj/item/storage/toolbox/drone{
-	pixel_x = 2;
-	pixel_y = -2
-	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/lumos/tile/red/fulltile,
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "aih" = (
-/obj/effect/turf_decal/delivery,
 /obj/machinery/door/poddoor/shutters/window{
 	id = "armory2"
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "aii" = (
-/obj/machinery/rnd/production/techfab/department/security,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
-	},
+/obj/structure/table,
+/obj/item/book/manual/wiki/security_space_law,
+/obj/item/book/manual/wiki/security_space_law,
+/obj/item/book/manual/wiki/security_space_law,
+/obj/effect/turf_decal/lumos/tile/red/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "aik" = (
@@ -3626,14 +3613,16 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark/corner{
+	dir = 1
+	},
 /area/security/main)
 "ail" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/range)
@@ -3662,13 +3651,13 @@
 	pixel_y = -3
 	},
 /obj/structure/window/reinforced,
-/obj/effect/turf_decal/lumos/tile/neutral/half{
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 4
 	},
-/obj/effect/turf_decal/lumos/tile/blue/half{
-	dir = 8
-	},
-/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "aio" = (
@@ -3683,7 +3672,10 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "aip" = (
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -3691,7 +3683,8 @@
 "aiq" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/lumos/tile/red/half{
+/obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -3712,15 +3705,18 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/main)
 "ait" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
@@ -3737,7 +3733,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/main)
 "aiv" = (
@@ -3752,13 +3747,13 @@
 	pixel_y = -3
 	},
 /obj/structure/window/reinforced,
-/obj/effect/turf_decal/lumos/tile/red/half{
-	dir = 4
-	},
-/obj/effect/turf_decal/lumos/tile/neutral/half{
-	dir = 8
-	},
 /obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "aiw" = (
@@ -3774,7 +3769,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/main)
 "aix" = (
@@ -3791,46 +3785,36 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/security/main)
-"aiy" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/security/brig)
+/area/security/main)
 "aiz" = (
 /obj/machinery/light,
-/obj/structure/chair/sofa{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/structure/chair/sofa{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/security/main)
 "aiA" = (
 /turf/open/floor/plating,
 /area/security/main)
 "aiB" = (
-/obj/structure/chair/sofa/right{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/structure/chair/sofa/right{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/security/main)
 "aiC" = (
@@ -3847,12 +3831,14 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/main)
 "aiD" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
@@ -3863,9 +3849,10 @@
 /obj/item/radio/intercom{
 	pixel_y = 20
 	},
-/obj/effect/turf_decal/lumos/tile/red/fullcorner{
-	dir = 8
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 9
 	},
+/obj/effect/turf_decal/trimline/red/filled/corner,
 /turf/open/floor/plasteel,
 /area/security/processing)
 "aiF" = (
@@ -3883,8 +3870,9 @@
 	c_tag = "Security Docking";
 	dir = 8
 	},
-/obj/effect/turf_decal/lumos/tile/red/fullcorner{
-	dir = 8
+/obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
@@ -3892,14 +3880,14 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/junction{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -3908,17 +3896,14 @@
 	c_tag = "Brig Central";
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aiI" = (
 /obj/structure/bodycontainer/morgue,
-/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
-/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "aiJ" = (
@@ -3935,39 +3920,43 @@
 /area/security/prison)
 "aiL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/brig)
+"aiM" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 6
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/brig)
-"aiM" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
+"aiN" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 10
 	},
-/obj/effect/turf_decal/lumos/tile/red/half{
+/obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/brig)
-"aiN" = (
-/obj/effect/turf_decal/lumos/tile/red/fullcorner,
 /turf/open/floor/plasteel,
 /area/security/processing)
 "aiO" = (
 /obj/machinery/shower{
-	dir = 1
-	},
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 11
+	dir = 1;
+	pixel_x = 3
 	},
 /obj/structure/mirror{
 	pixel_x = 28
 	},
-/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
-/obj/effect/turf_decal/box,
-/obj/effect/turf_decal/lumos/shower,
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/lumos/shower{
+	pixel_x = 3;
+	pixel_y = -2
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel/white,
 /area/security/brig)
 "aiQ" = (
 /obj/structure/rack,
@@ -3978,7 +3967,7 @@
 /area/security/prison)
 "aiR" = (
 /obj/structure/closet/l3closet/security,
-/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/box,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "aiS" = (
@@ -3994,14 +3983,16 @@
 /area/security/processing)
 "aiW" = (
 /obj/structure/closet/bombcloset/security,
-/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/box,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "aiX" = (
 /turf/closed/wall/r_wall,
 /area/security/brig)
 "aiY" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/security/courtroom)
 "aiZ" = (
@@ -4012,7 +4003,6 @@
 /turf/open/floor/plating,
 /area/ai_monitored/security/armory)
 "aja" = (
-/obj/effect/turf_decal/delivery,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -4022,7 +4012,6 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "ajb" = (
-/obj/effect/turf_decal/delivery,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -4056,7 +4045,10 @@
 	icon_state = "2-4"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/lumos/tile/red/fulltile,
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
 /area/ai_monitored/security/armory)
 "ajf" = (
 /obj/structure/table/wood,
@@ -4067,8 +4059,29 @@
 /turf/open/floor/wood,
 /area/lawoffice)
 "ajg" = (
-/obj/machinery/computer/secure_data,
-/obj/effect/turf_decal/bot,
+/obj/structure/table,
+/obj/item/clothing/mask/gas/sechailer{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/clothing/mask/gas/sechailer,
+/obj/item/clothing/mask/gas/sechailer{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/storage/toolbox/electrical{
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/obj/item/storage/toolbox/drone{
+	pixel_x = 2;
+	pixel_y = -2
+	},
+/obj/machinery/light/small{
+	dir = 1;
+	light_color = "#d8b1b1"
+	},
+/obj/effect/turf_decal/lumos/tile/red/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "ajh" = (
@@ -4076,61 +4089,73 @@
 	pixel_y = 28
 	},
 /obj/structure/closet/secure_closet/courtroom,
-/obj/effect/decal/cleanable/cobweb,
 /obj/structure/sign/warning/securearea{
 	pixel_x = -32
 	},
 /obj/item/gavelhammer,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/security/courtroom)
 "aji" = (
-/obj/structure/chair{
-	name = "Judge"
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
 	},
-/obj/effect/turf_decal/lumos/tile/blue/fullcorner{
+/obj/effect/turf_decal/trimline/neutral/filled/corner,
+/turf/open/floor/plasteel,
+/area/security/courtroom)
+"ajj" = (
+/obj/machinery/camera{
+	c_tag = "Courtroom North"
+	},
+/obj/item/radio/intercom{
+	dir = 8;
+	name = "Station Intercom (Court)";
+	pixel_x = 2;
+	pixel_y = 20
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/courtroom)
-"ajj" = (
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = 20
-	},
-/obj/machinery/camera{
-	c_tag = "Courtroom North"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
-/turf/open/floor/plasteel,
-/area/security/courtroom)
 "ajk" = (
-/obj/structure/chair{
-	name = "Judge"
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
 	},
-/obj/effect/turf_decal/lumos/tile/blue/fullcorner{
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/courtroom)
 "ajl" = (
-/obj/structure/chair{
-	name = "Judge"
-	},
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/lumos/tile/blue/half{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/neutral/filled/line,
+/obj/structure/chair/wood/wings,
 /turf/open/floor/plasteel,
 /area/security/courtroom)
 "ajm" = (
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/machinery/door/window/southleft{
+	dir = 8;
+	name = "Court Cell";
+	req_access_txt = "2"
+	},
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
 "ajn" = (
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner,
 /turf/open/floor/plasteel,
 /area/security/courtroom)
 "ajo" = (
@@ -4230,12 +4255,8 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "ajA" = (
-/obj/effect/landmark/start/security_officer,
-/obj/structure/chair{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
@@ -4244,15 +4265,11 @@
 /turf/open/floor/plasteel/checker,
 /area/security/prison)
 "ajE" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/security/courtroom)
@@ -4278,9 +4295,12 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "ajH" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/green/filled/line,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/security/courtroom)
@@ -4291,7 +4311,7 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -4302,14 +4322,15 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "ajL" = (
-/obj/machinery/computer/security,
-/obj/effect/turf_decal/bot,
+/obj/machinery/rnd/production/techfab/department/security,
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/lumos/tile/red/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "ajM" = (
@@ -4318,6 +4339,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/courtroom)
@@ -4328,80 +4352,74 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "ajO" = (
-/obj/structure/table/wood,
 /obj/item/radio/intercom{
 	dir = 8;
 	name = "Station Intercom (Court)"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/table/wood,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/courtroom)
 "ajP" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/security/courtroom)
 "ajQ" = (
 /obj/structure/table/wood,
 /obj/item/book/manual/wiki/security_space_law,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/courtroom)
 "ajR" = (
-/obj/structure/table/wood,
 /obj/item/gavelblock,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/structure/table/wood,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -4414,35 +4432,24 @@
 /obj/structure/chair{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
 "ajT" = (
-/obj/structure/chair{
-	dir = 8;
-	name = "Defense"
-	},
-/obj/effect/turf_decal/lumos/tile/green/fullcorner{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/courtroom)
 "ajU" = (
-/obj/machinery/door/window/southleft{
-	name = "Court Cell";
-	req_access_txt = "2"
+/obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
-/area/security/courtroom)
+/turf/open/floor/plasteel,
+/area/security/prison)
 "ajV" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -4459,22 +4466,23 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
 "ajX" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "ajY" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/door/window/westleft{
 	name = "Brig Operations";
 	req_one_access_txt = "4; 1"
 	},
-/obj/effect/turf_decal/lumos/tile/red/half{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -4502,7 +4510,9 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
+	},
 /area/security/main)
 "akd" = (
 /obj/effect/landmark/start/security_officer,
@@ -4543,9 +4553,7 @@
 	dir = 4;
 	pixel_x = -24
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 10
-	},
+/obj/effect/turf_decal/trimline/red/filled/corner,
 /turf/open/floor/plasteel,
 /area/security/main)
 "aki" = (
@@ -4563,10 +4571,12 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "akj" = (
-/obj/structure/chair{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
 /area/security/brig)
 "akk" = (
 /obj/machinery/door/firedoor,
@@ -4590,35 +4600,34 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "akl" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "akm" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "akn" = (
 /obj/structure/table/wood,
 /obj/item/folder/blue,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/courtroom)
 "ako" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
@@ -4627,6 +4636,9 @@
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -4640,7 +4652,6 @@
 	c_tag = "Brig West";
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "akq" = (
@@ -4656,17 +4667,17 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "akr" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/computer/security/telescreen/interrogation{
 	dir = 1;
 	pixel_y = -32
 	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
 /obj/effect/turf_decal/trimline/red/filled/line,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aks" = (
@@ -4681,6 +4692,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/security/main)
 "akt" = (
@@ -4697,16 +4711,7 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aku" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -4714,6 +4719,15 @@
 	},
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -4724,27 +4738,39 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "akw" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/green/filled/corner,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
+	},
+/obj/machinery/holopad,
 /turf/open/floor/plasteel,
 /area/security/courtroom)
 "akx" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 9
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aky" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/security/courtroom)
@@ -4764,11 +4790,12 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "akA" = (
-/obj/structure/chair{
-	dir = 8;
-	name = "Defense"
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 8
 	},
-/obj/effect/turf_decal/lumos/tile/green/fullcorner,
+/obj/item/kirbyplants{
+	icon_state = "applebush"
+	},
 /turf/open/floor/plasteel,
 /area/security/courtroom)
 "akB" = (
@@ -4793,15 +4820,12 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "akD" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/airalarm{
 	dir = 1;
 	pixel_y = -22
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -4817,9 +4841,6 @@
 "akF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "akG" = (
@@ -4858,6 +4879,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/turf_decal/lumos/tile/red/fulltile,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "akK" = (
@@ -4878,7 +4900,8 @@
 /area/security/prison)
 "akM" = (
 /obj/machinery/light,
-/obj/effect/turf_decal/trimline/green/filled/line,
+/obj/effect/turf_decal/trimline/green/filled/corner,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "akN" = (
@@ -4891,16 +4914,12 @@
 /area/security/prison)
 "akO" = (
 /obj/structure/table,
-/obj/machinery/microwave{
-	pixel_y = 6
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/main)
 "akP" = (
@@ -4919,7 +4938,10 @@
 	dir = 1
 	},
 /obj/structure/table,
-/obj/item/storage/box/donkpockets,
+/obj/item/storage/box/donkpockets{
+	pixel_x = 3;
+	pixel_y = 5
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
@@ -4930,7 +4952,6 @@
 	dir = 1;
 	pixel_y = -27
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/main)
 "akS" = (
@@ -4941,7 +4962,9 @@
 /obj/structure/table,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/machinery/microwave{
+	pixel_y = 6
+	},
 /turf/open/floor/plasteel,
 /area/security/main)
 "akT" = (
@@ -4962,84 +4985,76 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "akU" = (
-/obj/machinery/holopad,
-/turf/open/floor/plasteel,
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
+	},
 /area/security/brig)
 "akW" = (
 /obj/machinery/holopad,
 /turf/open/floor/plasteel/checker,
 /area/security/prison)
 "akY" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/warden)
-"akZ" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Brig Control";
-	req_access_txt = "3"
-	},
-/obj/machinery/door/firedoor,
+"ala" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
-"ala" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/warden)
 "alb" = (
-/obj/structure/chair{
-	dir = 4;
-	name = "Prosecution"
-	},
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/lumos/tile/red/fullcorner{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/courtroom)
 "alc" = (
 /obj/structure/table/wood,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 9
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/trimline/neutral/filled/corner,
 /turf/open/floor/plasteel,
 /area/security/courtroom)
 "ald" = (
-/obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/obj/item/beacon,
 /turf/open/floor/plasteel,
 /area/security/courtroom)
 "ale" = (
-/obj/structure/table/wood,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 6
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 1
+	},
+/obj/structure/chair/wood/normal{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/courtroom)
@@ -5078,8 +5093,8 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -5112,17 +5127,22 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "alo" = (
-/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/airlock/security/glass{
+	name = "Brig Control";
+	req_access_txt = "3"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/lumos/tile/red/fulltile,
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/dark/side,
 /area/security/warden)
 "alp" = (
 /turf/open/floor/plating,
@@ -5135,7 +5155,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/lumos/tile/red/fulltile,
+/turf/open/floor/plasteel/dark/side,
 /area/security/warden)
 "alr" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -5155,23 +5176,15 @@
 	name = "Cell 3";
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/red/filled/corner,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "alt" = (
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "innerbrig";
-	name = "Brig";
-	req_access_txt = "63"
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
 	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/effect/turf_decal/lumos/tile/red/fulltile,
 /turf/open/floor/plasteel,
-/area/security/brig)
+/area/security/prison)
 "alu" = (
 /obj/machinery/nuclearbomb/selfdestruct,
 /obj/effect/turf_decal/lumos/tile/neutral/fulltile,
@@ -5179,18 +5192,13 @@
 /area/ai_monitored/nuke_storage)
 "alv" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
 /obj/machinery/door/poddoor/preopen{
 	id = "Secure Gate";
 	name = "brig shutters"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/brig)
 "alw" = (
@@ -5208,7 +5216,8 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "alz" = (
@@ -5218,29 +5227,32 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "alA" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "alB" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -5254,84 +5266,85 @@
 	departmentType = 5;
 	pixel_x = -30
 	},
-/obj/machinery/computer/security{
-	dir = 4
-	},
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = -24;
 	pixel_y = 28
 	},
-/turf/open/floor/plasteel/showroomfloor,
+/obj/structure/filingcabinet/chestdrawer,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/warden)
 "alF" = (
 /obj/machinery/atmospherics/components/unary/tank/air,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "alG" = (
-/obj/structure/chair{
-	dir = 4;
-	name = "Prosecution"
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
 	},
-/obj/effect/turf_decal/lumos/tile/red/fullcorner{
-	dir = 1
+/obj/item/kirbyplants{
+	icon_state = "applebush"
 	},
 /turf/open/floor/plasteel,
 /area/security/courtroom)
 "alH" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 1
+	},
+/obj/structure/chair/wood/normal{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/courtroom)
 "alI" = (
-/obj/structure/table/wood,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 10
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 4
+	},
+/obj/structure/chair/wood/normal{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/courtroom)
 "alJ" = (
-/obj/item/beacon,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/security/courtroom)
 "alK" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/fore/secondary)
 "alL" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/power/apc{
-	areastring = "/area/security/courtroom";
-	dir = 8;
-	name = "Courtroom APC";
-	pixel_x = -24
-	},
 /obj/structure/cable{
-	icon_state = "0-4"
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/plating,
-/area/maintenance/fore/secondary)
+/obj/effect/turf_decal/loading_area,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "alM" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/plasteel/showroomfloor,
+/obj/machinery/computer/secure_data,
+/turf/open/floor/plasteel/dark,
 /area/security/warden)
 "alN" = (
-/obj/machinery/computer/prisoner/management,
-/turf/open/floor/plasteel/showroomfloor,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
+	},
+/obj/machinery/computer/security,
+/turf/open/floor/plasteel/dark,
 /area/security/warden)
 "alO" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -5391,8 +5404,13 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/computer/secure_data,
-/turf/open/floor/plasteel/showroomfloor,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/dark,
 /area/security/warden)
 "alZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -5440,23 +5458,33 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/warden)
 "ame" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 6
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "amf" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "amg" = (
@@ -5464,7 +5492,7 @@
 	name = "Evidence Closet"
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
+	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/warden)
@@ -5474,7 +5502,6 @@
 	name = "Cell 2";
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "amk" = (
@@ -5530,7 +5557,6 @@
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "amn" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
@@ -5538,6 +5564,7 @@
 	id = "Cell Interior Shutters";
 	name = "brig shutters"
 	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/brig)
 "amo" = (
@@ -5545,8 +5572,12 @@
 /turf/open/floor/plating,
 /area/security/prison)
 "amp" = (
-/obj/effect/turf_decal/lumos/tile/red/fullcorner{
-	dir = 4
+/obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -5570,7 +5601,13 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/trimline/green/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark/side,
 /area/security/courtroom)
 "amu" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -5604,16 +5641,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
-"amx" = (
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating,
-/area/security/brig)
 "amy" = (
 /obj/structure/chair/stool{
 	pixel_y = 8
@@ -5641,10 +5668,13 @@
 	id = "Cell Interior Shutters";
 	name = "brig shutters"
 	},
-/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/brig)
 "amC" = (
@@ -5690,19 +5720,32 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "amI" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "amJ" = (
-/obj/effect/turf_decal/lumos/tile/red/fullcorner{
+/obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 8
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -5728,13 +5771,25 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
+/obj/effect/turf_decal/lumos/tile/red/fulltile,
 /turf/open/floor/plasteel,
 /area/security/processing)
 "amN" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "Secure Brig Control";
+	name = "brig shutters"
+	},
 /obj/structure/table/reinforced,
+/obj/machinery/door/window/brigdoor{
+	dir = 4;
+	name = "Reception Desk";
+	req_access_txt = "3"
+	},
+/obj/machinery/door/window/southright{
+	dir = 8;
+	name = "Reception Desk";
+	req_access_txt = "63"
+	},
 /obj/item/paper_bin{
 	pixel_x = -3;
 	pixel_y = 7
@@ -5743,25 +5798,14 @@
 	pixel_x = 4;
 	pixel_y = 4
 	},
-/obj/machinery/door/window/brigdoor{
-	dir = 4;
-	name = "Reception Desk";
-	req_access_txt = "3"
-	},
 /obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/preopen{
-	id = "Secure Brig Control";
-	name = "brig shutters"
-	},
-/obj/machinery/door/window/southright{
-	dir = 8;
-	name = "Reception Desk";
-	req_access_txt = "63"
-	},
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plating,
 /area/security/warden)
 "amO" = (
-/obj/machinery/holopad,
+/obj/structure/chair,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "amP" = (
@@ -5783,26 +5827,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"amR" = (
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "Secure Gate";
-	name = "brig shutters"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/security/brig)
 "amS" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
 	},
-/turf/closed/wall/r_wall,
-/area/security/brig)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/main)
 "amT" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 9
@@ -5817,46 +5850,39 @@
 /obj/structure/chair/office/dark{
 	dir = 8
 	},
+/obj/effect/landmark/start/warden,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/warden)
+"amV" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
-"amV" = (
-/obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/dark,
 /area/security/warden)
 "amW" = (
-/obj/effect/landmark/start/warden,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8
+	dir = 4
 	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
-"amX" = (
-/obj/structure/chair{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/brig)
-"amY" = (
+/area/security/warden)
+"amX" = (
 /obj/structure/chair{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/courtroom)
-"amZ" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 4
+/area/security/brig)
+"amY" = (
+/obj/structure/chair/pew/left{
+	dir = 1
 	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/main)
+/turf/open/floor/plasteel/dark,
+/area/security/courtroom)
 "ana" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -5864,6 +5890,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -5884,6 +5913,9 @@
 "and" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "ane" = (
@@ -5974,23 +6006,31 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "anq" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 9
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "anr" = (
-/obj/structure/disposalpipe/segment,
-/turf/closed/wall/r_wall,
-/area/security/warden)
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/main)
 "ans" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/showroomfloor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/warden)
 "ant" = (
 /obj/machinery/door/firedoor,
@@ -5998,10 +6038,14 @@
 	name = "Evidence Storage";
 	req_access_txt = "3"
 	},
-/turf/open/floor/plasteel/showroomfloor,
+/obj/effect/turf_decal/lumos/tile/red/fulltile,
+/turf/open/floor/plasteel/dark,
 /area/security/warden)
 "anu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/warden)
 "anv" = (
@@ -6018,7 +6062,7 @@
 /turf/open/floor/plasteel/dark,
 /area/security/warden)
 "anw" = (
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -6035,34 +6079,12 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "any" = (
-/obj/effect/landmark/event_spawn,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 5
 	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"anz" = (
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"anA" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"anB" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/structure/closet/secure_closet/brig{
-	id = "Cell 2";
-	name = "Cell 2 Locker"
+	id = "Cell 3";
+	name = "Cell 3 Locker"
 	},
 /obj/item/radio/headset{
 	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
@@ -6070,14 +6092,29 @@
 	prison_radio = 1
 	},
 /obj/structure/cable{
-	icon_state = "1-4"
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8
+/turf/open/floor/plasteel,
+/area/security/brig)
+"anz" = (
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"anA" = (
+/obj/structure/reagent_dispensers/water_cooler,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
 	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"anB" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 6
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/bed,
+/obj/item/bedsheet/green,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "anC" = (
@@ -6175,25 +6212,25 @@
 /turf/open/space/basic,
 /area/space)
 "anP" = (
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
 /obj/structure/cable,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
 /area/security/brig)
 "anQ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 5
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
 	},
-/obj/structure/bed,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "anR" = (
@@ -6216,10 +6253,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "anT" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4
+/obj/effect/turf_decal/trimline/red/line,
+/obj/effect/turf_decal/trimline/red/line{
+	dir = 1
 	},
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel,
 /area/security/main)
 "anU" = (
 /obj/machinery/door/firedoor,
@@ -6268,11 +6306,17 @@
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "aoa" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/maintenance/fore/secondary)
+/obj/structure/closet/secure_closet/brig,
+/obj/item/radio/headset{
+	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
+	name = "prisoner headset";
+	prison_radio = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "aob" = (
 /obj/machinery/light_switch{
 	pixel_x = -20
@@ -6376,15 +6420,11 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aor" = (
-/obj/structure/table,
-/obj/item/restraints/handcuffs,
-/obj/item/taperecorder,
-/obj/item/folder/red,
 /obj/machinery/light_switch{
 	pixel_y = -24
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 4
+/obj/structure/chair{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -6397,30 +6437,32 @@
 /turf/open/floor/plasteel/checker,
 /area/security/prison)
 "aot" = (
-/obj/effect/turf_decal/lumos/tile/red/fullcorner{
-	dir = 1
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
 	},
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aou" = (
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
 /obj/structure/cable,
 /obj/machinery/door/poddoor/preopen{
 	id = "Secure Gate";
 	name = "brig shutters"
 	},
-/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/brig)
 "aov" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 1
 	},
+/obj/effect/turf_decal/trimline/red/filled/corner,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aow" = (
@@ -6435,9 +6477,10 @@
 	c_tag = "Fore Primary Hallway West";
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 8
 	},
+/obj/effect/turf_decal/trimline/red/filled/corner,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aoy" = (
@@ -6450,11 +6493,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aoz" = (
-/obj/effect/turf_decal/tile/red,
 /obj/structure/sign/departments/security{
 	pixel_x = 32;
 	pixel_y = -32
 	},
+/obj/effect/turf_decal/trimline/red/filled/corner,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aoA" = (
@@ -6462,10 +6505,10 @@
 	name = "Station Intercom (General)";
 	pixel_y = -29
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/structure/chair{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aoB" = (
@@ -6473,15 +6516,21 @@
 	dir = 1;
 	pixel_y = -24
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/structure/chair{
-	dir = 1
+/obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
+	},
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aoC" = (
-/obj/effect/turf_decal/tile/red,
-/obj/structure/reagent_dispensers/water_cooler,
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aoD" = (
@@ -6493,24 +6542,31 @@
 	pixel_x = 5;
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/tile/red,
 /obj/structure/chair{
 	dir = 1
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aoE" = (
-/obj/effect/turf_decal/tile/red,
-/obj/item/storage/box/cups,
 /obj/structure/table,
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"aoF" = (
-/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/trimline/red/filled/line,
 /obj/machinery/chem_dispenser/drinks{
 	dir = 1
 	},
-/obj/structure/table,
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"aoF" = (
+/obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
+	},
+/obj/structure/chair{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aoG" = (
@@ -6631,17 +6687,26 @@
 	pixel_x = 24;
 	pixel_y = -28
 	},
-/obj/effect/turf_decal/lumos/tile/red/fullcorner,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aoZ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
 /obj/machinery/door/poddoor/preopen{
 	id = "Secure Brig Control";
 	name = "brig shutters"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/security/warden)
@@ -6654,7 +6719,11 @@
 /area/engine/atmos)
 "apc" = (
 /obj/structure/chair/office/dark,
-/turf/open/floor/plasteel/showroomfloor,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/warden)
 "apd" = (
 /turf/closed/wall,
@@ -6691,7 +6760,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/lumos/tile/blue/fulltile,
+/turf/open/floor/plasteel/dark/side,
 /area/blueshield)
 "apj" = (
 /obj/machinery/door/firedoor,
@@ -6699,26 +6769,21 @@
 /area/hallway/primary/fore)
 "apk" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "apl" = (
 /obj/effect/landmark/secequipment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/lumos/tile/red/half{
-	dir = 8
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/box,
+/turf/open/floor/plasteel,
 /area/security/main)
 "apm" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "apn" = (
@@ -6741,7 +6806,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "app" = (
@@ -6798,19 +6865,16 @@
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "apv" = (
-/obj/structure/table/reinforced,
-/obj/machinery/recharger{
-	pixel_x = -6;
-	pixel_y = 3
+/obj/machinery/computer/crew{
+	dir = 1
 	},
-/obj/machinery/recharger{
-	pixel_x = 6;
-	pixel_y = 3
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
 	},
-/obj/item/phone{
-	pixel_y = -7
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/dark,
 /area/security/warden)
 "apx" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -6891,9 +6955,6 @@
 /turf/open/floor/plasteel,
 /area/janitor)
 "apH" = (
-/obj/machinery/computer/crew{
-	dir = 4
-	},
 /obj/machinery/button/door{
 	id = "outerbrig";
 	name = "Brig Exterior Doors Control";
@@ -6910,7 +6971,29 @@
 	pixel_y = -24;
 	req_access_txt = "2"
 	},
-/turf/open/floor/plasteel/showroomfloor,
+/obj/structure/table/reinforced,
+/obj/machinery/recharger{
+	pixel_x = -6;
+	pixel_y = 6
+	},
+/obj/machinery/recharger{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/obj/item/phone{
+	pixel_y = -4
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/warden)
 "apI" = (
 /obj/structure/disposalpipe/segment{
@@ -6922,12 +7005,13 @@
 /turf/closed/wall,
 /area/construction/mining/aux_base)
 "apK" = (
-/obj/structure/chair{
-	dir = 4
-	},
 /obj/machinery/airalarm{
 	dir = 4;
 	pixel_x = -22
+	},
+/obj/structure/table,
+/obj/item/flashlight/lamp{
+	pixel_y = 9
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -6980,9 +7064,6 @@
 	req_access_txt = "63"
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
@@ -6996,14 +7077,11 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "apT" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/closed/wall/r_wall,
-/area/security/warden)
+/turf/open/floor/plasteel,
+/area/security/brig)
 "apU" = (
 /obj/machinery/computer/security/telescreen/prison{
 	dir = 1;
@@ -7031,31 +7109,18 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "apW" = (
-/obj/structure/rack,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
 	},
-/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
-/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
-"apX" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "Secure Brig Control";
-	name = "brig shutters"
-	},
-/turf/open/floor/plating,
-/area/security/warden)
 "apY" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -7066,6 +7131,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
+/obj/effect/turf_decal/lumos/tile/red/fulltile,
 /turf/open/floor/plasteel,
 /area/security/main)
 "aqa" = (
@@ -7081,6 +7147,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
 	},
+/obj/effect/turf_decal/lumos/tile/red/fulltile,
 /turf/open/floor/plasteel,
 /area/security/main)
 "aqd" = (
@@ -7088,20 +7155,21 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/red/filled/corner,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aqf" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
+	},
+/obj/structure/disposalpipe/junction/yjunction{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
@@ -7129,18 +7197,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
-"aqi" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/fore/secondary)
 "aqj" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -7160,14 +7216,6 @@
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "aqk" = (
-/obj/machinery/power/apc{
-	areastring = "/area/crew_quarters/dorms";
-	name = "Dormitory APC";
-	pixel_y = -24
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
@@ -7176,6 +7224,9 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
@@ -7225,9 +7276,14 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
 "aqo" = (
-/obj/structure/closet/secure_closet/personal/cabinet,
-/turf/open/floor/wood,
-/area/crew_quarters/dorms)
+/obj/structure/table/wood/fancy,
+/obj/item/reagent_containers/food/drinks/britcup{
+	desc = "Kingston's personal cup.";
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
 "aqp" = (
 /obj/structure/chair/stool,
 /turf/open/floor/plasteel,
@@ -7254,9 +7310,6 @@
 	req_access_txt = "63"
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/door/poddoor/preopen{
 	id = "Secure Brig Control";
 	name = "brig shutters"
@@ -7274,13 +7327,11 @@
 /area/crew_quarters/fitness/pool)
 "aqt" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
 /obj/machinery/door/poddoor/preopen{
 	id = "Secure Brig Control";
 	name = "brig shutters"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/warden)
 "aqu" = (
@@ -7342,7 +7393,7 @@
 /turf/open/floor/plasteel/checker,
 /area/security/prison)
 "aqC" = (
-/obj/effect/turf_decal/lumos/tile/blue/half{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -7351,22 +7402,27 @@
 /obj/structure/sign/warning/electricshock{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/light{
 	dir = 1;
 	light_color = "#d1dfff"
 	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aqE" = (
-/obj/effect/turf_decal/lumos/tile/red/fulltile,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aqF" = (
-/obj/effect/turf_decal/lumos/tile/red/half{
-	dir = 1
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
@@ -7387,14 +7443,27 @@
 	dir = 1;
 	light_color = "#d1dfff"
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 4
 	},
+/obj/structure/chair,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aqI" = (
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
@@ -7431,13 +7500,15 @@
 /obj/structure/sign/poster/official/twelve_gauge{
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/bot,
 /obj/item/radio/intercom{
 	pixel_x = 32;
 	pixel_y = 20
 	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/showroomfloor,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner,
+/turf/open/floor/plasteel/dark,
 /area/security/warden)
 "aqO" = (
 /obj/structure/closet,
@@ -7465,12 +7536,24 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "aqS" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aqT" = (
@@ -7580,8 +7663,12 @@
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "ari" = (
-/obj/machinery/airalarm{
-	pixel_y = 23
+/obj/machinery/button/door{
+	id = "Dorm5";
+	name = "Cabin Bolt Control";
+	normaldoorcontrol = 1;
+	pixel_y = -25;
+	specialfunctions = 4
 	},
 /obj/structure/table/wood,
 /turf/open/floor/wood,
@@ -7615,6 +7702,7 @@
 /obj/machinery/airalarm{
 	pixel_y = 24
 	},
+/obj/structure/chair/sofa/left,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "arn" = (
@@ -7721,14 +7809,16 @@
 	pixel_y = -40;
 	req_access_txt = "2"
 	},
-/obj/structure/filingcabinet/chestdrawer,
 /obj/machinery/light,
 /obj/structure/cable,
 /obj/machinery/camera{
 	c_tag = "Brig Control";
 	dir = 1
 	},
-/turf/open/floor/plasteel/showroomfloor,
+/obj/machinery/computer/prisoner/management{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/warden)
 "arz" = (
 /obj/item/coin/gold,
@@ -7745,31 +7835,24 @@
 /turf/closed/wall/r_wall,
 /area/hallway/secondary/entry)
 "arC" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/showroomfloor,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/machinery/holopad,
+/turf/open/floor/plasteel/dark,
 /area/security/warden)
 "arD" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/closet/secure_closet/brig{
-	id = "Cell 3";
-	name = "Cell 3 Locker"
-	},
-/obj/item/radio/headset{
-	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
-	name = "prisoner headset";
-	prison_radio = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8
-	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 6
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/bed,
+/obj/item/bedsheet/orange,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "arF" = (
@@ -7855,8 +7938,19 @@
 /area/maintenance/fore)
 "arQ" = (
 /obj/structure/table,
-/obj/item/flashlight/lamp,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+/obj/item/restraints/handcuffs{
+	pixel_x = -17;
+	pixel_y = 2
+	},
+/obj/item/taperecorder{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/obj/item/folder/red{
+	pixel_x = -2;
+	pixel_y = 3
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -7868,11 +7962,9 @@
 /turf/open/floor/wood,
 /area/lawoffice)
 "arS" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
@@ -7935,9 +8027,10 @@
 /obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/red/filled/corner,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "asb" = (
@@ -7946,6 +8039,9 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -8052,11 +8148,12 @@
 /turf/open/floor/wood,
 /area/lawoffice)
 "asm" = (
-/obj/structure/chair/comfy/brown{
+/obj/effect/turf_decal/lumos/tile/red/fullcorner{
 	dir = 4
 	},
-/turf/open/floor/wood,
-/area/crew_quarters/dorms)
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
 "asn" = (
 /obj/effect/landmark/start/lawyer,
 /obj/structure/chair/office/dark,
@@ -8118,13 +8215,17 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
-/turf/open/floor/plasteel/showroomfloor,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/warden)
 "ass" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Labor Camp Shuttle Airlock"
 	},
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/lumos/tile/red/fulltile,
 /turf/open/floor/plasteel,
 /area/security/processing)
 "ast" = (
@@ -8137,6 +8238,8 @@
 	dir = 4;
 	light_color = "#d8b1b1"
 	},
+/obj/structure/bed,
+/obj/effect/spawner/lootdrop/bedsheet,
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
 "asv" = (
@@ -8147,7 +8250,12 @@
 	dir = 8;
 	pixel_x = 28
 	},
-/obj/effect/turf_decal/lumos/tile/red/fullcorner,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 10
+	},
 /turf/open/floor/plasteel,
 /area/security/processing)
 "asw" = (
@@ -8252,7 +8360,7 @@
 /area/maintenance/fore)
 "asT" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
-/obj/effect/turf_decal/lumos/tile/green/half{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -8292,10 +8400,13 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "asZ" = (
-/obj/structure/closet/wardrobe/white,
 /obj/structure/sign/poster/contraband/lizard{
 	pixel_x = -32
 	},
+/obj/structure/chair/sofa/left{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "ata" = (
@@ -8316,7 +8427,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -8326,12 +8437,12 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
 "atf" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/trimline/red/filled/line,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "atg" = (
@@ -8342,9 +8453,13 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/dorms)
 "ath" = (
-/obj/effect/turf_decal/trimline/red/filled/corner,
-/turf/open/floor/plasteel,
-/area/security/brig)
+/obj/structure/rack,
+/obj/item/gun/energy/temperature/security,
+/obj/item/clothing/suit/armor/laserproof,
+/obj/item/gun/energy/ionrifle,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "atj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -8352,7 +8467,7 @@
 /area/crew_quarters/dorms)
 "atk" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
-/obj/effect/turf_decal/lumos/tile/yellow/half{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -8392,6 +8507,16 @@
 "atq" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
@@ -8566,8 +8691,14 @@
 /turf/open/floor/plasteel/checker,
 /area/security/prison)
 "atZ" = (
-/obj/effect/turf_decal/lumos/tile/red/half{
+/obj/effect/turf_decal/lumos/tile/blue/half{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
 	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
@@ -8575,7 +8706,6 @@
 /obj/structure/closet/wardrobe/mixed,
 /obj/item/clothing/under/costume/kilt,
 /obj/item/clothing/under/costume/kilt,
-/obj/item/clothing/head/beret,
 /obj/item/clothing/head/beret,
 /obj/item/clothing/head/beret,
 /obj/item/clothing/under/dress/sundress,
@@ -8601,11 +8731,12 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aue" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "auf" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/trimline/green/filled/line,
 /turf/open/floor/plasteel,
@@ -8652,7 +8783,9 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "auk" = (
-/obj/effect/turf_decal/trimline/green/filled/line,
+/obj/effect/turf_decal/trimline/green/filled/corner{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aum" = (
@@ -8671,11 +8804,9 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aun" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aup" = (
@@ -8742,7 +8873,8 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
 "aux" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/effect/turf_decal/trimline/yellow/filled/corner,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "auz" = (
@@ -8764,7 +8896,10 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "auB" = (
-/obj/effect/turf_decal/lumos/tile/red/fullcorner{
+/obj/effect/turf_decal/lumos/tile/red/half{
+	dir = 8
+	},
+/obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -8981,14 +9116,16 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "avg" = (
-/obj/machinery/door/airlock{
-	id_tag = "Dorm5";
-	name = "Room Four"
+/obj/effect/turf_decal/lumos/tile/red/half{
+	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/dorms)
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
 "avi" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/plasteel,
@@ -9001,8 +9138,8 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
@@ -9010,15 +9147,15 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "avn" = (
 /obj/machinery/door/airlock{
-	id_tag = "Dorm6";
-	name = "Room Five"
+	id_tag = "Dorm5";
+	name = "Room Four"
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/dorms)
@@ -9074,6 +9211,9 @@
 /obj/machinery/camera{
 	c_tag = "Dorms West"
 	},
+/obj/machinery/washing_machine{
+	pixel_y = 6
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "avw" = (
@@ -9097,13 +9237,13 @@
 	dir = 1;
 	light_color = "#cee5d2"
 	},
-/obj/structure/table,
-/obj/structure/bedsheetbin/color,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "avA" = (
-/obj/structure/table,
-/obj/structure/bedsheetbin/towel,
+/obj/item/radio/intercom{
+	pixel_y = 25
+	},
+/obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "avB" = (
@@ -9234,14 +9374,11 @@
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
 "avR" = (
-/obj/structure/sign/warning/fire{
-	desc = "A sign that states the labeled room's number.";
-	dir = 8;
-	icon_state = "roomnum";
-	name = "Room Number 4";
-	pixel_y = 24
+/obj/machinery/door/airlock{
+	id_tag = "Dorm6";
+	name = "Room Five"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/crew_quarters/dorms)
 "avS" = (
 /obj/item/wrench,
@@ -9285,6 +9422,12 @@
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 9
 	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "avZ" = (
@@ -9317,12 +9460,21 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "awe" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 1
+	},
+/obj/structure/closet/secure_closet/brig,
+/obj/item/radio/headset{
+	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
+	name = "prisoner headset";
+	prison_radio = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -9373,10 +9525,15 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -9419,6 +9576,12 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "awm" = (
@@ -9456,12 +9619,14 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/dorms)
 "awq" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#cee5d2"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/lumos/tile/red/fullcorner{
+	dir = 4
 	},
+/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
+/area/crew_quarters/fitness)
 "awr" = (
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
@@ -9478,13 +9643,7 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "awt" = (
-/obj/structure/sign/warning/fire{
-	desc = "A sign that states the labeled room's number.";
-	dir = 6;
-	icon_state = "roomnum";
-	name = "Room Number 5";
-	pixel_y = 24
-	},
+/obj/machinery/vending/autodrobe,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "awu" = (
@@ -9492,14 +9651,20 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "awv" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 5
+	},
+/obj/structure/closet/secure_closet/brig{
+	id = "Cell 2";
+	name = "Cell 2 Locker"
+	},
+/obj/item/radio/headset{
+	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
+	name = "prisoner headset";
+	prison_radio = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -9524,9 +9689,7 @@
 /turf/open/pool,
 /area/crew_quarters/fitness/pool)
 "awz" = (
-/obj/item/radio/intercom{
-	pixel_y = 25
-	},
+/obj/machinery/vending/clothing,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "awA" = (
@@ -9571,6 +9734,13 @@
 "awD" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -9736,10 +9906,15 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -9839,12 +10014,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"axh" = (
-/obj/effect/turf_decal/lumos/tile/red/half{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
 "axi" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
@@ -9993,9 +10162,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "axA" = (
@@ -10021,14 +10188,14 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "axC" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/structure/sign/poster/contraband/pwr_game{
 	pixel_x = -32
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
@@ -10037,12 +10204,14 @@
 /turf/open/floor/plasteel/dark,
 /area/gateway)
 "axE" = (
-/obj/effect/turf_decal/tile/blue,
 /obj/structure/sign/poster/official/do_not_question{
 	pixel_x = 32
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
@@ -10102,11 +10271,29 @@
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
 "axO" = (
-/obj/structure/chair/comfy/black,
+/obj/structure/sign/warning/fire{
+	desc = "A sign that states the labeled room's number.";
+	dir = 8;
+	icon_state = "roomnum";
+	name = "Room Number 4";
+	pixel_y = 24
+	},
+/obj/structure/table/wood,
+/obj/structure/bedsheetbin/color,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "axP" = (
-/obj/structure/chair/comfy/brown,
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#cee5d2"
+	},
+/obj/structure/sign/warning/fire{
+	desc = "A sign that states the labeled room's number.";
+	dir = 6;
+	icon_state = "roomnum";
+	name = "Room Number 5";
+	pixel_y = 24
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "axS" = (
@@ -10145,14 +10332,13 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 5
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
 	},
-/obj/structure/bed,
 /obj/effect/turf_decal/trimline/green/filled/line,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "axY" = (
@@ -10602,37 +10788,32 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "ayY" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/structure/sign/poster/official/obey{
 	pixel_x = -32
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "ayZ" = (
-/obj/effect/turf_decal/tile/blue,
 /obj/structure/sign/poster/official/obey{
 	pixel_x = 32
 	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aza" = (
-/obj/structure/table/wood/poker,
-/obj/item/toy/cards/deck,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
+/obj/structure/chair/comfy/brown,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "azb" = (
-/obj/structure/table/wood/poker,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -10655,9 +10836,6 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
 "aze" = (
-/obj/structure/chair/comfy/brown{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -10701,9 +10879,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/effect/turf_decal/lumos/tile/red/half{
-	dir = 8
-	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "azh" = (
@@ -10728,31 +10903,25 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/holopad,
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
-"azm" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
+/obj/structure/table/wood/poker,
+/obj/item/toy/cards/deck,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
-/area/security/brig)
+/area/crew_quarters/dorms)
+"azm" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "azn" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/machinery/jukebox{
@@ -10770,27 +10939,15 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/structure/disposalpipe/junction{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "azp" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/disposalpipe/segment,
+/obj/structure/chair/comfy/black,
 /turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
+/area/crew_quarters/dorms)
 "azq" = (
 /obj/machinery/shower{
 	dir = 8;
@@ -11105,13 +11262,18 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "azZ" = (
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aAa" = (
-/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aAb" = (
@@ -11131,17 +11293,10 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
 "aAd" = (
-/obj/structure/closet/secure_closet/brig,
-/obj/item/radio/headset{
-	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
-	name = "prisoner headset";
-	prison_radio = 1
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 6
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel,
-/area/security/brig)
+/area/security/main)
 "aAe" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -11178,11 +11333,10 @@
 /turf/closed/wall,
 /area/crew_quarters/toilet)
 "aAi" = (
-/obj/structure/chair/comfy/brown{
-	dir = 1
-	},
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk,
 /turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
+/area/crew_quarters/fitness)
 "aAj" = (
 /obj/machinery/power/apc{
 	areastring = "/area/security/checkpoint/auxiliary";
@@ -11507,7 +11661,10 @@
 /area/ai_monitored/nuke_storage)
 "aBb" = (
 /obj/structure/closet/emcloset,
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/plasteel,
 /area/bridge)
 "aBc" = (
@@ -11656,7 +11813,10 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aBv" = (
@@ -11753,7 +11913,12 @@
 "aBC" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/lumos/tile/red/fulltile,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aBD" = (
@@ -12194,11 +12359,19 @@
 /turf/open/floor/plasteel,
 /area/storage/tools)
 "aCN" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/trimline/green/filled/corner{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/bridge)
 "aCO" = (
-/obj/effect/turf_decal/lumos/tile/green/half{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -12289,7 +12462,13 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
 "aDa" = (
-/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aDb" = (
@@ -12633,17 +12812,18 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/crew_quarters/toilet)
 "aDN" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 1
+/obj/structure/table/wood/poker,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
@@ -12676,7 +12856,7 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/crew_quarters/toilet)
 "aDQ" = (
-/obj/effect/turf_decal/lumos/tile/yellow/half{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -12728,11 +12908,14 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
+	},
+/obj/structure/chair/comfy/brown{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
@@ -12909,7 +13092,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
+/obj/structure/disposalpipe/junction/flip{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -13756,14 +13939,20 @@
 /area/crew_quarters/heads/hor)
 "aGt" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aGu" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aGv" = (
@@ -14444,7 +14633,7 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -14454,8 +14643,7 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -14490,11 +14678,13 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
 "aHW" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4
+/obj/effect/landmark/start/security_officer,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
 	},
-/turf/open/floor/wood,
-/area/bridge/meeting_room)
+/obj/effect/turf_decal/trimline/red/filled/corner,
+/turf/open/floor/plasteel,
+/area/security/main)
 "aHX" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -14520,22 +14710,19 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/wood,
 /area/bridge/meeting_room)
 "aIa" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/effect/landmark/start/security_officer,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 4
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
 	},
-/turf/open/floor/wood,
-/area/bridge/meeting_room)
+/turf/open/floor/plasteel,
+/area/security/main)
 "aIb" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
@@ -14649,9 +14836,6 @@
 /turf/open/floor/wood,
 /area/library)
 "aIs" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
@@ -14661,6 +14845,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/holopad,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "aIt" = (
@@ -15028,24 +15216,18 @@
 /obj/machinery/camera{
 	c_tag = "Central Hallway North"
 	},
-/obj/effect/turf_decal/lumos/tile/blue/half{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aJp" = (
-/obj/effect/turf_decal/lumos/tile/blue/fullcorner{
-	dir = 4
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aJq" = (
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"aJr" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aJt" = (
@@ -15064,7 +15246,7 @@
 	pixel_x = 32;
 	pixel_y = 24
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -15072,8 +15254,8 @@
 "aJu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/effect/turf_decal/lumos/tile/blue/fullcorner{
-	dir = 8
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -15465,10 +15647,10 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/effect/turf_decal/lumos/tile/green/half{
+/obj/effect/turf_decal/lumos/tile/green/half,
+/turf/open/floor/plasteel/dark/side{
 	dir = 1
 	},
-/turf/open/floor/plasteel/white/side,
 /area/crew_quarters/fitness)
 "aKr" = (
 /obj/machinery/light/small{
@@ -15579,8 +15761,8 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aKE" = (
-/obj/effect/turf_decal/lumos/tile/blue/half{
-	dir = 8
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -15591,7 +15773,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 9
 	},
-/obj/effect/turf_decal/lumos/tile/blue/half{
+/obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -15850,9 +16032,6 @@
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "aLm" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
@@ -15860,6 +16039,10 @@
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/obj/structure/chair/comfy/black{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -16013,8 +16196,8 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aLJ" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -16112,7 +16295,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aLX" = (
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -17122,9 +17305,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aOE" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aOF" = (
@@ -17133,9 +17314,7 @@
 	pixel_y = -32
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aOG" = (
@@ -17144,9 +17323,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/light,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aOH" = (
@@ -17485,86 +17662,83 @@
 /turf/closed/wall/r_wall,
 /area/bridge)
 "aPS" = (
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "bridge blast";
 	name = "bridge blast door"
 	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/bridge)
 "aPT" = (
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
 /obj/machinery/door/poddoor/preopen{
 	id = "bridge blast";
 	name = "bridge blast door"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/bridge)
 "aPU" = (
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/status_display/evac,
-/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "bridge blast";
 	name = "bridge blast door"
 	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/status_display/evac,
 /turf/open/floor/plating,
 /area/bridge)
 "aPV" = (
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "bridge blast";
 	name = "bridge blast door"
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/bridge)
 "aPW" = (
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/status_display/evac,
-/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "bridge blast";
 	name = "bridge blast door"
 	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/status_display/evac,
 /turf/open/floor/plating,
 /area/bridge)
 "aPX" = (
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "bridge blast";
 	name = "bridge blast door"
 	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/bridge)
 "aPY" = (
@@ -17619,10 +17793,12 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "aQf" = (
-/obj/effect/turf_decal/lumos/tile/green/fullcorner{
-	dir = 4
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 6
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark/corner{
+	dir = 1
+	},
 /area/hydroponics)
 "aQg" = (
 /obj/effect/spawner/structure/window,
@@ -17636,10 +17812,12 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/lumos/tile/green/fullcorner{
-	dir = 8
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 10
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark/corner{
+	dir = 4
+	},
 /area/hydroponics)
 "aQi" = (
 /obj/structure/disposalpipe/segment{
@@ -17659,7 +17837,7 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
 "aQm" = (
-/obj/effect/turf_decal/lumos/tile/green/half{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -17992,91 +18170,85 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aRi" = (
-/obj/machinery/computer/atmos_alert,
-/obj/effect/turf_decal/lumos/tile/yellow/fullcorner{
-	dir = 1
-	},
+/obj/machinery/computer/security,
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/bridge)
 "aRj" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/box/PDAs{
-	pixel_x = 6;
-	pixel_y = 7
-	},
-/obj/item/storage/box/ids{
-	pixel_x = -8;
-	pixel_y = 7
-	},
-/obj/item/storage/secure/briefcase{
-	pixel_y = -9
+/obj/machinery/computer/prisoner/management,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
 "aRk" = (
-/obj/machinery/computer/monitor{
-	name = "bridge power monitoring console"
-	},
 /obj/structure/cable{
-	icon_state = "0-2"
+	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/lumos/tile/yellow/fullcorner,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/obj/structure/reagent_dispensers/water_cooler,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/bridge)
 "aRl" = (
-/obj/machinery/computer/station_alert,
-/obj/effect/turf_decal/lumos/tile/yellow/half,
+/obj/machinery/computer/secure_data,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 6
+	},
 /turf/open/floor/plasteel,
 /area/bridge)
 "aRm" = (
 /obj/machinery/computer/communications,
-/obj/effect/turf_decal/lumos/tile/blue/half,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
 /area/bridge)
 "aRn" = (
 /obj/machinery/computer/shuttle/labor,
-/obj/effect/turf_decal/lumos/tile/blue/fullcorner{
-	dir = 1
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
 "aRo" = (
-/obj/machinery/modular_computer/console/preset/command,
-/obj/effect/turf_decal/lumos/tile/green/fullcorner{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/bridge)
-"aRp" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/obj/structure/filingcabinet/filingcabinet,
+/turf/open/floor/plasteel,
+/area/bridge)
+"aRp" = (
 /obj/machinery/computer/shuttle/mining,
-/obj/effect/turf_decal/lumos/tile/blue/fullcorner,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
 /turf/open/floor/plasteel,
 /area/bridge)
 "aRq" = (
-/obj/machinery/computer/med_data,
-/obj/effect/turf_decal/lumos/tile/green/fullcorner,
+/obj/machinery/computer/crew,
+/obj/effect/turf_decal/trimline/green/filled/line,
 /turf/open/floor/plasteel,
 /area/bridge)
 "aRr" = (
-/obj/machinery/computer/crew,
-/obj/effect/turf_decal/lumos/tile/green/half,
+/obj/machinery/modular_computer/console/preset/command,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 10
+	},
 /turf/open/floor/plasteel,
 /area/bridge)
 "aRs" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/toolbox/mechanical{
-	pixel_y = 9
-	},
-/obj/item/assembly/signaler{
-	pixel_x = 4;
-	pixel_y = 8
-	},
-/obj/item/assembly/signaler{
-	pixel_x = -4;
-	pixel_y = 8
+/obj/machinery/computer/med_data,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
@@ -18192,7 +18364,7 @@
 	dir = 9
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/lumos/tile/green/half{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -18472,7 +18644,14 @@
 /turf/open/floor/plasteel,
 /area/storage/tools)
 "aSu" = (
-/obj/effect/turf_decal/tile/yellow{
+/obj/structure/chair{
+	dir = 1;
+	name = "Engineering Station"
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -18491,21 +18670,38 @@
 	pixel_x = 5;
 	pixel_y = 3
 	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 9
+	},
 /turf/open/floor/plasteel,
 /area/bridge)
 "aSw" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
 "aSx" = (
-/obj/structure/chair{
-	dir = 1;
-	name = "Engineering Station"
+/obj/structure/table/reinforced,
+/obj/item/storage/box/ids{
+	pixel_x = -8;
+	pixel_y = 7
+	},
+/obj/item/storage/box/PDAs{
+	pixel_x = 6;
+	pixel_y = 7
+	},
+/obj/item/storage/secure/briefcase{
+	pixel_y = -9
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
@@ -18514,27 +18710,36 @@
 	dir = 1;
 	name = "Command Station"
 	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/bridge)
 "aSz" = (
 /obj/structure/table/reinforced,
-/obj/effect/turf_decal/lumos/tile/blue/half{
-	dir = 8
-	},
 /obj/item/storage/firstaid/regular,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
 /turf/open/floor/plasteel,
 /area/bridge)
 "aSA" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 1
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
 "aSB" = (
 /obj/structure/table/reinforced,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/item/phone,
 /obj/machinery/button/door{
 	id = "bridge blast";
@@ -18549,35 +18754,57 @@
 	pixel_y = 8;
 	plane = -4
 	},
-/obj/effect/turf_decal/lumos/tile/blue/half{
-	dir = 4
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
 "aSC" = (
-/obj/effect/turf_decal/tile/green{
+/obj/structure/chair{
+	dir = 1;
+	name = "Crew Station"
+	},
+/obj/effect/turf_decal/trimline/green/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
 "aSD" = (
-/obj/structure/chair{
-	dir = 1;
-	name = "Crew Station"
+/obj/structure/table/reinforced,
+/obj/item/storage/toolbox/mechanical{
+	pixel_y = 9
+	},
+/obj/item/assembly/signaler{
+	pixel_x = -4;
+	pixel_y = 8
+	},
+/obj/item/assembly/signaler{
+	pixel_x = 4;
+	pixel_y = 8
+	},
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
 "aSE" = (
+/obj/effect/turf_decal/trimline/yellow/filled/corner,
 /obj/structure/table/reinforced,
-/obj/item/multitool{
-	pixel_x = 10;
-	pixel_y = 13
-	},
 /obj/item/aicard{
 	pixel_x = -4;
 	pixel_y = 16
 	},
+/obj/item/multitool{
+	pixel_x = 10;
+	pixel_y = 13
+	},
 /obj/item/storage/fancy/donut_box,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 5
+	},
 /turf/open/floor/plasteel,
 /area/bridge)
 "aSF" = (
@@ -18712,6 +18939,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "aTa" = (
+/obj/structure/chair/comfy/brown,
 /turf/open/floor/wood{
 	icon_state = "wood-broken3"
 	},
@@ -18784,6 +19012,8 @@
 	dir = 4;
 	light_color = "#d8b1b1"
 	},
+/obj/structure/bed,
+/obj/effect/spawner/lootdrop/bedsheet,
 /turf/open/floor/wood{
 	icon_state = "wood-broken6"
 	},
@@ -18988,20 +19218,22 @@
 /turf/closed/wall,
 /area/bridge)
 "aTR" = (
-/obj/machinery/computer/prisoner/management,
-/obj/effect/turf_decal/lumos/tile/red/fullcorner{
-	dir = 1
+/obj/machinery/modular_computer/console/preset/engineering,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
 "aTS" = (
-/obj/machinery/computer/secure_data,
-/obj/effect/turf_decal/lumos/tile/red/fullcorner,
+/obj/machinery/computer/security/mining,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 6
+	},
 /turf/open/floor/plasteel,
 /area/bridge)
 "aTT" = (
-/obj/machinery/computer/security,
-/obj/effect/turf_decal/lumos/tile/red/half,
+/obj/machinery/computer/cargo/request,
+/obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/plasteel,
 /area/bridge)
 "aTV" = (
@@ -19012,42 +19244,42 @@
 	pixel_y = 22;
 	req_access_txt = "19"
 	},
-/obj/structure/reagent_dispensers/water_cooler,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/bridge)
 "aTW" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/bridge)
 "aTX" = (
 /turf/open/floor/plasteel,
 /area/bridge)
 "aTY" = (
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
 "aTZ" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
 "aUb" = (
-/obj/machinery/modular_computer/console/preset/engineering,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
+/obj/machinery/computer/atmos_alert,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
@@ -19059,27 +19291,23 @@
 	pixel_y = 22;
 	req_access_txt = "19"
 	},
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/bridge)
 "aUd" = (
-/obj/machinery/computer/security/mining,
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
+/obj/machinery/computer/monitor{
+	name = "bridge power monitoring console"
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
 "aUe" = (
-/obj/machinery/computer/cargo/request,
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
+/obj/machinery/computer/station_alert,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/plasteel,
 /area/bridge)
 "aUf" = (
@@ -19127,6 +19355,9 @@
 /area/maintenance/port/fore)
 "aUr" = (
 /obj/machinery/airalarm/directional/north,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aUs" = (
@@ -19277,7 +19508,7 @@
 	id = "visitflash";
 	pixel_y = 25
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -19318,9 +19549,6 @@
 /obj/machinery/light{
 	dir = 1;
 	light_color = "#cee5d2"
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -19379,8 +19607,8 @@
 	pixel_y = 32
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/lumos/tile/blue/fullcorner{
-	dir = 8
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -19408,19 +19636,31 @@
 	c_tag = "Bridge West";
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 1
+	},
+/obj/structure/table,
+/obj/item/paper_bin{
+	pixel_x = 3;
+	pixel_y = 4
+	},
+/obj/item/pen{
+	pixel_x = 3;
+	pixel_y = 5
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
 "aVf" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -19453,8 +19693,11 @@
 	dir = 4
 	},
 /obj/effect/landmark/event_spawn,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 1
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
@@ -19474,7 +19717,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/bridge)
 "aVk" = (
@@ -19485,10 +19730,11 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -19503,6 +19749,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/plasteel,
 /area/bridge)
 "aVm" = (
@@ -19512,13 +19759,15 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
-/turf/open/floor/plasteel,
-/area/bridge)
-"aVn" = (
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/bridge)
+"aVn" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -19527,6 +19776,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
@@ -19537,12 +19789,10 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/bridge)
 "aVp" = (
@@ -19562,14 +19812,14 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
@@ -19578,8 +19828,18 @@
 	c_tag = "Bridge East";
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/brown{
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 4
+	},
+/obj/structure/table,
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 4
+	},
+/obj/item/pen{
+	pixel_x = -3;
+	pixel_y = 5
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
@@ -19616,8 +19876,8 @@
 	pixel_y = 32
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/lumos/tile/blue/fullcorner{
-	dir = 4
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -19625,7 +19885,7 @@
 /obj/machinery/camera{
 	c_tag = "Bridge East Entrance"
 	},
-/obj/effect/turf_decal/lumos/tile/blue/half{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -19746,7 +20006,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
 "aVI" = (
-/obj/effect/turf_decal/lumos/tile/green/half{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -19997,7 +20257,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/quartermaster/sorting)
 "aWz" = (
 /obj/machinery/power/apc{
@@ -20082,7 +20342,7 @@
 /area/security/detectives_office)
 "aWH" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/lumos/tile/blue/half{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -20114,11 +20374,15 @@
 	name = "Bridge";
 	req_access_txt = "19"
 	},
+/obj/effect/turf_decal/lumos/tile/blue/fulltile,
 /turf/open/floor/plasteel,
 /area/bridge)
 "aWK" = (
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
@@ -20133,6 +20397,7 @@
 	name = "Bridge";
 	req_access_txt = "19"
 	},
+/obj/effect/turf_decal/lumos/tile/blue/fulltile,
 /turf/open/floor/plasteel,
 /area/bridge)
 "aWN" = (
@@ -20154,10 +20419,16 @@
 	pixel_y = -22
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/bridge)
 "aWP" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
 /turf/open/floor/plasteel,
 /area/bridge)
 "aWQ" = (
@@ -20166,6 +20437,12 @@
 	pixel_y = -22
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/bridge)
 "aWR" = (
@@ -20173,6 +20450,12 @@
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/bridge)
 "aWS" = (
@@ -20180,8 +20463,11 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/lumos/tile/blue/fulltile,
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/bridge)
 "aWT" = (
@@ -20192,11 +20478,25 @@
 	name = "Bridge RC";
 	pixel_y = -30
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/bridge)
 "aWU" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/bridge)
 "aWV" = (
@@ -20209,7 +20509,15 @@
 	c_tag = "Bridge Center";
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/bridge)
 "aWW" = (
@@ -20221,6 +20529,9 @@
 /obj/structure/cable,
 /obj/machinery/light,
 /obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/bridge)
 "aWX" = (
@@ -20228,14 +20539,20 @@
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/bridge)
 "aWY" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
+/obj/structure/disposalpipe/junction{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
@@ -20244,6 +20561,9 @@
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -20291,6 +20611,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/turf_decal/lumos/tile/blue/fulltile,
 /turf/open/floor/plasteel,
 /area/bridge)
 "aXd" = (
@@ -20301,7 +20622,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/lumos/tile/blue/half{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -20327,6 +20648,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/turf_decal/lumos/tile/blue/fulltile,
 /turf/open/floor/plasteel,
 /area/bridge)
 "aXf" = (
@@ -20406,7 +20728,7 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "aXo" = (
-/obj/effect/turf_decal/lumos/tile/green/half{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -20466,6 +20788,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aXD" = (
@@ -20486,10 +20811,6 @@
 	name = "Room Number 6";
 	pixel_y = 24
 	},
-/obj/machinery/washing_machine{
-	pixel_x = 7;
-	pixel_y = 7
-	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "aXH" = (
@@ -20500,6 +20821,10 @@
 	req_access_txt = "3"
 	},
 /obj/machinery/light,
+/obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aXI" = (
@@ -20539,6 +20864,9 @@
 /area/security/vacantoffice)
 "aXO" = (
 /obj/structure/table,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aXP" = (
@@ -20677,16 +21005,18 @@
 /area/security/detectives_office)
 "aYk" = (
 /obj/machinery/light,
-/obj/effect/turf_decal/lumos/tile/blue/half,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aYl" = (
-/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aYm" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/lumos/tile/blue/fullcorner,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aYn" = (
@@ -20694,7 +21024,7 @@
 	c_tag = "Bridge West Entrance";
 	dir = 1
 	},
-/obj/effect/turf_decal/lumos/tile/blue/half,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aYo" = (
@@ -20742,14 +21072,12 @@
 	dir = 1;
 	pixel_y = -24
 	},
-/obj/structure/table,
-/obj/item/paper_bin{
-	pixel_x = 5;
-	pixel_y = 3
-	},
-/obj/item/pen,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 6
+	},
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
@@ -20810,6 +21138,9 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
 "aYC" = (
@@ -20817,9 +21148,12 @@
 	dir = 1;
 	pixel_y = -24
 	},
-/obj/structure/filingcabinet/filingcabinet,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 10
+	},
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
@@ -20835,8 +21169,8 @@
 /area/bridge)
 "aYE" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/lumos/tile/blue/fullcorner{
-	dir = 1
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -20847,12 +21181,12 @@
 	pixel_y = -24
 	},
 /obj/structure/cable,
-/obj/effect/turf_decal/lumos/tile/blue/half,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aYG" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -20913,6 +21247,9 @@
 /area/crew_quarters/kitchen)
 "aYO" = (
 /obj/item/reagent_containers/glass/bucket,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aYP" = (
@@ -20930,14 +21267,17 @@
 /area/hydroponics)
 "aYQ" = (
 /obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/lumos/tile/green/half{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark/side,
 /area/hydroponics)
 "aYR" = (
 /obj/structure/chair/stool,
 /obj/effect/landmark/start/botanist,
+/obj/effect/turf_decal/trimline/green/filled/corner{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aYT" = (
@@ -20946,6 +21286,9 @@
 	dir = 8
 	},
 /obj/structure/reagent_dispensers/watertank/high,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aYU" = (
@@ -20977,6 +21320,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/turf_decal/lumos/tile/red/fulltile,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aZa" = (
@@ -21255,7 +21599,10 @@
 /area/bridge/meeting_room)
 "aZN" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aZO" = (
@@ -21266,6 +21613,9 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -21339,8 +21689,11 @@
 "aZY" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -21381,6 +21734,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/lumos/tile/red/fulltile,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "baf" = (
@@ -21440,6 +21794,9 @@
 	pixel_x = -24
 	},
 /obj/structure/reagent_dispensers/watertank/high,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bam" = (
@@ -21484,7 +21841,7 @@
 /area/hallway/primary/starboard)
 "bas" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/lumos/tile/green/half{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -21714,8 +22071,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/wood,
 /area/bridge/meeting_room)
 "bbj" = (
@@ -21846,17 +22203,19 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "bbz" = (
-/turf/open/floor/plasteel/white/corner{
+/obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bbA" = (
 /obj/machinery/camera{
 	c_tag = "Starboard Primary Hallway 2"
 	},
-/turf/open/floor/plasteel/white/corner{
+/obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bbB" = (
 /obj/machinery/door/firedoor,
@@ -21914,6 +22273,9 @@
 "bbM" = (
 /obj/structure/table/wood,
 /obj/item/storage/fancy/donut_box,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
+	},
 /turf/open/floor/carpet/blue,
 /area/bridge/meeting_room)
 "bbN" = (
@@ -22274,6 +22636,9 @@
 /obj/item/folder/blue,
 /obj/structure/table/wood,
 /obj/item/hand_labeler,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4
+	},
 /turf/open/floor/carpet/blue,
 /area/bridge/meeting_room)
 "bcO" = (
@@ -22282,6 +22647,12 @@
 	pixel_y = 25
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -22324,9 +22695,6 @@
 	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
 	name = "prisoner headset";
 	prison_radio = 1
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -22487,13 +22855,13 @@
 /obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bdo" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bdp" = (
@@ -22650,7 +23018,10 @@
 	dir = 9
 	},
 /obj/machinery/holopad,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/lumos/tile/brown/checker{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
 /area/quartermaster/miningdock)
 "bdJ" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
@@ -22904,8 +23275,11 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -22927,7 +23301,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bet" = (
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -23183,7 +23557,7 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/quartermaster/sorting)
 "beX" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -23255,7 +23629,13 @@
 "bff" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "bfg" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -23290,9 +23670,6 @@
 	network = list("ss13","prison");
 	start_active = 1
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
 /obj/item/clothing/suit/straight_jacket,
 /obj/item/clothing/suit/straight_jacket,
 /turf/open/floor/plasteel,
@@ -23302,7 +23679,7 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/quartermaster/sorting)
 "bfm" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -23318,7 +23695,7 @@
 /turf/open/floor/plating,
 /area/quartermaster/sorting)
 "bfo" = (
-/obj/effect/turf_decal/tile/brown{
+/obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -23516,11 +23893,12 @@
 /obj/item/storage/box,
 /obj/item/storage/box,
 /obj/item/storage/box,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/brown/filled/corner,
+/turf/open/floor/plasteel/dark,
 /area/quartermaster/sorting)
 "bfS" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bfT" = (
@@ -23640,14 +24018,14 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bgn" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -23656,10 +24034,10 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/effect/turf_decal/lumos/tile/green/fullcorner{
-	dir = 4
+/obj/effect/turf_decal/tile/green,
+/turf/open/floor/plasteel/dark/side{
+	dir = 9
 	},
-/turf/open/floor/plasteel/white/corner,
 /area/crew_quarters/fitness)
 "bgr" = (
 /obj/effect/turf_decal/stripes/line{
@@ -23685,6 +24063,9 @@
 	pixel_x = -1;
 	pixel_y = 24;
 	req_access_txt = "31"
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
@@ -23753,21 +24134,24 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/quartermaster/sorting)
 "bgE" = (
 /obj/machinery/airalarm{
 	dir = 4;
 	pixel_x = -23
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/quartermaster/sorting)
 "bgG" = (
 /obj/machinery/camera{
 	c_tag = "Central Hallway West";
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bgH" = (
@@ -23912,7 +24296,7 @@
 /area/crew_quarters/heads/captain)
 "bgY" = (
 /obj/machinery/light,
-/obj/effect/turf_decal/lumos/tile/blue/half,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bha" = (
@@ -24276,7 +24660,9 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
 	},
-/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bie" = (
@@ -24349,7 +24735,6 @@
 /obj/structure/sign/poster/official/help_others{
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "biF" = (
@@ -24368,6 +24753,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 6
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
@@ -24404,20 +24792,16 @@
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
 "biM" = (
-/obj/effect/turf_decal/loading_area{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "biN" = (
-/obj/effect/turf_decal/trimline/white/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/medical/morgue)
+/obj/effect/turf_decal/trimline/red/filled/corner,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "biO" = (
 /obj/machinery/camera{
 	c_tag = "Robotics Lab";
@@ -24533,9 +24917,6 @@
 	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
 	name = "prisoner headset";
 	prison_radio = 1
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -24654,18 +25035,12 @@
 	departmentType = 2;
 	pixel_y = 30
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 1
-	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "bjn" = (
 /obj/structure/table,
 /obj/item/clothing/head/soft,
 /obj/item/clothing/head/soft,
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 9
-	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "bjo" = (
@@ -24673,8 +25048,8 @@
 	c_tag = "Cargo Bay North"
 	},
 /obj/machinery/vending/wardrobe/cargo_wardrobe,
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 1
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
@@ -24683,9 +25058,6 @@
 /obj/machinery/cell_charger,
 /obj/item/radio/intercom{
 	pixel_y = 20
-	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
@@ -24697,7 +25069,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/brown/filled/corner{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -24720,7 +25092,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/lumos/tile/brown/fulltile,
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
 /area/quartermaster/sorting)
 "bjt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -24750,7 +25125,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 9
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/turf/open/floor/plasteel/dark,
 /area/quartermaster/sorting)
 "bjx" = (
 /obj/structure/cable{
@@ -24787,16 +25163,13 @@
 /area/maintenance/central)
 "bjD" = (
 /obj/machinery/light,
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/red/filled/corner,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "bjE" = (
 /obj/machinery/airalarm{
 	dir = 4;
 	pixel_x = -22
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 4
 	},
 /turf/open/floor/wood,
 /area/bridge/meeting_room)
@@ -24944,14 +25317,15 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "bkg" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 9
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "bki" = (
@@ -24979,8 +25353,8 @@
 /obj/machinery/airalarm{
 	pixel_y = 24
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 1
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
@@ -25006,14 +25380,16 @@
 	pixel_y = 10;
 	req_access_txt = "3"
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "bkm" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/quartermaster/miningdock)
 "bkn" = (
 /obj/machinery/light{
@@ -25022,7 +25398,7 @@
 /obj/machinery/firealarm{
 	pixel_y = 27
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -25102,6 +25478,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "bkx" = (
@@ -25134,6 +25513,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/turf_decal/lumos/tile/red/fulltile,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "bkB" = (
@@ -25197,6 +25577,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/lumos/tile/red/fulltile,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "bkJ" = (
@@ -25320,6 +25701,9 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27;
 	pixel_y = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -25641,8 +26025,8 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -25680,9 +26064,6 @@
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
-	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
@@ -25748,7 +26129,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/quartermaster/sorting)
 "bmj" = (
 /obj/structure/cable{
@@ -25768,7 +26149,10 @@
 	name = "Delivery Office";
 	req_access_txt = "50"
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/lumos/tile/brown/fulltile,
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
 /area/quartermaster/sorting)
 "bmm" = (
 /obj/structure/cable{
@@ -25784,12 +26168,12 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
 /obj/machinery/status_display/supply{
 	pixel_x = -28;
 	pixel_y = 2
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -25839,7 +26223,10 @@
 	pixel_y = 26;
 	req_access_txt = "3"
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -25905,6 +26292,9 @@
 /area/maintenance/central/secondary)
 "bmE" = (
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bmH" = (
@@ -26033,9 +26423,11 @@
 /area/science/robotics/mechbay)
 "bnd" = (
 /obj/machinery/camera,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
+/obj/structure/closet/secure_closet/brig,
+/obj/item/radio/headset{
+	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
+	name = "prisoner headset";
+	prison_radio = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -26265,6 +26657,9 @@
 /area/medical/medbay/front_office)
 "bnI" = (
 /obj/machinery/computer/cargo/request,
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "bnJ" = (
@@ -26283,7 +26678,7 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/quartermaster/sorting)
 "bnM" = (
 /obj/structure/cable{
@@ -26292,7 +26687,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bnN" = (
-/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/trimline/red/filled/corner,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bnO" = (
@@ -26300,6 +26695,9 @@
 	pixel_y = 32
 	},
 /obj/machinery/vending/cart,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
 "bnP" = (
@@ -26327,14 +26725,17 @@
 	pixel_y = 36
 	},
 /obj/machinery/pdapainter,
-/obj/effect/turf_decal/lumos/tile/blue/fullcorner{
-	dir = 4
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
 "bnQ" = (
 /obj/structure/table,
 /obj/machinery/photocopier/faxmachine,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
 "bnR" = (
@@ -26513,13 +26914,13 @@
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
 "bot" = (
-/obj/structure/table/glass,
-/obj/machinery/computer/med_data/laptop,
 /obj/machinery/vending/wallmed{
 	pixel_y = 30
 	},
-/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel/showroomfloor,
 /area/security/brig)
 "bou" = (
 /turf/open/floor/plasteel,
@@ -26713,11 +27114,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "boW" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 6
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -26743,7 +27144,7 @@
 	pixel_x = 32;
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/lumos/tile/red/half{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -26794,7 +27195,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/lumos/tile/blue/half{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -26817,8 +27218,8 @@
 /area/crew_quarters/heads/hop)
 "bpg" = (
 /obj/effect/landmark/start/brig_physician,
-/obj/effect/turf_decal/lumos/tile/red/fullcorner{
-	dir = 8
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/brig)
@@ -26835,10 +27236,10 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/effect/turf_decal/trimline/red/filled/line,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "bpj" = (
@@ -26979,6 +27380,7 @@
 /obj/machinery/computer/cargo{
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/brown/filled/corner,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "bpB" = (
@@ -26994,7 +27396,7 @@
 /area/quartermaster/office)
 "bpC" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -27084,10 +27486,10 @@
 /obj/effect/turf_decal/lumos/tile/blue/checker{
 	dir = 4
 	},
-/obj/effect/turf_decal/bot,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/turf_decal/box,
 /turf/open/floor/plasteel/cafeteria,
 /area/medical/medbay/lobby)
 "bpN" = (
@@ -27234,9 +27636,6 @@
 	dir = 4;
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
-	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bqf" = (
@@ -27328,7 +27727,7 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/quartermaster/sorting)
 "bqq" = (
 /obj/structure/cable{
@@ -27337,7 +27736,10 @@
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/hop)
 "bqs" = (
-/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/box,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "bqt" = (
@@ -27348,6 +27750,9 @@
 /area/crew_quarters/theatre)
 "bqu" = (
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "bqv" = (
@@ -27359,7 +27764,7 @@
 /turf/open/floor/plating,
 /area/hallway/primary/central)
 "bqw" = (
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -27386,8 +27791,8 @@
 /obj/machinery/computer/card{
 	dir = 1
 	},
-/obj/effect/turf_decal/lumos/tile/blue/fullcorner{
-	dir = 1
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
@@ -27465,6 +27870,9 @@
 "bqL" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bqN" = (
@@ -27475,10 +27883,10 @@
 /obj/effect/turf_decal/lumos/tile/blue/checker{
 	dir = 4
 	},
-/obj/effect/turf_decal/delivery,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/cafeteria,
 /area/medical/medbay/lobby)
 "bqS" = (
@@ -27850,6 +28258,10 @@
 	dir = 4
 	},
 /obj/machinery/disposal/bin,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
 "brX" = (
@@ -27906,9 +28318,10 @@
 /obj/machinery/newscaster{
 	pixel_y = 32
 	},
-/turf/open/floor/plasteel/white/corner{
+/obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bsi" = (
 /obj/structure/table,
@@ -27960,11 +28373,12 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/plasteel,
 /area/teleporter)
 "bsp" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/lumos/tile/blue/half{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -28419,7 +28833,7 @@
 /area/quartermaster/office)
 "btz" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/brown{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -28434,8 +28848,8 @@
 /obj/machinery/computer/bounty{
 	dir = 4
 	},
-/obj/effect/turf_decal/lumos/tile/blue/fullcorner{
-	dir = 4
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
@@ -28528,6 +28942,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/effect/turf_decal/lumos/tile/blue/fulltile,
 /turf/open/floor/plasteel,
 /area/teleporter)
 "btN" = (
@@ -28537,8 +28952,13 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
+	},
 /turf/open/floor/plasteel,
 /area/teleporter)
 "btO" = (
@@ -28546,7 +28966,7 @@
 	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/lumos/tile/blue/half{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -28629,6 +29049,7 @@
 /obj/effect/turf_decal/loading_area{
 	dir = 8
 	},
+/obj/effect/turf_decal/trimline/brown/filled/corner,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "buc" = (
@@ -28642,14 +29063,14 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/trimline/brown/filled/corner,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "bud" = (
-/obj/effect/turf_decal/tile/brown{
+/obj/machinery/computer/bounty{
 	dir = 8
 	},
-/obj/machinery/computer/bounty{
+/obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -28665,6 +29086,9 @@
 /obj/machinery/camera{
 	c_tag = "Head of Personnel's Office";
 	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
@@ -29007,7 +29431,7 @@
 /obj/machinery/computer/cargo{
 	dir = 4
 	},
-/obj/effect/turf_decal/lumos/tile/blue/half{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -29035,17 +29459,11 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
 "buT" = (
-/obj/machinery/door/firedoor/heavy,
-/obj/machinery/door/poddoor/preopen{
-	id = "Biohazard";
-	name = "biohazard containment door"
-	},
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
+/turf/open/floor/plasteel,
+/area/security/brig)
 "buU" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -29090,10 +29508,10 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/teleporter)
 "bva" = (
@@ -29104,7 +29522,7 @@
 	pixel_x = -32
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/lumos/tile/blue/half{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -29293,10 +29711,10 @@
 /obj/machinery/keycard_auth{
 	pixel_y = 25
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 9
+/obj/effect/turf_decal/lumos/tile/brown/checker{
+	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/cafeteria,
 /area/quartermaster/qm)
 "bvG" = (
 /obj/effect/turf_decal/stripes/line{
@@ -29311,6 +29729,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "bvJ" = (
@@ -29329,7 +29750,7 @@
 /obj/machinery/recharger{
 	pixel_y = 4
 	},
-/obj/effect/turf_decal/lumos/tile/red/half{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -29407,7 +29828,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/effect/turf_decal/lumos/tile/blue/half{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -29417,6 +29838,7 @@
 	c_tag = "Cargo Bay South";
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "bvY" = (
@@ -29427,6 +29849,9 @@
 	location = "QM #4"
 	},
 /obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "bvZ" = (
@@ -29437,7 +29862,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/effect/turf_decal/lumos/tile/blue/half{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -29452,7 +29877,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/effect/turf_decal/lumos/tile/brown/half,
+/obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "bwd" = (
@@ -29468,7 +29893,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/brown{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -29484,7 +29909,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bwh" = (
-/obj/effect/turf_decal/lumos/tile/blue/half{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -29496,16 +29921,18 @@
 	pixel_x = -28
 	},
 /obj/structure/filingcabinet/chestdrawer,
-/obj/effect/turf_decal/lumos/tile/blue/fullcorner{
-	dir = 1
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
 "bwj" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 8
+/obj/effect/turf_decal/lumos/tile/red/half{
+	dir = 1
 	},
+/obj/effect/turf_decal/lumos/tile/blue/half,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "bwk" = (
@@ -29521,6 +29948,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
 "bwq" = (
@@ -29768,7 +30196,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/lumos/tile/brown/checker{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
 /area/quartermaster/qm)
 "bwT" = (
 /obj/structure/cable{
@@ -29787,10 +30218,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/lumos/tile/brown/fulltile,
+/turf/open/floor/plasteel/white/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "bwU" = (
 /obj/structure/cable{
@@ -29805,10 +30236,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/lumos/tile/brown/checker{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/cafeteria,
 /area/quartermaster/qm)
 "bwV" = (
 /obj/structure/cable{
@@ -29842,6 +30273,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "bwX" = (
@@ -29870,6 +30304,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/turf_decal/lumos/tile/red/fulltile,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
 "bwZ" = (
@@ -30050,8 +30485,8 @@
 	name = "Quartermaster";
 	req_access_txt = "41"
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/lumos/tile/brown/fulltile,
+/turf/open/floor/plasteel/white/side,
 /area/quartermaster/qm)
 "bxx" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -30074,6 +30509,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/lumos/tile/brown/fulltile,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "bxB" = (
@@ -30083,14 +30519,14 @@
 	},
 /obj/item/pen,
 /obj/structure/table,
-/obj/effect/turf_decal/lumos/tile/red/fullcorner{
-	dir = 4
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
 "bxD" = (
 /obj/structure/table,
-/obj/effect/turf_decal/lumos/tile/red/half{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -30101,8 +30537,8 @@
 	pixel_x = 24
 	},
 /obj/structure/filingcabinet,
-/obj/effect/turf_decal/lumos/tile/red/fullcorner{
-	dir = 8
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
@@ -30132,6 +30568,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/lumos/tile/blue/fulltile,
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
 "bxH" = (
@@ -30198,18 +30635,11 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/hor)
 "bxQ" = (
-/obj/machinery/door/airlock/medical/glass{
-	id_tag = "GeneticsDoor";
-	name = "Genetics";
-	req_access_txt = "5; 68"
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
 	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/lumos/tile/blue/fulltile,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/dark,
-/area/medical/surgery)
+/turf/open/floor/plasteel,
+/area/security/brig)
 "bxS" = (
 /obj/machinery/sleeper{
 	dir = 8
@@ -30316,12 +30746,10 @@
 /obj/machinery/computer/card/minor/qm{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line,
-/turf/open/floor/plasteel,
-/area/quartermaster/qm)
-"byd" = (
-/obj/effect/turf_decal/trimline/brown/filled/line,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/lumos/tile/brown/checker{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
 /area/quartermaster/qm)
 "byf" = (
 /turf/closed/wall/r_wall,
@@ -30344,8 +30772,10 @@
 	pixel_x = -6;
 	pixel_y = 1
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/lumos/tile/brown/checker{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
 /area/quartermaster/qm)
 "byh" = (
 /obj/machinery/door/firedoor,
@@ -30387,7 +30817,6 @@
 	pixel_x = 2;
 	pixel_y = 3
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line,
 /obj/item/pen{
 	pixel_x = -1;
 	pixel_y = -1
@@ -30403,7 +30832,10 @@
 /obj/item/phone{
 	pixel_x = 14
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/lumos/tile/brown/checker{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
 /area/quartermaster/qm)
 "byn" = (
 /obj/machinery/light_switch{
@@ -30418,10 +30850,10 @@
 	},
 /obj/structure/table,
 /obj/machinery/photocopier/faxmachine,
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 6
+/obj/effect/turf_decal/lumos/tile/brown/checker{
+	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/cafeteria,
 /area/quartermaster/qm)
 "byo" = (
 /obj/structure/table,
@@ -30492,10 +30924,10 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "byz" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 1
+/obj/effect/turf_decal/lumos/tile/brown/checker{
+	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/cafeteria,
 /area/quartermaster/qm)
 "byA" = (
 /obj/machinery/power/apc{
@@ -30507,25 +30939,25 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 1
+/obj/effect/turf_decal/lumos/tile/brown/checker{
+	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/cafeteria,
 /area/quartermaster/qm)
 "byB" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 1
-	},
 /obj/structure/filingcabinet,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/lumos/tile/brown/checker{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
 /area/quartermaster/qm)
 "byC" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 1
-	},
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/disposal/bin,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/lumos/tile/brown/checker{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
 /area/quartermaster/qm)
 "byD" = (
 /obj/structure/closet/secure_closet/quartermaster,
@@ -30533,11 +30965,11 @@
 	pixel_y = 23
 	},
 /obj/item/clipboard,
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 5
-	},
 /obj/item/coin/silver,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/lumos/tile/brown/checker{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
 /area/quartermaster/qm)
 "byE" = (
 /turf/open/floor/plasteel,
@@ -30551,6 +30983,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
@@ -30569,8 +31004,8 @@
 	},
 /obj/structure/closet/secure_closet/security/cargo,
 /obj/item/book/manual/wiki/security_space_law,
-/obj/effect/turf_decal/lumos/tile/red/fullcorner{
-	dir = 1
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
@@ -30581,7 +31016,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/effect/turf_decal/lumos/tile/red/half{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -30602,7 +31037,7 @@
 	name = "Station Intercom (General)";
 	pixel_x = 27
 	},
-/obj/effect/turf_decal/lumos/tile/red/half{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -30619,15 +31054,15 @@
 	departmentType = 5;
 	pixel_y = -30
 	},
-/obj/effect/turf_decal/lumos/tile/red/half,
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
 "byP" = (
 /obj/structure/sign/warning/securearea{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/lumos/tile/blue/half{
-	dir = 1
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -30638,7 +31073,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/effect/turf_decal/lumos/tile/blue/half{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -30647,14 +31082,14 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/lumos/tile/blue/half{
+/obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "byT" = (
 /obj/machinery/vending/wardrobe/sec_wardrobe,
-/obj/effect/turf_decal/lumos/tile/red/half,
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
 "byU" = (
@@ -30945,6 +31380,7 @@
 	dir = 8;
 	pixel_x = 24
 	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "bzG" = (
@@ -30952,7 +31388,9 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
 	},
-/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bzH" = (
@@ -31014,10 +31452,10 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 8
+/obj/effect/turf_decal/lumos/tile/brown/checker{
+	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/cafeteria,
 /area/quartermaster/qm)
 "bzQ" = (
 /obj/structure/cable{
@@ -31027,13 +31465,19 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/lumos/tile/brown/checker{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
 /area/quartermaster/qm)
 "bzR" = (
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/lumos/tile/brown/checker{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
 /area/quartermaster/qm)
 "bzT" = (
 /obj/structure/chair/office/dark,
@@ -31050,7 +31494,10 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/lumos/tile/brown/checker{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
 /area/quartermaster/qm)
 "bzU" = (
 /obj/machinery/airalarm{
@@ -31114,7 +31561,10 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/shaft_miner,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/lumos/tile/brown/checker{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
 /area/quartermaster/miningdock)
 "bAc" = (
 /obj/structure/cable{
@@ -31129,7 +31579,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/lumos/tile/brown/checker{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
 /area/quartermaster/miningdock)
 "bAd" = (
 /obj/machinery/light{
@@ -31138,7 +31591,7 @@
 /obj/machinery/computer/secure_data{
 	dir = 8
 	},
-/obj/effect/turf_decal/lumos/tile/red/half{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -31200,7 +31653,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/obj/effect/turf_decal/lumos/tile/blue/half{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -31239,7 +31692,10 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/lumos/tile/brown/checker{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
 /area/quartermaster/miningdock)
 "bAn" = (
 /obj/machinery/door/airlock/maintenance{
@@ -31482,7 +31938,10 @@
 "bAO" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -31513,10 +31972,10 @@
 /obj/machinery/computer/security/qm{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 10
+/obj/effect/turf_decal/lumos/tile/brown/checker{
+	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/cafeteria,
 /area/quartermaster/qm)
 "bAT" = (
 /obj/structure/table,
@@ -31536,6 +31995,9 @@
 /area/janitor)
 "bAU" = (
 /obj/structure/closet/l3closet/janitor,
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/janitor)
 "bAV" = (
@@ -31564,6 +32026,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -31599,7 +32064,9 @@
 /obj/machinery/computer/security/mining{
 	dir = 8
 	},
-/obj/effect/turf_decal/lumos/tile/red/fullcorner,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 6
+	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
 "bBg" = (
@@ -31623,11 +32090,11 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bBi" = (
@@ -31717,6 +32184,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bBr" = (
@@ -31726,6 +32196,7 @@
 /obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
+/obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bBt" = (
@@ -31750,7 +32221,7 @@
 	dir = 8;
 	sortType = 22
 	},
-/obj/effect/turf_decal/lumos/tile/purple/half,
+/obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bBw" = (
@@ -31845,7 +32316,10 @@
 	},
 /obj/structure/closet/wardrobe/miner,
 /obj/item/radio/headset/headset_cargo/mining,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/lumos/tile/brown/checker{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
 /area/quartermaster/miningdock)
 "bBK" = (
 /obj/structure/cable{
@@ -31878,15 +32352,11 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics)
 "bBO" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Surgery Maintenance";
-	req_access_txt = "45"
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 6
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/medical/surgery)
+/turf/open/floor/plasteel,
+/area/security/main)
 "bBP" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -32110,7 +32580,9 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bCq" = (
@@ -32147,7 +32619,7 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
 	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -32480,7 +32952,10 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/lumos/tile/brown/checker{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
 /area/quartermaster/miningdock)
 "bDl" = (
 /obj/machinery/firealarm{
@@ -32507,7 +32982,10 @@
 "bDo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/lumos/tile/brown/checker{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
 /area/quartermaster/miningdock)
 "bDq" = (
 /obj/machinery/disposal/bin,
@@ -32525,6 +33003,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/plasteel,
 /area/janitor)
 "bDs" = (
@@ -32617,6 +33096,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/loading_area,
 /turf/open/floor/plasteel,
 /area/medical/storage)
 "bDB" = (
@@ -32658,7 +33138,10 @@
 /area/medical/storage)
 "bDG" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/trimline/yellow/filled/corner,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bDH" = (
@@ -32699,6 +33182,9 @@
 /obj/item/restraints/legcuffs/beartrap,
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 1
+	},
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/janitor)
@@ -32746,6 +33232,9 @@
 /area/janitor)
 "bDM" = (
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/janitor)
 "bDO" = (
@@ -33141,7 +33630,10 @@
 	dir = 4
 	},
 /obj/machinery/computer/security/mining,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/lumos/tile/brown/checker{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
 /area/quartermaster/miningdock)
 "bEL" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
@@ -33163,7 +33655,10 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/lumos/tile/brown/checker{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
 /area/quartermaster/miningdock)
 "bET" = (
 /obj/structure/cable{
@@ -33284,6 +33779,9 @@
 /obj/item/mop,
 /obj/item/broom,
 /obj/item/reagent_containers/glass/bucket,
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/janitor)
 "bFh" = (
@@ -33306,14 +33804,14 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -33662,10 +34160,10 @@
 /obj/machinery/computer/shuttle/mining{
 	dir = 4
 	},
-/obj/effect/turf_decal/lumos/tile/brown/fullcorner{
+/obj/effect/turf_decal/lumos/tile/brown/checker{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/cafeteria,
 /area/quartermaster/miningdock)
 "bGk" = (
 /obj/structure/chair/stool,
@@ -33693,7 +34191,10 @@
 /area/science/mixing)
 "bGn" = (
 /obj/structure/closet/secure_closet/miner,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/lumos/tile/brown/checker{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
 /area/quartermaster/miningdock)
 "bGo" = (
 /obj/machinery/door/airlock/maintenance/abandoned{
@@ -33702,6 +34203,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"bGp" = (
+/obj/structure/table/wood,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/corner,
+/turf/open/floor/plasteel,
+/area/security/courtroom)
 "bGq" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -33819,6 +34328,7 @@
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 8
 	},
+/obj/effect/turf_decal/trimline/purple/filled/corner,
 /turf/open/floor/plasteel,
 /area/janitor)
 "bGE" = (
@@ -33927,11 +34437,14 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/yellow,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -34075,18 +34588,20 @@
 /area/hallway/primary/aft)
 "bHk" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bHl" = (
-/obj/effect/turf_decal/tile/yellow,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -34171,23 +34686,29 @@
 	name = "Station Intercom (General)";
 	pixel_x = 27
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /obj/structure/closet/emcloset/anchored,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
 /area/quartermaster/miningdock)
 "bHz" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
 /area/quartermaster/miningdock)
 "bHA" = (
-/obj/effect/turf_decal/lumos/tile/brown/half{
-	dir = 8
+/obj/effect/turf_decal/lumos/tile/brown/checker{
+	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/cafeteria,
 /area/quartermaster/miningdock)
 "bHB" = (
 /obj/effect/turf_decal/tile/red{
@@ -34293,10 +34814,6 @@
 /obj/machinery/light/small,
 /turf/open/floor/plating,
 /area/storage/tech)
-"bHP" = (
-/obj/effect/turf_decal/tile/yellow,
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "bHQ" = (
 /obj/machinery/vending/assist,
 /turf/open/floor/plating,
@@ -34307,7 +34824,10 @@
 	c_tag = "Aft Primary Hallway 2";
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -34325,7 +34845,9 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/lumos/tile/blue/fulltile,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/airless/white/side{
+	dir = 4
+	},
 /area/medical/medbay/central)
 "bHU" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
@@ -34399,7 +34921,7 @@
 /obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -34835,7 +35357,14 @@
 	name = "Mining Dock";
 	req_access_txt = "48"
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/stripes/end{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/turf/open/floor/plasteel/dark,
 /area/quartermaster/miningdock)
 "bJe" = (
 /obj/structure/table,
@@ -34972,7 +35501,8 @@
 /area/maintenance/aft)
 "bJx" = (
 /obj/effect/landmark/event_spawn,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -34997,7 +35527,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -35302,21 +35832,29 @@
 	c_tag = "Mining Dock External";
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
 /area/quartermaster/miningdock)
 "bKk" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
 /area/quartermaster/miningdock)
 "bKl" = (
 /obj/structure/closet/emcloset,
-/obj/effect/turf_decal/lumos/tile/brown/fullcorner{
-	dir = 1
+/obj/effect/turf_decal/lumos/tile/brown/checker{
+	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/cafeteria,
 /area/quartermaster/miningdock)
 "bKm" = (
 /obj/structure/sign/warning/vacuum/external,
@@ -35334,22 +35872,34 @@
 /obj/item/shovel{
 	pixel_x = -5
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/lumos/tile/brown/checker{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
 /area/quartermaster/miningdock)
 "bKo" = (
 /obj/machinery/light,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/lumos/tile/brown/checker{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
 /area/quartermaster/miningdock)
 "bKp" = (
 /obj/structure/closet/crate,
 /obj/item/stack/ore/iron,
 /obj/item/stack/ore/silver,
 /obj/item/stack/ore/silver,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/lumos/tile/brown/checker{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
 /area/quartermaster/miningdock)
 "bKq" = (
 /obj/machinery/mineral/equipment_vendor,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/lumos/tile/brown/checker{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
 /area/quartermaster/miningdock)
 "bKr" = (
 /obj/structure/cable{
@@ -35466,7 +36016,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/quartermaster/sorting)
 "bKG" = (
 /obj/structure/cable{
@@ -35914,12 +36467,16 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/quartermaster/sorting)
 "bLH" = (
 /obj/structure/closet/emcloset,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
+/obj/effect/turf_decal/trimline/yellow/filled/corner,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -35973,11 +36530,11 @@
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
 "bLS" = (
-/obj/effect/decal/cleanable/cobweb{
-	icon_state = "cobweb2"
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 10
 	},
-/turf/open/floor/plasteel/dark,
-/area/security/courtroom)
+/turf/open/floor/plasteel,
+/area/security/main)
 "bLU" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
@@ -36024,7 +36581,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bLY" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+/obj/structure/chair/comfy/black{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -36660,7 +37217,10 @@
 /obj/item/folder/yellow{
 	pixel_x = 4
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/quartermaster/sorting)
 "bNI" = (
 /turf/closed/wall,
@@ -36683,6 +37243,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/turf_decal/lumos/tile/brown/fulltile,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "bNL" = (
@@ -36709,14 +37270,15 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "bNO" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/turf_decal/loading_area{
 	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -37089,16 +37651,14 @@
 /turf/open/floor/plating,
 /area/science/test_area)
 "bOL" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/disposalpipe/sorting/mail{
-	sortType = 9
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
 	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "bOM" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -38000,6 +38560,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bRk" = (
@@ -38054,19 +38617,22 @@
 /area/security/checkpoint/engineering)
 "bRp" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bRq" = (
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -38077,6 +38643,7 @@
 	pixel_y = -24
 	},
 /obj/structure/tank_dispenser,
+/obj/effect/turf_decal/trimline/yellow/filled/corner,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bRs" = (
@@ -38111,17 +38678,18 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bRx" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/door/airlock/atmos{
 	name = "Atmospherics";
 	req_access_txt = "24"
 	},
-/turf/open/floor/plasteel/dark/corner{
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/turf/open/floor/plasteel/dark/side,
 /area/engine/atmos)
 "bRy" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
@@ -38493,13 +39061,6 @@
 /obj/structure/table,
 /turf/open/floor/plating,
 /area/construction)
-"bSA" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "bSC" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 10
@@ -38514,7 +39075,13 @@
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
 /area/engine/atmos)
 "bSH" = (
 /obj/effect/turf_decal/bot,
@@ -38855,7 +39422,7 @@
 	icon_state = "0-4"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -38875,12 +39442,10 @@
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 4
 	},
-/turf/open/floor/plasteel/dark/corner{
-	dir = 1
-	},
+/turf/open/floor/plasteel/dark/corner,
 /area/engine/atmos)
 "bTM" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
@@ -38888,7 +39453,13 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/corner,
 /area/engine/atmos)
 "bTP" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
@@ -38905,16 +39476,8 @@
 /turf/open/floor/plating,
 /area/engine/atmos)
 "bTR" = (
-/obj/item/crowbar,
-/obj/item/wrench,
 /obj/structure/window/reinforced,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark/corner,
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bTT" = (
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible{
@@ -39055,10 +39618,10 @@
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
 "bUl" = (
-/obj/effect/turf_decal/tile/yellow{
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bUm" = (
@@ -39197,11 +39760,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow{
-	dir = 8
+	dir = 4
 	},
-/turf/open/floor/plasteel/dark/corner{
-	dir = 1
-	},
+/turf/open/floor/plasteel/dark/corner,
 /area/engine/atmos)
 "bUG" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
@@ -39222,13 +39783,13 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/oil{
 	icon_state = "floor5"
 	},
-/turf/open/floor/plasteel/dark/corner,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bUJ" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
@@ -39239,7 +39800,15 @@
 	name = "Atmospherics";
 	req_access_txt = "24"
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
 /area/engine/atmos)
 "bUK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
@@ -39354,28 +39923,32 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
 	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner,
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "bVc" = (
-/obj/effect/turf_decal/lumos/tile/yellow/half{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bVd" = (
-/obj/effect/turf_decal/lumos/tile/yellow/fullcorner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bVf" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bVg" = (
@@ -39383,17 +39956,21 @@
 	name = "Station Intercom (General)";
 	pixel_y = 20
 	},
-/obj/effect/turf_decal/lumos/tile/yellow/fullcorner{
-	dir = 8
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bVh" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -39577,11 +40154,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow{
-	dir = 8
+	dir = 4
 	},
-/turf/open/floor/plasteel/dark/corner{
-	dir = 1
-	},
+/turf/open/floor/plasteel/dark/corner,
 /area/engine/atmos)
 "bVO" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
@@ -39592,19 +40167,20 @@
 "bVQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bVR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
 /obj/machinery/suit_storage_unit/atmos,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark/corner,
 /area/engine/atmos)
 "bVS" = (
@@ -39634,7 +40210,13 @@
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/corner,
 /area/engine/atmos)
 "bVY" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
@@ -39642,11 +40224,9 @@
 	},
 /obj/structure/closet/secure_closet/atmospherics,
 /obj/effect/turf_decal/tile/yellow{
-	dir = 4
+	dir = 8
 	},
-/turf/open/floor/plasteel/dark/corner{
-	dir = 1
-	},
+/turf/open/floor/plasteel/dark/corner,
 /area/engine/atmos)
 "bVZ" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
@@ -39845,6 +40425,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
+/obj/effect/turf_decal/lumos/tile/yellow/fulltile,
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "bWv" = (
@@ -39852,6 +40433,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -39948,7 +40532,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/obj/effect/turf_decal/lumos/tile/yellow/half{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -39962,7 +40546,10 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -39985,11 +40572,9 @@
 	pixel_x = -22
 	},
 /obj/effect/turf_decal/tile/yellow{
-	dir = 8
+	dir = 4
 	},
-/turf/open/floor/plasteel/dark/corner{
-	dir = 1
-	},
+/turf/open/floor/plasteel/dark/corner,
 /area/engine/atmos)
 "bWO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
@@ -40243,7 +40828,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/lumos/tile/yellow/half{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -40279,6 +40864,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bXq" = (
@@ -40299,6 +40887,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/turf_decal/lumos/tile/yellow/fulltile,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bXr" = (
@@ -40442,7 +41031,12 @@
 	name = "Atmospherics Blast Door"
 	},
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/corner{
+	dir = 1
+	},
 /area/engine/atmos)
 "bXM" = (
 /obj/machinery/door/poddoor/preopen{
@@ -40451,6 +41045,10 @@
 	},
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner,
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -40666,7 +41264,6 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/lumos/tile/yellow/half,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
@@ -40682,14 +41279,13 @@
 /obj/structure/sign/warning/securearea{
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/lumos/tile/yellow/fullcorner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bYq" = (
 /obj/machinery/light,
-/obj/effect/turf_decal/lumos/tile/yellow/half,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bYr" = (
@@ -40770,7 +41366,6 @@
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "bYE" = (
-/obj/effect/turf_decal/lumos/tile/yellow/half,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
@@ -40785,7 +41380,9 @@
 /obj/structure/sign/departments/engineering{
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/lumos/tile/yellow/fullcorner,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bYH" = (
@@ -40796,7 +41393,10 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/trimline/yellow/filled/corner,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bYK" = (
@@ -40825,7 +41425,6 @@
 	dir = 1;
 	pixel_y = -22
 	},
-/obj/effect/turf_decal/lumos/tile/yellow/half,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bYN" = (
@@ -41040,7 +41639,7 @@
 "bZx" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -41115,8 +41714,8 @@
 /turf/open/floor/plating,
 /area/crew_quarters/heads/chief)
 "bZE" = (
-/obj/effect/turf_decal/lumos/tile/yellow/fullcorner{
-	dir = 1
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
@@ -41399,7 +41998,9 @@
 "cap" = (
 /obj/machinery/light,
 /obj/structure/closet/firecloset,
-/obj/effect/turf_decal/lumos/tile/yellow/fullcorner,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 6
+	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "caq" = (
@@ -41831,7 +42432,9 @@
 	dir = 8;
 	pixel_y = -22
 	},
-/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "cbu" = (
@@ -42201,7 +42804,10 @@
 	c_tag = "Engineering Access"
 	},
 /obj/structure/closet/radiation,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "cco" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -42562,7 +43168,10 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "cdo" = (
 /obj/machinery/light{
@@ -42572,7 +43181,10 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "cdp" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
@@ -42581,7 +43193,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "cdr" = (
 /obj/structure/cable{
@@ -42834,6 +43446,9 @@
 /area/tcommsat/computer)
 "ceh" = (
 /obj/effect/landmark/event_spawn,
+/obj/effect/turf_decal/trimline/green/filled/corner{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/bridge)
 "cei" = (
@@ -42841,6 +43456,9 @@
 /obj/item/storage/toolbox/mechanical{
 	pixel_x = -2;
 	pixel_y = -1
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
@@ -42853,7 +43471,10 @@
 /obj/machinery/shower{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "cek" = (
 /obj/machinery/door/poddoor/preopen{
@@ -42870,7 +43491,10 @@
 /obj/structure/sign/poster/official/safety_eye_protection{
 	pixel_y = -32
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "cel" = (
 /obj/machinery/door/poddoor/preopen{
@@ -42880,7 +43504,11 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/yellow/filled/corner,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "cem" = (
 /obj/structure/disposalpipe/segment,
@@ -42921,15 +43549,15 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 6
 	},
-/obj/effect/turf_decal/lumos/tile/yellow/fullcorner{
-	dir = 4
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cet" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/lumos/tile/yellow/fullcorner{
-	dir = 8
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -42947,6 +43575,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 6
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
@@ -43111,6 +43742,7 @@
 	name = "Power Storage";
 	req_access_txt = "11"
 	},
+/obj/effect/turf_decal/lumos/tile/yellow/fulltile,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cfa" = (
@@ -43122,8 +43754,8 @@
 	pixel_y = 5
 	},
 /obj/item/clothing/glasses/welding,
-/obj/effect/turf_decal/lumos/tile/yellow/half{
-	dir = 1
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -43147,9 +43779,6 @@
 	pixel_x = 24
 	},
 /obj/structure/closet/radiation,
-/obj/effect/turf_decal/lumos/tile/yellow/half{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cfe" = (
@@ -43174,15 +43803,15 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cfh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/effect/turf_decal/lumos/tile/yellow/half,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "cfi" = (
@@ -43279,23 +43908,20 @@
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
 "cfz" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/lumos/tile/blue/half,
+/obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
-/area/engine/engineering)
+/area/crew_quarters/fitness)
 "cfB" = (
 /obj/structure/closet/secure_closet/engineering_personal,
 /obj/item/clothing/under/misc/overalls,
 /obj/item/clothing/under/misc/overalls,
 /obj/item/radio/headset/headset_eng,
 /obj/item/airlock_painter/floor_painter,
-/obj/effect/turf_decal/lumos/tile/yellow/half{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cfD" = (
@@ -43347,9 +43973,6 @@
 /obj/item/clothing/under/misc/overalls,
 /obj/item/radio/headset/headset_eng,
 /obj/item/airlock_painter/floor_painter,
-/obj/effect/turf_decal/lumos/tile/yellow/half{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cfJ" = (
@@ -43382,7 +44005,13 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/side,
 /area/engine/engineering)
 "cfN" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
@@ -43713,9 +44342,6 @@
 	dir = 8
 	},
 /obj/machinery/vending/wardrobe/engi_wardrobe,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cgR" = (
@@ -44554,6 +45180,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cjd" = (
@@ -44696,7 +45325,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -44870,7 +45499,10 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
+/obj/effect/turf_decal/lumos/tile/neutral/half{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
 "cjY" = (
@@ -44893,6 +45525,7 @@
 /obj/item/phone{
 	pixel_y = 12
 	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner,
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
 "cka" = (
@@ -44931,6 +45564,18 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
+"cke" = (
+/obj/machinery/door/firedoor/heavy,
+/obj/machinery/door/poddoor/preopen{
+	id = "Biohazard";
+	name = "biohazard containment door"
+	},
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "ckf" = (
 /obj/machinery/atmospherics/pipe/simple/dark/visible{
 	dir = 4
@@ -45101,6 +45746,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "ckI" = (
@@ -45158,16 +45806,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/yellow/fulltile,
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
 "ckQ" = (
@@ -45192,7 +45831,10 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/lumos/tile/yellow/half{
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -45440,38 +46082,42 @@
 /obj/item/storage/box/lights/mixed,
 /obj/item/clothing/glasses/meson,
 /obj/item/clothing/glasses/meson,
-/obj/effect/turf_decal/lumos/tile/yellow/fullcorner{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "clN" = (
-/obj/effect/turf_decal/tile/yellow{
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "clO" = (
-/obj/structure/closet/wardrobe/grey,
 /obj/machinery/camera{
 	c_tag = "Dorms East - Holodeck";
 	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
-"clQ" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
+/obj/structure/table/wood/fancy,
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = -3;
+	pixel_y = 9
+	},
+/obj/item/reagent_containers/food/condiment/peppermill{
+	dir = 1;
+	pixel_x = 3;
+	pixel_y = 9
+	},
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
 	},
 /turf/open/floor/plasteel,
-/area/engine/engineering)
+/area/crew_quarters/fitness)
 "clR" = (
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -45545,12 +46191,15 @@
 	},
 /area/maintenance/aft)
 "cmh" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 2;
 	sortType = 6
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -45682,7 +46331,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cmF" = (
-/obj/effect/turf_decal/lumos/tile/yellow/half{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -45695,30 +46344,22 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/effect/turf_decal/lumos/tile/yellow/fullcorner{
-	dir = 4
-	},
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cmL" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/lumos/tile/yellow/half{
+/obj/effect/turf_decal/lumos/tile/blue/half,
+/obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/engineering)
+/area/crew_quarters/fitness)
 "cmN" = (
 /obj/structure/sign/warning/nosmoking{
 	pixel_y = 32
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/lumos/tile/yellow/half{
-	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -45896,9 +46537,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/start/station_engineer,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cnv" = (
@@ -46369,13 +47007,12 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
 /obj/structure/closet/secure_closet/engineering_welding,
 /obj/item/clothing/glasses/welding,
 /obj/item/clothing/glasses/welding,
 /obj/item/clothing/glasses/welding,
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/trimline/yellow/filled/corner,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cpb" = (
@@ -46495,12 +47132,10 @@
 /area/engine/engineering)
 "cpC" = (
 /obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/bridge)
 "cpE" = (
@@ -46510,11 +47145,11 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cpF" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/structure/sign/poster/official/space_cops{
 	pixel_x = -32
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
@@ -46670,8 +47305,11 @@
 /obj/structure/sign/warning/pods{
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -46834,6 +47472,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"crj" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "crk" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space,
@@ -47062,7 +47710,8 @@
 	name = "Brig Operations";
 	req_one_access_txt = "4; 1"
 	},
-/obj/effect/turf_decal/lumos/tile/red/half,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "csM" = (
@@ -48735,6 +49384,16 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
 	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/security/processing)
 "cxU" = (
@@ -48896,7 +49555,15 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
 /area/engine/engineering)
 "cyT" = (
 /obj/docking_port/stationary{
@@ -49552,7 +50219,10 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/lumos/tile/brown/checker{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
 /area/quartermaster/miningdock)
 "cBC" = (
 /obj/structure/cable{
@@ -49835,7 +50505,10 @@
 /area/space/nearstation)
 "cCT" = (
 /obj/structure/closet/firecloset,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "cCY" = (
 /obj/effect/turf_decal/stripes/line{
@@ -49865,6 +50538,17 @@
 /obj/machinery/vending/engivend,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"cDt" = (
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/brown/filled/corner,
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/quartermaster/miningdock)
 "cDB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -49924,6 +50608,18 @@
 	dir = 8
 	},
 /area/ai_monitored/storage/eva)
+"cEO" = (
+/obj/structure/window/reinforced,
+/obj/effect/turf_decal/bot,
+/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "cHf" = (
 /obj/machinery/light{
 	dir = 1
@@ -50293,6 +50989,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"cKW" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/fore/secondary)
 "cMC" = (
 /obj/machinery/computer/security/telescreen/engine{
 	dir = 8;
@@ -50340,14 +51043,14 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/quartermaster/sorting)
 "cNI" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/quartermaster/sorting)
 "cNJ" = (
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/quartermaster/sorting)
 "cNL" = (
 /obj/machinery/power/apc{
@@ -50371,7 +51074,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/quartermaster/sorting)
 "cNR" = (
 /obj/structure/cable{
@@ -50695,12 +51401,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
 "cTa" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/turf_decal/stripes/end,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cTb" = (
@@ -50724,14 +51425,17 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cTe" = (
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
-/obj/effect/turf_decal/lumos/tile/yellow/half{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/engineering)
+/area/crew_quarters/dorms)
 "cTf" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -50741,9 +51445,6 @@
 	departmentType = 4;
 	name = "Engineering RC";
 	pixel_y = 30
-	},
-/obj/effect/turf_decal/lumos/tile/yellow/half{
-	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -50871,10 +51572,10 @@
 /turf/open/floor/wood,
 /area/bridge/meeting_room)
 "cXU" = (
-/obj/effect/turf_decal/tile/red,
 /obj/machinery/light{
 	light_color = "#c9d3e8"
 	},
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "cYz" = (
@@ -50920,9 +51621,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/lumos/tile/red/fullcorner{
-	dir = 8
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 9
 	},
+/obj/effect/turf_decal/trimline/red/filled/corner,
 /turf/open/floor/plasteel,
 /area/security/processing)
 "dbU" = (
@@ -50938,6 +51640,13 @@
 /obj/machinery/meter,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"ddk" = (
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
 "ddK" = (
 /obj/structure/chair/office/dark{
 	dir = 4
@@ -51051,12 +51760,11 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/lumos/tile/green/fulltile,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "dng" = (
@@ -51109,6 +51817,17 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/toilet)
+"duR" = (
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/plating,
+/area/security/brig)
 "dvc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
@@ -51155,17 +51874,14 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
 "dys" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
 /obj/machinery/door/poddoor/preopen{
 	id = "Secure Gate";
 	name = "brig shutters"
 	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/brig)
 "dyB" = (
@@ -51192,6 +51908,21 @@
 	},
 /turf/open/floor/grass,
 /area/medical/virology)
+"dAI" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "dBm" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /turf/open/floor/plating,
@@ -51216,10 +51947,10 @@
 /turf/open/floor/plating,
 /area/science/explab)
 "dCV" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
 /obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -51257,6 +51988,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
 	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/security/processing)
 "dKP" = (
@@ -51283,6 +52017,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"dLE" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "dMi" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
@@ -51347,11 +52088,20 @@
 /obj/item/clothing/shoes/jackboots,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"dPs" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "dRQ" = (
 /obj/structure/chair/office/dark{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/lumos/tile/brown/checker{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
 /area/quartermaster/miningdock)
 "dTC" = (
 /obj/structure/disposalpipe/segment{
@@ -51389,13 +52139,13 @@
 /area/medical/virology)
 "dWM" = (
 /obj/structure/table,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
 /obj/machinery/recharger,
 /obj/item/gun/energy/laser/practice,
 /obj/item/gun/energy/laser/practice,
 /obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -51413,7 +52163,9 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/lumos/tile/blue/fulltile,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/airless/white/side{
+	dir = 4
+	},
 /area/medical/medbay/central)
 "dXq" = (
 /obj/machinery/light{
@@ -51504,6 +52256,18 @@
 	},
 /turf/closed/wall,
 /area/maintenance/disposal/incinerator)
+"efm" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 4
+	},
+/obj/structure/chair/wood/normal{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/courtroom)
 "efO" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -51655,13 +52419,10 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "epD" = (
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#e8eaff"
-	},
 /obj/structure/chair/sofa/right{
 	dir = 1
 	},
+/obj/structure/window/reinforced,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "esZ" = (
@@ -51669,6 +52430,16 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"evt" = (
+/obj/structure/closet/emcloset,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/bridge)
 "evR" = (
 /turf/open/floor/plating,
 /area/maintenance/bar)
@@ -51731,12 +52502,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
-"eAJ" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
 "eBX" = (
 /obj/machinery/vending/snack/random,
 /turf/open/floor/plasteel/dark,
@@ -51749,20 +52514,19 @@
 /obj/item/clothing/suit/hooded/wintercoat,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
-"eCQ" = (
-/obj/structure/rack,
-/obj/item/storage/box/zipties{
-	pixel_x = -1;
-	pixel_y = 1
-	},
-/obj/item/storage/box/zipties{
-	pixel_x = 1;
-	pixel_y = -1
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
+"eCO" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel,
+/area/security/brig)
+"eCQ" = (
+/obj/machinery/computer/security{
+	dir = 4
+	},
+/obj/effect/turf_decal/lumos/tile/red/fulltile,
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "eDf" = (
 /obj/machinery/light/small{
@@ -51792,6 +52556,10 @@
 /obj/effect/turf_decal/lumos/tile/red/checker,
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
+"eFC" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/turf/open/floor/plasteel,
+/area/crew_quarters/heads/hop)
 "eFW" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -51853,15 +52621,15 @@
 /area/crew_quarters/dorms)
 "eRh" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
 /obj/machinery/door/poddoor/preopen{
 	id = "Secure Gate";
 	name = "brig shutters"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
 /turf/open/floor/plating,
 /area/security/brig)
 "eRz" = (
@@ -51910,6 +52678,9 @@
 	},
 /obj/machinery/light{
 	dir = 1
+	},
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
@@ -52018,9 +52789,18 @@
 	dir = 4
 	},
 /area/crew_quarters/theatre)
+"fhl" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "fhP" = (
 /obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/lumos/tile/brown/checker{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
 /area/quartermaster/miningdock)
 "fjS" = (
 /obj/structure/closet/radiation,
@@ -52147,6 +52927,15 @@
 	dir = 1
 	},
 /area/hallway/secondary/entry)
+"fqf" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/corner,
+/area/engine/atmos)
 "fqT" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
@@ -52190,8 +52979,20 @@
 	dir = 8;
 	pixel_x = 24
 	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/security/range)
+"fsD" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/teleporter)
 "ftE" = (
 /obj/item/radio/intercom{
 	pixel_y = 25
@@ -52273,7 +53074,7 @@
 	pixel_x = 32;
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/lumos/tile/blue/half{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -52297,19 +53098,40 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
+"fDh" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "fEk" = (
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/maintenance/port)
-"fEw" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
+"fEn" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"fEw" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 5
+	},
+/obj/structure/closet/secure_closet/brig{
+	id = "Cell 1";
+	name = "Cell 1 Locker"
+	},
+/obj/item/radio/headset{
+	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
+	name = "prisoner headset";
+	prison_radio = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -52377,9 +53199,17 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"fMA" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "fOA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -52424,12 +53254,13 @@
 /turf/open/floor/carpet/black,
 /area/maintenance/bar)
 "fPy" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/structure/sign/nanotrasen{
 	pixel_y = -32
 	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "fSS" = (
@@ -52525,6 +53356,29 @@
 	},
 /turf/open/floor/plating,
 /area/construction)
+"gbw" = (
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp{
+	pixel_x = -2;
+	pixel_y = 9
+	},
+/obj/effect/decal/cleanable/cobweb,
+/obj/item/paper_bin/bundlenatural{
+	pixel_x = 6;
+	pixel_y = 4
+	},
+/obj/item/pen{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/food/drinks/soda_cans/space_mountain_wind{
+	pixel_x = -6
+	},
+/obj/structure/sign/poster/contraband/manly{
+	pixel_y = 29
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore/secondary)
 "gbM" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -52619,11 +53473,19 @@
 /obj/structure/chair/sofa/corp/left,
 /turf/open/floor/plating,
 /area/maintenance/port)
-"gfC" = (
-/obj/effect/turf_decal/tile/red,
-/obj/structure/chair{
+"gfz" = (
+/obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/item/storage/box/cups,
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"gfC" = (
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "gfD" = (
@@ -52632,6 +53494,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/cryopod)
+"gfQ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "ghq" = (
 /obj/structure/lattice/catwalk,
 /obj/item/stack/marker_beacon{
@@ -52687,9 +53558,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "gjl" = (
@@ -52701,14 +53569,11 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "gjY" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/crew_quarters/fitness)
 "gkf" = (
 /obj/structure/lattice,
 /turf/closed/wall,
@@ -52761,9 +53626,16 @@
 /obj/structure/sign/departments/custodian{
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/trimline/purple/filled/corner,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"gns" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "gnI" = (
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plating{
@@ -52782,6 +53654,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/medical/medbay/front_office)
+"gon" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "gpD" = (
 /obj/machinery/light_switch{
 	pixel_y = 28
@@ -52931,6 +53813,14 @@
 /obj/structure/curtain,
 /turf/open/floor/mineral/titanium/blue,
 /area/crew_quarters/dorms)
+"gzH" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/obj/structure/closet/secure_closet/atmospherics,
+/obj/effect/turf_decal/trimline/yellow/filled/corner,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "gAf" = (
 /obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 8
@@ -52956,18 +53846,19 @@
 /area/science/circuit)
 "gBu" = (
 /obj/effect/landmark/event_spawn,
-/turf/open/floor/plasteel,
-/area/hydroponics)
-"gCm" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/effect/turf_decal/lumos/tile/red/half{
+/obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
+/area/hydroponics)
+"gCm" = (
+/obj/machinery/holopad,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 9
+	},
 /area/security/brig)
 "gCC" = (
 /obj/structure/sign/poster/contraband/tools,
@@ -53258,6 +54149,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/medical/storage)
+"gZI" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "gZQ" = (
 /obj/machinery/door/airlock/security/glass{
 	id_tag = "innerbrig";
@@ -53369,6 +54269,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"hfh" = (
+/obj/machinery/door/airlock/medical/glass{
+	id_tag = "GeneticsDoor";
+	name = "Genetics";
+	req_access_txt = "5; 68"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/lumos/tile/blue/fulltile,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/medical/surgery)
 "hfj" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/glass/beaker/cryoxadone{
@@ -53437,6 +54350,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/front_office)
+"hiA" = (
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/break_room)
 "hiG" = (
 /obj/structure/fans/tiny,
 /obj/structure/window/reinforced{
@@ -53455,6 +54374,13 @@
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
+"hje" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "hjD" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -53478,21 +54404,24 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"hkH" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+"hkk" = (
+/obj/machinery/computer/arcade/tetris{
+	dir = 4
 	},
+/turf/open/floor/plating,
+/area/maintenance/fore/secondary)
+"hkH" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -53503,6 +54432,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
+"hln" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/turf/open/floor/plasteel,
+/area/bridge)
 "hlx" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
@@ -53519,9 +54452,6 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/medical/medbay/lobby)
 "hnU" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /obj/machinery/door/window/westleft{
 	base_state = "right";
 	dir = 4;
@@ -53569,7 +54499,9 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
 /area/ai_monitored/security/armory)
 "hrF" = (
 /obj/structure/lattice/catwalk,
@@ -53635,39 +54567,28 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
 "hvD" = (
-/obj/machinery/smartfridge/organ,
-/turf/closed/wall,
-/area/medical/surgery)
-"hwJ" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/closet/secure_closet/brig{
-	id = "Cell 1";
-	name = "Cell 1 Locker"
-	},
-/obj/item/radio/headset{
-	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
-	name = "prisoner headset";
-	prison_radio = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"hwJ" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/bed,
+/obj/item/bedsheet/blue,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "hxc" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -53722,12 +54643,12 @@
 /area/security/checkpoint/medical)
 "hEW" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = -24
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -53749,6 +54670,19 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/wood,
 /area/library)
+"hGZ" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/item/wrench,
+/obj/item/crowbar,
+/turf/open/floor/plasteel/dark/corner{
+	dir = 1
+	},
+/area/engine/atmos)
 "hHQ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -53757,18 +54691,27 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"hIL" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 8
+"hHU" = (
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
-"hIM" = (
-/obj/effect/turf_decal/trimline/brown/filled/corner{
+/obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/quartermaster/storage)
+/area/hallway/primary/fore)
+"hIL" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
+"hIM" = (
+/obj/structure/chair/comfy/brown{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/dorms)
 "hIZ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -53828,6 +54771,23 @@
 /obj/structure/disposaloutlet,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"hMa" = (
+/obj/structure/sign/nanotrasen{
+	pixel_y = -32
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"hMi" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/obj/structure/chair,
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "hMo" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -53842,6 +54802,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/processing)
 "hMM" = (
@@ -53901,7 +54862,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "hWd" = (
-/obj/effect/turf_decal/lumos/tile/blue/half,
+/obj/structure/closet/wardrobe/pjs,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "hXr" = (
@@ -53925,14 +54886,22 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner,
 /turf/open/floor/plasteel,
 /area/security/range)
 "ifX" = (
-/obj/effect/turf_decal/lumos/tile/blue/half{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"ihu" = (
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "ihL" = (
 /obj/structure/window/reinforced,
 /obj/effect/turf_decal/lumos/tile/red/half{
@@ -53966,11 +54935,12 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "ikm" = (
-/obj/effect/turf_decal/lumos/tile/green/half{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
+/area/crew_quarters/fitness)
 "ikr" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /obj/structure/window/reinforced{
@@ -54053,6 +55023,15 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"itN" = (
+/obj/structure/chair/comfy/black{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/carpet/blue,
+/area/bridge/meeting_room)
 "itQ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -54097,15 +55076,20 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/lumos/tile/red/fulltile,
 /turf/open/floor/plasteel,
 /area/security/processing)
 "iuR" = (
-/obj/effect/turf_decal/lumos/tile/green/fullcorner{
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
+/area/crew_quarters/fitness)
 "iwg" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
@@ -54153,6 +55137,18 @@
 /obj/structure/frame/machine,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"izA" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "iBi" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -54178,6 +55174,22 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"iCS" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Surgery Maintenance";
+	req_access_txt = "45"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/medical/surgery)
+"iCU" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "iCZ" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 10
@@ -54234,6 +55246,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/medical/psych)
+"iID" = (
+/obj/structure/closet/emcloset,
+/turf/open/floor/plating,
+/area/maintenance/fore/secondary)
 "iIL" = (
 /obj/effect/landmark/start/detective,
 /obj/structure/chair/comfy/brown{
@@ -54250,6 +55266,9 @@
 "iLJ" = (
 /obj/item/reagent_containers/glass/bucket,
 /mob/living/simple_animal/pet/bumbles,
+/obj/effect/turf_decal/trimline/green/filled/corner{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "iMv" = (
@@ -54277,6 +55296,12 @@
 /obj/structure/reagent_dispensers/cooking_oil,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
+"iNT" = (
+/obj/effect/turf_decal/loading_area{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "iOm" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -54552,6 +55577,10 @@
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"jfk" = (
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/storage/eva)
 "jfp" = (
 /obj/effect/landmark/start/prisoner/prilate,
 /turf/open/floor/plasteel/elevatorshaft{
@@ -54589,7 +55618,8 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/lumos/tile/red/fulltile,
+/turf/open/floor/plasteel/dark/side,
 /area/security/brig)
 "jiM" = (
 /obj/structure/disposalpipe/segment,
@@ -54607,11 +55637,21 @@
 /area/hallway/secondary/entry)
 "jjv" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
 /obj/machinery/atm{
 	pixel_x = -30
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"jjV" = (
+/obj/effect/turf_decal/trimline/yellow/filled/corner,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -54648,9 +55688,7 @@
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 5
-	},
+/obj/effect/turf_decal/trimline/red/filled/corner,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "jmp" = (
@@ -54692,8 +55730,25 @@
 	pixel_x = 5;
 	pixel_y = 5
 	},
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#e8eaff"
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
+"jnC" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/brown/filled/corner,
+/turf/open/floor/plasteel/dark,
+/area/quartermaster/sorting)
 "jpj" = (
 /obj/structure/closet/wardrobe/black,
 /obj/item/clothing/shoes/jackboots,
@@ -54727,6 +55782,13 @@
 /obj/structure/table,
 /turf/open/floor/wood,
 /area/maintenance/bar)
+"jsy" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "jtq" = (
 /mob/living/simple_animal/pet/dog/pug{
 	desc = "Because just like you, Doug can't breath too.";
@@ -54776,10 +55838,23 @@
 	icon_state = "wood-broken5"
 	},
 /area/maintenance/bar)
+"jvX" = (
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner,
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "jxF" = (
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"jxM" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "jxW" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/preopen{
@@ -54787,6 +55862,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"jyc" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "jyt" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Surgery Observation"
@@ -54861,9 +55943,11 @@
 /obj/machinery/vr_sleeper{
 	dir = 1
 	},
-/obj/effect/turf_decal/lumos/tile/red/fullcorner,
-/turf/open/floor/plasteel/white/corner{
+/obj/effect/turf_decal/tile/red{
 	dir = 1
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 6
 	},
 /area/crew_quarters/fitness)
 "jEf" = (
@@ -54962,9 +56046,14 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/front_office)
 "jIr" = (
-/obj/effect/turf_decal/lumos/tile/red/fullcorner,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
@@ -54995,15 +56084,16 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "jKP" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/disposalpipe/segment{
+	dir = 10
 	},
-/obj/structure/cable{
-	icon_state = "2-8"
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 1
 	},
-/turf/open/floor/plating,
-/area/maintenance/fore/secondary)
+/turf/open/floor/plasteel/dark/corner{
+	dir = 1
+	},
+/area/security/brig)
 "jLl" = (
 /obj/structure/sign/warning/securearea{
 	pixel_x = 32
@@ -55106,16 +56196,18 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
 "jOY" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
 /area/ai_monitored/security/armory)
 "jPh" = (
 /obj/machinery/door/airlock/external{
@@ -55225,6 +56317,13 @@
 	},
 /turf/open/space/basic,
 /area/science/xenobiology)
+"jUY" = (
+/obj/structure/closet/crate/bin,
+/obj/structure/sign/poster/contraband/mama2{
+	pixel_x = -30
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore/secondary)
 "jVg" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -55232,10 +56331,10 @@
 	pixel_y = 5
 	},
 /obj/item/pen,
-/obj/effect/turf_decal/lumos/tile/brown/half{
-	dir = 8
+/obj/effect/turf_decal/lumos/tile/brown/checker{
+	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/cafeteria,
 /area/quartermaster/miningdock)
 "jWs" = (
 /obj/structure/sign/poster/contraband/antifurry{
@@ -55341,6 +56440,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/range)
 "keg" = (
@@ -55380,6 +56480,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
+"kex" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/quartermaster/sorting)
 "kfe" = (
 /obj/structure/flora/ausbushes/fernybush,
 /turf/open/floor/grass,
@@ -55452,6 +56564,16 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/medical/surgery)
+"kiK" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/green/filled/line,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/courtroom)
 "kkH" = (
 /obj/machinery/suit_storage_unit/cmo,
 /obj/item/radio/intercom{
@@ -55467,12 +56589,22 @@
 /obj/structure/lattice,
 /turf/open/space,
 /area/space/nearstation)
-"kmw" = (
-/obj/structure/chair/comfy/black{
-	dir = 1
+"klT" = (
+/obj/machinery/power/apc{
+	areastring = "/area/security/courtroom";
+	dir = 4;
+	name = "Courtroom APC";
+	pixel_x = 25
 	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/courtroom)
+"kmw" = (
+/obj/effect/turf_decal/trimline/green/filled/corner,
 /turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
+/area/hydroponics)
 "kmS" = (
 /obj/structure/dresser,
 /obj/item/flashlight/lamp/green{
@@ -55498,7 +56630,8 @@
 	name = "Corporate Showroom";
 	req_access_txt = "19"
 	},
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/lumos/tile/blue/fulltile,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "kob" = (
 /obj/structure/disposalpipe/segment,
@@ -55665,6 +56798,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
+"kAv" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/processing)
 "kAH" = (
 /obj/machinery/camera{
 	c_tag = "Bar West";
@@ -55703,7 +56852,8 @@
 	name = "Brig Operations";
 	req_one_access_txt = "4; 1"
 	},
-/obj/effect/turf_decal/lumos/tile/red/half,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "kGJ" = (
@@ -55776,18 +56926,16 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "kPY" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "kQk" = (
@@ -55841,6 +56989,16 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/maintenance/starboard/aft)
+"kVb" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "kWp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -55900,15 +57058,16 @@
 /area/medical/surgery)
 "laq" = (
 /obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/security/range)
+"lcg" = (
+/obj/machinery/portable_atmospherics/scrubber,
+/turf/open/floor/plating,
+/area/maintenance/fore/secondary)
 "lcu" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -55916,7 +57075,9 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
 /area/ai_monitored/security/armory)
 "lea" = (
 /obj/machinery/airalarm{
@@ -55926,6 +57087,10 @@
 /obj/structure/table,
 /turf/open/floor/plasteel,
 /area/medical/medbay/central)
+"leh" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/storage/eva)
 "lfJ" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -55939,14 +57104,13 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 5
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
 	},
-/obj/structure/bed,
 /obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "lip" = (
@@ -55985,11 +57149,11 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "lof" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
 /obj/machinery/atm{
 	pixel_y = 30
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -55997,8 +57161,16 @@
 /obj/machinery/door/poddoor/incinerator_atmos_aux,
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
+"lqw" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner,
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "lsk" = (
-/obj/machinery/vending/clothing,
+/obj/structure/closet/wardrobe/white,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "lsG" = (
@@ -56082,7 +57254,9 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
 /area/ai_monitored/security/armory)
 "lCi" = (
 /obj/docking_port/stationary/public_mining_dock{
@@ -56096,6 +57270,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/pool)
+"lCr" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/corner{
+	dir = 1
+	},
+/area/engine/atmos)
 "lDF" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
@@ -56169,9 +57352,21 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "lKL" = (
-/obj/structure/disposalpipe/segment,
-/turf/closed/wall,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/turf/open/floor/plasteel,
 /area/security/brig)
+"lLE" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/bridge)
 "lLR" = (
 /obj/structure/chair/comfy/black{
 	dir = 1
@@ -56180,6 +57375,19 @@
 	icon_state = "wood-broken4"
 	},
 /area/maintenance/bar)
+"lMa" = (
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/processing)
 "lMg" = (
 /turf/open/floor/circuit/telecomms,
 /area/science/xenobiology)
@@ -56275,13 +57483,15 @@
 	},
 /area/maintenance/starboard/aft)
 "lZR" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
 /obj/item/radio/intercom{
 	pixel_y = 20
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark/corner{
+	dir = 1
+	},
 /area/ai_monitored/security/armory)
 "maC" = (
 /obj/machinery/door/airlock/security{
@@ -56370,6 +57580,12 @@
 	},
 /turf/open/floor/wood,
 /area/medical/psych)
+"mko" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/storage/eva)
 "mkv" = (
 /obj/machinery/camera{
 	c_tag = "Gravity Generator Room";
@@ -56392,6 +57608,16 @@
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/crew_quarters/toilet)
+"mmf" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/processing)
 "mmR" = (
 /obj/structure/chair/comfy/black{
 	dir = 1
@@ -56412,6 +57638,15 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"mph" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "mps" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -56564,7 +57799,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/lumos/tile/red/fulltile,
 /turf/open/floor/plasteel,
 /area/security/range)
 "mHj" = (
@@ -56617,6 +57852,14 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"mMc" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "mNi" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -56636,9 +57879,10 @@
 /obj/structure/sign/poster/official/fruit_bowl{
 	pixel_y = 32
 	},
-/turf/open/floor/plasteel/white/corner{
-	dir = 1
+/obj/effect/turf_decal/trimline/white/filled/corner{
+	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "mOB" = (
 /obj/structure/cable{
@@ -56662,17 +57906,9 @@
 /turf/open/floor/wood,
 /area/maintenance/bar)
 "mPk" = (
-/obj/structure/bed,
-/obj/machinery/button/door{
-	id = "Dorm5";
-	name = "Cabin Bolt Control";
-	normaldoorcontrol = 1;
-	pixel_y = -25;
-	specialfunctions = 4
-	},
-/obj/effect/spawner/lootdrop/bedsheet,
-/turf/open/floor/wood,
-/area/crew_quarters/dorms)
+/obj/effect/turf_decal/trimline/green/filled/line,
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "mPr" = (
 /obj/structure/rack,
 /obj/item/tank/internals/emergency_oxygen,
@@ -56718,6 +57954,16 @@
 	},
 /turf/open/floor/grass,
 /area/medical/genetics)
+"mSI" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "mTG" = (
 /obj/effect/turf_decal/lumos/tile/bar/checker,
 /obj/structure/table,
@@ -56752,6 +57998,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"mWT" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/trimline/brown/filled/corner,
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "mXe" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 1
@@ -56784,6 +58035,34 @@
 	},
 /turf/open/floor/plasteel/stairs/right,
 /area/medical/sleeper)
+"mXI" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "Secure Gate";
+	name = "brig shutters"
+	},
+/obj/structure/cable,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/security/brig)
+"mYT" = (
+/obj/structure/closet/secure_closet{
+	name = "Persuasion Storage";
+	req_access = "list(2)"
+	},
+/obj/item/melee/baton/cattleprod,
+/obj/item/electropack,
+/obj/item/stock_parts/cell/high,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "mYU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -56901,6 +58180,15 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"niS" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "njg" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -56950,6 +58238,13 @@
 /mob/living/simple_animal/opossum,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"nnS" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "noy" = (
 /obj/structure/sign/poster/contraband/smoke{
 	desc = "This poster reminds us all that the Detective is a parasite. Year after year, they must get replacement lungs because of their addiction. ";
@@ -57047,6 +58342,15 @@
 /mob/living/carbon/monkey,
 /turf/open/floor/grass,
 /area/medical/virology)
+"nzG" = (
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "nzL" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -57064,13 +58368,28 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/security/brig)
+"nBs" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/sign/poster/contraband/mama1{
+	pixel_x = 28
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore/secondary)
 "nBM" = (
 /obj/docking_port/stationary/random{
 	dir = 4;
@@ -57163,6 +58482,19 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/hallway/secondary/entry)
+"nHh" = (
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/break_room)
+"nHn" = (
+/obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
 "nIl" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -57193,15 +58525,15 @@
 /area/maintenance/bar)
 "nKt" = (
 /obj/structure/table,
-/obj/effect/turf_decal/lumos/tile/red/half{
-	dir = 1
-	},
 /obj/item/screwdriver{
 	pixel_y = 10
 	},
 /obj/item/radio/off{
 	pixel_x = 3;
 	pixel_y = 8
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
@@ -57215,8 +58547,9 @@
 /turf/open/floor/plating,
 /area/maintenance/bar)
 "nLu" = (
-/obj/effect/turf_decal/lumos/tile/blue/half{
-	dir = 4
+/obj/effect/turf_decal/lumos/tile/blue/fullcorner,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
@@ -57226,6 +58559,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"nLD" = (
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "nLL" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel/dark,
@@ -57370,6 +58709,13 @@
 /obj/structure/sign/warning/fire,
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
+"nUQ" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "nVd" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -57388,12 +58734,11 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/lumos/tile/yellow/fulltile,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "nXg" = (
@@ -57424,6 +58769,13 @@
 /obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
+"nYi" = (
+/obj/machinery/light/small,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/courtroom)
 "nYD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
@@ -57451,13 +58803,12 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "oaZ" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
 /area/ai_monitored/security/armory)
 "oce" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
@@ -57540,20 +58891,11 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/virology)
 "ofU" = (
-/obj/structure/chair/comfy/black{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/effect/turf_decal/trimline/green/filled/corner{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
+/area/hydroponics)
 "ohq" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
@@ -57563,39 +58905,69 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"oiq" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/corner,
+/area/engine/atmos)
 "oiu" = (
 /obj/structure/chair/stool/bar,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
 /area/maintenance/bar)
-"oiW" = (
+"oiL" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
 /obj/structure/cable{
-	icon_state = "1-8"
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore/secondary)
+"oiW" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"ojh" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/chair/stool,
+/obj/effect/mob_spawn/human/skeleton/alive,
+/turf/open/floor/plating,
+/area/maintenance/fore/secondary)
 "okI" = (
 /obj/machinery/door/airlock/security{
 	name = "Firing Range";
 	req_access_txt = "2"
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
+/obj/effect/turf_decal/lumos/tile/red/fulltile,
 /turf/open/floor/plasteel,
 /area/security/range)
 "old" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/structure/sign/departments/security{
 	pixel_x = -32;
 	pixel_y = -32
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
@@ -57638,12 +59010,29 @@
 /obj/item/pen,
 /turf/open/floor/wood,
 /area/lawoffice)
+"oow" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/bridge/meeting_room)
 "ooH" = (
 /obj/machinery/atmospherics/pipe/simple/violet/hidden{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"oqw" = (
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
 "oqJ" = (
 /obj/effect/turf_decal/box,
 /obj/effect/turf_decal/vg_decals/numbers/one,
@@ -57784,6 +59173,8 @@
 /obj/machinery/atm{
 	pixel_y = 30
 	},
+/obj/structure/table/wood,
+/obj/structure/bedsheetbin/color,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "oAB" = (
@@ -57806,6 +59197,29 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"oDx" = (
+/obj/structure/rack,
+/obj/item/storage/box/zipties{
+	pixel_x = -1;
+	pixel_y = 1
+	},
+/obj/item/storage/box/zipties{
+	pixel_x = 1;
+	pixel_y = -1
+	},
+/obj/effect/turf_decal/box,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
+"oEj" = (
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner,
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "oEP" = (
 /obj/machinery/status_display/evac,
 /turf/closed/wall,
@@ -57845,9 +59259,10 @@
 /turf/open/floor/plasteel/white,
 /area/science/explab)
 "oIJ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8
+/obj/effect/turf_decal/lumos/tile/red/half{
+	dir = 1
 	},
+/obj/effect/turf_decal/lumos/tile/blue/half,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "oIW" = (
@@ -57869,6 +59284,12 @@
 /obj/machinery/chem_master,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"oKf" = (
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "oKh" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -57899,8 +59320,11 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "oMZ" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
+/obj/structure/closet/secure_closet/brig,
+/obj/item/radio/headset{
+	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
+	name = "prisoner headset";
+	prison_radio = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -57911,12 +59335,13 @@
 /turf/open/floor/wood,
 /area/hallway/primary/central)
 "oOt" = (
-/obj/effect/turf_decal/lumos/tile/red/fullcorner{
-	dir = 8
-	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner,
 /turf/open/floor/plasteel,
 /area/security/processing)
 "oPU" = (
@@ -57995,6 +59420,16 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/engine,
 /area/science/explab)
+"oVg" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore/secondary)
 "oVk" = (
 /obj/machinery/button/door{
 	id = "xenobio6";
@@ -58021,6 +59456,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "oWe" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -58050,10 +59486,17 @@
 	},
 /area/hallway/secondary/exit)
 "oZl" = (
-/obj/structure/closet/wardrobe/pjs,
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/structure/closet/wardrobe/black,
+/obj/item/clothing/under/misc/assistantformal,
+/obj/item/clothing/under/misc/assistantformal,
+/obj/item/clothing/under/custom/trendy_fit,
+/obj/item/clothing/under/custom/trendy_fit,
+/obj/item/clothing/head/beret/black,
+/obj/item/clothing/head/beret/black,
+/obj/item/clothing/under/dress/skirt,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "oZv" = (
@@ -58177,6 +59620,32 @@
 "poI" = (
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
+"poV" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore/secondary)
+"ppg" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "atmos";
+	name = "Atmospherics Blast Door"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/corner{
+	dir = 1
+	},
+/area/engine/atmos)
 "ppo" = (
 /obj/machinery/camera{
 	c_tag = "Virology Break Room";
@@ -58217,6 +59686,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
+"pqA" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "pro" = (
 /obj/structure/fans/tiny,
 /obj/structure/window/reinforced{
@@ -58264,6 +59742,15 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/front_office)
+"ptc" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/green/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "ptM" = (
 /obj/machinery/door/airlock/research{
 	name = "Robotics Lab";
@@ -58282,10 +59769,10 @@
 /obj/machinery/vr_sleeper{
 	dir = 1
 	},
-/obj/effect/turf_decal/lumos/tile/red/half,
-/turf/open/floor/plasteel/white/side{
+/obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 1
 	},
+/turf/open/floor/plasteel/dark/side,
 /area/crew_quarters/fitness)
 "pvh" = (
 /obj/structure/sign/poster/official/obey,
@@ -58379,9 +59866,11 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "pHO" = (
-/obj/effect/turf_decal/tile/blue,
 /obj/structure/sign/poster/contraband/fun_police{
 	pixel_x = 32
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
@@ -58451,13 +59940,17 @@
 /obj/structure/sign/warning/securearea{
 	pixel_x = -32
 	},
+/obj/machinery/door/airlock/security/glass{
+	name = "Prison Wing";
+	req_access_txt = "2"
+	},
+/obj/effect/turf_decal/lumos/tile/red/fulltile,
 /obj/machinery/door/poddoor/preopen{
 	id = "Prison Gate";
 	name = "prison blast door"
 	},
-/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
-/area/security/prison)
+/area/security/brig)
 "pLh" = (
 /obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 1
@@ -58496,7 +59989,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/lumos/tile/red/half{
-	dir = 1
+	dir = 8
+	},
+/obj/effect/turf_decal/lumos/tile/blue/half{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
@@ -58580,8 +60076,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
+"pUF" = (
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "pWM" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
@@ -58589,6 +60090,7 @@
 	id = "Secure Gate";
 	name = "brig shutters"
 	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/brig)
 "pXv" = (
@@ -58613,6 +60115,12 @@
 /obj/effect/turf_decal/lumos/tile/red/checker,
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
+"qcC" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "qeb" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -58691,11 +60199,11 @@
 /turf/open/floor/plating,
 /area/maintenance/bar)
 "qmV" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /obj/structure/sign/warning/electricshock{
 	pixel_y = 32
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
@@ -58835,11 +60343,11 @@
 /turf/closed/wall/r_wall,
 /area/crew_quarters/heads/captain)
 "qCC" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
 /obj/structure/window/reinforced{
 	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/security/range)
@@ -58860,15 +60368,11 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "qGA" = (
-/obj/effect/landmark/secequipment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 10
+/obj/structure/closet/secure_closet/security/sec{
+	anchored = 1
 	},
-/obj/effect/turf_decal/lumos/tile/red/half{
-	dir = 8
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/box,
+/turf/open/floor/plasteel,
 /area/security/main)
 "qGR" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -58911,17 +60415,32 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
+"qKF" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/bridge/meeting_room)
 "qLc" = (
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/door/airlock/security/glass{
+	name = "Prison Wing";
+	req_access_txt = "2"
+	},
+/obj/effect/turf_decal/lumos/tile/red/fulltile,
 /obj/machinery/door/poddoor/preopen{
 	id = "Prison Gate";
 	name = "prison blast door"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
-/area/security/prison)
+/area/security/brig)
 "qLn" = (
 /obj/machinery/door/airlock/medical{
 	name = "Medbay Reception";
@@ -58975,6 +60494,23 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"qPd" = (
+/obj/effect/turf_decal/trimline/green/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/courtroom)
+"qPT" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 6
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/corner{
+	dir = 1
+	},
+/area/engine/atmos)
 "qTG" = (
 /obj/structure/table/wood,
 /obj/structure/mirror{
@@ -59014,11 +60550,11 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "qWV" = (
-/obj/effect/turf_decal/lumos/tile/green/half{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 9
+	},
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
@@ -59045,6 +60581,26 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"raq" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/power/apc{
+	areastring = "/area/crew_quarters/dorms";
+	name = "Dormitory APC";
+	pixel_y = -24
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore/secondary)
 "rcD" = (
 /obj/structure/sink{
 	dir = 8;
@@ -59079,7 +60635,6 @@
 	dir = 4;
 	light_color = "#e8eaff"
 	},
-/obj/machinery/vending/autodrobe,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "rfW" = (
@@ -59095,7 +60650,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/bridge)
 "rjQ" = (
@@ -59145,6 +60702,9 @@
 /obj/structure/chair/comfy/black{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/carpet/blue,
 /area/bridge/meeting_room)
 "roQ" = (
@@ -59191,14 +60751,8 @@
 	},
 /area/crew_quarters/theatre)
 "rrM" = (
-/obj/structure/closet/wardrobe/black,
-/obj/item/clothing/under/dress/skirt,
-/obj/item/clothing/head/beret/black,
-/obj/item/clothing/head/beret/black,
-/obj/item/clothing/under/custom/trendy_fit,
-/obj/item/clothing/under/custom/trendy_fit,
-/obj/item/clothing/under/misc/assistantformal,
-/obj/item/clothing/under/misc/assistantformal,
+/obj/structure/chair/sofa/right,
+/obj/effect/landmark/start/assistant,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "rtl" = (
@@ -59247,22 +60801,31 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/front_office)
 "rvr" = (
-/obj/structure/chair{
+/obj/effect/turf_decal/lumos/tile/red/half{
+	dir = 8
+	},
+/obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/structure/chair{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "ryr" = (
-/obj/effect/turf_decal/lumos/tile/blue/fullcorner,
+/obj/structure/closet/wardrobe/grey,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
+"rAn" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
 "rBc" = (
 /obj/machinery/shower{
 	dir = 8;
@@ -59313,8 +60876,15 @@
 	dir = 8
 	},
 /obj/machinery/airalarm/directional/south,
+/obj/effect/turf_decal/trimline/red/filled/corner,
 /turf/open/floor/plasteel,
 /area/security/prison)
+"rDL" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "rEQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
@@ -59435,6 +61005,15 @@
 	dir = 8
 	},
 /area/crew_quarters/theatre)
+"rRB" = (
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "rTu" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -59502,9 +61081,10 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/lumos/tile/red/fullcorner{
-	dir = 8
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 9
 	},
+/obj/effect/turf_decal/trimline/red/filled/corner,
 /turf/open/floor/plasteel,
 /area/security/processing)
 "rZB" = (
@@ -59515,12 +61095,11 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/lumos/tile/blue/fulltile,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "sak" = (
@@ -59567,19 +61146,21 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/medical/surgery)
 "sci" = (
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
+	},
 /area/crew_quarters/fitness)
 "sda" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/grass,
 /area/medical/virology)
 "sea" = (
-/obj/item/melee/baton/cattleprod,
-/obj/item/stock_parts/cell/high,
-/obj/item/electropack,
-/obj/structure/closet/secure_closet{
-	name = "Persuasion Storage";
-	req_access = "list(2)"
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -59593,9 +61174,6 @@
 /area/maintenance/department/medical/morgue)
 "seP" = (
 /obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/structure/cable{
 	icon_state = "0-8"
 	},
 /obj/machinery/door/poddoor/preopen{
@@ -59603,9 +61181,6 @@
 	name = "brig shutters"
 	},
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
 /turf/open/floor/plating,
 /area/security/brig)
 "sfa" = (
@@ -59676,11 +61251,18 @@
 	},
 /turf/open/floor/plating,
 /area/engine/atmos)
+"snN" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
+"sog" = (
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "soA" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
@@ -59739,11 +61321,11 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/medical/medbay/front_office)
 "ssB" = (
-/obj/effect/turf_decal/lumos/tile/green/fullcorner{
-	dir = 4
+/obj/effect/turf_decal/trimline/green/filled/corner{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
+/area/hydroponics)
 "ssP" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -59779,12 +61361,39 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/closed/wall/r_wall,
 /area/hallway/primary/central)
+"stz" = (
+/obj/effect/turf_decal/lumos/loading_area{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "stF" = (
 /obj/machinery/light_switch{
 	pixel_y = -25
 	},
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
+"suu" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/light,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"svn" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/courtroom)
 "svE" = (
 /turf/closed/wall,
 /area/security/checkpoint/medical)
@@ -59835,13 +61444,27 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/wood,
 /area/medical/psych)
+"szz" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "Secure Gate";
+	name = "brig shutters"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/security/brig)
 "szG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/carpet,
 /area/crew_quarters/theatre)
 "sAr" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -59881,11 +61504,11 @@
 /obj/machinery/vr_sleeper{
 	dir = 1
 	},
-/obj/effect/turf_decal/lumos/tile/red/fullcorner{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white/corner{
+/obj/effect/turf_decal/tile/red{
 	dir = 4
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 10
 	},
 /area/crew_quarters/fitness)
 "sEt" = (
@@ -59979,6 +61602,15 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"sLp" = (
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "sLt" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -59990,14 +61622,17 @@
 /area/science/xenobiology)
 "sLL" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 6
+	},
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -60071,6 +61706,9 @@
 "sRH" = (
 /obj/machinery/autolathe{
 	name = "public autolathe"
+	},
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
@@ -60272,7 +61910,7 @@
 /turf/open/floor/plasteel,
 /area/medical/storage)
 "tkB" = (
-/obj/effect/turf_decal/lumos/tile/blue/half,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "tkU" = (
@@ -60373,11 +62011,17 @@
 /turf/open/floor/plating,
 /area/space/nearstation)
 "trb" = (
-/obj/machinery/light{
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/security/courtroom)
+/area/security/brig)
 "tss" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -60427,6 +62071,12 @@
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/floor/grass,
 /area/medical/virology)
+"twp" = (
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "twP" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/effect/turf_decal/lumos/tile/green/checker{
@@ -60488,6 +62138,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
+"tzp" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "tzQ" = (
 /obj/machinery/shower{
 	dir = 4
@@ -60578,6 +62235,21 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/theatre)
+"tIc" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore/secondary)
 "tIF" = (
 /obj/structure/lattice,
 /obj/machinery/camera{
@@ -60607,6 +62279,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"tJG" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "tJK" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Gravity Generator";
@@ -60759,6 +62440,9 @@
 /obj/machinery/light{
 	light_color = "#cee5d2"
 	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/security/processing)
 "udW" = (
@@ -60794,9 +62478,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "ufD" = (
-/obj/structure/reagent_dispensers/water_cooler,
+/obj/effect/turf_decal/trimline/white/filled/corner{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
+/area/hallway/primary/starboard)
 "ugu" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -60852,6 +62538,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/pool)
+"ukf" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "ukM" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/maintenance{
@@ -60863,6 +62556,9 @@
 "ulM" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
@@ -60976,8 +62672,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -60993,11 +62689,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"uto" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+"usX" = (
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/plasteel,
+/area/bridge)
+"uto" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "uua" = (
@@ -61020,20 +62724,15 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/brig)
 "uxY" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 1
+/obj/effect/turf_decal/trimline/white/filled/corner{
+	dir = 4
 	},
-/obj/machinery/disposal/bin,
-/obj/machinery/light,
 /turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
+/area/hallway/primary/starboard)
 "uyA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -61373,7 +63072,10 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/lumos/tile/blue/fulltile,
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
 /area/ai_monitored/storage/eva)
 "vcN" = (
 /obj/structure/cable{
@@ -61396,12 +63098,12 @@
 /turf/open/floor/carpet,
 /area/hallway/primary/central)
 "vcQ" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /obj/machinery/light{
 	dir = 1;
 	light_color = "#d1dfff"
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
@@ -61416,12 +63118,10 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/medical/surgery)
 "vda" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
 /obj/structure/window/reinforced{
 	dir = 4
 	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/security/range)
 "vdu" = (
@@ -61483,6 +63183,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/teleporter)
+"vjI" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "bridge blast";
+	name = "bridge blast door"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/bridge)
 "vkx" = (
 /obj/structure/bed,
 /obj/item/bedsheet/blue,
@@ -61635,6 +63352,19 @@
 "vuj" = (
 /turf/open/floor/plasteel/showroomfloor,
 /area/maintenance/bar)
+"vvh" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"vvt" = (
+/obj/structure/chair/pew{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/courtroom)
 "vvx" = (
 /turf/closed/wall,
 /area/hallway/secondary/exit)
@@ -61903,6 +63633,12 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"vEZ" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
 "vFr" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -61945,9 +63681,6 @@
 /area/science/mixing)
 "vIi" = (
 /obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
 	icon_state = "0-8"
 	},
 /obj/machinery/light{
@@ -61987,6 +63720,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
+"vOw" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "vOU" = (
 /obj/structure/showcase/machinery/cloning_pod{
 	layer = 4;
@@ -62033,6 +63772,20 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"vUK" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "bridge blast";
+	name = "bridge blast door"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/bridge)
 "vUP" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -62072,6 +63825,13 @@
 /obj/structure/cable,
 /turf/open/space,
 /area/solar/starboard/aft)
+"vZI" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "vZR" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/wood,
@@ -62174,10 +63934,12 @@
 	dir = 1;
 	light_color = "#cee5d2"
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark/corner{
+	dir = 4
+	},
 /area/ai_monitored/security/armory)
 "wgd" = (
 /obj/machinery/hydroponics/constructable,
@@ -62208,6 +63970,23 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/surgery)
+"wgL" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "bridge blast";
+	name = "bridge blast door"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/bridge)
 "wig" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
@@ -62390,6 +64169,9 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/security/processing)
 "wto" = (
@@ -62430,6 +64212,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"wwU" = (
+/obj/structure/chair,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "wxi" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -62516,6 +64305,7 @@
 /obj/item/radio/intercom{
 	pixel_y = 20
 	},
+/obj/effect/turf_decal/trimline/red/filled/corner,
 /turf/open/floor/plasteel,
 /area/security/processing)
 "wHk" = (
@@ -62537,6 +64327,20 @@
 /obj/machinery/computer/arcade,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"wJZ" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "bridge blast";
+	name = "bridge blast door"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/bridge)
 "wKe" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -62564,9 +64368,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "wPh" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/airalarm{
 	dir = 8;
 	pixel_x = 24
@@ -62603,6 +64404,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"wRT" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "wTJ" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 10
@@ -62642,7 +64452,7 @@
 /obj/item/radio/intercom{
 	pixel_y = 20
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/plasteel,
 /area/security/range)
 "wVk" = (
@@ -62661,8 +64471,13 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "wWS" = (
-/obj/machinery/holopad,
-/turf/open/floor/plasteel/showroomfloor,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/lumos/loading_area,
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
 /area/security/main)
 "wWT" = (
 /obj/effect/landmark/start/roboticist,
@@ -62947,6 +64762,10 @@
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3,
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
+"xmR" = (
+/obj/machinery/smartfridge/organ,
+/turf/closed/wall,
+/area/medical/surgery)
 "xmS" = (
 /obj/structure/chair/comfy/beige{
 	dir = 8
@@ -62968,6 +64787,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"xqi" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "xqG" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/food/drinks/soda_cans/starkist{
@@ -63049,11 +64875,10 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "xCp" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "xDh" = (
@@ -63150,6 +64975,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
+"xFW" = (
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/plating,
+/area/maintenance/fore/secondary)
 "xIa" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/grille_or_trash,
@@ -63190,12 +65019,22 @@
 	pixel_y = 32;
 	poster_item_desc = "This poster promotes obesity, it also promotes giving the Chef a reason to keep their job."
 	},
-/turf/open/floor/plasteel/white/corner{
+/obj/effect/turf_decal/trimline/white/filled/corner{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"xOA" = (
+/obj/structure/table/wood,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/courtroom)
 "xPk" = (
-/obj/structure/bed,
 /obj/machinery/button/door{
 	id = "Dorm6";
 	name = "Cabin Bolt Control";
@@ -63203,9 +65042,14 @@
 	pixel_y = -25;
 	specialfunctions = 4
 	},
-/obj/effect/spawner/lootdrop/bedsheet,
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
+"xPF" = (
+/obj/structure/chair/pew/right{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/courtroom)
 "xPY" = (
 /obj/machinery/light{
 	dir = 4
@@ -63219,6 +65063,21 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"xRp" = (
+/obj/effect/turf_decal/trimline/white/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/medical/morgue)
+"xRH" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/break_room)
 "xTy" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -63294,11 +65153,11 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/effect/turf_decal/lumos/tile/green/fullcorner{
+/obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white/corner{
-	dir = 8
+/turf/open/floor/plasteel/dark/side{
+	dir = 5
 	},
 /area/crew_quarters/fitness)
 "xYb" = (
@@ -63424,6 +65283,17 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/wood,
 /area/hallway/primary/central)
+"yhG" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/disposalpipe/sorting/mail{
+	sortType = 9
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "ykU" = (
 /obj/structure/table/wood,
 /turf/open/floor/plating{
@@ -82846,8 +84716,8 @@ aSg
 bjk
 aZE
 bjn
-hIL
-hIM
+bjr
+bjr
 bmh
 boK
 hlx
@@ -83886,7 +85756,7 @@ bvX
 bxu
 byA
 bzR
-byd
+byz
 bxx
 aaa
 aaa
@@ -84139,7 +86009,7 @@ bjr
 bjr
 bjr
 bjr
-bjr
+ihu
 bxw
 byz
 bzQ
@@ -84387,7 +86257,7 @@ bcF
 bfg
 aUv
 bhW
-bjt
+mMc
 bjt
 bjt
 aYA
@@ -84396,7 +86266,7 @@ bqn
 brN
 brN
 brN
-brN
+stz
 bxx
 byC
 bzT
@@ -84663,7 +86533,7 @@ aaa
 aaa
 bGi
 bHy
-byE
+cDt
 bKj
 bGi
 aoV
@@ -85428,13 +87298,13 @@ bbR
 qje
 byF
 bwW
-byE
-byE
+vEZ
+ddk
 bDk
 bEK
 dRQ
-byE
-byE
+bHA
+bHA
 fhP
 bGi
 aaf
@@ -85686,12 +87556,12 @@ bxy
 eVL
 bwV
 byE
-byE
+snN
 bAb
-byE
-byE
+bHA
+bHA
 bEQ
-byE
+bHA
 bKn
 bGi
 aoV
@@ -85943,12 +87813,12 @@ bxA
 bvI
 bwX
 byG
-bvI
+rAn
 bAm
 bDo
 bDo
 bdI
-byE
+bHA
 bKp
 bGi
 aaf
@@ -86193,19 +88063,19 @@ bnG
 bnz
 bpA
 aZO
-bqs
+jyc
 jlm
 bud
 qje
-byE
+nHn
 bAZ
-byE
+oqw
 bzF
 bAc
-byE
-byE
+bHA
+bHA
 cBB
-byE
+bHA
 bKo
 bxy
 aaH
@@ -86444,7 +88314,7 @@ aZH
 bgD
 cNJ
 bgE
-cNN
+kex
 cNI
 bfm
 boS
@@ -86661,7 +88531,7 @@ akI
 ahU
 aiT
 aiD
-akI
+mmf
 ubI
 kgH
 qpg
@@ -86701,12 +88571,12 @@ aZH
 bnL
 cNG
 cNJ
-cNN
+jnC
 cNI
 bnI
 boR
 bqs
-aZO
+dAI
 ulM
 bbR
 bwd
@@ -86918,7 +88788,7 @@ ahD
 ahV
 aiU
 oOt
-wUV
+kAv
 jIr
 arP
 arP
@@ -86960,9 +88830,9 @@ bfl
 bmi
 bjw
 bmk
-bbR
-bbR
-bbR
+iCU
+iNT
+dPs
 aZW
 buI
 vZS
@@ -87689,7 +89559,7 @@ apK
 amX
 aiX
 aiE
-xDQ
+lMa
 aiN
 arP
 arc
@@ -87734,7 +89604,7 @@ aZK
 bnK
 bnK
 bqu
-bqu
+mWT
 bnK
 bnK
 bwe
@@ -87983,19 +89853,19 @@ aJq
 aRh
 bbV
 bfo
-bfo
-bfo
+rDL
+nzG
 bgn
-bfo
+nzG
 bmn
-bfo
+nzG
 boW
-bmE
-bmE
+tzp
+vvh
 btz
-btz
+kVb
 bwf
-btz
+kVb
 btz
 sLL
 bBh
@@ -88455,12 +90325,12 @@ dXP
 gjc
 ajX
 agj
-amL
+mYT
 asp
 sea
 aiX
 qmV
-anz
+jxM
 aov
 aph
 aph
@@ -88483,25 +90353,25 @@ ayW
 ayW
 aLW
 aNs
-aJq
-aLX
-aLX
-aLX
-aLX
+aYl
+ifX
+nUQ
+ifX
+vZI
 aLX
 aJq
 aYl
 aZN
-aYl
-aYl
-aYl
-aYl
-aYl
+ifX
+vZI
+ifX
+vZI
+ifX
 bgG
 bid
-aYl
-bBi
-aLY
+vZI
+mph
+bpC
 bnN
 boY
 bqw
@@ -88694,7 +90564,7 @@ aMR
 aat
 aat
 oWn
-aas
+biM
 aYX
 acG
 anW
@@ -88702,7 +90572,7 @@ biM
 bkA
 qkG
 xDo
-azG
+biN
 agj
 afH
 agY
@@ -88718,7 +90588,7 @@ agj
 aiX
 vcQ
 anz
-aov
+gfC
 cCi
 air
 aqY
@@ -88955,11 +90825,11 @@ aXH
 acd
 bcO
 aow
-aat
+ajU
 acd
 bmu
-aev
-uto
+aeV
+azG
 agO
 afI
 ahb
@@ -88975,7 +90845,7 @@ mym
 pWM
 aqC
 anz
-aov
+oEj
 cCi
 air
 arR
@@ -88997,7 +90867,7 @@ aYx
 ayW
 aLX
 aJq
-aOE
+jsy
 aJn
 aaa
 aaa
@@ -89216,14 +91086,14 @@ acJ
 bkI
 bmv
 bop
-azG
+buT
 agj
 bot
 bpg
 aid
 aiM
 afn
-alz
+trb
 xCp
 afW
 rZB
@@ -89250,7 +91120,7 @@ aDD
 aCi
 aEZ
 aHB
-aEZ
+leh
 aBt
 bwh
 aJq
@@ -89469,7 +91339,7 @@ aXO
 acd
 aUr
 aat
-aat
+alt
 acd
 awe
 fLS
@@ -89480,7 +91350,7 @@ ahu
 aie
 aiO
 afn
-usv
+uto
 agL
 aue
 uwq
@@ -89489,7 +91359,7 @@ hwJ
 seP
 aqC
 anR
-aov
+oEj
 cCi
 ata
 ata
@@ -89507,7 +91377,7 @@ ayU
 aEX
 ayU
 aAc
-aEZ
+jfk
 vbD
 bwh
 aJq
@@ -89730,7 +91600,7 @@ biZ
 acd
 oMZ
 apn
-ahE
+afM
 agj
 agj
 agj
@@ -89743,10 +91613,10 @@ akp
 akQ
 amB
 amn
-amS
-anz
+aiX
+ptc
 anR
-aov
+gfC
 cCi
 aIl
 arT
@@ -89764,7 +91634,7 @@ cEC
 aCi
 aEZ
 aHC
-aEZ
+mko
 aBt
 bwh
 aJq
@@ -89987,17 +91857,17 @@ aai
 acd
 bnd
 apo
-ahE
+bxQ
 agj
 aii
-afM
+eCQ
 aig
 agp
 agj
 hkH
 akl
 akM
-uwq
+duR
 avY
 anM
 dys
@@ -90025,7 +91895,7 @@ aJf
 ayW
 lof
 aJq
-aOE
+jsy
 aJn
 aaa
 aPR
@@ -90236,20 +92106,20 @@ aPh
 aai
 aLJ
 aat
-aaJ
+abR
 bbr
-aaJ
+aeS
 aat
 bjD
 acd
-oMZ
-aev
-aeS
+aoa
+aeV
+afM
 agj
 ajg
-afM
+gCm
 akU
-afM
+jKP
 kGl
 alA
 hxc
@@ -90257,10 +92127,10 @@ auf
 dmX
 awi
 axX
-seP
+mXI
 aCO
 anR
-aov
+gfC
 aXs
 aqR
 aqR
@@ -90294,10 +92164,10 @@ aZP
 aZC
 bca
 rnt
-rnt
+itN
 bca
 bbX
-aHW
+bbX
 bjE
 bbX
 bmo
@@ -90307,7 +92177,7 @@ bqz
 bqq
 btC
 buN
-brS
+eFC
 bmr
 byP
 aJq
@@ -90346,7 +92216,7 @@ cSN
 cSS
 ckD
 cTc
-cTe
+cja
 cfG
 cgw
 cgI
@@ -90493,20 +92363,20 @@ aPj
 aTx
 aLS
 ams
-aaJ
+abR
 bbN
-aaJ
+aeS
 bgl
 bjW
 blN
 ayd
 aeT
-aAd
+afM
 agj
 ajL
 akj
-afM
-afM
+hvD
+lKL
 csK
 kPY
 alB
@@ -90514,10 +92384,10 @@ auk
 uwq
 awv
 anB
-amR
+seP
 asT
 atM
-aov
+oEj
 jGc
 jGc
 jGc
@@ -90539,7 +92409,7 @@ ayW
 djj
 aJq
 aJq
-aOE
+jsy
 aJn
 aaa
 aPR
@@ -90550,12 +92420,12 @@ aYs
 aZQ
 bbi
 kvL
-kvL
-kvL
+qKF
+oow
 kvL
 gNC
 aHY
-aIa
+kvL
 kvL
 bms
 aYB
@@ -90603,7 +92473,7 @@ cSO
 cen
 ckG
 clJ
-cmF
+twp
 cgR
 cgI
 cgI
@@ -90750,31 +92620,31 @@ aPw
 aai
 aUP
 axT
-aat
+aev
 acd
-aat
+afm
 bgx
 bke
 acd
-oMZ
-azm
+apT
+aeV
+biN
 agj
 agj
 agj
-gCm
 ahG
 ajY
-lKL
+agj
 ako
-afM
+agL
 amj
 akQ
 amB
 amn
-amS
-anz
+aiX
+hHU
 anR
-aov
+gfC
 jGc
 aob
 ara
@@ -90860,7 +92730,7 @@ cSP
 cST
 cTa
 ceZ
-clQ
+cmF
 cgR
 cgI
 cgI
@@ -91005,11 +92875,11 @@ aJN
 acd
 acd
 aai
-aLJ
+aat
 azh
-aaJ
+abR
 bbN
-aaJ
+aeS
 abS
 bkg
 acd
@@ -91017,18 +92887,18 @@ aeP
 afC
 agk
 pKR
-agP
+qkG
 ajJ
-all
+izA
 all
 all
 aku
-afM
+eCO
 aux
-uwq
+duR
 awD
 guS
-dys
+pWM
 atk
 atO
 fPy
@@ -91053,12 +92923,12 @@ aaa
 aJn
 aJq
 aJq
-aOE
+jsy
 aPT
 aRj
 aSv
 aTV
-aVi
+lLE
 aWP
 aYu
 bfv
@@ -91117,7 +92987,7 @@ cSQ
 cSU
 cTb
 cTd
-ckF
+nnS
 ckF
 cgI
 cgI
@@ -91264,31 +93134,31 @@ aPP
 aai
 aUV
 jdL
-aaJ
+abR
 bbr
-aaJ
+aeS
 bgR
 bkl
 acd
 aer
 afB
-agi
+atn
 qLc
 afN
 ajK
 aiH
 akF
-aiy
+akF
 akv
 sAr
 avi
 nVk
 awX
 anQ
-seP
+szz
 aDQ
 atP
-aun
+vOw
 api
 avH
 arb
@@ -91314,7 +93184,7 @@ aOE
 aPS
 aRi
 aSu
-aTX
+hln
 cpC
 aWO
 bfv
@@ -91337,7 +93207,7 @@ fxV
 fxV
 fxV
 fxV
-gjY
+aXf
 aJq
 byU
 bCs
@@ -91534,18 +93404,18 @@ aiX
 afS
 ahx
 aiX
-aiX
-eCQ
+oDx
+afM
 akz
 afM
-aux
-amx
+sog
+uwq
 any
 arD
-amR
+seP
 aDQ
 anR
-fPy
+hMa
 jGc
 aqb
 iuv
@@ -91567,11 +93437,11 @@ aJp
 aKE
 aMa
 aNw
-aOE
+jsy
 aPU
 aRl
 aSx
-aTX
+usX
 aVi
 aWR
 bfv
@@ -91594,9 +93464,9 @@ yhz
 ouQ
 cQT
 kxg
-byS
+gfQ
 aJq
-bBi
+xqi
 bCs
 bFa
 bFa
@@ -91792,17 +93662,17 @@ afT
 ahy
 aiX
 aiR
-oMZ
+afM
 akz
 afM
 als
 akQ
 amB
 amn
-amS
+aiX
 aqD
 anR
-aov
+gfC
 jGc
 jGc
 ssP
@@ -91825,7 +93695,7 @@ aJq
 aLZ
 aNv
 aOE
-aPS
+vjI
 aRk
 aSw
 aTW
@@ -91851,9 +93721,9 @@ vCn
 wql
 kcO
 nbT
-byS
+niS
 aJq
-bBi
+hje
 bCs
 bCs
 bCs
@@ -91888,7 +93758,7 @@ cjd
 cSW
 ckI
 clJ
-cmL
+cje
 cBO
 cgI
 cgI
@@ -92041,7 +93911,7 @@ gXs
 aaZ
 aeW
 acl
-agJ
+ath
 aaZ
 adL
 adL
@@ -92049,11 +93919,11 @@ ago
 ahz
 aiX
 aiW
-oMZ
+afM
 akz
 afM
 azG
-alt
+alw
 amp
 aot
 apR
@@ -92061,10 +93931,10 @@ aqE
 anR
 old
 apk
-anw
-anw
-anw
-anw
+sLp
+jxM
+sLp
+jxM
 aVh
 avj
 awl
@@ -92072,17 +93942,17 @@ axC
 ayY
 cpF
 azZ
+fhl
 azZ
-azZ
-azZ
+fhl
 aGt
 aHQ
-aJr
+aKE
 bdj
 aMc
 aNy
-aOE
-aPS
+jsy
+wJZ
 aRn
 aSz
 aTY
@@ -92113,26 +93983,26 @@ bAg
 bBq
 bCu
 bAO
-bSA
-bSA
+bUl
+gon
 bFj
-bSA
+gon
 bHk
 bHR
 bIe
 cmh
 bJz
 bRp
-bSA
-bSA
+bUl
+gon
 bTJ
-bSA
-bSA
+gon
+bUl
 bWL
-bSA
+bUl
 jjv
 bZx
-bSA
+gon
 bUl
 bVf
 bXm
@@ -92145,7 +94015,7 @@ cjf
 cSX
 ckK
 clJ
-cmL
+cje
 cgR
 cgI
 cgI
@@ -92309,7 +94179,7 @@ aaZ
 wfA
 aAe
 aAl
-atn
+wRT
 eRh
 amI
 aqS
@@ -92339,7 +94209,7 @@ bfi
 aMb
 aNx
 aOE
-aPS
+vUK
 aRm
 aSy
 aTX
@@ -92402,7 +94272,7 @@ cMC
 cSY
 ckI
 clJ
-cmL
+cje
 cnv
 cgI
 cgI
@@ -92554,7 +94424,7 @@ gXs
 abG
 aaZ
 aeY
-acn
+aco
 agR
 ahm
 ahA
@@ -92576,10 +94446,10 @@ anz
 aoz
 apm
 aqd
-anA
+fDh
 asa
 atd
-anA
+jvX
 avk
 awc
 axE
@@ -92587,7 +94457,7 @@ ayZ
 pHO
 aBu
 aAa
-aAa
+gns
 aAa
 aGu
 aHR
@@ -92595,7 +94465,7 @@ aJt
 bgA
 aMe
 aNA
-aOE
+jsy
 aPV
 aRp
 aSB
@@ -92624,15 +94494,15 @@ bHf
 nbT
 bwh
 bAh
-aXf
+ukf
 bzG
 bDG
 bCp
 bYI
-bHP
+bRq
 bGO
 bHl
-bQg
+nLD
 bQg
 apI
 bQg
@@ -92644,9 +94514,9 @@ bQg
 bQg
 bQg
 bQg
-bYI
-bDG
-bHP
+lqw
+dLE
+jjV
 cbt
 bVh
 bXo
@@ -92822,12 +94692,12 @@ aip
 aja
 lCf
 akz
-ath
+afM
 agn
 agn
 amN
 aoZ
-apT
+agn
 anw
 anz
 cXU
@@ -92853,7 +94723,7 @@ bkV
 aMd
 aNz
 aOE
-aPS
+wgL
 aRo
 aSA
 aCN
@@ -92892,10 +94762,10 @@ bzs
 bLH
 bRq
 bNO
-bQg
 bRq
+nLD
 bTR
-bTK
+hGZ
 bTK
 bXR
 bUE
@@ -92916,7 +94786,7 @@ cjg
 cjU
 cfb
 clM
-cfz
+cje
 cgR
 cgI
 cgI
@@ -93068,10 +94938,10 @@ gXs
 bdM
 aaZ
 afc
-aco
+alL
 agU
 ahp
-afd
+ahp
 apW
 aqu
 ahB
@@ -93079,16 +94949,16 @@ aiq
 ajb
 hrE
 ajF
-azG
+afM
 akY
 alE
 amU
 apH
-apX
+aqt
 aqF
 anz
 aDa
-ahn
+cKW
 aqf
 xkL
 xkL
@@ -93109,7 +94979,7 @@ aJu
 aKF
 aMf
 aNB
-aOE
+jsy
 aPW
 aRr
 aSD
@@ -93136,9 +95006,9 @@ vOU
 xBk
 fTC
 drE
-bwh
+aKE
 aJq
-bBu
+suu
 bCv
 bAT
 bDL
@@ -93336,13 +95206,13 @@ ait
 aje
 jOY
 alj
-atn
-akZ
+bxQ
+ala
 alM
 amV
 apc
 aqr
-aqF
+aqE
 anz
 aoA
 ahn
@@ -93367,10 +95237,10 @@ aJn
 aJq
 aJq
 aOE
-aPS
+wJZ
 aRq
 aSC
-aTX
+hln
 aVo
 aWW
 bfv
@@ -93393,7 +95263,7 @@ fxV
 fxV
 fxV
 fxV
-aJr
+aJq
 aJq
 bBt
 bCv
@@ -93416,12 +95286,12 @@ bVN
 bWN
 bXM
 bLK
-bZy
+nHh
 bZy
 cbu
-bVm
+xRH
 bXp
-bZy
+hiA
 cfc
 cgO
 ccj
@@ -93580,26 +95450,26 @@ aaf
 adR
 aaY
 abJ
-abR
+afU
 adR
 acq
-agS
+azm
 adi
 adP
-ahX
-ahX
+bOL
+bOL
 ahR
 aiv
 adg
 oaZ
 akz
-azG
+biN
 ala
 alN
 amW
 apv
 aqt
-aqF
+rRB
 anz
 aoB
 ahn
@@ -93623,7 +95493,7 @@ aaa
 aJn
 aJq
 aJq
-aOE
+jsy
 aPX
 aRs
 aSE
@@ -93671,7 +95541,7 @@ bTM
 bUH
 bKE
 bYN
-bXM
+ppg
 bRx
 cew
 bTh
@@ -93686,7 +95556,7 @@ cdm
 cio
 cjY
 ceq
-clQ
+cmF
 cje
 cgR
 cgI
@@ -93836,8 +95706,8 @@ aaf
 aaa
 abo
 abk
-abk
-abk
+agi
+agP
 adR
 agq
 agV
@@ -93922,12 +95792,12 @@ bOd
 bNQ
 bOU
 bQj
-bOd
+oKf
 bMK
 bVX
-bTP
-bRy
-cfN
+fqf
+qPT
+lCr
 bXL
 bLK
 bRj
@@ -94094,26 +95964,26 @@ aaa
 adR
 abO
 wWS
-abO
+ajA
 abV
 ags
-ags
-adj
+akc
+akc
 afQ
 afr
 akc
 aik
 akh
 apg
-oMZ
+pUF
 aiG
 amf
-anr
+agn
 aqN
 arC
 asq
 agn
-anA
+gfz
 anz
 aoD
 ahn
@@ -94137,7 +96007,7 @@ aJw
 oEP
 aJq
 aJq
-aOE
+jsy
 aJn
 aaa
 aPR
@@ -94182,7 +96052,7 @@ bQm
 bRv
 bRs
 bVY
-bTP
+oiq
 bYK
 bWQ
 bWQ
@@ -94349,12 +96219,12 @@ aaa
 aaf
 aaa
 abo
-amZ
+qGA
 anT
-abO
-abO
-abO
-abO
+apl
+aaK
+amS
+afU
 adk
 abo
 afD
@@ -94364,13 +96234,13 @@ aki
 akk
 akq
 gbM
-azG
+biN
 agn
 agn
 ant
 agn
 agn
-anA
+wwU
 anz
 aoC
 ahn
@@ -94401,7 +96271,7 @@ aPR
 aUd
 aVr
 aWZ
-aBb
+evt
 aZV
 aZG
 aGv
@@ -94438,7 +96308,7 @@ bOW
 bQl
 bRu
 bRs
-bVY
+gzH
 bUI
 bVR
 bWQ
@@ -94607,11 +96477,11 @@ aaf
 aaa
 adR
 qGA
-abN
+anT
 apl
-apl
+aaK
 acO
-acO
+aAd
 adl
 aet
 agy
@@ -94619,7 +96489,7 @@ aha
 ahC
 aia
 apx
-oMZ
+apT
 akE
 atn
 alq
@@ -94651,7 +96521,7 @@ aJy
 aJy
 aMj
 bTI
-aOE
+jsy
 aJn
 aaa
 aPR
@@ -94863,11 +96733,11 @@ aaf
 aaf
 aaf
 abo
-abm
-abm
-abm
-abm
-abm
+qGA
+anT
+apl
+aaK
+anr
 acP
 adm
 abo
@@ -94884,7 +96754,7 @@ amg
 anv
 apQ
 agn
-anA
+hMi
 anz
 aoE
 ahn
@@ -94952,9 +96822,9 @@ bOd
 bQo
 bRz
 bSH
-plm
-bTP
-bRA
+cEO
+gZI
+pqA
 bWQ
 bXO
 bQq
@@ -95120,11 +96990,11 @@ aaa
 aaa
 aaf
 adR
-abn
+qGA
 abH
-abn
+apl
 aaK
-abn
+anr
 adR
 adR
 adR
@@ -95165,7 +97035,7 @@ aZx
 blU
 aJq
 aNr
-aOE
+jsy
 aJn
 aaa
 aaa
@@ -95385,7 +97255,7 @@ abq
 abq
 aff
 aeU
-ajA
+akd
 akd
 ahI
 aiB
@@ -95404,9 +97274,9 @@ aoG
 ajo
 aqg
 arf
-aqo
-aTa
 atm
+aTa
+ari
 arf
 avv
 awr
@@ -95445,7 +97315,7 @@ bmx
 bmx
 bqH
 buX
-btL
+fsD
 buX
 buX
 viG
@@ -95653,19 +97523,19 @@ aky
 alc
 alI
 amr
-amY
-amY
+vvt
+vvt
 ajp
 ajp
 aoH
 ajo
-aqg
+raq
 arf
-asm
 atm
 atm
-avg
-awr
+atm
+arf
+axO
 awr
 axy
 awr
@@ -95679,7 +97549,7 @@ aBy
 aAh
 rqf
 aNr
-aOE
+jsy
 aJn
 aaa
 aaa
@@ -95897,8 +97767,8 @@ acQ
 adn
 agw
 abq
-afD
-afU
+aHW
+bBO
 apZ
 ahc
 ahH
@@ -95906,25 +97776,25 @@ akR
 abp
 aji
 ajO
-ajn
-ajn
+svn
+xOA
 alH
 amr
-amY
-amY
+xPF
+xPF
 ajp
 anV
 ajo
 ajo
-aqg
+tIc
 arf
-ari
+ark
 asu
-mPk
-arf
-avR
+atm
+avn
 awr
-ofU
+awr
+axW
 awr
 sFW
 aAh
@@ -96173,16 +98043,16 @@ aHt
 anY
 ajo
 apq
-aqg
+tIc
 arf
 arf
 arf
 arf
 arf
 jWs
-axP
+awr
 azb
-aAi
+awr
 awr
 aAh
 aAh
@@ -96193,23 +98063,23 @@ aDM
 aAh
 aVZ
 cBg
-aJq
-aJr
-aJr
-aJr
-aJr
-aJr
+fMA
+qcC
+tJG
+fEn
+tJG
+aKE
 aXh
 aYG
 aZY
-aYG
-aYG
+bsp
+mSI
 bdn
 bep
-aYG
-aYG
+bsp
+mSI
 hEW
-aYG
+mSI
 ble
 bmE
 vpB
@@ -96218,7 +98088,7 @@ bqL
 bsp
 btO
 bva
-bwu
+crj
 bwu
 bwu
 kPj
@@ -96411,8 +98281,8 @@ acu
 acu
 acF
 abq
-afD
-afU
+aIa
+bLS
 aqc
 ahe
 ahJ
@@ -96420,9 +98290,9 @@ ais
 abp
 ajk
 ajQ
-ajn
-ajn
-alH
+kiK
+bGp
+efm
 amr
 amY
 amY
@@ -96430,16 +98300,16 @@ ajp
 anX
 ajo
 app
-aqi
+aqk
 arf
 ask
 atm
 aUf
-arf
-awq
-axO
-aza
-kmw
+avR
+awr
+awr
+axW
+awr
 xrN
 aAh
 aLo
@@ -96681,8 +98551,8 @@ ajH
 akn
 ale
 amr
-amY
-amY
+vvt
+vvt
 ajp
 ajp
 ajo
@@ -96692,8 +98562,8 @@ arf
 avZ
 atm
 aHw
-avn
-awr
+arf
+axP
 awr
 aze
 aGm
@@ -96934,14 +98804,14 @@ aiu
 abp
 ajm
 ajS
-ajn
+qPd
 ajT
 akA
 amr
-amY
-amY
-ajp
-anV
+xPF
+xPF
+klT
+nYi
 ajo
 apr
 aqj
@@ -96952,7 +98822,7 @@ xPk
 arf
 awt
 awr
-axW
+cTe
 awr
 aAZ
 aAh
@@ -97182,23 +99052,23 @@ aaa
 aaf
 abo
 aeB
-afm
+afU
 agb
 agG
 ahi
 ahN
 aix
 abp
-ajp
-ajU
-ajn
-trb
-ajn
-amr
-bLS
-ajp
-ajp
-ajp
+ajo
+ajo
+ajo
+ajo
+ajo
+ajo
+ajo
+ajo
+ajo
+oiL
 ajo
 aVw
 aqm
@@ -97446,17 +99316,17 @@ ahj
 abp
 wBr
 abp
-ajo
-ajo
-ajo
-ajo
-ajo
-ajo
-ajo
-ajo
-ajo
-aoa
-ajo
+arN
+apq
+ahn
+gbw
+jUY
+hkk
+arN
+lcg
+iID
+anE
+xFW
 apt
 aql
 aoJ
@@ -97706,13 +99576,13 @@ apy
 xkL
 aAk
 xkL
+ojh
 xkL
 xkL
 xkL
-alL
 xkL
 xkL
-xkL
+poV
 xkL
 anZ
 apu
@@ -97722,7 +99592,7 @@ arf
 arf
 arf
 awA
-awr
+awu
 aLm
 awr
 awr
@@ -97965,11 +99835,11 @@ anD
 anD
 anD
 fpz
+nBs
 anD
-jKP
 anD
 anD
-auq
+oVg
 auq
 anD
 aoI
@@ -97979,9 +99849,9 @@ asN
 aur
 avy
 awr
-awr
+aza
 azk
-axB
+hIM
 awr
 awr
 awr
@@ -98013,7 +99883,7 @@ wbE
 bvw
 bxb
 lsG
-bqP
+bpM
 bqV
 bKQ
 nvk
@@ -98236,7 +100106,7 @@ eQb
 aut
 arf
 aXF
-awr
+azp
 aDN
 bLY
 awr
@@ -98495,7 +100365,7 @@ arf
 avz
 awr
 aDY
-awr
+axB
 awr
 awr
 plC
@@ -98752,8 +100622,8 @@ arf
 avA
 awr
 azo
-aAp
-uxY
+awr
+xrN
 arf
 aCt
 aEA
@@ -99007,10 +100877,10 @@ arf
 arf
 arf
 arf
-oHB
+arf
 azf
 oHB
-arf
+oHB
 arf
 arf
 arf
@@ -99264,12 +101134,12 @@ asZ
 aua
 oZl
 awB
-fHG
+aAi
 aEr
 fHG
 fHG
 fHG
-ufD
+fHG
 alP
 aGI
 aIf
@@ -99516,14 +101386,14 @@ ecg
 jLT
 dFX
 arm
-fHG
-fHG
-fHG
-fHG
+aqo
+epD
+asm
+auB
 auB
 atZ
 azg
-azp
+qOc
 qOc
 qOc
 qOc
@@ -99776,11 +101646,11 @@ coh
 awa
 aBU
 bwj
-coh
+awq
 pPi
-coh
+cfz
 axz
-hWd
+fHG
 aCv
 aCv
 mbU
@@ -100033,10 +101903,10 @@ fHG
 fHG
 aGl
 oIJ
-fHG
-axh
-fHG
-fHG
+auB
+nLu
+cmL
+gjY
 hWd
 bgo
 sci
@@ -100289,14 +102159,14 @@ dFX
 afa
 sJI
 afE
-fHG
-eAJ
+avg
+rvr
 rvr
 nLu
-nLu
+hIL
 ryr
 aKq
-sci
+ikm
 puh
 alP
 aGA
@@ -100553,7 +102423,7 @@ fHG
 reA
 lsk
 xXi
-sci
+iuR
 jEc
 alP
 aGL
@@ -101088,7 +102958,7 @@ aJI
 mNW
 aYV
 pPL
-bdo
+bet
 brC
 gRl
 bdr
@@ -101856,7 +103726,7 @@ aIk
 aXm
 aIm
 juG
-bbz
+ufD
 aYV
 aYV
 aYV
@@ -102113,7 +103983,7 @@ bmS
 aVz
 aSN
 bak
-bbz
+uxY
 aYV
 bro
 aYV
@@ -102889,7 +104759,7 @@ aYV
 aYV
 bqN
 omm
-biN
+xRp
 qVZ
 nQv
 hvd
@@ -103422,7 +105292,7 @@ bFO
 bFO
 bFO
 rVj
-hvD
+xmR
 bFO
 bFO
 jyt
@@ -103654,7 +105524,7 @@ aVI
 aVI
 aVI
 aYO
-aRJ
+ssB
 bbB
 aYV
 aYV
@@ -103909,7 +105779,7 @@ aCy
 aCH
 nLw
 aVK
-aRJ
+kmw
 gBu
 aRJ
 bbB
@@ -104166,7 +106036,7 @@ aCB
 aSS
 aUj
 sJx
-aRJ
+mPk
 aYQ
 bam
 bam
@@ -104423,10 +106293,10 @@ aCB
 aST
 bhx
 bne
-aRJ
+mPk
 aYQ
 bam
-ssB
+aYV
 aYV
 aYV
 brz
@@ -104446,7 +106316,7 @@ bvs
 bEh
 qZC
 gdi
-bxQ
+hfh
 bDa
 sgD
 scf
@@ -104680,10 +106550,10 @@ aCE
 aCJ
 ohq
 aRJ
-aRJ
+ofU
 aYR
 ban
-ikm
+aYV
 aYV
 aYV
 bez
@@ -104940,7 +106810,7 @@ aXo
 aXo
 iLJ
 bap
-ikm
+aYV
 aYV
 aYV
 beB
@@ -104961,7 +106831,7 @@ bvA
 nTb
 nTb
 bFO
-bBO
+iCS
 bFO
 bFO
 bFO
@@ -105197,7 +107067,7 @@ aVM
 aOX
 aYT
 bam
-iuR
+aYV
 aYV
 bcb
 bdl
@@ -105218,7 +107088,7 @@ bvz
 bdO
 bna
 bna
-bOL
+yhG
 bna
 cbL
 cbL
@@ -105983,7 +107853,7 @@ boE
 bsQ
 bsQ
 box
-buT
+cke
 buU
 byf
 bzu

--- a/_maps/map_files/BoxStation/BoxStation_Lumos.dmm
+++ b/_maps/map_files/BoxStation/BoxStation_Lumos.dmm
@@ -27812,7 +27812,7 @@
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hop)
 "bqy" = (
-/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/box,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bqz" = (
@@ -29451,7 +29451,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/box,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "buL" = (
@@ -37939,12 +37939,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"bPg" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
 "bPi" = (
 /obj/machinery/light{
 	dir = 4
@@ -39998,20 +39992,6 @@
 /obj/machinery/atmospherics/miner/n2o,
 /turf/open/floor/engine/n2o,
 /area/engine/atmos)
-"bUX" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white/side{
-	dir = 1
-	},
-/area/science/research)
 "bUY" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -50254,7 +50234,7 @@
 /area/quartermaster/office)
 "cBr" = (
 /obj/effect/landmark/event_spawn,
-/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/box,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "cBt" = (
@@ -52018,6 +51998,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"dyR" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "dzi" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
@@ -52088,6 +52074,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"dEN" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "dFX" = (
 /turf/closed/wall,
 /area/crew_quarters/fitness/pool)
@@ -52176,6 +52168,11 @@
 /obj/item/clothing/under/color/grey,
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
+"dNK" = (
+/turf/open/floor/plasteel/white/side{
+	dir = 10
+	},
+/area/science/research)
 "dOd" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -52252,12 +52249,6 @@
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/crew_quarters/toilet)
-"dTX" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/science/lab)
 "dVk" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 10
@@ -52323,6 +52314,14 @@
 "dXP" = (
 /turf/closed/wall/r_wall,
 /area/security/range)
+"dYj" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 8
+	},
+/area/science/research)
 "dZo" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -52537,11 +52536,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/hallway/secondary/entry)
-"eoW" = (
-/turf/open/floor/plasteel/white/side{
-	dir = 6
-	},
-/area/science/research)
 "epC" = (
 /obj/machinery/door/airlock{
 	desc = "To keep the station within regulations, space IKEA requires one storage cupboard for their Nanotrasen partnership to continue.";
@@ -52790,14 +52784,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"eTg" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/plasteel/white/side,
-/area/science/research)
 "eTo" = (
 /obj/machinery/holopad,
 /turf/open/floor/wood,
@@ -52808,6 +52794,13 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
+"eVj" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "eVC" = (
 /obj/effect/spawner/structure/window,
 /obj/machinery/door/firedoor,
@@ -52839,6 +52832,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
+"eWm" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/lab)
 "eXi" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/mechanical,
@@ -52938,21 +52937,6 @@
 	dir = 4
 	},
 /area/crew_quarters/theatre)
-"fhg" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
 "fhl" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -53314,12 +53298,6 @@
 /obj/item/watertank,
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"fHp" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white/side,
-/area/science/research)
 "fHG" = (
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
@@ -53567,6 +53545,12 @@
 /obj/item/storage/box/lights/mixed,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
+"gch" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/science/misc_lab)
 "gcj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 10
@@ -53780,10 +53764,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/medical/storage)
-"gle" = (
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel/white,
-/area/science/mixing)
 "gli" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -53850,14 +53830,6 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/nuke_storage)
-"grQ" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white/side{
-	dir = 8
-	},
-/area/science/research)
 "grS" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -54177,6 +54149,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
+"gNf" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/dark,
+/area/science/research)
 "gNC" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -54500,15 +54476,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal/incinerator)
-"hfH" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/mixing)
 "hgO" = (
 /obj/structure/table,
 /obj/item/storage/pill_bottle/dice{
@@ -55066,12 +55033,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"iae" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner,
-/turf/open/floor/plasteel/white/side{
-	dir = 9
-	},
-/area/science/robotics/lab)
 "idK" = (
 /obj/machinery/camera{
 	c_tag = "Firing Range";
@@ -55553,14 +55514,6 @@
 /obj/machinery/droneDispenser/preloaded,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"iQs" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white/side{
-	dir = 4
-	},
-/area/science/research)
 "iQR" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -55597,6 +55550,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"iUr" = (
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
+/area/science/research)
 "iUL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -55753,12 +55711,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"jer" = (
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel/white/side{
-	dir = 8
-	},
-/area/science/xenobiology)
 "jex" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -55869,12 +55821,6 @@
 /obj/item/coin/iron,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"jkZ" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/science/mixing)
 "jlm" = (
 /obj/machinery/rnd/production/techfab/department/cargo,
 /turf/open/floor/plasteel,
@@ -56476,12 +56422,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"jSn" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner,
-/turf/open/floor/plasteel/white/side{
-	dir = 8
-	},
-/area/science/research)
 "jSC" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -56575,20 +56515,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"jWZ" = (
-/obj/machinery/atmospherics/pipe/simple/violet/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white/side{
-	dir = 4
-	},
-/area/science/xenobiology)
 "jYH" = (
 /obj/machinery/vending/cola/space_up,
 /turf/open/floor/plasteel/dark,
@@ -57078,6 +57004,10 @@
 /obj/effect/turf_decal/lumos/tile/red/checker,
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
+"kEL" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "kEY" = (
 /obj/effect/landmark/stationroom/box/engine,
 /turf/open/space/basic,
@@ -57105,12 +57035,6 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"kKB" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/science/misc_lab)
 "kKY" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/structure/closet,
@@ -57332,12 +57256,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
-"lfG" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel/white,
-/area/science/mixing)
 "lfJ" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -57416,6 +57334,12 @@
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"lrg" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner,
+/turf/open/floor/plasteel/white/side{
+	dir = 9
+	},
+/area/science/robotics/lab)
 "lsk" = (
 /obj/structure/closet/wardrobe/white,
 /turf/open/floor/plasteel,
@@ -57449,15 +57373,6 @@
 "lun" = (
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics/cloning)
-"luE" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
 "luQ" = (
 /obj/structure/lattice,
 /obj/structure/window/reinforced,
@@ -57541,12 +57456,6 @@
 	},
 /turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/captain)
-"lEq" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white/side,
-/area/science/research)
 "lEt" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -57665,6 +57574,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/medical/medbay/front_office)
+"lPe" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 8
+	},
+/area/science/xenobiology)
 "lPr" = (
 /obj/item/kirbyplants{
 	icon_state = "applebush"
@@ -57693,6 +57613,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/explab)
+"lRn" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "lRG" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -57870,17 +57799,6 @@
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/crew_quarters/toilet)
-"mlf" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white/side{
-	dir = 8
-	},
-/area/science/xenobiology)
 "mmf" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -57961,6 +57879,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/front_office)
+"mtQ" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/side,
+/area/science/research)
 "mvt" = (
 /obj/machinery/airalarm{
 	dir = 1;
@@ -58469,23 +58393,6 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"niG" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/violet/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white/side{
-	dir = 4
-	},
-/area/science/xenobiology)
 "niS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -58829,11 +58736,6 @@
 /obj/structure/barricade/wooden/crude,
 /turf/open/floor/plasteel/showroomfloor,
 /area/maintenance/bar)
-"nKg" = (
-/turf/open/floor/plasteel/white/side{
-	dir = 4
-	},
-/area/science/research)
 "nKt" = (
 /obj/structure/table,
 /obj/item/screwdriver{
@@ -59179,10 +59081,6 @@
 /obj/machinery/light/small,
 /turf/open/floor/plasteel/showroomfloor,
 /area/maintenance/bar)
-"odD" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/dark,
-/area/science/research)
 "oem" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -59380,11 +59278,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
-"orX" = (
-/turf/open/floor/plasteel/white/side{
-	dir = 10
-	},
-/area/science/research)
 "osJ" = (
 /obj/structure/railing/corner{
 	dir = 4
@@ -59812,6 +59705,14 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"oXI" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white/corner{
+	dir = 1
+	},
+/area/science/research)
 "oZc" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -59849,6 +59750,14 @@
 /obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"pcz" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 8
+	},
+/area/science/research)
 "pek" = (
 /obj/machinery/door/airlock/external{
 	name = "Labor Camp Shuttle Airlock"
@@ -60045,23 +59954,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"pse" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white/side{
-	dir = 4
-	},
-/area/science/research)
 "pst" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -60345,6 +60237,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
+"pPI" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "pPL" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
@@ -60646,6 +60544,21 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"quh" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "qus" = (
 /obj/effect/turf_decal/trimline/red/filled/corner,
 /turf/open/floor/plasteel,
@@ -60661,6 +60574,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"qwk" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/violet/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
+/area/science/xenobiology)
 "qxq" = (
 /turf/closed/wall,
 /area/security/range)
@@ -60730,10 +60660,6 @@
 /obj/structure/sign/warning/docking,
 /turf/open/floor/plating,
 /area/security/checkpoint/auxiliary)
-"qHA" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
 "qIw" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -60866,20 +60792,6 @@
 	dir = 1
 	},
 /area/engine/atmos)
-"qRZ" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/machinery/disposal/bin,
-/obj/structure/window/reinforced,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/science/xenobiology)
 "qTG" = (
 /obj/structure/table/wood,
 /obj/structure/mirror{
@@ -61029,6 +60941,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
+"rjG" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "rjQ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
@@ -61264,6 +61182,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"rFJ" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white/side,
+/area/science/research)
 "rGq" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -61405,14 +61329,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge/meeting_room)
-"rTX" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white/corner{
-	dir = 1
-	},
-/area/science/research)
 "rVj" = (
 /obj/machinery/door/airlock/medical{
 	name = "Operating Theatre";
@@ -61547,15 +61463,6 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/grass,
 /area/medical/virology)
-"sdo" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/mixing)
 "sea" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
@@ -61672,6 +61579,20 @@
 /obj/effect/turf_decal/lumos/tile/red/fulltile,
 /turf/open/floor/plasteel,
 /area/security/brig)
+"soC" = (
+/obj/machinery/atmospherics/pipe/simple/violet/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
+/area/science/xenobiology)
 "sqc" = (
 /obj/structure/table,
 /obj/machinery/recharger{
@@ -61886,9 +61807,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
-"sBT" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
+"sBL" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
@@ -61905,6 +61826,14 @@
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics)
+"sEc" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
+/area/science/research)
 "sEi" = (
 /obj/machinery/vr_sleeper{
 	dir = 1
@@ -62828,10 +62757,10 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "tZe" = (
-/obj/effect/turf_decal/bot,
 /obj/structure/sign/poster/official/pda_ad{
 	pixel_y = -32
 	},
+/obj/effect/turf_decal/box,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "uap" = (
@@ -63037,6 +62966,14 @@
 	},
 /turf/open/floor/engine,
 /area/science/mixing)
+"uoD" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
+/area/science/xenobiology)
 "uoG" = (
 /obj/machinery/power/apc{
 	areastring = "/area/security/detectives_office";
@@ -63080,6 +63017,14 @@
 "uqP" = (
 /obj/machinery/atmospherics/pipe/simple/violet/hidden,
 /turf/closed/wall,
+/area/science/xenobiology)
+"urt" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 8
+	},
 /area/science/xenobiology)
 "usv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -63143,6 +63088,10 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/brig)
+"uwt" = (
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "uxY" = (
 /obj/effect/turf_decal/trimline/white/filled/corner{
 	dir = 4
@@ -63164,14 +63113,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
-"uyW" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white/side{
-	dir = 4
-	},
-/area/science/xenobiology)
 "uzs" = (
 /turf/open/floor/plasteel/yellowsiding{
 	dir = 4
@@ -63391,6 +63332,23 @@
 /obj/structure/window/reinforced,
 /turf/open/space,
 /area/space/nearstation)
+"uUN" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
+/area/science/research)
 "uVS" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -63760,12 +63718,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
-"vsF" = (
-/obj/effect/turf_decal/trimline/purple/filled/line,
-/turf/open/floor/plasteel/white/side{
-	dir = 1
-	},
-/area/science/robotics/lab)
 "vsT" = (
 /obj/structure/chair/comfy/black{
 	dir = 8
@@ -64060,6 +64012,20 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"vET" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/disposal/bin,
+/obj/structure/window/reinforced,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
 "vEZ" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
@@ -64202,6 +64168,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"vRE" = (
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel/white/side{
+	dir = 8
+	},
+/area/science/xenobiology)
 "vUK" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "bridge blast";
@@ -64426,6 +64398,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/pool)
+"wiA" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 1
+	},
+/area/science/research)
 "wiN" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/metal/twenty,
@@ -64502,6 +64488,12 @@
 	dir = 4
 	},
 /area/medical/cryo)
+"wnq" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner,
+/turf/open/floor/plasteel/white/side{
+	dir = 8
+	},
+/area/science/research)
 "wor" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1;
@@ -64750,13 +64742,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
-"wHB" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
 "wJs" = (
 /obj/machinery/computer/arcade,
 /turf/open/floor/plasteel,
@@ -64832,6 +64817,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"wRa" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "wRn" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible/layer1{
 	dir = 4
@@ -64866,6 +64860,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
+"wUh" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "wUV" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
@@ -65088,13 +65091,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
-"xgE" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 4
+"xgJ" = (
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/white/side{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/plasteel/white/side,
 /area/science/research)
 "xhj" = (
 /obj/effect/turf_decal/lumos/tile/purple/checker,
@@ -65232,6 +65235,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"xpE" = (
+/obj/effect/turf_decal/trimline/purple/filled/line,
+/turf/open/floor/plasteel/white/side{
+	dir = 1
+	},
+/area/science/robotics/lab)
 "xqi" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -65429,12 +65438,6 @@
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"xJj" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel/white,
-/area/science/mixing)
 "xLX" = (
 /obj/structure/lattice/catwalk,
 /obj/item/stack/marker_beacon{
@@ -65634,6 +65637,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/pool)
+"yal" = (
+/turf/open/floor/plasteel/white/side{
+	dir = 6
+	},
+/area/science/research)
 "ybX" = (
 /obj/structure/chair/office/light,
 /obj/structure/cable{
@@ -65745,14 +65753,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"yhN" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white/side{
-	dir = 8
-	},
-/area/science/xenobiology)
 "ykU" = (
 /obj/structure/table/wood,
 /turf/open/floor/plating{
@@ -108570,7 +108570,7 @@ bht
 bsQ
 box
 btw
-bUX
+wiA
 byf
 bzt
 bAy
@@ -108827,7 +108827,7 @@ bsQ
 bsR
 box
 bvE
-bUX
+wiA
 byf
 bzw
 bAB
@@ -108839,7 +108839,7 @@ bEm
 bEm
 bJL
 bLa
-luE
+wUh
 aLt
 bPy
 bPA
@@ -109341,7 +109341,7 @@ cHZ
 cIf
 box
 btA
-bUX
+wiA
 byf
 bzy
 bAD
@@ -109361,17 +109361,17 @@ bQM
 cTZ
 mNi
 rcD
-uyW
-jWZ
+uoD
+soC
 mNi
 bRZ
-jWZ
+soC
 mNi
-uyW
-niG
+uoD
+qwk
 mNi
-uyW
-jWZ
+uoD
+soC
 ccQ
 bDb
 hYH
@@ -109598,7 +109598,7 @@ bqc
 bsS
 box
 bvE
-bUX
+wiA
 byf
 bzx
 bAC
@@ -109874,17 +109874,17 @@ cmk
 bQN
 eFW
 ooH
-yhN
-jer
+urt
+vRE
 sbt
-yhN
-jer
+urt
+vRE
 ooH
-mlf
-jer
+lPe
+vRE
 ooH
-yhN
-jer
+urt
+vRE
 ooH
 mDa
 bDb
@@ -110112,7 +110112,7 @@ cIb
 bsT
 box
 btP
-bUX
+wiA
 byi
 bzz
 bAE
@@ -110125,11 +110125,11 @@ bIz
 bIz
 bJN
 bMl
-fhg
-qHA
+quh
+kEL
 bPE
 bLe
-qRZ
+vET
 bTd
 bUg
 cKp
@@ -110369,7 +110369,7 @@ bqd
 biL
 box
 btS
-bUX
+wiA
 byi
 bwN
 bAG
@@ -110382,8 +110382,8 @@ bIB
 bIB
 bJN
 bMo
-fhg
-qHA
+quh
+kEL
 bPH
 bJN
 bSa
@@ -110623,9 +110623,9 @@ blM
 qpj
 cHX
 cIc
-iae
+lrg
 buj
-lEq
+mtQ
 bve
 byj
 bwM
@@ -110639,7 +110639,7 @@ bIA
 bIA
 bJN
 bMn
-fhg
+quh
 bOz
 bPG
 bJN
@@ -110880,10 +110880,10 @@ bou
 cHT
 bou
 cId
-vsF
+xpE
 bsw
 gOB
-bUX
+wiA
 byk
 bzD
 bxv
@@ -110897,7 +110897,7 @@ bIA
 bJN
 bMq
 chu
-wHB
+eVj
 bPJ
 cAc
 bEm
@@ -111139,8 +111139,8 @@ bpU
 brq
 bsW
 buj
-fHp
-bUX
+rFJ
+wiA
 byk
 bzC
 bAH
@@ -111154,7 +111154,7 @@ bGY
 bJN
 bMp
 bNp
-bPg
+dyR
 bPI
 cTY
 bEm
@@ -111397,7 +111397,7 @@ brs
 box
 box
 bvE
-bUX
+wiA
 byk
 byk
 byk
@@ -111653,20 +111653,20 @@ boM
 bzE
 bsX
 bsz
-eoW
+yal
 bEf
 aIL
-nKg
-nKg
-nKg
+iUr
+iUr
+iUr
 bDd
 bEq
 bDl
-pse
+uUN
 bFQ
 bHc
 bHK
-iQs
+sEc
 bID
 bOA
 bPK
@@ -111902,7 +111902,7 @@ dLA
 esZ
 bhB
 oMT
-odD
+gNf
 aIe
 blX
 bow
@@ -112165,26 +112165,26 @@ bvx
 boz
 bpX
 bBD
-orX
+dNK
 bsA
 bBD
 bBD
 brt
-xgE
+pcz
 bxF
 bzA
 bzZ
-jSn
-xgE
-xgE
-xgE
-grQ
+wnq
+pcz
+pcz
+pcz
+dYj
 bHL
 bBD
 bBD
-rTX
+oXI
 bPK
-kKB
+gch
 bWr
 bWr
 bWr
@@ -112946,9 +112946,9 @@ bxY
 bCh
 bvK
 bEv
-lfG
-sdo
-xJj
+pPI
+wRa
+rjG
 bJV
 bEC
 bMu
@@ -113204,8 +113204,8 @@ bCg
 bvK
 bEu
 bHv
-gle
-sBT
+uwt
+dEN
 bJU
 bEC
 bMt
@@ -113450,7 +113450,7 @@ blZ
 bnk
 bpo
 bqk
-eTg
+xgJ
 bsD
 bvK
 bxl
@@ -113703,7 +113703,7 @@ bhE
 bLI
 sKl
 blL
-dTX
+eWm
 bnh
 biU
 brx
@@ -114489,7 +114489,7 @@ chq
 fzX
 bEB
 bFW
-hfH
+lRn
 tOq
 bNy
 bLi
@@ -115006,7 +115006,7 @@ bFX
 gvR
 bGF
 bKa
-jkZ
+sBL
 bMA
 bNz
 bOI

--- a/_maps/map_files/BoxStation/BoxStation_Lumos.dmm
+++ b/_maps/map_files/BoxStation/BoxStation_Lumos.dmm
@@ -27557,6 +27557,7 @@
 /obj/effect/turf_decal/lumos/tile/blue/checker{
 	dir = 4
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/cafeteria,
 /area/medical/medbay/front_office)
 "brc" = (
@@ -28052,6 +28053,7 @@
 	dir = 4
 	},
 /obj/item/storage/firstaid/regular,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/cafeteria,
 /area/medical/medbay/front_office)
 "bsz" = (
@@ -30658,11 +30660,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner,
-/obj/machinery/door/window/eastright{
-	dir = 2;
-	name = "Chemistry Storage";
-	req_access_txt = "33"
-	},
 /turf/open/floor/plasteel,
 /area/medical/chemistry)
 "byZ" = (
@@ -30959,6 +30956,7 @@
 	req_access_txt = "5"
 	},
 /obj/effect/turf_decal/lumos/tile/blue/fulltile,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "bzL" = (
@@ -31036,9 +31034,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/airalarm{
 	dir = 1;
 	pixel_y = -22
@@ -31049,12 +31044,12 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "bzV" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
@@ -31064,19 +31059,19 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "bzW" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
@@ -32210,9 +32205,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
@@ -32221,6 +32213,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel,
 /area/medical/storage)
@@ -32247,13 +32242,13 @@
 /area/medical/storage)
 "bCG" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -32261,18 +32256,6 @@
 "bCH" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
 	},
 /obj/structure/table,
 /obj/item/storage/belt/medical{
@@ -32285,6 +32268,12 @@
 	pixel_y = 2
 	},
 /obj/item/clothing/neck/stethoscope,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
 /turf/open/floor/plasteel,
 /area/medical/storage)
 "bCJ" = (
@@ -32292,25 +32281,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/medical/storage)
-"bCK" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/obj/structure/closet/l3closet,
 /turf/open/floor/plasteel,
 /area/medical/storage)
 "bCL" = (
@@ -32361,13 +32331,13 @@
 	dir = 1;
 	pixel_y = -24
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -32399,6 +32369,7 @@
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /obj/machinery/power/apc/auto_name/north,
+/obj/structure/closet/l3closet,
 /turf/open/floor/plasteel,
 /area/medical/storage)
 "bCT" = (
@@ -32414,6 +32385,7 @@
 /obj/item/folder/white,
 /obj/item/gun/syringe,
 /obj/item/reagent_containers/dropper,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "bCU" = (
@@ -32672,6 +32644,15 @@
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/medical/storage)
@@ -33400,26 +33381,14 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bFt" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/medical/storage)
-"bFu" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 9
-	},
 /obj/structure/cable{
-	icon_state = "1-8"
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/medical/storage)
@@ -33508,13 +33477,8 @@
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "bFF" = (
-/obj/structure/closet/secure_closet/medical3,
-/obj/item/sensor_device,
-/obj/item/reagent_containers/spray/cleaner,
-/obj/item/storage/box/medipens,
-/obj/item/storage/box/gloves,
-/obj/item/reagent_containers/spray/cleaner,
 /obj/machinery/light,
+/obj/structure/closet/crate/freezer/blood,
 /turf/open/floor/plasteel,
 /area/medical/storage)
 "bFH" = (
@@ -33554,12 +33518,9 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bFK" = (
-/obj/structure/closet/secure_closet/medical3,
-/obj/item/sensor_device,
-/obj/item/reagent_containers/spray/cleaner,
-/obj/item/storage/box/medipens,
-/obj/item/storage/box/gloves,
-/obj/item/reagent_containers/spray/cleaner,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/medical/storage)
 "bFL" = (
@@ -33965,6 +33926,7 @@
 	},
 /obj/item/clothing/suit/straight_jacket,
 /obj/item/clothing/mask/muzzle,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "bGV" = (
@@ -46354,9 +46316,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
 	},
@@ -49560,7 +49519,6 @@
 	dir = 1;
 	network = list("ss13","medbay")
 	},
-/obj/structure/closet/crate/freezer/blood,
 /turf/open/floor/plasteel,
 /area/medical/storage)
 "cCq" = (
@@ -51170,14 +51128,15 @@
 /area/quartermaster/miningdock)
 "dTC" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/structure/disposalpipe/segment{
-	dir = 9
+	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "dTI" = (
@@ -52484,6 +52443,9 @@
 	dir = 1
 	},
 /obj/effect/landmark/start/paramedic,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/medical/storage)
 "gli" = (
@@ -52968,6 +52930,16 @@
 /area/ai_monitored/storage/eva)
 "gZG" = (
 /obj/machinery/holopad,
+/obj/effect/landmark/start/medical_doctor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/medical/storage)
 "gZQ" = (
@@ -52992,9 +52964,14 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
@@ -54082,6 +54059,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/medical/storage)
 "iYb" = (
@@ -54198,6 +54176,9 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "jex" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
 /turf/open/floor/plasteel,
 /area/medical/storage)
 "jez" = (
@@ -54775,6 +54756,12 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
 "jRq" = (
@@ -56529,6 +56516,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "nmw" = (
@@ -58298,6 +58286,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 1
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/front_office)
 "qsr" = (
@@ -58444,6 +58433,7 @@
 	req_access_txt = "5"
 	},
 /obj/effect/turf_decal/lumos/tile/blue/fulltile,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "qLR" = (
@@ -58813,19 +58803,16 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "rCF" = (
-/obj/effect/turf_decal/lumos/tile/blue/fulltile,
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/door/airlock/medical/glass{
-	name = "Medbay Storage";
-	req_access_txt = "5"
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/medical/storage)
 "rCT" = (
 /obj/machinery/firealarm{
@@ -59791,15 +59778,10 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "tjt" = (
-/obj/structure/closet/secure_closet/medical3,
-/obj/item/sensor_device,
-/obj/item/reagent_containers/spray/cleaner,
-/obj/item/storage/box/medipens,
-/obj/item/storage/box/gloves,
-/obj/item/reagent_containers/spray/cleaner,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
 	},
+/obj/structure/closet/crate/freezer/surplus_limbs,
 /turf/open/floor/plasteel,
 /area/medical/storage)
 "tkB" = (
@@ -60567,7 +60549,6 @@
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
 "uzZ" = (
-/obj/structure/closet/crate/freezer/surplus_limbs,
 /turf/open/floor/plasteel,
 /area/medical/storage)
 "uAH" = (
@@ -60641,6 +60622,15 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "uIO" = (
@@ -60685,7 +60675,16 @@
 /turf/closed/wall/r_wall,
 /area/ai_monitored/nuke_storage)
 "uPz" = (
-/obj/effect/landmark/start/medical_doctor,
+/obj/effect/landmark/start/paramedic,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/medical/storage)
 "uPT" = (
@@ -62114,21 +62113,17 @@
 /turf/open/floor/plasteel,
 /area/security/processing)
 "wZB" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 6
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/white,
-/area/medical/sleeper)
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/medical/storage)
 "wZI" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -62589,7 +62584,12 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
-/obj/effect/landmark/start/paramedic,
+/obj/structure/closet/secure_closet/medical3,
+/obj/item/storage/box/gloves,
+/obj/item/storage/box/medipens,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/item/sensor_device,
 /turf/open/floor/plasteel,
 /area/medical/storage)
 "xOj" = (
@@ -97942,10 +97942,10 @@ bAp
 bAp
 bAp
 oTJ
-wZB
+oTQ
+bBc
+xNE
 rCF
-bFu
-jex
 uzZ
 kpr
 caU
@@ -98202,7 +98202,7 @@ hjD
 dTC
 bBc
 xNE
-jex
+wZB
 bFK
 kpr
 caU
@@ -98458,7 +98458,7 @@ hdo
 hbs
 bCG
 bBc
-bCK
+xNE
 uPz
 bFF
 kpr

--- a/_maps/map_files/BoxStation/BoxStation_Lumos.dmm
+++ b/_maps/map_files/BoxStation/BoxStation_Lumos.dmm
@@ -15601,7 +15601,9 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/dark/side{
+	dir = 10
+	},
 /area/hallway/primary/central)
 "aKH" = (
 /obj/structure/sink{
@@ -25385,18 +25387,10 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
 "blo" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
-	},
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "1-4"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
+/obj/machinery/light/small,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
 "blp" = (
@@ -26513,11 +26507,13 @@
 /area/medical/medbay/front_office)
 "boo" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/front_office)
 "bop" = (
 /obj/structure/cable{
@@ -27066,18 +27062,18 @@
 /turf/open/floor/plasteel,
 /area/medical/medbay/front_office)
 "bpI" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
-	icon_state = "1-4"
+/obj/structure/railing/corner{
+	dir = 1
 	},
-/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/medical/medbay/front_office)
 "bpJ" = (
@@ -27096,14 +27092,25 @@
 /obj/machinery/vending/medical{
 	pixel_x = -2
 	},
-/turf/open/floor/plasteel,
-/area/medical/medbay/front_office)
-"bpL" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
+/area/medical/medbay/front_office)
+"bpL" = (
 /obj/structure/cable{
 	icon_state = "2-8"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/medical/medbay/front_office)
@@ -27546,6 +27553,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/front_office)
 "bqX" = (
@@ -27564,30 +27572,35 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/railing,
 /obj/machinery/camera{
 	c_tag = "Upper East Medical Hallway";
 	dir = 1;
 	network = list("ss13","medbay")
 	},
-/obj/structure/disposalpipe/segment{
+/turf/open/floor/plasteel/stairs/left{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/area/medical/medbay/front_office)
+"bre" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner,
 /obj/structure/railing/corner{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/medical/medbay/front_office)
-"bre" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 9
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
+	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/obj/structure/disposalpipe/segment{
-	dir = 9
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/medical/medbay/front_office)
@@ -27874,9 +27887,14 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
 "brX" = (
-/obj/machinery/holopad,
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
+/obj/structure/rack,
+/obj/item/extinguisher,
+/obj/item/stack/cable_coil/red,
+/obj/item/stack/cable_coil/red,
+/obj/item/stack/cable_coil/red,
+/obj/item/stack/cable_coil/red,
+/turf/open/floor/plating,
+/area/maintenance/department/medical/morgue)
 "brZ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -28608,14 +28626,14 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "btT" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
 /obj/structure/railing/corner{
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -28796,6 +28814,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 5
 	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics/cloning)
 "bus" = (
@@ -29205,6 +29224,9 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics/cloning)
 "bvw" = (
@@ -29556,12 +29578,15 @@
 	dir = 4;
 	pixel_x = -23
 	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 1
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bwy" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 5
 	},
@@ -29580,9 +29605,6 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/front_office)
 "bwA" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
@@ -29591,6 +29613,9 @@
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
@@ -29606,7 +29631,10 @@
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
 /obj/structure/table/glass,
-/obj/item/storage/box/syringes,
+/obj/item/storage/box/syringes{
+	pixel_x = 2;
+	pixel_y = 4
+	},
 /obj/item/clothing/glasses/science{
 	pixel_x = 2;
 	pixel_y = 4
@@ -29616,6 +29644,14 @@
 	pixel_y = 4
 	},
 /obj/item/clothing/glasses/science,
+/obj/machinery/camera{
+	c_tag = "Chemistry";
+	dir = 1;
+	network = list("ss13","medbay")
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 1
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bwD" = (
@@ -29631,19 +29667,11 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/medical/medbay/lobby)
 "bwE" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
 	},
 /obj/machinery/chem_master,
-/obj/machinery/camera{
-	c_tag = "Chemistry";
-	dir = 1;
-	network = list("ss13","medbay")
-	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bwF" = (
@@ -29898,17 +29926,15 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "bxf" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
-/obj/structure/railing/corner{
+/obj/structure/railing{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/stairs/right{
+	dir = 4
+	},
 /area/medical/medbay/front_office)
 "bxg" = (
 /obj/structure/reagent_dispensers/watertank,
@@ -30188,6 +30214,9 @@
 "bxS" = (
 /obj/machinery/sleeper{
 	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
@@ -30659,26 +30688,21 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/turf/open/floor/plasteel,
-/area/medical/chemistry)
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/sleeper)
 "byZ" = (
-/obj/structure/window/reinforced,
-/obj/machinery/requests_console{
-	department = "Medbay";
-	departmentType = 1;
-	name = "Medbay RC";
-	pixel_x = -30
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 9
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 4
-	},
-/obj/machinery/vending/wardrobe/chem_wardrobe,
-/turf/open/floor/plasteel,
-/area/medical/chemistry)
+/turf/open/floor/plasteel/white,
+/area/medical/sleeper)
 "bza" = (
 /obj/structure/chair/office/light,
 /obj/effect/landmark/start/chemist,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bzb" = (
@@ -30721,6 +30745,9 @@
 	dir = 8
 	},
 /obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -30927,17 +30954,13 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bzH" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel,
-/area/medical/storage)
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/white,
+/area/medical/sleeper)
 "bzJ" = (
 /obj/machinery/computer/mecha{
 	dir = 8
@@ -30948,15 +30971,10 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/hor)
 "bzK" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
 	},
-/obj/machinery/door/airlock/medical/glass{
-	name = "Medbay Storage";
-	req_access_txt = "5"
-	},
-/obj/effect/turf_decal/lumos/tile/blue/fulltile,
-/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "bzL" = (
@@ -31204,6 +31222,9 @@
 /obj/machinery/chem_dispenser,
 /obj/machinery/light{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 6
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
@@ -31529,17 +31550,17 @@
 /turf/open/floor/plasteel,
 /area/janitor)
 "bAW" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/lumos/tile/blue/fulltile,
+/obj/machinery/door/airlock/medical/glass{
+	name = "Medbay Storage";
+	req_access_txt = "5"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/white,
 /area/medical/storage)
 "bAZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -31742,6 +31763,9 @@
 	pixel_x = 24
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bBx" = (
@@ -32182,10 +32206,11 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/medical/medbay/lobby)
 "bCA" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bCB" = (
 /obj/effect/turf_decal/lumos/tile/blue/checker{
@@ -32199,43 +32224,33 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/medical/medbay/lobby)
 "bCE" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
+/turf/open/floor/plasteel,
+/area/medical/storage)
+"bCF" = (
+/obj/machinery/airalarm{
+	pixel_y = 32
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel,
-/area/medical/storage)
-"bCF" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
 /obj/structure/sink{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
+	pixel_x = 8;
+	pixel_y = 26
 	},
 /obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/plasteel,
@@ -32258,21 +32273,22 @@
 	dir = 1
 	},
 /obj/structure/table,
-/obj/item/storage/belt/medical{
+/obj/item/storage/box/beakers{
+	pixel_x = 2;
 	pixel_y = 2
 	},
-/obj/item/storage/belt/medical{
-	pixel_y = 2
+/obj/item/storage/box/syringes,
+/obj/item/reagent_containers/glass/bottle/epinephrine{
+	pixel_x = 7;
+	pixel_y = -3
 	},
-/obj/item/storage/belt/medical{
-	pixel_y = 2
+/obj/item/reagent_containers/glass/bottle/morphine{
+	pixel_x = 8;
+	pixel_y = -3
 	},
-/obj/item/clothing/neck/stethoscope,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
+/obj/item/reagent_containers/syringe{
+	pixel_x = 6;
+	pixel_y = -3
 	},
 /turf/open/floor/plasteel,
 /area/medical/storage)
@@ -32358,6 +32374,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bCS" = (
@@ -32389,15 +32408,13 @@
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "bCU" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
 /obj/structure/railing/corner{
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bCX" = (
@@ -32619,22 +32636,26 @@
 	dir = 6
 	},
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "2-4"
 	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/medical/storage)
 "bDB" = (
+/obj/effect/turf_decal/stripes/line,
 /obj/structure/disposalpipe/segment{
-	dir = 9
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 9
+	dir = 4
 	},
 /obj/structure/cable{
-	icon_state = "1-8"
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/medical/storage)
@@ -32653,6 +32674,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/medical/storage)
@@ -32691,6 +32715,10 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
 	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bDJ" = (
@@ -32789,6 +32817,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "bDT" = (
@@ -32825,13 +32856,18 @@
 /turf/open/floor/plasteel/white,
 /area/science/storage)
 "bDZ" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "chemsh";
-	name = "chemistry shutters"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/airlock/maintenance{
+	name = "Starboard Storage Maintenance";
+	req_access_txt = "5"
+	},
 /turf/open/floor/plating,
-/area/medical/chemistry)
+/area/maintenance/department/medical/morgue)
 "bEa" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -32865,7 +32901,6 @@
 /turf/open/floor/plasteel,
 /area/medical/cryo)
 "bEe" = (
-/obj/machinery/chem_master,
 /obj/machinery/button/door{
 	id = "chemsh";
 	name = "Chemistry Shutters";
@@ -32876,6 +32911,13 @@
 /obj/machinery/light{
 	dir = 8;
 	light_color = "#e8eaff"
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 4
+	},
+/obj/machinery/chem_dispenser,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
@@ -32914,6 +32956,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics/cloning)
@@ -33384,11 +33429,14 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 5
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 5
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/medical/storage)
@@ -33417,46 +33465,34 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/spawner/structure/window/hollow/directional,
-/turf/open/floor/plating,
-/area/maintenance/aft)
-"bFz" = (
-/obj/structure/table,
-/obj/item/storage/firstaid/toxin{
-	pixel_x = 3;
-	pixel_y = 3
+/obj/machinery/door/airlock/maintenance{
+	name = "Surgery Maintenance";
+	req_access_txt = "45"
 	},
-/obj/item/storage/firstaid/toxin,
-/obj/item/storage/firstaid/regular{
-	pixel_x = -3;
-	pixel_y = -3
+/obj/machinery/door/firedoor,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/machinery/door/window/northleft{
-	name = "First-Aid Supplies";
-	red_alert_access = 1;
-	req_access_txt = "5"
-	},
-/obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/medical/storage)
-"bFB" = (
-/obj/structure/table,
-/obj/item/storage/firstaid/o2{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/firstaid/o2,
-/obj/item/storage/firstaid/regular{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/structure/window/reinforced{
+"bFz" = (
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/structure/window/reinforced{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
+/area/medical/storage)
+"bFB" = (
+/obj/machinery/shower{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/storage)
 "bFC" = (
 /obj/structure/showcase/cyborg/old{
@@ -33477,8 +33513,22 @@
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "bFF" = (
+/obj/structure/table,
+/obj/item/storage/firstaid/fire{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/firstaid/fire,
+/obj/item/storage/firstaid/regular{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/machinery/door/window/northright{
+	name = "First-Aid Supplies";
+	red_alert_access = 1;
+	req_access_txt = "5"
+	},
 /obj/machinery/light,
-/obj/structure/closet/crate/freezer/blood,
 /turf/open/floor/plasteel,
 /area/medical/storage)
 "bFH" = (
@@ -33518,8 +33568,20 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bFK" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1
+/obj/structure/table,
+/obj/item/storage/firstaid/toxin{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/firstaid/toxin,
+/obj/item/storage/firstaid/regular{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/machinery/door/window/northleft{
+	name = "First-Aid Supplies";
+	red_alert_access = 1;
+	req_access_txt = "5"
 	},
 /turf/open/floor/plasteel,
 /area/medical/storage)
@@ -33528,14 +33590,15 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bFN" = (
 /obj/machinery/computer/operating{
 	dir = 4
-	},
-/obj/machinery/light{
-	dir = 8
 	},
 /obj/effect/turf_decal/lumos/tile/blue/fulltile,
 /turf/open/floor/plasteel/white,
@@ -33839,8 +33902,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/grille/broken,
-/obj/item/assembly/mousetrap/armed,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "bGK" = (
@@ -33917,6 +33978,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "bGR" = (
@@ -33940,11 +34004,17 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "bGX" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -34073,6 +34143,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -34308,70 +34381,41 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "bHY" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bIa" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/effect/turf_decal/trimline/green/filled/line,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
 /obj/structure/cable{
-	icon_state = "1-4"
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bIc" = (
-/obj/structure/table,
-/obj/item/storage/firstaid/brute{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/firstaid/brute,
-/obj/item/storage/firstaid/regular{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
+/obj/structure/closet/crate/freezer/surplus_limbs,
 /turf/open/floor/plasteel,
 /area/medical/storage)
 "bId" = (
-/obj/structure/table,
-/obj/item/storage/firstaid/fire{
-	pixel_x = 3;
-	pixel_y = 3
+/obj/effect/landmark/start/paramedic,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
 	},
-/obj/item/storage/firstaid/fire,
-/obj/item/storage/firstaid/regular{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/machinery/door/window/northright{
-	name = "First-Aid Supplies";
-	red_alert_access = 1;
-	req_access_txt = "5"
-	},
+/obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/medical/storage)
 "bIe" = (
@@ -34646,7 +34690,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/dark,
 /area/medical/virology)
 "bIM" = (
 /obj/structure/disposalpipe/segment,
@@ -34661,13 +34705,16 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "bIN" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 5
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
 	},
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/lumos/tile/green/checker{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
+	},
+/turf/open/floor/plasteel/cafeteria,
 /area/medical/virology)
 "bIO" = (
 /obj/machinery/computer/camera_advanced/xenobio{
@@ -34696,7 +34743,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/lumos/tile/green/checker{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel/cafeteria,
 /area/medical/virology)
 "bIS" = (
 /obj/machinery/door/airlock/research{
@@ -34877,10 +34930,16 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/lumos/tile/green/checker{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/cafeteria,
 /area/medical/virology)
 "bJt" = (
 /obj/machinery/camera{
@@ -34937,11 +34996,14 @@
 /area/hallway/primary/central)
 "bJy" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/lumos/tile/green/half{
+/obj/effect/turf_decal/lumos/tile/green/checker{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/cafeteria,
 /area/medical/virology)
 "bJz" = (
 /obj/structure/disposalpipe/segment,
@@ -34958,12 +35020,14 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bJA" = (
-/obj/effect/landmark/blobstart,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
@@ -34977,14 +35041,24 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 10
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
+/obj/effect/turf_decal/lumos/tile/green/checker{
+	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/vending/wardrobe/viro_wardrobe,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
 /area/medical/virology)
 "bJD" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/lumos/tile/green/checker{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/cafeteria,
 /area/medical/virology)
 "bJF" = (
 /obj/machinery/pipedispenser/disposal/transit_tube,
@@ -35340,11 +35414,14 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/aft)
 "bKz" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/lumos/tile/green/checker{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/cafeteria,
 /area/medical/virology)
 "bKA" = (
 /obj/structure/chair/sofa/right,
@@ -35357,10 +35434,13 @@
 /turf/open/floor/plating,
 /area/construction)
 "bKB" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1
+/obj/machinery/door/window/northleft{
+	name = "Virology Desk";
+	req_access_txt = "39"
 	},
-/turf/open/floor/plasteel/white,
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel/dark,
 /area/medical/virology)
 "bKC" = (
 /obj/effect/spawner/structure/window,
@@ -35445,9 +35525,9 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "bKM" = (
-/obj/structure/bed,
-/obj/item/bedsheet/medical,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bKN" = (
@@ -35469,6 +35549,19 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bKP" = (
@@ -35488,21 +35581,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "bKQ" = (
-/obj/structure/table/glass{
-	layer = 3
-	},
-/obj/item/storage/box/beakers{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/storage/box/beakers{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/dropper,
-/obj/item/reagent_containers/dropper,
+/obj/machinery/vending/wardrobe/chem_wardrobe,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bKR" = (
@@ -35510,11 +35589,13 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "bKS" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 8
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 4
+/obj/structure/chair{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/surgery)
@@ -35642,7 +35723,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/dark,
 /area/medical/virology)
 "bLe" = (
 /obj/structure/sign/warning/biohazard,
@@ -35655,7 +35736,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/dark,
 /area/medical/virology)
 "bLg" = (
 /obj/structure/disposalpipe/segment{
@@ -35926,6 +36007,9 @@
 	dir = 1
 	},
 /obj/effect/landmark/start/chemist,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bLY" = (
@@ -35942,49 +36026,31 @@
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
 "bMc" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Surgery Observation"
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/lumos/tile/blue/fulltile,
 /turf/open/floor/plasteel/white,
-/area/medical/surgery)
+/area/medical/medbay/front_office)
 "bMd" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/light,
 /obj/machinery/airalarm{
 	dir = 1;
 	pixel_y = -22
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/structure/chair{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/medical/surgery)
 "bMe" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "bMf" = (
@@ -36206,23 +36272,33 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bMH" = (
-/obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
+/obj/effect/turf_decal/lumos/tile/green/checker{
+	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/obj/item/kirbyplants{
+	icon_state = "plant-21"
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/cafeteria,
 /area/medical/virology)
 "bMI" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+/obj/effect/turf_decal/lumos/tile/green/checker{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/cafeteria,
 /area/medical/virology)
 "bMJ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
+/obj/effect/turf_decal/lumos/tile/green/checker{
+	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/cafeteria,
 /area/medical/virology)
 "bMK" = (
 /turf/closed/wall,
@@ -36361,25 +36437,32 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "bNh" = (
-/obj/machinery/computer/pandemic,
-/obj/effect/turf_decal/lumos/tile/green/half{
-	dir = 4
+/obj/machinery/door/airlock/virology{
+	name = "Virology Desk";
+	req_access_txt = "39"
 	},
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/lumos/tile/green/fulltile,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
 /area/medical/virology)
 "bNi" = (
-/obj/structure/chair/stool,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+/obj/machinery/chem_master,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
-/area/medical/virology)
+/area/medical/chemistry)
 "bNj" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/virology/glass{
 	name = "Isolation A";
 	req_access_txt = "39"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bNk" = (
@@ -36456,11 +36539,9 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "bNs" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
+/obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/plasteel/white,
-/area/medical/virology)
+/area/medical/sleeper)
 "bNt" = (
 /turf/open/floor/engine/vacuum,
 /area/science/mixing)
@@ -36661,12 +36742,14 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bNU" = (
-/obj/effect/spawner/structure/window,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+/obj/machinery/sleeper{
 	dir = 8
 	},
-/turf/open/floor/plating,
-/area/medical/virology)
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/sleeper)
 "bNV" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
@@ -36760,12 +36843,14 @@
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "bOm" = (
-/obj/structure/bed,
-/obj/item/bedsheet/medical,
 /obj/structure/sign/warning/nosmoking{
 	pixel_y = 32
 	},
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/lumos/tile/green/checker{
+	dir = 4
+	},
+/obj/structure/closet/l3closet/virology,
+/turf/open/floor/plasteel/cafeteria,
 /area/medical/virology)
 "bOo" = (
 /obj/item/radio/intercom{
@@ -36785,17 +36870,27 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/dark,
 /area/medical/virology)
 "bOq" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/dark,
 /area/medical/virology)
 "bOr" = (
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/lumos/tile/green/checker{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/machinery/reagentgrinder{
+	pixel_x = -5;
+	pixel_y = 7
+	},
+/obj/item/stack/sheet/mineral/plasma,
+/obj/item/stack/sheet/mineral/plasma,
+/turf/open/floor/plasteel/cafeteria,
 /area/medical/virology)
 "bOs" = (
 /obj/machinery/light/small{
@@ -37007,20 +37102,9 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
 "bOP" = (
-/obj/structure/table/glass,
-/obj/structure/reagent_dispensers/virusfood{
-	pixel_x = -30
-	},
-/obj/item/book/manual/wiki/infections{
-	pixel_y = 7
-	},
-/obj/item/reagent_containers/syringe/antiviral,
-/obj/item/reagent_containers/dropper,
-/obj/item/reagent_containers/spray/cleaner,
-/obj/effect/turf_decal/lumos/tile/green/half{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/lumos/tile/green/fulltile,
+/obj/machinery/computer/pandemic,
+/turf/open/floor/plasteel/dark,
 /area/medical/virology)
 "bOQ" = (
 /obj/structure/disposalpipe/segment{
@@ -37171,7 +37255,10 @@
 	pixel_x = -3;
 	pixel_y = 6
 	},
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/lumos/tile/green/checker{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
 /area/medical/virology)
 "bPp" = (
 /obj/machinery/light/small{
@@ -37190,7 +37277,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/lumos/shower,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/dark,
 /area/medical/virology)
 "bPr" = (
 /obj/machinery/airalarm{
@@ -37204,7 +37291,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/dark,
 /area/medical/virology)
 "bPs" = (
 /obj/structure/cable{
@@ -37680,31 +37767,38 @@
 /area/engine/atmos)
 "bQD" = (
 /obj/structure/chair/stool,
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/lumos/tile/green/checker{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
 /area/medical/virology)
 "bQE" = (
-/obj/structure/table,
-/obj/item/storage/box/donkpockets{
-	pixel_x = 3;
-	pixel_y = 3
-	},
 /obj/machinery/newscaster{
 	pixel_x = -30
 	},
-/obj/item/stack/sheet/mineral/plasma,
-/obj/item/stack/sheet/mineral/plasma,
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/lumos/tile/green/checker{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
 /area/medical/virology)
 "bQF" = (
-/obj/machinery/iv_drip,
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/lumos/tile/green/checker{
+	dir = 4
+	},
+/obj/structure/bed,
+/obj/item/bedsheet/medical,
+/obj/item/storage/secure/safe{
+	pixel_x = 33;
+	pixel_y = 3
+	},
+/turf/open/floor/plasteel/cafeteria,
 /area/medical/virology)
 "bQH" = (
 /obj/structure/closet/l3closet,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/dark,
 /area/medical/virology)
 "bQJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -37713,8 +37807,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 6
 	},
-/obj/effect/turf_decal/lumos/tile/green/fulltile,
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/trimline/green/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/green/filled/corner,
+/turf/open/floor/plasteel/dark,
 /area/medical/virology)
 "bQK" = (
 /obj/machinery/door/airlock/command/glass{
@@ -38085,12 +38182,13 @@
 /turf/open/floor/engine/vacuum,
 /area/engine/atmos)
 "bRM" = (
-/obj/structure/table,
 /obj/machinery/light_switch{
 	pixel_x = -23
 	},
-/obj/machinery/reagentgrinder,
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/lumos/tile/green/checker{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
 /area/medical/virology)
 "bRN" = (
 /turf/closed/wall,
@@ -38100,9 +38198,12 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/lumos/tile/green/checker{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/turf/open/floor/plasteel/cafeteria,
 /area/medical/virology)
 "bRP" = (
 /obj/structure/cable{
@@ -38122,7 +38223,10 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/lumos/tile/green/checker{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
 /area/medical/virology)
 "bRQ" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -38136,8 +38240,13 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/lumos/tile/green/fulltile,
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/medical/virology)
 "bRS" = (
 /obj/structure/chair/office/dark,
@@ -38418,10 +38527,16 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bSQ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/lumos/tile/green/checker{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/cafeteria,
 /area/medical/virology)
 "bSS" = (
 /obj/machinery/door/firedoor,
@@ -38435,7 +38550,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/lumos/tile/green/checker{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
 /area/medical/virology)
 "bST" = (
 /obj/machinery/doorButtons/airlock_controller{
@@ -38454,10 +38572,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/lumos/tile/green/checker{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
 /area/medical/virology)
 "bSU" = (
 /obj/structure/extinguisher_cabinet{
@@ -38470,40 +38591,41 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/lumos/tile/green/checker{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
 /area/medical/virology)
 "bSV" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/firealarm{
 	pixel_y = 25
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/obj/effect/turf_decal/lumos/tile/green/checker{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/cafeteria,
 /area/medical/virology)
 "bSW" = (
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/effect/turf_decal/lumos/tile/green/checker{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/cafeteria,
 /area/medical/virology)
 "bSX" = (
-/obj/machinery/power/apc/highcap/five_k{
-	areastring = "/area/medical/virology";
-	dir = 1;
-	name = "Virology APC";
-	pixel_y = 24
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
 /obj/machinery/camera{
 	c_tag = "Virology Module";
 	network = list("ss13","medbay")
@@ -38511,11 +38633,28 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/lumos/tile/green/checker{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/obj/machinery/holopad,
+/obj/structure/sign/poster/contraband/buzzfuzz{
+	pixel_x = 3;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel/cafeteria,
 /area/medical/virology)
 "bSY" = (
 /obj/machinery/vending/medical,
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/lumos/tile/green/checker{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/turf/open/floor/plasteel/cafeteria,
 /area/medical/virology)
 "bTa" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -38783,12 +38922,28 @@
 	dir = 4;
 	pixel_x = -22
 	},
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
+/obj/structure/table/glass,
+/obj/item/healthanalyzer{
+	pixel_x = 7;
+	pixel_y = -1
 	},
-/turf/open/floor/plasteel/white,
+/obj/item/clothing/glasses/hud/health{
+	pixel_x = 7;
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_x = -8;
+	pixel_y = 6
+	},
+/obj/item/radio/headset/headset_med{
+	pixel_x = -8;
+	pixel_y = -2
+	},
+/obj/effect/turf_decal/lumos/tile/green/checker{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel/cafeteria,
 /area/medical/virology)
 "bUc" = (
 /obj/machinery/requests_console{
@@ -39151,12 +39306,11 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "bVa" = (
-/obj/machinery/smartfridge/chemistry/virology/preloaded,
-/obj/effect/turf_decal/lumos/tile/green/half{
-	dir = 8
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
-/area/medical/virology)
+/area/medical/sleeper)
 "bVb" = (
 /obj/machinery/light_switch{
 	pixel_x = 27
@@ -39493,31 +39647,40 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "bWf" = (
-/obj/structure/table/glass,
-/obj/item/clothing/gloves/color/latex,
 /obj/machinery/requests_console{
 	department = "Virology";
 	name = "Virology Requests Console";
 	pixel_x = -32
 	},
-/obj/item/healthanalyzer,
-/obj/item/clothing/glasses/hud/health,
-/obj/effect/turf_decal/lumos/tile/green/half{
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 9
+	},
+/obj/structure/table/glass,
+/obj/item/storage/box/beakers{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/storage/box/syringes,
+/obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/dark,
 /area/medical/virology)
 "bWg" = (
-/obj/structure/table,
-/obj/item/hand_labeler,
-/obj/item/radio/headset/headset_med,
-/obj/effect/turf_decal/lumos/tile/green/half{
-	dir = 4
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 5
 	},
-/turf/open/floor/plasteel/white,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
 /area/medical/virology)
 "bWi" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/medical/virology)
@@ -39846,53 +40009,45 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "bWX" = (
-/obj/structure/table/glass,
-/obj/item/radio/intercom{
-	pixel_x = -25
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 10
 	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/item/storage/box/beakers{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/storage/box/syringes,
-/obj/effect/turf_decal/lumos/tile/green/half{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/obj/machinery/smartfridge/chemistry/virology/preloaded,
+/turf/open/floor/plasteel/dark,
 /area/medical/virology)
 "bWY" = (
-/obj/structure/table,
-/obj/item/paper_bin{
-	pixel_x = -2;
-	pixel_y = 5
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 6
 	},
-/obj/item/pen/red,
-/obj/effect/turf_decal/lumos/tile/green/half{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
 	},
-/turf/open/floor/plasteel/white,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
 /area/medical/virology)
 "bWZ" = (
-/obj/structure/chair/office/light{
+/obj/effect/turf_decal/trimline/green/filled/corner,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/landmark/start/virologist,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/dark,
 /area/medical/virology)
 "bXc" = (
-/obj/structure/table,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1
-	},
+/obj/structure/bed,
+/obj/item/bedsheet/medical,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bXd" = (
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/item/bedsheet/medical,
+/obj/structure/bed,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bXe" = (
@@ -40353,23 +40508,32 @@
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bYc" = (
-/obj/machinery/disposal/bin,
 /obj/structure/sign/warning/deathsposal{
 	pixel_y = -32
 	},
-/obj/structure/disposalpipe/trunk{
-	dir = 8
+/obj/effect/turf_decal/lumos/tile/green/fulltile,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1
 	},
-/obj/effect/turf_decal/lumos/tile/green/half{
-	dir = 4
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
 	},
-/turf/open/floor/plasteel/white,
+/obj/machinery/power/apc/highcap/five_k{
+	areastring = "/area/medical/virology";
+	dir = 4;
+	name = "Virology APC";
+	pixel_x = 26
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel/dark,
 /area/medical/virology)
 "bYd" = (
-/obj/structure/disposalpipe/segment{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 6
 	},
-/turf/open/floor/plasteel/white,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/dark,
 /area/medical/virology)
 "bYe" = (
 /obj/structure/closet/secure_closet/personal/patient,
@@ -40673,20 +40837,38 @@
 /turf/open/floor/engine/plasma,
 /area/engine/atmos)
 "bYX" = (
-/obj/structure/closet/l3closet/virology,
-/obj/effect/turf_decal/lumos/tile/green/half,
-/turf/open/floor/plasteel/white,
+/obj/structure/table,
+/obj/effect/turf_decal/lumos/tile/green/fulltile,
+/obj/item/clothing/gloves/color/latex,
+/obj/machinery/light/small,
+/obj/structure/reagent_dispensers/virusfood{
+	pixel_x = -30
+	},
+/obj/item/radio/intercom{
+	pixel_y = -28
+	},
+/turf/open/floor/plasteel/dark,
 /area/medical/virology)
 "bYY" = (
-/obj/structure/closet/secure_closet/medical1,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/lumos/tile/green/half,
-/turf/open/floor/plasteel/white,
+/obj/structure/table,
+/obj/effect/turf_decal/lumos/tile/green/fulltile,
+/obj/item/paper_bin{
+	pixel_x = -2;
+	pixel_y = 5
+	},
+/obj/item/pen/red,
+/turf/open/floor/plasteel/dark,
 /area/medical/virology)
 "bYZ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/closed/wall/r_wall,
-/area/medical/virology)
+/obj/machinery/sleeper{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/sleeper)
 "bZa" = (
 /obj/structure/table/glass,
 /obj/machinery/camera{
@@ -40991,33 +41173,34 @@
 /turf/closed/wall/r_wall,
 /area/medical/virology)
 "bZQ" = (
-/obj/machinery/atmospherics/components/binary/valve/on{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
-"bZR" = (
-/obj/machinery/airalarm{
-	pixel_y = 23
-	},
-/obj/item/wrench,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/obj/item/wrench,
+/obj/machinery/airalarm{
+	pixel_y = 23
+	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"bZS" = (
-/obj/machinery/atmospherics/components/unary/tank/air{
+"bZR" = (
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel/white,
+/area/medical/sleeper)
+"bZS" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 5
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/binary/valve/on{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 1;
+	light_color = "#ffc1c1"
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
@@ -41027,13 +41210,17 @@
 	dir = 1
 	},
 /obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/aft)
-"bZU" = (
-/obj/structure/closet/emcloset,
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"bZU" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/medical/sleeper)
 "bZV" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -41351,52 +41538,45 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "caP" = (
-/obj/machinery/atmospherics/components/binary/valve{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating,
-/area/maintenance/aft)
-"caQ" = (
-/obj/structure/chair/stool{
-	pixel_y = 8
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
+	},
+/obj/structure/chair/stool{
+	pixel_y = 8
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"caR" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
+"caQ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 10
 	},
-/obj/machinery/portable_atmospherics/canister/air,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"caR" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/components/binary/valve{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "caS" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
+/obj/machinery/door/airlock/medical/glass{
+	id_tag = "MedbayFoyer";
+	name = "Medbay";
+	req_access_txt = "5"
 	},
-/obj/structure/cable{
-	icon_state = "2-4"
+/obj/effect/turf_decal/lumos/tile/blue/fulltile,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
+/turf/open/floor/plasteel/white,
+/area/medical/sleeper)
 "caT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -41779,12 +41959,17 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "cbO" = (
-/obj/machinery/door/airlock/atmos/abandoned{
-	name = "Atmospherics Maintenance";
-	req_access_txt = "12;24"
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 1
 	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/sleeper)
 "cbP" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -42195,16 +42380,15 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "ccN" = (
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 9
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "ccO" = (
@@ -45739,13 +45923,19 @@
 /turf/closed/wall,
 /area/maintenance/aft)
 "cnE" = (
-/obj/structure/sign/poster/contraband/hacking_guide{
-	pixel_y = 32
+/obj/structure/sign/poster/contraband/busty_backdoor_xeno_babes_6{
+	pixel_y = 30
 	},
-/obj/effect/spawner/structure/window/hollow/directional{
+/obj/effect/decal/cleanable/semen,
+/obj/structure/window{
 	dir = 8
 	},
-/turf/open/floor/plating,
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
 /area/maintenance/aft)
 "cnF" = (
 /obj/machinery/atmospherics/components/binary/pump/on/layer3{
@@ -46310,35 +46500,27 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 1
-	},
-/obj/machinery/airalarm{
-	pixel_y = 23
+/obj/machinery/requests_console{
+	department = "Medbay";
+	departmentType = 1;
+	name = "Medbay RC";
+	pixel_x = -1;
+	pixel_y = 27
 	},
 /obj/structure/table,
-/obj/item/storage/box/beakers{
-	pixel_x = 2;
+/obj/item/storage/belt/medical{
 	pixel_y = 2
 	},
-/obj/item/storage/box/syringes,
-/obj/item/reagent_containers/glass/bottle/morphine{
-	pixel_x = 8;
-	pixel_y = -3
+/obj/item/storage/belt/medical{
+	pixel_y = 2
 	},
-/obj/item/reagent_containers/glass/bottle/epinephrine{
-	pixel_x = 7;
-	pixel_y = -3
+/obj/item/storage/belt/medical{
+	pixel_y = 2
 	},
-/obj/item/reagent_containers/syringe{
-	pixel_x = 6;
-	pixel_y = -3
+/obj/item/clothing/neck/stethoscope,
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#cee5d2"
 	},
 /turf/open/floor/plasteel,
 /area/medical/storage)
@@ -48874,11 +49056,20 @@
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "cAg" = (
-/obj/structure/sign/poster/contraband/lusty_xenomorph{
-	pixel_x = 32
+/obj/effect/turf_decal/delivery,
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
+/obj/machinery/door/window/eastleft{
+	dir = 2;
+	name = "Medical Delivery";
+	req_access_txt = "5"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/medical/storage)
 "cAh" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -49203,6 +49394,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "cBn" = (
@@ -49519,6 +49713,7 @@
 	dir = 1;
 	network = list("ss13","medbay")
 	},
+/obj/structure/closet/crate/freezer/blood,
 /turf/open/floor/plasteel,
 /area/medical/storage)
 "cCq" = (
@@ -50685,7 +50880,6 @@
 /obj/machinery/shower{
 	dir = 4
 	},
-/obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/lumos/shower,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
@@ -50844,6 +51038,9 @@
 /obj/structure/railing/corner{
 	dir = 1
 	},
+/obj/structure/sign/poster/contraband/earthhh{
+	pixel_y = 32
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "dqb" = (
@@ -50963,6 +51160,9 @@
 "dAc" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
 /turf/open/floor/grass,
 /area/medical/virology)
 "dBm" = (
@@ -51151,11 +51351,13 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/crew_quarters/toilet)
 "dVk" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 10
+	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/effect/turf_decal/lumos/tile/green/fulltile,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/dark,
 /area/medical/virology)
 "dWM" = (
 /obj/structure/table,
@@ -51342,6 +51544,7 @@
 /obj/machinery/computer/med_data{
 	dir = 8
 	},
+/obj/effect/turf_decal/lumos/tile/blue/fulltile,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "ejm" = (
@@ -51371,7 +51574,20 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
 "elf" = (
-/obj/structure/closet/wardrobe/chemistry_white,
+/obj/structure/table/glass,
+/obj/item/grenade/chem_grenade,
+/obj/item/grenade/chem_grenade,
+/obj/item/grenade/chem_grenade,
+/obj/item/grenade/chem_grenade,
+/obj/item/stack/cable_coil/random,
+/obj/item/stack/cable_coil/random,
+/obj/item/screwdriver{
+	pixel_x = -2;
+	pixel_y = 6
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "elh" = (
@@ -51385,6 +51601,15 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
+	},
 /turf/open/floor/plasteel,
 /area/medical/medbay/front_office)
 "emL" = (
@@ -51514,6 +51739,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"eCY" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
+	},
+/obj/structure/chair/stool{
+	pixel_y = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/medical/virology)
 "eDf" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -51742,6 +51976,10 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
+"feB" = (
+/obj/structure/table,
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "feE" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -52018,6 +52256,29 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/crew_quarters/abandoned_gambling_den)
+"fCm" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
+	},
+/obj/structure/table/glass,
+/obj/item/book/manual/wiki/infections{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/dropper{
+	pixel_x = -3;
+	pixel_y = -2
+	},
+/obj/item/hand_labeler{
+	pixel_x = -6;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/syringe/antiviral{
+	pixel_x = -5;
+	pixel_y = -3
+	},
+/turf/open/floor/plasteel/dark,
+/area/medical/virology)
 "fCx" = (
 /obj/machinery/button/door{
 	id = "holoprivacy";
@@ -52210,6 +52471,9 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 9
 	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics/cloning)
 "fYb" = (
@@ -52363,6 +52627,9 @@
 /mob/living/simple_animal/bot/cleanbot{
 	name = "Dr. Blow-His-Load"
 	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "gib" = (
@@ -52439,12 +52706,17 @@
 /turf/open/floor/engine,
 /area/science/storage)
 "gkD" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 1
-	},
-/obj/effect/landmark/start/paramedic,
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/medical/storage)
@@ -52499,9 +52771,13 @@
 /area/ai_monitored/nuke_storage)
 "grS" = (
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "2-8"
 	},
-/turf/open/floor/plating,
+/obj/effect/landmark/blobstart,
+/turf/open/floor/plating{
+	initial_gas_mix = "o2=0.01;n2=0.01";
+	luminosity = 2
+	},
 /area/maintenance/aft)
 "guI" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -52725,6 +53001,14 @@
 	},
 /turf/open/floor/plating,
 /area/space/nearstation)
+"gIV" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/snacks/grown/strawberry{
+	pixel_x = -5;
+	pixel_y = 10
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "gJi" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
@@ -52783,6 +53067,15 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
+"gMZ" = (
+/obj/effect/turf_decal/trimline/green/filled/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/medical/virology)
 "gNC" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -52931,14 +53224,17 @@
 "gZG" = (
 /obj/machinery/holopad,
 /obj/effect/landmark/start/medical_doctor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/medical/storage)
@@ -52988,6 +53284,10 @@
 /area/library)
 "haO" = (
 /obj/structure/flora/ausbushes/brflowers,
+/obj/structure/window/reinforced{
+	dir = 4;
+	layer = 2.9
+	},
 /turf/open/floor/grass,
 /area/medical/virology)
 "hbh" = (
@@ -53343,14 +53643,14 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "hzu" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
 /obj/machinery/vending/wardrobe/medi_wardrobe,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/sign/poster/contraband/docta{
+	pixel_x = 5;
+	pixel_y = 32
+	},
 /turf/open/floor/plasteel,
 /area/medical/storage)
 "hzK" = (
@@ -53366,9 +53666,13 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "hCI" = (
-/obj/effect/spawner/structure/window/hollow/directional{
-	dir = 10
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/window,
+/obj/structure/window{
+	dir = 8
 	},
+/obj/structure/grille/broken,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "hCJ" = (
@@ -53400,9 +53704,26 @@
 /area/hallway/primary/central)
 "hFP" = (
 /obj/structure/table/glass,
-/obj/item/stack/sheet/mineral/plasma,
-/obj/item/stack/sheet/mineral/plasma,
-/obj/item/reagent_containers/glass/bottle/epinephrine,
+/obj/item/stack/sheet/mineral/plasma{
+	pixel_x = 5;
+	pixel_y = 4
+	},
+/obj/item/stack/sheet/mineral/plasma{
+	pixel_x = 5;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/glass/bottle/epinephrine{
+	pixel_x = 10;
+	pixel_y = -1
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 23
+	},
+/obj/machinery/reagentgrinder{
+	pixel_x = -8;
+	pixel_y = 6
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "hGH" = (
@@ -53436,7 +53757,6 @@
 /area/quartermaster/storage)
 "hIZ" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
@@ -53446,7 +53766,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/front_office)
 "hKk" = (
 /obj/structure/table,
@@ -53696,18 +54019,25 @@
 /turf/open/floor/plating,
 /area/security/processing)
 "ism" = (
-/obj/structure/sign/poster/contraband/busty_backdoor_xeno_babes_6{
-	pixel_y = 30
+/obj/item/reagent_containers/rag{
+	pixel_x = -4;
+	pixel_y = 8
 	},
-/obj/structure/chair{
-	dir = 1
+/obj/structure/table,
+/obj/structure/sign/poster/contraband/lusty_xenomorph{
+	pixel_x = 32
 	},
-/obj/effect/decal/cleanable/semen,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "iso" = (
 /obj/structure/grille/broken,
-/turf/open/floor/plating,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/item/assembly/mousetrap/armed,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
 /area/maintenance/aft)
 "itK" = (
 /obj/structure/table,
@@ -53727,11 +54057,14 @@
 /turf/open/floor/plating,
 /area/security/range)
 "ium" = (
-/obj/structure/window,
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/aft)
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "iuv" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
@@ -53829,10 +54162,20 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "iCM" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
+	},
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -54043,10 +54386,6 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "iWI" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Surgery Maintenance";
-	req_access_txt = "45"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -54059,8 +54398,8 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel,
 /area/medical/storage)
 "iYb" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -54176,8 +54515,23 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "jex" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
+	},
 /obj/structure/cable{
-	icon_state = "1-4"
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel,
 /area/medical/storage)
@@ -54421,11 +54775,22 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "jyt" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
+/obj/machinery/door/airlock/medical/glass{
+	name = "Surgery Observation"
 	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/lumos/tile/blue/fulltile,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/medical/surgery)
 "jAg" = (
 /turf/open/floor/engine,
 /area/science/mixing)
@@ -54762,6 +55127,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
 "jRq" = (
@@ -54776,11 +55144,11 @@
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "jSb" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 9
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
@@ -54870,6 +55238,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"jWP" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "jYH" = (
 /obj/machinery/vending/cola/space_up,
 /turf/open/floor/plasteel/dark,
@@ -54967,11 +55348,21 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "kep" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
+/obj/structure/plasticflaps/opaque,
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=4";
+	dir = 4;
+	freq = 1400;
+	location = "Medbay"
 	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
+/obj/effect/turf_decal/bot,
+/obj/machinery/door/poddoor/preopen{
+	id = "cmoofficesh1";
+	name = "biohazard containment door"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/medical/storage)
 "ker" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -55046,6 +55437,9 @@
 	icon_state = "0-8"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "kkH" = (
@@ -55121,6 +55515,14 @@
 "ksE" = (
 /turf/closed/mineral/random/labormineral,
 /area/space/nearstation)
+"ksS" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 10
+	},
+/obj/effect/landmark/start/virologist,
+/obj/structure/chair/office/light,
+/turf/open/floor/plasteel/dark,
+/area/medical/virology)
 "ktA" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/backpack/duffelbag/med/surgery,
@@ -55278,6 +55680,12 @@
 /obj/effect/turf_decal/lumos/tile/red/checker,
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
+"kEG" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "kEY" = (
 /obj/effect/landmark/stationroom/box/engine,
 /turf/open/space/basic,
@@ -55417,15 +55825,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"kTs" = (
-/obj/structure/chair{
-	dir = 1
+"kTU" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/medical/surgery)
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "kUA" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -55447,7 +55852,10 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "kXT" = (
-/obj/machinery/chem_dispenser,
+/obj/structure/closet/wardrobe/chemistry_white,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "kYk" = (
@@ -55477,8 +55885,14 @@
 /obj/structure/chair{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/surgery)
@@ -55615,9 +56029,8 @@
 /obj/machinery/shower{
 	dir = 4
 	},
-/obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/lumos/shower,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
 "luQ" = (
 /obj/structure/lattice,
@@ -55760,6 +56173,15 @@
 "lOi" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/starboard/aft)
+"lOk" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/machinery/atmospherics/components/unary/tank/air{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "lOY" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-10"
@@ -56119,9 +56541,6 @@
 	dir = 8;
 	network = list("ss13","medbay")
 	},
-/obj/machinery/light{
-	dir = 4
-	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "mEb" = (
@@ -56186,16 +56605,14 @@
 /turf/open/floor/plasteel,
 /area/medical/cryo)
 "mLy" = (
-/obj/machinery/door/window/eastleft{
-	name = "Medical Delivery";
-	req_access_txt = "5"
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
 	},
-/obj/effect/turf_decal/delivery,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/item/kirbyplants{
+	icon_state = "plant-22"
 	},
-/turf/open/floor/plasteel,
-/area/medical/medbay/front_office)
+/turf/open/floor/plasteel/white,
+/area/medical/sleeper)
 "mNi" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -56332,18 +56749,17 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "mXe" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Medbay Maintenance";
-	req_access_txt = "5"
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/maintenance/department/medical/morgue)
+/turf/open/floor/plasteel/dark,
+/area/medical/surgery)
 "mXw" = (
 /obj/structure/table/wood,
 /obj/machinery/airalarm{
@@ -56378,10 +56794,7 @@
 /turf/open/floor/plasteel,
 /area/medical/cryo)
 "nac" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
+/obj/machinery/holopad,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "nat" = (
@@ -56627,8 +57040,11 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "nAh" = (
-/obj/machinery/vending/wardrobe/viro_wardrobe,
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/lumos/tile/green/checker{
+	dir = 4
+	},
+/obj/machinery/iv_drip,
+/turf/open/floor/plasteel/cafeteria,
 /area/medical/virology)
 "nBb" = (
 /obj/structure/cable{
@@ -56805,13 +57221,21 @@
 /turf/open/floor/plating,
 /area/science/explab)
 "nMS" = (
-/obj/item/reagent_containers/rag{
-	pixel_x = -4;
-	pixel_y = 8
+/obj/machinery/door/airlock/maintenance{
+	name = "Medbay Maintenance";
+	req_access_txt = "5"
 	},
-/obj/structure/table,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plating,
-/area/maintenance/aft)
+/area/medical/surgery)
 "nNF" = (
 /obj/structure/chair/comfy/black,
 /turf/open/floor/plating{
@@ -56826,7 +57250,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/dark,
 /area/medical/virology)
 "nQi" = (
 /obj/effect/turf_decal/stripes/line{
@@ -57253,14 +57677,21 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/pool)
 "ozX" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 4
 	},
-/turf/open/floor/plasteel/white,
-/area/medical/sleeper)
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "oAw" = (
 /obj/structure/window{
 	dir = 1
@@ -57373,10 +57804,19 @@
 	dir = 4
 	},
 /obj/structure/table/glass,
-/obj/machinery/reagentgrinder{
-	pixel_x = -5;
-	pixel_y = 9
+/obj/item/storage/box/beakers{
+	pixel_x = 2;
+	pixel_y = 2
 	},
+/obj/item/storage/box/beakers{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/dropper,
+/obj/item/reagent_containers/dropper,
+/obj/effect/turf_decal/trimline/yellow/filled/corner,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "oKh" = (
@@ -57692,7 +58132,18 @@
 	pixel_x = 5;
 	pixel_y = 29
 	},
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/lumos/tile/green/checker{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/item/storage/box/donkpockets{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/turf/open/floor/plasteel/cafeteria,
 /area/medical/virology)
 "pqe" = (
 /obj/structure/chair/sofa,
@@ -57786,11 +58237,13 @@
 /turf/closed/wall,
 /area/security/checkpoint/auxiliary)
 "pvS" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 6
+	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
 	},
-/obj/effect/turf_decal/lumos/tile/green/fulltile,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/dark,
 /area/medical/virology)
 "pvX" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -57863,21 +58316,12 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
 "pHl" = (
-/obj/structure/table/glass,
-/obj/item/grenade/chem_grenade,
-/obj/item/grenade/chem_grenade,
-/obj/item/grenade/chem_grenade,
-/obj/item/grenade/chem_grenade,
-/obj/item/screwdriver{
-	pixel_x = -2;
-	pixel_y = 6
-	},
-/obj/item/stack/cable_coil/random,
-/obj/item/stack/cable_coil/random,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 25
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "pHO" = (
@@ -58314,6 +58758,16 @@
 "qxq" = (
 /turf/closed/wall,
 /area/security/range)
+"qxG" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "qyb" = (
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating,
@@ -58435,7 +58889,7 @@
 /obj/effect/turf_decal/lumos/tile/blue/fulltile,
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/white,
-/area/medical/sleeper)
+/area/medical/medbay/front_office)
 "qLR" = (
 /obj/structure/mirror{
 	pixel_y = 32
@@ -58554,6 +59008,9 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics/cloning)
 "qZF" = (
@@ -58577,20 +59034,10 @@
 /turf/open/floor/plasteel/dark,
 /area/hydroponics)
 "rdR" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/chair{
+	dir = 1
 	},
-/obj/machinery/door/airlock/maintenance{
-	name = "Medbay Maintenance";
-	req_access_txt = "5"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/dark,
 /area/medical/surgery)
 "ret" = (
 /obj/effect/turf_decal/lumos/tile/red/checker,
@@ -59049,23 +59496,12 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "sak" = (
-/obj/effect/turf_decal/bot,
-/obj/machinery/door/poddoor/preopen{
-	id = "cmoofficesh1";
-	name = "biohazard containment door"
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1
 	},
-/obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=4";
-	dir = 4;
-	freq = 1400;
-	location = "Medbay"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/plasticflaps/opaque,
-/turf/open/floor/plasteel,
-/area/medical/medbay/front_office)
+/obj/machinery/light,
+/turf/open/floor/plasteel/dark,
+/area/medical/surgery)
 "sax" = (
 /obj/machinery/requests_console{
 	department = "Theatre";
@@ -59297,6 +59733,9 @@
 	},
 /turf/open/floor/plating,
 /area/blueshield)
+"ssW" = (
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "ssX" = (
 /obj/machinery/button/door{
 	id = "xenobio1";
@@ -59612,7 +60051,10 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/obj/structure/disposalpipe/junction/yjunction{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -59778,10 +60220,22 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "tjt" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/structure/table,
+/obj/item/storage/firstaid/brute{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/firstaid/brute,
+/obj/item/storage/firstaid/regular{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/structure/closet/crate/freezer/surplus_limbs,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/medical/storage)
 "tkB" = (
@@ -59794,9 +60248,13 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "tla" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/space)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/lumos/tile/green/checker{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel/cafeteria,
+/area/medical/virology)
 "tle" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -59825,6 +60283,9 @@
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 1
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics/cloning)
 "tmo" = (
@@ -59832,6 +60293,10 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
 	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "tmO" = (
@@ -59931,7 +60396,10 @@
 /area/medical/virology)
 "twP" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/lumos/tile/green/checker{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
 /area/medical/virology)
 "txm" = (
 /obj/structure/table/wood/fancy/royalblue,
@@ -60061,6 +60529,11 @@
 /obj/machinery/iv_drip,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"tFv" = (
+/obj/structure/closet/secure_closet/personal/patient,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "tFO" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 9
@@ -60523,20 +60996,17 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "uyA" = (
-/obj/structure/rack,
-/obj/item/stack/cable_coil/red,
-/obj/item/stack/cable_coil/red,
-/obj/item/stack/cable_coil/red,
-/obj/item/extinguisher,
-/obj/machinery/light/small,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
+	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
+	dir = 6
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
@@ -60549,6 +61019,22 @@
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
 "uzZ" = (
+/obj/structure/table,
+/obj/item/storage/firstaid/o2{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/firstaid/o2,
+/obj/item/storage/firstaid/regular{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/medical/storage)
 "uAH" = (
@@ -60675,7 +61161,6 @@
 /turf/closed/wall/r_wall,
 /area/ai_monitored/nuke_storage)
 "uPz" = (
-/obj/effect/landmark/start/paramedic,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
@@ -60684,6 +61169,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/medical/storage)
@@ -61135,6 +61623,9 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "vxA" = (
@@ -61198,7 +61689,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 10
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	initial_gas_mix = "o2=0.01;n2=0.01";
+	luminosity = 2
+	},
 /area/maintenance/aft)
 "vyH" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
@@ -61422,13 +61916,14 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "vKc" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/machinery/airalarm{
 	pixel_y = 23
 	},
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/lumos/tile/green/checker{
+	dir = 4
+	},
+/obj/structure/closet/secure_closet/medical1,
+/turf/open/floor/plasteel/cafeteria,
 /area/medical/virology)
 "vNi" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -61504,8 +61999,10 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "vXz" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/lumos/tile/green/checker{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
 /area/medical/virology)
 "vZl" = (
 /obj/machinery/vending/wardrobe/sec_wardrobe,
@@ -61552,15 +62049,10 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/medical/medbay/lobby)
 "wcO" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
+/obj/machinery/light,
 /turf/open/floor/plasteel/dark,
 /area/medical/surgery)
 "wcR" = (
@@ -61646,8 +62138,14 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "wgv" = (
-/obj/structure/chair{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/surgery)
@@ -61813,19 +62311,20 @@
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
+"wuc" = (
+/obj/machinery/door/airlock/atmos/abandoned{
+	name = "Atmospherics Maintenance";
+	req_access_txt = "12;24"
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "wuH" = (
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -24
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
+/obj/structure/chair{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/surgery)
@@ -62064,6 +62563,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
+"wVO" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "wVV" = (
 /obj/machinery/light{
 	dir = 1
@@ -62119,9 +62633,13 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/landmark/start/paramedic,
 /turf/open/floor/plasteel,
 /area/medical/storage)
 "wZI" = (
@@ -62435,11 +62953,13 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"xAp" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/closed/wall/r_wall,
+/area/medical/virology)
 "xBk" = (
 /obj/machinery/light{
 	dir = 4;
@@ -62693,6 +63213,7 @@
 	dir = 8;
 	pixel_x = 24
 	},
+/obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "xXi" = (
@@ -86903,7 +87424,7 @@ aaf
 aaf
 bLv
 bHE
-tla
+bLv
 aaa
 bCq
 bUs
@@ -95888,9 +96409,9 @@ bAj
 qvm
 aKG
 bzs
-nMS
-grS
-ium
+bKy
+bKy
+bKy
 bGQ
 bHp
 bLK
@@ -96142,7 +96663,7 @@ ymc
 aJq
 aRt
 xWV
-aXh
+caQ
 bCA
 kep
 cAg
@@ -96399,10 +96920,10 @@ bAp
 bqV
 bAp
 bAp
-bAp
-sak
-kpr
-kpr
+caS
+bAs
+bDW
+hzu
 iWI
 kpr
 kpr
@@ -96658,7 +97179,7 @@ bwB
 bAp
 byZ
 mLy
-hzu
+bDW
 bCF
 bDB
 bFB
@@ -97164,13 +97685,13 @@ bCz
 lsG
 bpM
 bqT
+bNi
 bFD
-brX
 nac
 bFD
 bwE
-bAp
-bDT
+bqT
+cbO
 bzK
 bDW
 cpG
@@ -97420,7 +97941,7 @@ bvw
 bxb
 lsG
 bqP
-bDZ
+bqV
 bKQ
 nvk
 bwy
@@ -97428,7 +97949,7 @@ oXc
 bza
 dwA
 jSb
-ozX
+oTQ
 bBc
 bCH
 bFt
@@ -97677,13 +98198,13 @@ bvy
 bxT
 lsG
 bpM
-bqV
+bAp
 hFP
 pHl
 bwA
 oJp
 bAl
-bqT
+bqV
 gHt
 oTQ
 bBc
@@ -98452,7 +98973,7 @@ bqX
 ssm
 dLb
 bug
-ejD
+bDT
 vPb
 hdo
 hbs
@@ -98968,7 +99489,7 @@ qLn
 bAs
 bDT
 cZP
-bAs
+bDT
 bNZ
 bCQ
 bDW
@@ -99224,8 +99745,8 @@ col
 tFr
 bwG
 vwy
-wkm
-bxQ
+bZR
+bZU
 bNZ
 bzW
 bGR
@@ -99735,9 +100256,9 @@ bpJ
 mta
 bxQ
 wkm
-wkm
+bNs
 ghS
-wkm
+bVa
 wkm
 bxQ
 wkm
@@ -99990,11 +100511,11 @@ rlS
 iIj
 jHZ
 mta
-bDT
+bAs
 bxS
-bxS
+bNU
 eiE
-bxS
+bYZ
 bzh
 bAs
 eSO
@@ -101039,7 +101560,7 @@ xtF
 ppo
 bQD
 bOr
-bOr
+vXz
 bNd
 caU
 bzs
@@ -101530,7 +102051,7 @@ uJi
 uJi
 uJi
 uJi
-bol
+bMc
 bqW
 bTk
 iZB
@@ -101812,7 +102333,7 @@ bNd
 bNd
 bSU
 bUb
-bVa
+bRQ
 bWf
 bWX
 bOP
@@ -102060,7 +102581,7 @@ bCU
 bCR
 bGX
 bHq
-bGX
+ium
 edA
 bRN
 bIK
@@ -102070,9 +102591,9 @@ bNd
 bST
 bJD
 bKB
-bOr
-bOr
-bOr
+eCY
+gMZ
+ksS
 bYX
 bNd
 ccK
@@ -102326,8 +102847,8 @@ bLf
 bRP
 bSW
 bMH
-bNi
-bOr
+bRQ
+fCm
 bWZ
 bYd
 bYY
@@ -102589,8 +103110,8 @@ bWY
 bYc
 bNd
 bNd
-bzs
-bzs
+bAw
+bAw
 caU
 bHd
 bzs
@@ -102831,8 +103352,8 @@ rVj
 bFO
 bFO
 bFO
+jyt
 bFO
-bMc
 bNd
 bNd
 bNd
@@ -102841,12 +103362,12 @@ bNd
 bSX
 bMI
 bNk
-bNU
+bNk
 bWi
-bWi
-bYZ
-bZR
-caQ
+bNd
+bNd
+bzs
+bzs
 bzs
 ccK
 cnb
@@ -103096,15 +103617,15 @@ nzt
 haO
 bRQ
 bIR
-bSQ
+bMJ
 bNj
-bNs
-bOr
-bOr
-bNd
+bNW
+kEG
+tFv
+xAp
 bZQ
 caP
-cbO
+bzs
 ccJ
 cnd
 bKR
@@ -103345,7 +103866,7 @@ tRe
 pTl
 bIw
 iFz
-kTs
+kZs
 wuH
 bNd
 bOt
@@ -103357,11 +103878,11 @@ bKz
 bKC
 bKM
 bXc
-bYe
+gIV
 bNd
 bZS
 caR
-bzs
+wuc
 bGP
 bHd
 ceL
@@ -103585,7 +104106,7 @@ ciI
 ciI
 ciI
 blo
-mXe
+bpE
 bpI
 bre
 nTb
@@ -103614,10 +104135,10 @@ vXz
 bWj
 bWj
 bWj
-bWj
 bNd
-bzs
-bzs
+bNd
+lOk
+qxG
 bzs
 bGP
 bHd
@@ -103842,7 +104363,7 @@ cTM
 cTM
 cTM
 uyA
-bpE
+bDZ
 bpL
 elW
 bDV
@@ -103860,24 +104381,24 @@ bHb
 bIw
 iFz
 kZs
-wcO
+rdR
 bNd
 oZP
 tvR
 pvS
 bRQ
 bJC
-bKz
+tla
 bKC
 bKM
-bXc
+ssW
 bYe
 bNd
-bZU
-caS
-bna
+bzs
+bzs
+bzs
 ccN
-jyt
+bHd
 bzs
 caK
 cfn
@@ -104097,7 +104618,7 @@ bpE
 gbT
 fqU
 nwW
-cTM
+brX
 jNQ
 bpE
 bpK
@@ -104116,8 +104637,8 @@ sgD
 ktA
 jRq
 iFz
-wgv
-wcO
+mXe
+sak
 bNd
 kfe
 nzt
@@ -104128,13 +104649,13 @@ bMJ
 bNl
 bNW
 bXd
-bOr
+feB
 bNd
 bZT
-caU
-bAw
-bAw
-bAw
+wVO
+bDO
+jWP
+kTU
 bzs
 cfq
 bAw
@@ -104373,8 +104894,8 @@ hvD
 bFO
 bFO
 bFO
+nMS
 bFO
-rdR
 bNd
 bNd
 bNd
@@ -104387,9 +104908,9 @@ bNd
 bNd
 bNd
 bNd
-afF
+ceF
 caU
-bAw
+afF
 cNW
 cNW
 cNW
@@ -104630,7 +105151,7 @@ izA
 cbL
 bna
 bna
-bna
+ozX
 bMe
 bIg
 bIM


### PR DESCRIPTION
## About The Pull Request

Most of medical was overhauled for a more streamlined approach for different portions of it, but I also went throughout the station and redid some decal-work. Not to mention, I also touched on security a bit.

## Why It's Good For The Game

It looks nice and creates a fluid space for members to move around in. 

## Changelog
add: Doors to the front desk that lead into chemistry and into medbay.
add: Door leading from chemistry to medical storage.
add: Some disposal systems were added.
rem: Removed some whack wiring and redid all that I saw. Will probably look more into this in a further PR.
tweak: Made some areas larger and some smaller.
tweak: Redid some decals.
tweak: Rearranged some of the bridge.
tweak: Rearranged the area to the right of dorms