### PR TITLE
Fixes beach turf variation

### DIFF
--- a/code/game/turfs/simulated/floor/plating/misc_plating.dm
+++ b/code/game/turfs/simulated/floor/plating/misc_plating.dm
@@ -130,10 +130,12 @@
 	desc = "Surf's up."
 	icon_state = "desert0"
 	baseturfs = /turf/open/floor/plating/beach/sand
+	can_allow_icy = FALSE // Hot sands don't get frosty
 
 /turf/open/floor/plating/beach/sand/Initialize()
 	. = ..()
-	icon_state = "desert[rand(0,6)]"
+	if(prob(15))
+		icon_state = "desert[rand(0,6)]"
 
 /turf/open/floor/plating/beach/coastline_t
 	name = "coastline"


### PR DESCRIPTION
## About The Pull Request

Beach turf had no variation, and I added some earlier, however I didn't specify it to be occasional so ALL beach turfs would get the variations. Fixed.

also made beach sand turf immune to icy, even though that's so rare it hardly matters.

## Why It's Good For The Game

technically a incompetence/bug fix

## Changelog
:cl:
fix: sand turf variation
/:cl: