### PR TITLE
load the correct modular lavaland file

### DIFF
--- a/modular_skyrat/code/controllers/subsystem/mapping.dm
+++ b/modular_skyrat/code/controllers/subsystem/mapping.dm
@@ -289,7 +289,7 @@ SUBSYSTEM_DEF(mapping)
 
 	// load mining
 	if(config.minetype == "lavaland")
-		LoadGroup(FailedZs, "Lavaland", "map_files/Mining", "Lavaland_Skyrat.dmm", traits = list(ZTRAITS_LAVALAND_JUNGLE, ZTRAITS_LAVALAND), default_traits = ZTRAITS_LAVALAND)
+		LoadGroup(FailedZs, "Lavaland", "map_files/Mining", "Lavaland_Lumos.dmm", traits = list(ZTRAITS_LAVALAND_JUNGLE, ZTRAITS_LAVALAND), default_traits = ZTRAITS_LAVALAND)
 	if(config.minetype == "asteroid")
 		LoadGroup(FailedZs, "Asteroid", "map_files/Mining", "AsteroidMining.dmm", traits = list(ZTRAITS_ASTEROID), default_traits = ZTRAITS_ASTEROID)
 	else if (!isnull(config.minetype) && config.minetype != "none")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Turns out the game was hardcoded to load the old skyrat modular lavaland file, this didn't show up as an issue until #261 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: the game now loads the correct lavaland map
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
