### PR TITLE
Armory Nerf

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation_Lumos.dmm
+++ b/_maps/map_files/BoxStation/BoxStation_Lumos.dmm
@@ -663,6 +663,7 @@
 	icon_state = "1-2"
 	},
 /obj/item/phone,
+/obj/item/key/security,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
 "abV" = (
@@ -755,6 +756,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
+/obj/vehicle/ridden/secway,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "ack" = (
@@ -763,9 +765,6 @@
 	pixel_x = 4
 	},
 /obj/item/grenade/barrier,
-/obj/item/grenade/barrier{
-	pixel_x = -4
-	},
 /obj/machinery/power/apc/highcap/five_k{
 	areastring = "/area/ai_monitored/security/armory";
 	dir = 8;
@@ -810,6 +809,7 @@
 /obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "acn" = (
@@ -825,6 +825,7 @@
 /obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "aco" = (
@@ -837,6 +838,7 @@
 /obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "acq" = (
@@ -1019,6 +1021,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "acN" = (
@@ -1187,19 +1190,12 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "adi" = (
 /obj/structure/rack,
-/obj/item/gun/ballistic/shotgun/riot{
-	pixel_x = -3;
-	pixel_y = 3
-	},
 /obj/item/gun/ballistic/shotgun/riot,
-/obj/item/gun/ballistic/shotgun/riot{
-	pixel_x = 3;
-	pixel_y = -3
-	},
 /obj/structure/window/reinforced{
 	dir = 1;
 	pixel_y = 1
@@ -1215,6 +1211,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/bot,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "adj" = (
@@ -1494,15 +1491,7 @@
 /area/crew_quarters/heads/hos)
 "adP" = (
 /obj/structure/rack,
-/obj/item/gun/energy/e_gun{
-	pixel_x = -3;
-	pixel_y = 3
-	},
 /obj/item/gun/energy/e_gun,
-/obj/item/gun/energy/e_gun{
-	pixel_x = 3;
-	pixel_y = -3
-	},
 /obj/structure/window/reinforced,
 /obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 4
@@ -1913,13 +1902,10 @@
 /area/ai_monitored/security/armory)
 "aeF" = (
 /obj/structure/table/reinforced,
-/obj/item/storage/box/firingpins{
-	pixel_x = 6
-	},
-/obj/item/storage/box/firingpins{
-	pixel_x = -3
-	},
 /obj/effect/turf_decal/lumos/tile/neutral/fulltile,
+/obj/item/grenade/barrier{
+	pixel_x = -4
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "aeG" = (
@@ -2112,13 +2098,6 @@
 /area/security/brig)
 "aeW" = (
 /obj/structure/table/reinforced,
-/obj/item/storage/box/chemimp{
-	pixel_x = 6
-	},
-/obj/item/storage/box/trackimp{
-	pixel_x = -3
-	},
-/obj/item/storage/lockbox/loyalty,
 /obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
@@ -2131,8 +2110,6 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "aeY" = (
-/obj/vehicle/ridden/secway,
-/obj/item/key/security,
 /obj/effect/turf_decal/lumos/tile/blue/fullcorner{
 	dir = 4
 	},
@@ -2142,9 +2119,6 @@
 /area/ai_monitored/security/armory)
 "aeZ" = (
 /obj/structure/rack,
-/obj/item/gun/energy/ionrifle,
-/obj/item/gun/energy/temperature/security,
-/obj/item/clothing/suit/armor/laserproof,
 /obj/machinery/airalarm{
 	pixel_y = 23
 	},
@@ -2181,12 +2155,16 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/delivery,
+/obj/effect/spawner/lootdrop/armory_contraband{
+	loot = list(/obj/item/gun/ballistic/automatic/pistol = 5, /obj/item/gun/ballistic/shotgun/automatic/combat = 5, /obj/item/gun/ballistic/revolver/mateba, /obj/item/gun/ballistic/automatic/pistol/deagle, /obj/item/storage/box/syndie_kit/throwing_weapons = 3)
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "afd" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /obj/effect/turf_decal/bot,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "afe" = (
@@ -2199,6 +2177,7 @@
 /obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "aff" = (
@@ -2784,10 +2763,6 @@
 	},
 /obj/item/storage/box/rubbershot,
 /obj/item/storage/box/rubbershot,
-/obj/item/storage/box/rubbershot,
-/obj/item/storage/box/rubbershot,
-/obj/item/storage/box/rubbershot,
-/obj/item/storage/box/rubbershot,
 /obj/effect/turf_decal/lumos/tile/neutral/half{
 	dir = 4
 	},
@@ -2887,16 +2862,15 @@
 /obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "agJ" = (
-/obj/machinery/flasher/portable,
 /obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "agK" = (
-/obj/machinery/flasher/portable,
 /obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/dark,
@@ -2979,10 +2953,12 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "agS" = (
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "agU" = (
 /obj/machinery/holopad,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "agV" = (
@@ -3169,10 +3145,6 @@
 	pixel_x = -1;
 	pixel_y = 1
 	},
-/obj/item/storage/box/handcuffs{
-	pixel_x = 1;
-	pixel_y = -1
-	},
 /obj/machinery/camera/motion{
 	c_tag = "Armory Motion Sensor";
 	dir = 4
@@ -3191,6 +3163,7 @@
 /area/maintenance/fore/secondary)
 "aho" = (
 /obj/effect/turf_decal/tile/red,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "ahp" = (
@@ -3270,14 +3243,6 @@
 "ahA" = (
 /obj/structure/rack,
 /obj/structure/window/reinforced,
-/obj/item/storage/box/teargas{
-	pixel_x = -1;
-	pixel_y = 1
-	},
-/obj/item/storage/box/flashbangs{
-	pixel_x = 1;
-	pixel_y = -1
-	},
 /obj/item/radio/intercom{
 	pixel_x = -30
 	},
@@ -3287,22 +3252,6 @@
 /obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 8
 	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
-"ahB" = (
-/obj/structure/rack,
-/obj/item/gun/energy/e_gun/dragnet{
-	pixel_x = 2;
-	pixel_y = -2
-	},
-/obj/item/gun/energy/e_gun/dragnet{
-	pixel_x = -2;
-	pixel_y = 2
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
@@ -3425,15 +3374,6 @@
 /area/security/prison)
 "ahR" = (
 /obj/structure/rack,
-/obj/item/gun/energy/laser{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/gun/energy/laser,
-/obj/item/gun/energy/laser{
-	pixel_x = 3;
-	pixel_y = -3
-	},
 /obj/structure/window/reinforced{
 	dir = 1;
 	pixel_y = 1
@@ -3479,28 +3419,16 @@
 	pixel_y = 3
 	},
 /obj/item/clothing/suit/armor/riot,
-/obj/item/clothing/suit/armor/riot{
-	pixel_x = 3;
-	pixel_y = -3
-	},
 /obj/item/clothing/head/helmet/riot{
 	pixel_x = -3;
 	pixel_y = 3
 	},
 /obj/item/clothing/head/helmet/riot,
-/obj/item/clothing/head/helmet/riot{
-	pixel_x = 3;
-	pixel_y = -3
-	},
 /obj/item/shield/riot{
 	pixel_x = -3;
 	pixel_y = 3
 	},
 /obj/item/shield/riot,
-/obj/item/shield/riot{
-	pixel_x = 3;
-	pixel_y = -3
-	},
 /obj/structure/window/reinforced{
 	dir = 1;
 	layer = 2.9
@@ -3644,10 +3572,6 @@
 	pixel_y = 3
 	},
 /obj/item/clothing/suit/armor/bulletproof,
-/obj/item/clothing/suit/armor/bulletproof{
-	pixel_x = 3;
-	pixel_y = -3
-	},
 /obj/item/clothing/head/helmet/alt{
 	layer = 3.00001;
 	pixel_x = -3;
@@ -3655,11 +3579,6 @@
 	},
 /obj/item/clothing/head/helmet/alt{
 	layer = 3.00001
-	},
-/obj/item/clothing/head/helmet/alt{
-	layer = 3.00001;
-	pixel_x = 3;
-	pixel_y = -3
 	},
 /obj/structure/window/reinforced,
 /obj/effect/turf_decal/lumos/tile/neutral/half{
@@ -3686,6 +3605,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "aiq" = (
@@ -3742,15 +3662,6 @@
 /area/security/main)
 "aiv" = (
 /obj/structure/rack,
-/obj/item/gun/energy/e_gun/advtaser{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/gun/energy/e_gun/advtaser,
-/obj/item/gun/energy/e_gun/advtaser{
-	pixel_x = 3;
-	pixel_y = -3
-	},
 /obj/structure/window/reinforced,
 /obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 4
@@ -7040,6 +6951,7 @@
 	},
 /obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /obj/effect/turf_decal/bot,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "apX" = (
@@ -7289,6 +7201,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /obj/effect/turf_decal/bot,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "aqv" = (
@@ -26886,6 +26799,9 @@
 /obj/item/pen/fountain/captain,
 /obj/item/clothing/mask/cigarette/cigar,
 /obj/structure/safe/floor,
+/obj/item/storage/lockbox/loyalty{
+	pixel_y = 14
+	},
 /turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/captain)
 "bpl" = (
@@ -55195,6 +55111,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"lgC" = (
+/obj/effect/turf_decal/lumos/tile/red/half{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "lhh" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -58557,6 +58480,16 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/grass,
 /area/medical/virology)
+"sdg" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/lumos/tile/red/half{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "sea" = (
 /obj/item/melee/baton/cattleprod,
 /obj/item/stock_parts/cell/high,
@@ -91483,10 +91416,10 @@ aeZ
 aco
 agS
 aho
-ahX
+lgC
 afb
 ahX
-ahX
+lgC
 aip
 aja
 lCf
@@ -91743,7 +91676,7 @@ ahp
 afd
 apW
 aqu
-ahB
+aqu
 aiq
 ajb
 hrE
@@ -91997,7 +91930,7 @@ adR
 abI
 acM
 adh
-adM
+sdg
 afe
 agI
 adM
@@ -94040,7 +93973,7 @@ aaa
 aaa
 aaa
 aaa
-aaf
+aag
 aaf
 aaf
 aaf

--- a/_maps/map_files/Deltastation/DeltaStation2_Lumos.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2_Lumos.dmm
@@ -25055,6 +25055,7 @@
 /obj/structure/cable/white{
 	icon_state = "1-8"
 	},
+/obj/item/key/security,
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/heads/hos)
 "biR" = (
@@ -29257,6 +29258,7 @@
 /obj/machinery/camera{
 	c_tag = "Security - Head of Security's Office"
 	},
+/obj/vehicle/ridden/secway,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "brz" = (
@@ -40263,8 +40265,8 @@
 /turf/open/floor/plasteel,
 /area/security/warden)
 "bNp" = (
-/obj/machinery/flasher/portable,
 /obj/effect/turf_decal/delivery,
+/obj/machinery/flasher/portable,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "bNq" = (
@@ -40290,10 +40292,6 @@
 	pixel_y = 22
 	},
 /obj/structure/closet/secure_closet/lethalshots,
-/obj/item/ammo_box/c9mm,
-/obj/item/ammo_box/c9mm,
-/obj/item/ammo_box/c9mm,
-/obj/item/ammo_box/c9mm,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "bNt" = (
@@ -42134,43 +42132,13 @@
 "bRu" = (
 /obj/structure/rack,
 /obj/item/storage/box/rubbershot,
-/obj/item/storage/box/rubbershot,
-/obj/item/storage/box/rubbershot,
-/obj/item/storage/box/rubbershot,
-/obj/item/gun/ballistic/shotgun/riot{
-	pixel_x = 3;
-	pixel_y = 6
-	},
 /obj/item/gun/ballistic/shotgun/riot,
-/obj/item/gun/ballistic/shotgun/riot{
-	pixel_x = -3;
-	pixel_y = -6
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "bRw" = (
 /obj/item/clothing/suit/armor/riot{
-	pixel_x = -4;
 	pixel_y = -1
-	},
-/obj/item/clothing/suit/armor/riot{
-	pixel_y = -1
-	},
-/obj/item/clothing/suit/armor/riot{
-	pixel_x = 4;
-	pixel_y = -1
-	},
-/obj/item/clothing/head/helmet/riot{
-	pixel_x = -5;
-	pixel_y = 6
-	},
-/obj/item/clothing/head/helmet/riot{
-	pixel_y = 6
-	},
-/obj/item/clothing/head/helmet/riot{
-	pixel_x = 5;
-	pixel_y = 6
 	},
 /obj/structure/rack,
 /obj/item/storage/secure/safe{
@@ -42781,6 +42749,7 @@
 	name = "Captain's Desk";
 	req_access_txt = "20"
 	},
+/obj/item/storage/lockbox/loyalty,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain)
 "bSN" = (
@@ -42999,26 +42968,7 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
-"bTj" = (
-/obj/structure/rack,
-/obj/item/gun/energy/laser{
-	pixel_y = 6
-	},
-/obj/item/gun/energy/laser,
-/obj/item/gun/energy/laser{
-	pixel_y = -6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
 "bTk" = (
-/obj/item/shield/riot{
-	pixel_x = -8;
-	pixel_y = 2
-	},
-/obj/item/shield/riot{
-	pixel_y = 2
-	},
 /obj/item/shield/riot{
 	pixel_x = 8;
 	pixel_y = 2
@@ -44230,28 +44180,11 @@
 /area/ai_monitored/security/armory)
 "bVq" = (
 /obj/structure/rack,
-/obj/item/gun/energy/e_gun/advtaser,
-/obj/item/gun/energy/e_gun/advtaser{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/gun/energy/e_gun/advtaser{
-	pixel_x = 3;
-	pixel_y = -3
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "bVr" = (
 /obj/item/clothing/suit/armor/vest{
-	pixel_x = -8;
-	pixel_y = -2
-	},
-/obj/item/clothing/suit/armor/vest{
-	pixel_y = -2
-	},
-/obj/item/clothing/suit/armor/vest{
-	pixel_x = 8;
 	pixel_y = -2
 	},
 /obj/item/clothing/head/helmet{
@@ -44259,20 +44192,13 @@
 	pixel_x = -9;
 	pixel_y = 7
 	},
-/obj/item/clothing/head/helmet{
-	layer = 3.00001;
-	pixel_x = -1;
-	pixel_y = 7
-	},
-/obj/item/clothing/head/helmet{
-	layer = 3.00001;
-	pixel_x = 8;
-	pixel_y = 7
-	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
 	},
 /obj/structure/rack,
+/obj/item/clothing/head/helmet{
+	pixel_x = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "bVs" = (
@@ -45477,13 +45403,7 @@
 /area/ai_monitored/security/armory)
 "bXP" = (
 /obj/structure/rack,
-/obj/item/gun/energy/e_gun{
-	pixel_y = 5
-	},
 /obj/item/gun/energy/e_gun,
-/obj/item/gun/energy/e_gun{
-	pixel_y = -5
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
 	},
@@ -46625,17 +46545,6 @@
 /area/ai_monitored/security/armory)
 "bZY" = (
 /obj/structure/table/reinforced,
-/obj/item/storage/lockbox/loyalty{
-	pixel_y = 12
-	},
-/obj/item/storage/box/trackimp{
-	pixel_x = -5;
-	pixel_y = 1
-	},
-/obj/item/storage/box/chemimp{
-	pixel_x = 5;
-	pixel_y = 1
-	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "bZZ" = (
@@ -47419,19 +47328,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/vehicle/ridden/secway,
-/obj/item/key/security,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "cbI" = (
 /obj/structure/rack,
-/obj/item/storage/box/flashes,
-/obj/item/gun/energy/e_gun/dragnet{
-	pixel_y = 4
-	},
-/obj/item/gun/energy/e_gun/dragnet{
-	pixel_y = -3
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -47452,61 +47352,24 @@
 	dir = 1
 	},
 /obj/structure/rack,
-/obj/item/gun/energy/ionrifle{
-	pixel_x = -4;
-	pixel_y = 2
-	},
-/obj/item/clothing/suit/armor/laserproof,
-/obj/item/gun/energy/temperature/security,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "cbK" = (
 /obj/structure/table/reinforced,
-/obj/item/storage/box/firingpins{
-	pixel_x = -5;
-	pixel_y = 9
-	},
-/obj/item/storage/box/firingpins{
-	pixel_x = -5;
-	pixel_y = 2
-	},
 /obj/item/assembly/flash/handheld{
 	pixel_x = 8;
 	pixel_y = 9
-	},
-/obj/item/assembly/flash/handheld{
-	pixel_x = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "cbL" = (
 /obj/structure/table/reinforced,
 /obj/item/grenade/barrier{
-	pixel_x = -8;
-	pixel_y = 10
-	},
-/obj/item/grenade/barrier{
-	pixel_x = -4;
-	pixel_y = 10
-	},
-/obj/item/grenade/barrier{
-	pixel_y = 10
-	},
-/obj/item/grenade/barrier{
-	pixel_x = 4;
 	pixel_y = 10
 	},
 /obj/item/grenade/barrier{
 	pixel_x = 8;
 	pixel_y = 10
-	},
-/obj/item/storage/box/teargas{
-	pixel_x = -6;
-	pixel_y = 3
-	},
-/obj/item/storage/box/flashbangs{
-	pixel_x = 6;
-	pixel_y = 3
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
@@ -99673,7 +99536,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "mMC" = (
-/obj/machinery/flasher/portable,
 /obj/effect/turf_decal/loading_area{
 	dir = 4
 	},
@@ -101376,6 +101238,10 @@
 /obj/structure/closet/crate/freezer/blood,
 /turf/open/floor/plasteel/white,
 /area/security/brig)
+"rAZ" = (
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "rCp" = (
 /obj/structure/cable/white{
 	icon_state = "4-8"
@@ -156890,7 +156756,7 @@ bHI
 bJE
 bLs
 bNp
-bNp
+rAZ
 mMC
 bTi
 bVp
@@ -157406,7 +157272,7 @@ kYf
 bNr
 bPy
 bRu
-bTj
+bVq
 bVq
 bXP
 bZW

--- a/_maps/map_files/FridgeStation/FridgeStation.dmm
+++ b/_maps/map_files/FridgeStation/FridgeStation.dmm
@@ -309,6 +309,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "ajf" = (
@@ -1124,6 +1125,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "aHB" = (
@@ -1429,6 +1431,7 @@
 /area/security/warden)
 "aOF" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "aOM" = (
@@ -2239,6 +2242,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "bli" = (
@@ -5796,6 +5800,7 @@
 /obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "dhD" = (
@@ -5940,6 +5945,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"dlM" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "dlW" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -7067,8 +7079,7 @@
 /area/icemoon/surface/outdoors)
 "dNX" = (
 /obj/effect/turf_decal/bot_white,
-/obj/vehicle/ridden/atv/snowmobile/snowcurity,
-/obj/item/key/security,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "dOe" = (
@@ -8278,6 +8289,7 @@
 /obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "eut" = (
@@ -9242,6 +9254,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "eUS" = (
@@ -9794,6 +9807,7 @@
 /area/medical/genetics)
 "flJ" = (
 /obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "flM" = (
@@ -10524,6 +10538,7 @@
 	pixel_y = -22
 	},
 /obj/effect/turf_decal/lumos/tile/red/fullcorner,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "fMd" = (
@@ -10541,6 +10556,7 @@
 /obj/effect/turf_decal/lumos/tile/red/fullcorner{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "fMs" = (
@@ -11020,6 +11036,7 @@
 	icon_state = "1-4"
 	},
 /obj/effect/turf_decal/lumos/tile/red/half,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "fXW" = (
@@ -11624,20 +11641,7 @@
 	pixel_x = -3;
 	pixel_y = 3
 	},
-/obj/item/clothing/suit/armor/riot,
-/obj/item/clothing/suit/armor/riot{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/clothing/head/helmet/riot{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/clothing/head/helmet/riot,
-/obj/item/clothing/head/helmet/riot{
-	pixel_x = 3;
-	pixel_y = -3
-	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "gog" = (
@@ -11964,27 +11968,10 @@
 	},
 /obj/effect/turf_decal/bot_white,
 /obj/structure/rack,
-/obj/item/clothing/suit/armor/bulletproof{
-	pixel_x = -3;
-	pixel_y = 3
-	},
 /obj/item/clothing/suit/armor/bulletproof,
 /obj/item/clothing/suit/armor/bulletproof{
 	pixel_x = 3;
 	pixel_y = -3
-	},
-/obj/item/clothing/head/helmet/alt{
-	layer = 3.00001;
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/clothing/head/helmet/alt{
-	layer = 3.00001;
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/clothing/head/helmet/alt{
-	layer = 3.00001
 	},
 /obj/machinery/airalarm{
 	pixel_y = 26
@@ -13368,17 +13355,6 @@
 	icon_state = "wood-broken5"
 	},
 /area/hallway/secondary/exit/departure_lounge)
-"hlA" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/effect/turf_decal/bot_white,
-/obj/structure/rack,
-/obj/item/gun/energy/temperature/security,
-/obj/item/clothing/suit/armor/laserproof,
-/obj/item/gun/energy/ionrifle,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
 "hmg" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/lumos/tile/blue/half{
@@ -15557,6 +15533,9 @@
 /obj/item/lighter/gold{
 	desc = "A shiny and relatively expensive zippo lighter. This is a limited series, only ten were produced. It's engraved with a ornate 'NT' on the bottom."
 	},
+/obj/item/storage/lockbox/loyalty{
+	pixel_y = 17
+	},
 /obj/item/phone{
 	pixel_x = -6;
 	pixel_y = 9
@@ -16261,6 +16240,10 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/hor)
+"iPE" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "iPF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -16586,6 +16569,7 @@
 /obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "jde" = (
@@ -16735,15 +16719,6 @@
 	},
 /obj/effect/turf_decal/bot_white,
 /obj/structure/rack,
-/obj/item/gun/energy/e_gun/advtaser,
-/obj/item/gun/energy/e_gun/advtaser{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/gun/energy/e_gun/advtaser{
-	pixel_x = 3;
-	pixel_y = -3
-	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "jhY" = (
@@ -18287,7 +18262,6 @@
 /obj/item/grenade/barrier{
 	pixel_x = 4
 	},
-/obj/item/grenade/barrier,
 /obj/item/grenade/barrier{
 	pixel_x = -4
 	},
@@ -23986,6 +23960,7 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "nrm" = (
@@ -25196,6 +25171,7 @@
 "ocm" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/lumos/tile/red/half,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "odr" = (
@@ -25864,6 +25840,7 @@
 /obj/effect/turf_decal/lumos/tile/red/fullcorner{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "ovq" = (
@@ -28510,6 +28487,7 @@
 /obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "pQC" = (
@@ -29461,11 +29439,9 @@
 /obj/effect/turf_decal/bot_white,
 /obj/structure/rack,
 /obj/item/storage/box/firingpins{
-	pixel_x = 6
-	},
-/obj/item/storage/box/firingpins{
 	pixel_x = -3
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "qpd" = (
@@ -30190,21 +30166,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
-"qLv" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/effect/turf_decal/bot_white,
-/obj/structure/rack,
-/obj/item/storage/lockbox/loyalty,
-/obj/item/storage/box/chemimp{
-	pixel_x = 6
-	},
-/obj/item/storage/box/trackimp{
-	pixel_x = -3
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
 "qLx" = (
 /obj/machinery/vending/wallmed{
 	pixel_y = 28
@@ -30806,9 +30767,7 @@
 	pixel_x = 3;
 	pixel_y = -3
 	},
-/obj/item/shield/riot{
-	pixel_x = -6
-	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "rcN" = (
@@ -30950,6 +30909,7 @@
 /obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "riP" = (
@@ -31470,9 +31430,7 @@
 	pixel_x = 3;
 	pixel_y = -3
 	},
-/obj/item/gun/ballistic/shotgun/riot{
-	pixel_y = 6
-	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "rwX" = (
@@ -32896,10 +32854,7 @@
 	req_access = "list(3)"
 	},
 /obj/item/storage/box/rubbershot,
-/obj/item/storage/box/rubbershot,
-/obj/item/storage/box/rubbershot,
-/obj/item/storage/box/rubbershot,
-/obj/item/storage/box/rubbershot,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "sjy" = (
@@ -33602,19 +33557,6 @@
 /obj/effect/turf_decal/bot_white,
 /obj/structure/rack,
 /obj/item/storage/box/flashbangs,
-/obj/item/storage/box/flashbangs{
-	pixel_x = 1;
-	pixel_y = -1
-	},
-/obj/item/storage/box/flashbangs{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/storage/box/teargas,
-/obj/item/storage/box/teargas{
-	pixel_x = -1;
-	pixel_y = 1
-	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "sBG" = (
@@ -34189,14 +34131,6 @@
 /obj/effect/turf_decal/bot_white,
 /obj/structure/rack,
 /obj/item/gun/energy/e_gun/dragnet,
-/obj/item/gun/energy/e_gun/dragnet{
-	pixel_x = 2;
-	pixel_y = -2
-	},
-/obj/item/gun/energy/e_gun/dragnet{
-	pixel_x = -2;
-	pixel_y = 2
-	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "sSs" = (
@@ -34914,6 +34848,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "tos" = (
@@ -38559,6 +38494,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "vkk" = (
@@ -38953,11 +38889,10 @@
 	pixel_x = -1;
 	pixel_y = 1
 	},
-/obj/item/storage/box/handcuffs,
 /obj/item/storage/box/handcuffs{
-	pixel_x = 1;
-	pixel_y = -1
+	pixel_x = 3
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "vwy" = (
@@ -40194,15 +40129,6 @@
 	},
 /obj/effect/turf_decal/bot_white,
 /obj/structure/rack,
-/obj/item/gun/energy/laser{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/gun/energy/laser,
-/obj/item/gun/energy/laser{
-	pixel_x = 3;
-	pixel_y = -3
-	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "wgX" = (
@@ -41640,6 +41566,7 @@
 /obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "wZm" = (
@@ -47755,7 +47682,7 @@ sjq
 rwU
 wgS
 kpK
-gzG
+dlM
 gzG
 gzG
 fMq
@@ -48009,11 +47936,11 @@ qvG
 fci
 diy
 riI
-pEA
+iPE
 aOF
 aHm
 aiY
-pEA
+iPE
 pEA
 ocm
 iJl
@@ -48523,8 +48450,8 @@ fgZ
 lWF
 euI
 xTO
-qLv
-hlA
+wgS
+wgS
 pPZ
 rcM
 vwb
@@ -64009,8 +63936,8 @@ rMm
 eXj
 kSg
 kSg
-jsJ
-jsJ
+kSg
+kSg
 kSg
 kSg
 xlg

--- a/_maps/map_files/KiloStation/KiloStation_Lumos.dmm
+++ b/_maps/map_files/KiloStation/KiloStation_Lumos.dmm
@@ -5027,6 +5027,7 @@
 /area/science/robotics/mechbay)
 "akC" = (
 /obj/structure/closet/secure_closet/lethalshots,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "akD" = (
@@ -5051,10 +5052,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/medical/surgery)
-"akG" = (
-/obj/machinery/flasher/portable,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
 "akH" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/grunge{
@@ -5195,6 +5192,7 @@
 	dir = 4;
 	pixel_x = -23
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "akW" = (
@@ -5470,29 +5468,10 @@
 "alv" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/armor/riot{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/clothing/suit/armor/riot,
-/obj/item/clothing/suit/armor/riot{
 	pixel_x = 3;
 	pixel_y = -3
 	},
 /obj/item/clothing/head/helmet/riot{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/clothing/head/helmet/riot,
-/obj/item/clothing/head/helmet/riot{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/shield/riot{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/shield/riot,
-/obj/item/shield/riot{
 	pixel_x = 3;
 	pixel_y = -3
 	},
@@ -5500,15 +5479,6 @@
 /area/ai_monitored/security/armory)
 "alx" = (
 /obj/structure/rack,
-/obj/item/gun/energy/e_gun{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/gun/energy/e_gun,
-/obj/item/gun/energy/e_gun{
-	pixel_x = 3;
-	pixel_y = -3
-	},
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -5519,15 +5489,6 @@
 /area/ai_monitored/security/armory)
 "aly" = (
 /obj/structure/rack,
-/obj/item/gun/energy/laser{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/gun/energy/laser,
-/obj/item/gun/energy/laser{
-	pixel_x = 3;
-	pixel_y = -3
-	},
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -5664,6 +5625,7 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "alP" = (
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "alQ" = (
@@ -5683,15 +5645,7 @@
 /area/security/warden)
 "alS" = (
 /obj/structure/rack,
-/obj/item/gun/energy/disabler{
-	pixel_x = -3;
-	pixel_y = 3
-	},
 /obj/item/gun/energy/disabler,
-/obj/item/gun/energy/disabler{
-	pixel_x = 3;
-	pixel_y = -3
-	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 8
@@ -6101,20 +6055,12 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/brig)
 "amJ" = (
-/obj/item/storage/box/chemimp{
-	pixel_x = 6;
-	pixel_y = 6
-	},
-/obj/item/storage/box/trackimp{
-	pixel_x = -6;
-	pixel_y = 6
-	},
-/obj/item/storage/lockbox/loyalty,
 /obj/structure/table,
 /obj/machinery/light,
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_y = -30
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "amK" = (
@@ -6145,11 +6091,6 @@
 /area/maintenance/fore)
 "amM" = (
 /obj/structure/rack,
-/obj/item/gun/energy/ionrifle{
-	pixel_y = 4
-	},
-/obj/item/gun/energy/temperature/security,
-/obj/item/clothing/suit/armor/laserproof,
 /obj/item/radio/intercom{
 	pixel_y = -28
 	},
@@ -6474,15 +6415,6 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "anF" = (
-/obj/item/storage/box/teargas{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/box/handcuffs,
-/obj/item/storage/box/flashbangs{
-	pixel_x = -3;
-	pixel_y = -3
-	},
 /obj/structure/table,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 24
@@ -6612,8 +6544,6 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "anV" = (
-/obj/item/storage/box/firingpins,
-/obj/item/storage/box/firingpins,
 /obj/structure/table,
 /obj/machinery/power/apc{
 	areastring = "/area/ai_monitored/security/armory";
@@ -10043,6 +9973,9 @@
 /obj/item/storage/fancy/donut_box,
 /obj/item/card/id/captains_spare,
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/item/storage/lockbox/loyalty{
+	pixel_y = 17
+	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain)
 "avk" = (
@@ -11389,13 +11322,13 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "aye" = (
-/obj/machinery/flasher/portable,
 /obj/machinery/light{
 	dir = 1
 	},
 /obj/machinery/firealarm{
 	pixel_y = 26
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "ayg" = (
@@ -12017,15 +11950,7 @@
 /area/medical/morgue)
 "azo" = (
 /obj/structure/rack,
-/obj/item/clothing/suit/armor/bulletproof{
-	pixel_x = -3;
-	pixel_y = 3
-	},
 /obj/item/clothing/suit/armor/bulletproof,
-/obj/item/clothing/suit/armor/bulletproof{
-	pixel_x = 3;
-	pixel_y = -3
-	},
 /obj/item/clothing/head/helmet/alt{
 	layer = 3.00001;
 	pixel_x = -3;
@@ -12033,11 +11958,6 @@
 	},
 /obj/item/clothing/head/helmet/alt{
 	layer = 3.00001
-	},
-/obj/item/clothing/head/helmet/alt{
-	layer = 3.00001;
-	pixel_x = 3;
-	pixel_y = -3
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
@@ -13592,15 +13512,7 @@
 /area/engine/break_room)
 "aCz" = (
 /obj/structure/rack,
-/obj/item/gun/ballistic/shotgun/riot{
-	pixel_x = -3;
-	pixel_y = 3
-	},
 /obj/item/gun/ballistic/shotgun/riot,
-/obj/item/gun/ballistic/shotgun/riot{
-	pixel_x = 3;
-	pixel_y = -3
-	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 4
@@ -13677,9 +13589,6 @@
 	pixel_x = 4
 	},
 /obj/item/grenade/barrier,
-/obj/item/grenade/barrier{
-	pixel_x = -4
-	},
 /obj/structure/table,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
@@ -14972,28 +14881,12 @@
 /turf/open/floor/plasteel/dark,
 /area/security/warden)
 "aEX" = (
-/obj/item/storage/box/rubbershot{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/storage/box/rubbershot{
-	pixel_x = -3;
-	pixel_y = 3
-	},
 /obj/item/storage/box/rubbershot,
-/obj/item/storage/box/rubbershot,
-/obj/item/storage/box/rubbershot{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/storage/box/rubbershot{
-	pixel_x = 3;
-	pixel_y = -3
-	},
 /obj/structure/closet/secure_closet{
 	name = "shotgun rubber rounds";
 	req_access_txt = "1"
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "aEY" = (
@@ -27542,13 +27435,8 @@
 /area/science/research)
 "bdK" = (
 /obj/structure/rack,
-/obj/item/gun/energy/e_gun/dragnet{
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/obj/item/gun/energy/e_gun/dragnet,
 /obj/item/gun/energy/e_gun/advtaser,
-/obj/item/gun/energy/e_gun/advtaser,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "bdL" = (
@@ -43105,7 +42993,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bIS" = (
-/obj/machinery/flasher/portable,
 /obj/machinery/camera/motion{
 	c_tag = "Armoury Internal";
 	dir = 8
@@ -48661,7 +48548,7 @@
 	name = "security locker"
 	},
 /obj/item/clothing/gloves/color/black,
-/obj/item/clothing/under/rank/security/officer/skirt,
+/obj/item/clothing/under/rank/security/officer,
 /obj/item/clothing/shoes/jackboots,
 /obj/structure/grille/broken,
 /turf/open/floor/plating,
@@ -55283,6 +55170,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 6
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/showroomfloor,
 /area/ai_monitored/security/armory)
 "chd" = (
@@ -55295,6 +55183,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/showroomfloor,
 /area/ai_monitored/security/armory)
 "che" = (
@@ -55304,6 +55193,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/showroomfloor,
 /area/ai_monitored/security/armory)
 "chf" = (
@@ -55324,6 +55214,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/showroomfloor,
 /area/ai_monitored/security/armory)
 "chh" = (
@@ -55949,6 +55840,7 @@
 	name = "Warden Armsky";
 	weaponscheck = 1
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/showroomfloor,
 /area/ai_monitored/security/armory)
 "cin" = (
@@ -57150,6 +57042,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/showroomfloor,
 /area/ai_monitored/security/armory)
 "ckH" = (
@@ -57269,6 +57162,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/showroomfloor,
 /area/ai_monitored/security/armory)
 "ckW" = (
@@ -67985,6 +67879,14 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
+"iqa" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/showroomfloor,
+/area/ai_monitored/security/armory)
 "irl" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
@@ -68666,6 +68568,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"muC" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/showroomfloor,
+/area/ai_monitored/security/armory)
 "myg" = (
 /turf/open/floor/wood,
 /area/maintenance/starboard/fore)
@@ -69944,6 +69850,11 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
+"wHb" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/showroomfloor,
+/area/ai_monitored/security/armory)
 "wJG" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -91098,7 +91009,7 @@ aka
 akC
 chc
 cil
-cil
+wHb
 ckG
 amJ
 aka
@@ -91356,7 +91267,7 @@ cgt
 chd
 alx
 aCz
-ckT
+muC
 bdK
 aka
 aeu
@@ -92123,9 +92034,9 @@ ccf
 ccQ
 ceg
 amN
-akG
+alP
 bIS
-cio
+iqa
 cio
 aFh
 anF

--- a/_maps/map_files/MetaStation/MetaStation_Lumos.dmm
+++ b/_maps/map_files/MetaStation/MetaStation_Lumos.dmm
@@ -7770,20 +7770,9 @@
 /area/maintenance/port/fore)
 "avd" = (
 /obj/structure/table/reinforced,
-/obj/item/storage/box/firingpins{
-	pixel_x = -5;
-	pixel_y = 9
-	},
-/obj/item/storage/box/firingpins{
-	pixel_x = -5;
-	pixel_y = 2
-	},
 /obj/item/assembly/flash/handheld{
 	pixel_x = 8;
 	pixel_y = 9
-	},
-/obj/item/assembly/flash/handheld{
-	pixel_x = 8
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -7792,13 +7781,7 @@
 /area/ai_monitored/security/armory)
 "ave" = (
 /obj/structure/rack,
-/obj/item/storage/box/flashes,
-/obj/item/gun/energy/e_gun/dragnet{
-	pixel_y = 4
-	},
-/obj/item/gun/energy/e_gun/dragnet{
-	pixel_y = -3
-	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "avf" = (
@@ -8259,39 +8242,10 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "avZ" = (
-/obj/item/shield/riot{
-	pixel_x = -8;
-	pixel_y = 2
-	},
-/obj/item/shield/riot{
-	pixel_y = 2
-	},
-/obj/item/shield/riot{
-	pixel_x = 8;
-	pixel_y = 2
-	},
 /obj/structure/rack,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "awa" = (
-/obj/item/clothing/suit/armor/riot{
-	pixel_x = -4;
-	pixel_y = -1
-	},
-/obj/item/clothing/suit/armor/riot{
-	pixel_y = -1
-	},
-/obj/item/clothing/suit/armor/riot{
-	pixel_x = 4;
-	pixel_y = -1
-	},
-/obj/item/clothing/head/helmet/riot{
-	pixel_x = -5;
-	pixel_y = 6
-	},
-/obj/item/clothing/head/helmet/riot{
-	pixel_y = 6
-	},
 /obj/item/clothing/head/helmet/riot{
 	pixel_x = 5;
 	pixel_y = 6
@@ -8310,6 +8264,7 @@
 /obj/item/melee/baton/loaded{
 	pixel_y = 3
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "awc" = (
@@ -8382,27 +8337,12 @@
 	pixel_y = 10
 	},
 /obj/item/grenade/barrier{
-	pixel_x = -4;
-	pixel_y = 10
-	},
-/obj/item/grenade/barrier{
-	pixel_y = 10
-	},
-/obj/item/grenade/barrier{
 	pixel_x = 4;
 	pixel_y = 10
 	},
 /obj/item/grenade/barrier{
 	pixel_x = 8;
 	pixel_y = 10
-	},
-/obj/item/storage/box/teargas{
-	pixel_x = -6;
-	pixel_y = 3
-	},
-/obj/item/storage/box/flashbangs{
-	pixel_x = 6;
-	pixel_y = 3
 	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -8416,6 +8356,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "awn" = (
@@ -8448,6 +8389,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "awq" = (
@@ -8463,6 +8405,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "awr" = (
@@ -8537,10 +8480,6 @@
 /obj/structure/rack,
 /obj/item/gun/energy/e_gun/advtaser,
 /obj/item/gun/energy/e_gun/advtaser{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/gun/energy/e_gun/advtaser{
 	pixel_x = 3;
 	pixel_y = -3
 	},
@@ -8550,6 +8489,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "awx" = (
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "awy" = (
@@ -8560,20 +8500,17 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "awz" = (
 /obj/structure/rack,
 /obj/item/storage/box/rubbershot,
-/obj/item/storage/box/rubbershot,
 /obj/item/gun/ballistic/shotgun/riot{
 	pixel_y = -3
 	},
-/obj/item/gun/ballistic/shotgun/riot{
-	pixel_x = -3;
-	pixel_y = 3
-	},
 /obj/effect/turf_decal/lumos/tile/red/fulltile,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "awA" = (
@@ -8680,13 +8617,8 @@
 /area/maintenance/port/fore)
 "awN" = (
 /obj/structure/rack,
-/obj/item/gun/energy/ionrifle{
-	pixel_x = -4;
-	pixel_y = 2
-	},
-/obj/item/gun/energy/temperature/security,
-/obj/item/clothing/suit/armor/laserproof,
 /obj/effect/turf_decal/lumos/tile/red/fulltile,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "awP" = (
@@ -8747,21 +8679,12 @@
 	pixel_x = -1;
 	pixel_y = 4
 	},
-/obj/item/gun/energy/laser{
-	pixel_y = -3
-	},
 /obj/effect/turf_decal/lumos/tile/red/fulltile,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "awY" = (
 /obj/structure/rack,
-/obj/item/gun/energy/e_gun{
-	pixel_y = 5
-	},
-/obj/item/gun/energy/e_gun,
-/obj/item/gun/energy/e_gun{
-	pixel_y = -5
-	},
 /obj/effect/turf_decal/lumos/tile/red/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
@@ -8804,33 +8727,21 @@
 /area/crew_quarters/heads/hos)
 "axc" = (
 /obj/item/clothing/suit/armor/bulletproof{
-	pixel_x = -7;
-	pixel_y = -2
-	},
-/obj/item/clothing/suit/armor/bulletproof{
-	pixel_y = -2
-	},
-/obj/item/clothing/suit/armor/bulletproof{
 	pixel_x = 7;
 	pixel_y = -2
 	},
 /obj/item/clothing/head/helmet/alt{
 	layer = 3.00001;
-	pixel_x = -8;
-	pixel_y = 7
-	},
-/obj/item/clothing/head/helmet/alt{
-	layer = 3.00001;
-	pixel_y = 7
-	},
-/obj/item/clothing/head/helmet/alt{
-	layer = 3.00001;
-	pixel_x = 8;
-	pixel_y = 7
+	pixel_x = -4
 	},
 /obj/structure/rack,
 /obj/structure/window/reinforced{
 	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/clothing/head/helmet/alt{
+	pixel_x = -7;
+	pixel_y = 5
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
@@ -8876,6 +8787,7 @@
 	},
 /obj/vehicle/ridden/secway,
 /obj/item/key/security,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "axg" = (
@@ -8907,6 +8819,7 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "axj" = (
@@ -8945,6 +8858,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "axp" = (
@@ -9077,6 +8991,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/light,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "axz" = (
@@ -10632,12 +10547,6 @@
 /area/security/nuke_storage)
 "aAU" = (
 /obj/structure/closet/secure_closet/lethalshots,
-/obj/item/ammo_box/c10mm,
-/obj/item/ammo_box/c10mm,
-/obj/item/ammo_box/c10mm,
-/obj/item/ammo_box/c10mm,
-/obj/item/ammo_box/c10mm,
-/obj/item/ammo_box/c10mm,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -10664,6 +10573,7 @@
 /area/space)
 "aAX" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "aAY" = (
@@ -14152,17 +14062,6 @@
 /area/crew_quarters/toilet/restrooms)
 "aHP" = (
 /obj/structure/table/reinforced,
-/obj/item/storage/lockbox/loyalty{
-	pixel_y = 12
-	},
-/obj/item/storage/box/trackimp{
-	pixel_x = -5;
-	pixel_y = 1
-	},
-/obj/item/storage/box/chemimp{
-	pixel_x = 5;
-	pixel_y = 1
-	},
 /obj/machinery/camera{
 	c_tag = "Security - Armoury";
 	dir = 4;
@@ -15496,6 +15395,7 @@
 	req_access_txt = "3"
 	},
 /obj/machinery/light,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "aKL" = (
@@ -15511,25 +15411,11 @@
 /area/engine/engineering)
 "aKM" = (
 /obj/item/clothing/suit/armor/vest{
-	pixel_x = -8;
-	pixel_y = -2
-	},
-/obj/item/clothing/suit/armor/vest{
 	pixel_y = -2
 	},
 /obj/item/clothing/suit/armor/vest{
 	pixel_x = 8;
 	pixel_y = -2
-	},
-/obj/item/clothing/head/helmet{
-	layer = 3.00001;
-	pixel_x = -9;
-	pixel_y = 7
-	},
-/obj/item/clothing/head/helmet{
-	layer = 3.00001;
-	pixel_x = -1;
-	pixel_y = 7
 	},
 /obj/item/clothing/head/helmet{
 	layer = 3.00001;
@@ -27467,7 +27353,7 @@
 /area/crew_quarters/heads/captain/private)
 "bjj" = (
 /obj/structure/table/wood,
-/obj/item/melee/chainofcommand,
+/obj/item/storage/fancy/donut_box,
 /turf/open/floor/carpet/green,
 /area/crew_quarters/heads/captain/private)
 "bjk" = (
@@ -32486,6 +32372,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
 /obj/item/stamp/captain,
+/obj/item/melee/chainofcommand,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain/private)
 "btg" = (
@@ -34041,7 +33928,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/item/storage/fancy/donut_box,
+/obj/item/storage/lockbox/loyalty,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain/private)
 "bwE" = (
@@ -74952,6 +74839,13 @@
 /obj/machinery/biogenerator,
 /turf/open/floor/grass,
 /area/maintenance/starboard/aft)
+"lcl" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "liJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
@@ -103224,7 +103118,7 @@ asC
 avd
 awm
 awx
-awo
+lcl
 axR
 asl
 ayB
@@ -103993,7 +103887,7 @@ arq
 asp
 asE
 avX
-awo
+lcl
 awN
 axl
 awv
@@ -104250,7 +104144,7 @@ arq
 asp
 asE
 avX
-awo
+lcl
 awX
 axo
 awv
@@ -104507,7 +104401,7 @@ aru
 asq
 asz
 aBl
-awo
+lcl
 awY
 aKK
 asz
@@ -104764,7 +104658,7 @@ arq
 ast
 asA
 avZ
-awo
+lcl
 awZ
 aAX
 aIG

--- a/_maps/map_files/OmegaStation/OmegaStation_Lumos.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation_Lumos.dmm
@@ -3132,6 +3132,7 @@
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
+/obj/item/storage/lockbox/loyalty,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hop)
 "ags" = (
@@ -10689,12 +10690,6 @@
 /area/maintenance/starboard)
 "att" = (
 /obj/structure/closet/secure_closet/lethalshots,
-/obj/item/ammo_box/c10mm,
-/obj/item/ammo_box/c10mm,
-/obj/item/ammo_box/c10mm,
-/obj/item/ammo_box/c10mm,
-/obj/item/ammo_box/c10mm,
-/obj/item/ammo_box/c10mm,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "atx" = (
@@ -11329,6 +11324,7 @@
 	},
 /obj/structure/closet/secure_closet/armory2,
 /obj/item/storage/box/rubbershot,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "avh" = (
@@ -11648,6 +11644,7 @@
 /area/maintenance/port/fore)
 "avS" = (
 /obj/structure/closet/secure_closet/armory3,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "avT" = (
@@ -14255,8 +14252,7 @@
 	dir = 8
 	},
 /obj/structure/rack,
-/obj/item/storage/lockbox/loyalty,
-/obj/item/gun/energy/pumpaction/blaster,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "aBO" = (
@@ -16373,8 +16369,7 @@
 /obj/structure/cable/white{
 	icon_state = "0-8"
 	},
-/obj/vehicle/ridden/secway,
-/obj/item/key/security,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "aGm" = (
@@ -23462,11 +23457,6 @@
 "aXO" = (
 /obj/structure/rack,
 /obj/item/grenade/barrier{
-	pixel_x = -3;
-	pixel_y = 1
-	},
-/obj/item/grenade/barrier,
-/obj/item/grenade/barrier{
 	pixel_x = 3;
 	pixel_y = -1
 	},
@@ -23480,6 +23470,7 @@
 /obj/item/melee/baton/loaded{
 	pixel_y = -4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "aXR" = (
@@ -26466,6 +26457,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/red,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "bgz" = (
@@ -27119,9 +27111,7 @@
 	name = "contraband locker";
 	req_access_txt = "3"
 	},
-/obj/effect/spawner/lootdrop/armory_contraband{
-	loot = list(/obj/item/gun/ballistic/automatic/pistol = 5, /obj/item/gun/ballistic/shotgun/automatic/combat = 5, /obj/item/gun/ballistic/revolver/mateba, /obj/item/gun/ballistic/automatic/pistol/deagle, /obj/item/storage/box/syndie_kit/throwing_weapons = 3)
-	},
+/obj/effect/spawner/lootdrop/armory_contraband,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "bia" = (
@@ -29786,6 +29776,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 5
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "bFs" = (
@@ -31477,6 +31468,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "doE" = (
@@ -32073,6 +32065,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/red,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "dTK" = (
@@ -32296,11 +32289,11 @@
 /obj/structure/cable/white{
 	icon_state = "1-4"
 	},
-/obj/structure/cable/white{
-	icon_state = "1-8"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 9
+	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/dark,
 /area/gateway)
@@ -34081,6 +34074,9 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"fLw" = (
+/turf/closed/wall/r_wall,
+/area/maintenance/port/fore)
 "fLU" = (
 /obj/structure/cable/white{
 	icon_state = "1-2"
@@ -36046,13 +36042,7 @@
 	pixel_x = -26
 	},
 /obj/structure/rack,
-/obj/item/storage/box/flashes,
-/obj/item/gun/energy/e_gun/dragnet{
-	pixel_y = 4
-	},
-/obj/item/gun/energy/e_gun/dragnet{
-	pixel_y = -3
-	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "hpP" = (
@@ -38640,6 +38630,7 @@
 /obj/structure/closet{
 	name = "Evidence Closet"
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "jEP" = (
@@ -41433,6 +41424,7 @@
 	name = "Sergeant-at-Armsky";
 	weaponscheck = 1
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "mou" = (
@@ -43146,28 +43138,10 @@
 "ooV" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/armor/bulletproof{
-	pixel_x = -7;
-	pixel_y = -2
-	},
-/obj/item/clothing/suit/armor/bulletproof{
-	pixel_y = -2
-	},
-/obj/item/clothing/suit/armor/bulletproof{
-	pixel_x = 7;
 	pixel_y = -2
 	},
 /obj/item/clothing/head/helmet/alt{
 	layer = 3.00001;
-	pixel_x = -8;
-	pixel_y = 7
-	},
-/obj/item/clothing/head/helmet/alt{
-	layer = 3.00001;
-	pixel_y = 7
-	},
-/obj/item/clothing/head/helmet/alt{
-	layer = 3.00001;
-	pixel_x = 8;
 	pixel_y = 7
 	},
 /turf/open/floor/plasteel/dark,
@@ -43514,6 +43488,21 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/science/mixing)
+"oCl" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/delivery/red,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "oCy" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/machinery/firealarm{
@@ -44395,6 +44384,7 @@
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "prZ" = (
@@ -44736,6 +44726,7 @@
 	pixel_x = -6;
 	pixel_y = 6
 	},
+/obj/item/key/security,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "pFX" = (
@@ -45807,6 +45798,7 @@
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "qHq" = (
@@ -46256,9 +46248,6 @@
 	dir = 4
 	},
 /obj/structure/rack,
-/obj/item/gun/energy/temperature/security{
-	pixel_y = -5
-	},
 /obj/item/gun/energy/e_gun/advtaser{
 	pixel_y = 5
 	},
@@ -46620,6 +46609,7 @@
 /obj/structure/closet{
 	name = "Evidence Closet"
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "rDx" = (
@@ -46862,6 +46852,7 @@
 	desc = "An adorable fruit bat with a cute little hat, may or may not have a reputation for biting out eyeballs, or at least that's what the HoS'd tell you.";
 	name = "Colonel Chomps"
 	},
+/obj/vehicle/ridden/secway,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "rOg" = (
@@ -51684,6 +51675,7 @@
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "vmW" = (
@@ -51871,6 +51863,7 @@
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "vwa" = (
@@ -77944,17 +77937,17 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
 sdX
 atJ
 atJ
 atJ
-sdX
-sdX
 atJ
 atJ
 atJ
-sdX
-sdX
+pZU
+pZU
 atJ
 atJ
 atJ
@@ -78201,9 +78194,9 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
 sdX
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -78458,9 +78451,9 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
 sdX
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -78715,14 +78708,14 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
 sdX
 sdX
 sdX
 atJ
 atJ
 atJ
-atJ
-sdX
 atJ
 atJ
 atJ
@@ -78972,9 +78965,9 @@ bhT
 aaa
 aaa
 aaa
+aaa
+aaa
 sdX
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -79229,9 +79222,9 @@ bhT
 aaa
 aaa
 aaa
+aaa
+aaa
 sdX
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -85383,7 +85376,7 @@ aac
 aac
 aac
 aad
-aro
+fLw
 vhy
 hYQ
 azg
@@ -85640,8 +85633,8 @@ aad
 aad
 aac
 aac
-aro
-aro
+fLw
+fLw
 upR
 kjp
 arp
@@ -88985,7 +88978,7 @@ dTl
 vmK
 ppf
 dnI
-aXo
+oCl
 onM
 aBo
 diU

--- a/_maps/map_files/PubbyStation/PubbyStation_Lumos.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation_Lumos.dmm
@@ -1509,6 +1509,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/obj/structure/closet/emcloset/anchored,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat_interior)
 "afS" = (
@@ -2239,21 +2240,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"aii" = (
-/obj/structure/table,
-/obj/item/storage/box/chemimp{
-	pixel_x = 6
-	},
-/obj/item/storage/box/trackimp{
-	pixel_x = -3
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/armory)
 "aij" = (
 /obj/structure/closet/secure_closet/contraband/armory,
-/obj/item/poster/random_contraband,
-/obj/item/clothing/suit/armor/navyblue/russian,
-/obj/item/grenade/plastic/c4,
+/obj/effect/spawner/lootdrop/armory_contraband,
 /turf/open/floor/plasteel/dark,
 /area/security/armory)
 "aik" = (
@@ -2261,19 +2250,16 @@
 /obj/machinery/camera/motion{
 	c_tag = "Armory Motion Sensor"
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/security/armory)
 "ail" = (
-/obj/vehicle/ridden/secway,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/security/armory)
 "aim" = (
 /obj/item/grenade/barrier{
 	pixel_x = 4
-	},
-/obj/item/grenade/barrier,
-/obj/item/grenade/barrier{
-	pixel_x = -4
 	},
 /obj/structure/table,
 /turf/open/floor/plasteel/dark,
@@ -2388,17 +2374,6 @@
 /area/security/prison)
 "aiL" = (
 /obj/structure/table,
-/obj/item/storage/box/flashbangs{
-	pixel_x = 6;
-	pixel_y = 3
-	},
-/obj/item/storage/box/flashbangs{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/storage/lockbox/loyalty{
-	layer = 4
-	},
 /turf/open/floor/plasteel/dark,
 /area/security/armory)
 "aiM" = (
@@ -2408,11 +2383,11 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/security/armory)
 "aiO" = (
 /obj/structure/table,
-/obj/item/storage/box/firingpins,
 /obj/item/storage/box/firingpins,
 /obj/machinery/power/apc/highcap/five_k{
 	dir = 4;
@@ -2422,6 +2397,7 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/security/armory)
 "aiP" = (
@@ -2545,9 +2521,6 @@
 /area/security/prison)
 "ajg" = (
 /obj/structure/rack,
-/obj/item/gun/energy/ionrifle,
-/obj/item/gun/energy/temperature/security,
-/obj/item/clothing/suit/armor/laserproof,
 /obj/machinery/light{
 	dir = 8;
 	light_color = "#e8eaff"
@@ -2564,20 +2537,6 @@
 	pixel_x = -3;
 	pixel_y = 3
 	},
-/obj/item/clothing/suit/armor/riot{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/clothing/head/helmet/riot,
-/obj/item/clothing/head/helmet/riot{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/shield/riot,
-/obj/item/shield/riot{
-	pixel_x = 3;
-	pixel_y = -3
-	},
 /turf/open/floor/plasteel/dark,
 /area/security/armory)
 "aji" = (
@@ -2588,20 +2547,8 @@
 /area/security/armory)
 "ajj" = (
 /obj/structure/rack,
-/obj/item/storage/box/rubbershot{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/storage/box/rubbershot{
-	pixel_x = -3;
-	pixel_y = 3
-	},
 /obj/item/storage/box/rubbershot,
 /obj/item/storage/box/rubbershot,
-/obj/item/storage/box/rubbershot{
-	pixel_x = 3;
-	pixel_y = -3
-	},
 /obj/machinery/light{
 	dir = 4;
 	light_color = "#e8eaff"
@@ -2609,6 +2556,7 @@
 /obj/structure/sign/warning/nosmoking{
 	pixel_x = 32
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/security/armory)
 "ajk" = (
@@ -2843,21 +2791,18 @@
 /area/security/brig)
 "ajP" = (
 /obj/structure/rack,
-/obj/item/gun/energy/e_gun{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/gun/energy/e_gun,
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = -27
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/security/armory)
 "ajQ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/security/armory)
 "ajR" = (
@@ -2866,14 +2811,8 @@
 	pixel_x = -3;
 	pixel_y = 3
 	},
-/obj/item/clothing/suit/armor/bulletproof,
 /obj/item/clothing/head/helmet/alt{
 	layer = 3.00001
-	},
-/obj/item/clothing/head/helmet/alt{
-	layer = 3.00001;
-	pixel_x = 3;
-	pixel_y = -3
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 10
@@ -2881,6 +2820,7 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
 	dir = 6
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/security/armory)
 "ajS" = (
@@ -2890,18 +2830,12 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/security/armory)
 "ajT" = (
 /obj/structure/rack,
-/obj/item/gun/energy/laser{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/gun/energy/laser{
-	pixel_x = 3;
-	pixel_y = -3
-	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/security/armory)
 "ajU" = (
@@ -3292,33 +3226,22 @@
 /area/security/brig)
 "akL" = (
 /obj/structure/rack,
-/obj/item/gun/energy/e_gun/advtaser{
-	pixel_x = -3;
-	pixel_y = 3
-	},
 /obj/item/gun/energy/e_gun/advtaser,
-/obj/item/gun/energy/e_gun/advtaser{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/gun/energy/e_gun/advtaser,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/security/armory)
 "akN" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/rack,
-/obj/item/key/security,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/security/armory)
 "akP" = (
 /obj/structure/rack,
 /obj/item/gun/ballistic/shotgun/riot,
-/obj/item/gun/ballistic/shotgun/riot{
-	pixel_x = 3;
-	pixel_y = -3
-	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/security/armory)
 "akQ" = (
@@ -3559,6 +3482,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/security/armory)
 "alB" = (
@@ -11759,9 +11683,12 @@
 /area/crew_quarters/heads/captain)
 "aEy" = (
 /obj/structure/table/wood,
-/obj/item/hand_tele,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
+	},
+/obj/item/hand_tele,
+/obj/item/storage/lockbox/loyalty{
+	layer = 4
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain)
@@ -48255,6 +48182,13 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/security/brig)
+"eRy" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark,
+/area/security/armory)
 "eSB" = (
 /obj/structure/lattice,
 /obj/machinery/camera{
@@ -50288,6 +50222,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/security/armory)
 "iyg" = (
@@ -54200,6 +54135,20 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine,
 /area/engine/supermatter)
+"ptM" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark,
+/area/security/armory)
 "pud" = (
 /obj/structure/plasticflaps,
 /turf/open/floor/plating,
@@ -80835,7 +80784,7 @@ jTc
 jTc
 jTc
 ahL
-aii
+aiL
 aiL
 ajg
 ajP
@@ -81093,10 +81042,10 @@ iZZ
 gKc
 ahL
 aij
-aiM
-aiM
+ail
+ail
 ajQ
-aiM
+ail
 aiM
 ami
 amX
@@ -81610,8 +81559,8 @@ ail
 aiN
 aji
 ajS
-aji
-aji
+eRy
+eRy
 amk
 amX
 anI
@@ -81868,7 +81817,7 @@ aiO
 ajj
 ajT
 akP
-alA
+ptM
 amj
 amZ
 anJ

--- a/_maps/map_files/Snaxi/Snaxi_Lumos.dmm
+++ b/_maps/map_files/Snaxi/Snaxi_Lumos.dmm
@@ -728,6 +728,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "ajP" = (
@@ -3011,6 +3012,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "aLu" = (
@@ -4126,6 +4128,12 @@
 /obj/structure/lattice/catwalk,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"bfK" = (
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/median/darktogrime{
+	dir = 1
+	},
+/area/chapel/main/monastery)
 "bfR" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -7501,17 +7509,11 @@
 /area/security/vacantoffice/b)
 "bYU" = (
 /obj/structure/table/reinforced,
-/obj/item/storage/lockbox/loyalty{
-	pixel_y = 12
-	},
 /obj/item/storage/box/trackimp{
 	pixel_x = -5;
 	pixel_y = 1
 	},
-/obj/item/storage/box/chemimp{
-	pixel_x = 5;
-	pixel_y = 1
-	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "bYY" = (
@@ -7594,6 +7596,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/vehicle/ridden/secway,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
 "cbL" = (
@@ -8600,6 +8603,7 @@
 /obj/effect/spawner/lootdrop/armory_contraband{
 	loot = list(/obj/item/gun/ballistic/automatic/pistol = 5, /obj/item/gun/ballistic/shotgun/automatic/combat = 5, /obj/item/gun/ballistic/revolver/mateba, /obj/item/gun/ballistic/automatic/pistol/deagle, /obj/item/storage/box/syndie_kit/throwing_weapons = 3)
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "cry" = (
@@ -9098,6 +9102,7 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/atmospherics_engine)
 "cCd" = (
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "cCg" = (
@@ -10506,6 +10511,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "dfd" = (
@@ -13697,6 +13703,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 6
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "eHK" = (
@@ -14390,8 +14397,6 @@
 /turf/open/floor/carpet,
 /area/hallway/secondary/exit/departure_lounge)
 "eVW" = (
-/obj/vehicle/ridden/secway,
-/obj/item/key/security,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "eWp" = (
@@ -15067,13 +15072,7 @@
 /area/quartermaster/storage)
 "fnc" = (
 /obj/structure/rack,
-/obj/item/storage/box/flashes,
-/obj/item/gun/energy/e_gun/dragnet{
-	pixel_y = 4
-	},
-/obj/item/gun/energy/e_gun/dragnet{
-	pixel_y = -3
-	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "fne" = (
@@ -16418,6 +16417,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "fRK" = (
@@ -16884,6 +16884,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "gcY" = (
@@ -21685,10 +21686,7 @@
 	pixel_y = 22
 	},
 /obj/structure/closet/secure_closet/lethalshots,
-/obj/item/ammo_box/c9mm,
-/obj/item/ammo_box/c9mm,
-/obj/item/ammo_box/c9mm,
-/obj/item/ammo_box/c9mm,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "iiM" = (
@@ -22584,6 +22582,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/break_room)
+"iEu" = (
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "iEz" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -23316,18 +23318,7 @@
 "iTJ" = (
 /obj/structure/rack,
 /obj/item/storage/box/rubbershot,
-/obj/item/storage/box/rubbershot,
-/obj/item/storage/box/rubbershot,
-/obj/item/storage/box/rubbershot,
-/obj/item/gun/ballistic/shotgun/riot{
-	pixel_x = 3;
-	pixel_y = 6
-	},
 /obj/item/gun/ballistic/shotgun/riot,
-/obj/item/gun/ballistic/shotgun/riot{
-	pixel_x = -3;
-	pixel_y = -6
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -24885,6 +24876,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "jGF" = (
@@ -27026,17 +27018,10 @@
 "kEd" = (
 /obj/structure/rack,
 /obj/item/gun/energy/e_gun/advtaser,
-/obj/item/gun/energy/e_gun/advtaser{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/gun/energy/e_gun/advtaser{
-	pixel_x = 3;
-	pixel_y = -3
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "kEf" = (
@@ -29926,32 +29911,6 @@
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "lZi" = (
-/obj/item/clothing/suit/armor/vest{
-	pixel_x = -8;
-	pixel_y = -2
-	},
-/obj/item/clothing/suit/armor/vest{
-	pixel_y = -2
-	},
-/obj/item/clothing/suit/armor/vest{
-	pixel_x = 8;
-	pixel_y = -2
-	},
-/obj/item/clothing/head/helmet{
-	layer = 3.00001;
-	pixel_x = -9;
-	pixel_y = 7
-	},
-/obj/item/clothing/head/helmet{
-	layer = 3.00001;
-	pixel_x = -1;
-	pixel_y = 7
-	},
-/obj/item/clothing/head/helmet{
-	layer = 3.00001;
-	pixel_x = 8;
-	pixel_y = 7
-	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
 	},
@@ -29965,6 +29924,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "lZn" = (
@@ -33169,16 +33129,10 @@
 /area/maintenance/port/fore)
 "nyZ" = (
 /obj/structure/rack,
-/obj/item/gun/energy/laser{
-	pixel_y = 6
-	},
-/obj/item/gun/energy/laser,
-/obj/item/gun/energy/laser{
-	pixel_y = -6
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "nzn" = (
@@ -34090,14 +34044,6 @@
 /area/medical/storage)
 "nQM" = (
 /obj/item/shield/riot{
-	pixel_x = -8;
-	pixel_y = 2
-	},
-/obj/item/shield/riot{
-	pixel_y = 2
-	},
-/obj/item/shield/riot{
-	pixel_x = 8;
 	pixel_y = 2
 	},
 /obj/structure/rack,
@@ -34256,6 +34202,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "nUk" = (
@@ -37801,6 +37748,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "pwo" = (
@@ -38237,29 +38185,7 @@
 	pixel_x = -8;
 	pixel_y = 10
 	},
-/obj/item/grenade/barrier{
-	pixel_x = -4;
-	pixel_y = 10
-	},
-/obj/item/grenade/barrier{
-	pixel_y = 10
-	},
-/obj/item/grenade/barrier{
-	pixel_x = 4;
-	pixel_y = 10
-	},
-/obj/item/grenade/barrier{
-	pixel_x = 8;
-	pixel_y = 10
-	},
-/obj/item/storage/box/teargas{
-	pixel_x = -6;
-	pixel_y = 3
-	},
-/obj/item/storage/box/flashbangs{
-	pixel_x = 6;
-	pixel_y = 3
-	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "pDN" = (
@@ -38721,6 +38647,9 @@
 /obj/machinery/recharger,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
+	},
+/obj/item/storage/lockbox/loyalty{
+	pixel_y = 16
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/bridge)
@@ -43828,6 +43757,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "siY" = (
@@ -46198,35 +46128,15 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "toz" = (
-/obj/item/clothing/suit/armor/bulletproof{
-	pixel_x = -7;
-	pixel_y = -2
-	},
-/obj/item/clothing/suit/armor/bulletproof{
-	pixel_y = -2
-	},
-/obj/item/clothing/suit/armor/bulletproof{
-	pixel_x = 7;
-	pixel_y = -2
-	},
 /obj/item/clothing/head/helmet/alt{
 	layer = 3.00001;
-	pixel_x = -8;
-	pixel_y = 7
-	},
-/obj/item/clothing/head/helmet/alt{
-	layer = 3.00001;
-	pixel_y = 7
-	},
-/obj/item/clothing/head/helmet/alt{
-	layer = 3.00001;
-	pixel_x = 8;
 	pixel_y = 7
 	},
 /obj/structure/rack,
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_x = 32
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "toL" = (
@@ -47357,6 +47267,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "tPP" = (
@@ -49073,6 +48984,7 @@
 /obj/machinery/light,
 /obj/structure/table/wood,
 /obj/item/stamp/hos,
+/obj/item/key/security,
 /turf/open/floor/carpet/black,
 /area/crew_quarters/heads/hos)
 "uKr" = (
@@ -54466,16 +54378,11 @@
 /area/hallway/primary/starboard)
 "xfE" = (
 /obj/structure/rack,
-/obj/item/gun/energy/e_gun{
-	pixel_y = 5
-	},
 /obj/item/gun/energy/e_gun,
-/obj/item/gun/energy/e_gun{
-	pixel_y = -5
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "xfG" = (
@@ -54903,13 +54810,8 @@
 	dir = 1
 	},
 /obj/structure/rack,
-/obj/item/gun/energy/ionrifle{
-	pixel_x = -4;
-	pixel_y = 2
-	},
-/obj/item/clothing/suit/armor/laserproof,
-/obj/item/gun/energy/temperature/security,
 /obj/structure/cable,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "xrL" = (
@@ -55295,31 +55197,17 @@
 /area/security/brig)
 "xBv" = (
 /obj/item/clothing/suit/armor/riot{
-	pixel_x = -4;
-	pixel_y = -1
-	},
-/obj/item/clothing/suit/armor/riot{
 	pixel_y = -1
 	},
 /obj/item/clothing/suit/armor/riot{
 	pixel_x = 4;
 	pixel_y = -1
 	},
-/obj/item/clothing/head/helmet/riot{
-	pixel_x = -5;
-	pixel_y = 6
-	},
-/obj/item/clothing/head/helmet/riot{
-	pixel_y = 6
-	},
-/obj/item/clothing/head/helmet/riot{
-	pixel_x = 5;
-	pixel_y = 6
-	},
 /obj/structure/rack,
 /obj/item/storage/secure/safe{
 	pixel_x = 32
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "xBV" = (
@@ -55550,18 +55438,11 @@
 /obj/structure/table/reinforced,
 /obj/item/storage/box/firingpins{
 	pixel_x = -5;
-	pixel_y = 9
-	},
-/obj/item/storage/box/firingpins{
-	pixel_x = -5;
 	pixel_y = 2
 	},
 /obj/item/assembly/flash/handheld{
 	pixel_x = 8;
 	pixel_y = 9
-	},
-/obj/item/assembly/flash/handheld{
-	pixel_x = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
@@ -83123,8 +83004,8 @@ bDv
 kfv
 fQi
 nxv
-adf
-adf
+iEu
+iEu
 adf
 fLB
 oZC
@@ -102670,7 +102551,7 @@ nbC
 nbC
 nbC
 gUW
-ydp
+xUL
 ydp
 kpG
 mEi
@@ -104737,7 +104618,7 @@ lzR
 nKf
 qAo
 xDu
-jNv
+bfK
 eNc
 ydp
 ydp


### PR DESCRIPTION
## About The Pull Request

NT Defunded Security after a long string of thefts across multiple stations.

A majority of the armories have been haphazardly cleared, while mindshield implants have been moved to the captain's office

## Why It's Good For The Game

Gives the Security budget a purpose

## Changelog
:cl:
del: armory shit
/:cl: