### PR TITLE
fixes turf decals opacity issue

### DIFF
--- a/modular_lumos/code/game/effects/lumosdecals.dm
+++ b/modular_lumos/code/game/effects/lumosdecals.dm
@@ -10,10 +10,10 @@
 	icon_state = "baddecal"
 	name = "Bad Decal"
 	layer = TURF_PLATING_DECAL_LAYER
-	alpha = 110
 
 /obj/effect/turf_decal/lumos/shower
 	icon_state = "shower"
+	name = "shower drain"
 
 /obj/effect/turf_decal/lumos/loading_area
 	name = "loading area corner"


### PR DESCRIPTION
## About The Pull Request

fixes an opacity issue where things like the shower drain and loading area decals were transparent

## Why It's Good For The Game

fixsting is 300 bucks

## Changelog
:cl:
add: shower decal name
fix: opacity for non-tile decals
/:cl: