### PR TITLE
Dwarf Alcohol Buff

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/dwarves.dm
+++ b/code/modules/mob/living/carbon/human/species_types/dwarves.dm
@@ -131,7 +131,7 @@ GLOBAL_LIST_INIT(dwarf_last, world.file2list("strings/names/dwarf_last.txt")) //
 			if(last_alcohol_spam + 8 SECONDS < world.time)
 				to_chat(owner, "<span class='userdanger'>DAMNATION INCARNATE, WHY AM I CURSED WITH THIS DRY-SPELL? I MUST DRINK.</span>")
 				last_alcohol_spam = world.time
-			owner.adjustToxLoss(6)
+			owner.adjustToxLoss(8)
 		if(25 to 50)
 			if(last_alcohol_spam + 20 SECONDS < world.time)
 				to_chat(owner, "<span class='danger'>Oh DAMN, I need some brew!</span>")

--- a/code/modules/mob/living/carbon/human/species_types/dwarves.dm
+++ b/code/modules/mob/living/carbon/human/species_types/dwarves.dm
@@ -80,7 +80,7 @@ GLOBAL_LIST_INIT(dwarf_last, world.file2list("strings/names/dwarf_last.txt")) //
 	icon_state = "liver"
 	desc = "A dwarven liver, theres something magical about seeing one of these up close."
 	alcohol_tolerance = 0 //dwarves really shouldn't be dying to alcohol.
-	toxTolerance = 5 //Shrugs off 5 units of toxins damage.
+	toxTolerance = 6 //Shrugs off 5 units of toxins damage.
 	maxHealth = 150 //More health than the average liver, as you aren't going to be replacing this.
 	//If it does need replaced with a standard human liver, prepare for hell.
 
@@ -92,8 +92,8 @@ GLOBAL_LIST_INIT(dwarf_last, world.file2list("strings/names/dwarf_last.txt")) //
 	icon_state = "plasma" //Yes this is a actual icon in icons/obj/surgery.dmi
 	desc = "A genetically engineered gland which is hopefully a step forward for humanity."
 	w_class = WEIGHT_CLASS_NORMAL
-	var/stored_alcohol = 250 //They start with 250 units, that ticks down and eventaully bad effects occur
-	var/max_alcohol = 500 //Max they can attain, easier than you think to OD on alcohol.
+	var/stored_alcohol = 400 //They start with 250 units, that ticks down and eventaully bad effects occur
+	var/max_alcohol = 600 //Max they can attain, easier than you think to OD on alcohol.
 	var/heal_rate = 0.5 //The rate they heal damages over 400 alcohol stored. Default is 0.5 so we times 3 since 3 seconds.
 	var/alcohol_rate = 0.25 //The rate the alcohol ticks down per each iteration of dwarf_eth_ticker completing.
 	//These count in on_life ticks which should be 2 seconds per every increment of 1 in a perfect world.
@@ -131,7 +131,7 @@ GLOBAL_LIST_INIT(dwarf_last, world.file2list("strings/names/dwarf_last.txt")) //
 			if(last_alcohol_spam + 8 SECONDS < world.time)
 				to_chat(owner, "<span class='userdanger'>DAMNATION INCARNATE, WHY AM I CURSED WITH THIS DRY-SPELL? I MUST DRINK.</span>")
 				last_alcohol_spam = world.time
-			owner.adjustToxLoss(10)
+			owner.adjustToxLoss(6)
 		if(25 to 50)
 			if(last_alcohol_spam + 20 SECONDS < world.time)
 				to_chat(owner, "<span class='danger'>Oh DAMN, I need some brew!</span>")

--- a/code/modules/mob/living/carbon/human/species_types/dwarves.dm
+++ b/code/modules/mob/living/carbon/human/species_types/dwarves.dm
@@ -132,19 +132,19 @@ GLOBAL_LIST_INIT(dwarf_last, world.file2list("strings/names/dwarf_last.txt")) //
 				to_chat(owner, "<span class='userdanger'>DAMNATION INCARNATE, WHY AM I CURSED WITH THIS DRY-SPELL? I MUST DRINK.</span>")
 				last_alcohol_spam = world.time
 			owner.adjustToxLoss(8)
-		if(25 to 50)
+		if(25 to 75)
 			if(last_alcohol_spam + 20 SECONDS < world.time)
 				to_chat(owner, "<span class='danger'>Oh DAMN, I need some brew!</span>")
 				last_alcohol_spam = world.time
-		if(51 to 75)
+		if(75 to 100)
 			if(last_alcohol_spam + 35 SECONDS < world.time)
 				to_chat(owner, "<span class='warning'>Your body aches, you need to get ahold of some booze...</span>")
 				last_alcohol_spam = world.time
-		if(76 to 100)
+		if(100 to 150)
 			if(last_alcohol_spam + 40 SECONDS < world.time)
 				to_chat(owner, "<span class='notice'>A pint of anything would really hit the spot right now.</span>")
 				last_alcohol_spam = world.time
-		if(101 to 150)
+		if(150 to 200)
 			if(last_alcohol_spam + 50 SECONDS < world.time)
 				to_chat(owner, "<span class='notice'>You feel like you could use a good brew.</span>")
 				last_alcohol_spam = world.time

--- a/code/modules/mob/living/carbon/human/species_types/dwarves.dm
+++ b/code/modules/mob/living/carbon/human/species_types/dwarves.dm
@@ -80,7 +80,7 @@ GLOBAL_LIST_INIT(dwarf_last, world.file2list("strings/names/dwarf_last.txt")) //
 	icon_state = "liver"
 	desc = "A dwarven liver, theres something magical about seeing one of these up close."
 	alcohol_tolerance = 0 //dwarves really shouldn't be dying to alcohol.
-	toxTolerance = 6 //Shrugs off 5 units of toxins damage.
+	toxTolerance = 5 //Shrugs off 5 units of toxins damage.
 	maxHealth = 150 //More health than the average liver, as you aren't going to be replacing this.
 	//If it does need replaced with a standard human liver, prepare for hell.
 


### PR DESCRIPTION
## About The Pull Request
Buff's dwarf's ability to keep alcohol in them and lessens the damage of being depraved of such.
## Why It's Good For The Game
Trying to do your job as a dwarf and constantly needing a flow of alcohol into your body is a good gimmick, but it has the same problem that hunger did, so this will hopefully help dwarfs stock up internally on some drink before working for a decent amount of time.
## Changelog
:cl:
balance: Initial stored alcohol on spawn increased from 250 to 400
balance: Maximum alcohol reserves increased from 500 to 600
balance: Toxin damage taken from being without alcohol reduced from 10 to 8
/:cl: