### PR TITLE
Box Total Perma Revert

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/lostbrig_box.dmm
+++ b/_maps/RandomRuins/SpaceRuins/lostbrig_box.dmm
@@ -1,0 +1,3266 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"ar" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"aI" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"aO" = (
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/item/bedsheet/orange{
+	icon_state = "sheetorange_flip"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/unpowered)
+"aT" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/light,
+/turf/open/floor/plasteel/checker,
+/area/ruin/unpowered)
+"aU" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/obj/structure/chair/stool,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"bb" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/ruin/unpowered)
+"bi" = (
+/obj/effect/turf_decal/trimline/green/filled/line,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"bm" = (
+/obj/structure/table,
+/obj/machinery/microwave{
+	pixel_y = 6
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/unpowered)
+"bP" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/turf/open/floor/wood,
+/area/ruin/unpowered)
+"bT" = (
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/structure/sign/nanotrasen{
+	icon = 'modular_skyrat/icons/obj/contraband.dmi';
+	icon_state = "poster2_legit";
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"ca" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"ce" = (
+/obj/structure/bed,
+/obj/effect/mob_spawn/human/corpse/nanotrasensoldier,
+/turf/open/floor/plasteel/dark,
+/area/ruin/unpowered)
+"cg" = (
+/obj/structure/rack,
+/obj/item/tank/internals/emergency_oxygen,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"cA" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/poddoor/preopen,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"cN" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/machinery/seed_extractor,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"cT" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/turf/open/floor/wood,
+/area/ruin/unpowered)
+"cV" = (
+/obj/machinery/airalarm/directional/east,
+/obj/structure/sink/kitchen{
+	dir = 8;
+	pixel_x = 11
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/unpowered)
+"du" = (
+/obj/structure/bed,
+/obj/item/bedsheet/orange,
+/turf/open/floor/plasteel/dark,
+/area/ruin/unpowered)
+"dM" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"dO" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/remains/human,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"ef" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"el" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"eu" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "Library"
+	},
+/turf/open/floor/wood,
+/area/ruin/unpowered)
+"ex" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/unpowered)
+"eN" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"eU" = (
+/turf/open/floor/wood{
+	icon_state = "wood-broken4"
+	},
+/area/ruin/unpowered)
+"fn" = (
+/turf/template_noop,
+/area/template_noop)
+"fJ" = (
+/obj/structure/fluff/empty_sleeper,
+/turf/open/floor/circuit,
+/area/ruin/unpowered)
+"fR" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"fU" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"fX" = (
+/obj/effect/spawner/structure/window,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"gb" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"gk" = (
+/turf/closed/mineral/random/labormineral,
+/area/ruin/unpowered)
+"gn" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/effect/turf_decal/lumos/tile/blue/checker,
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 12;
+	pixel_y = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/ruin/unpowered)
+"gw" = (
+/obj/structure/lattice,
+/turf/template_noop,
+/area/template_noop)
+"gx" = (
+/obj/machinery/holopad,
+/obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"gz" = (
+/obj/machinery/smartfridge/food,
+/turf/closed/wall,
+/area/ruin/unpowered)
+"gV" = (
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#cee5d2"
+	},
+/obj/structure/closet/crate/bin,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"he" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/closed,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"hf" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"hh" = (
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#cee5d2"
+	},
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 5
+	},
+/obj/machinery/biogenerator/prisoner,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"ho" = (
+/obj/structure/girder,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/ruin/unpowered)
+"hp" = (
+/obj/structure/chair/stool,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"hq" = (
+/obj/structure/grille,
+/obj/structure/lattice,
+/turf/template_noop,
+/area/template_noop)
+"hr" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/preopen{
+	id = "permalock2"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"hy" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"hE" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -24;
+	pixel_y = 28
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"hG" = (
+/obj/structure/chair/stool,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/structure/sign/nanotrasen{
+	icon = 'modular_skyrat/icons/obj/contraband.dmi';
+	icon_state = "poster2_legit";
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"hP" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 9
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"hY" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/lumos/tile/blue/checker,
+/turf/open/floor/plasteel/cafeteria,
+/area/ruin/unpowered)
+"ib" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/ruin/unpowered)
+"ie" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/closed,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"iE" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"iF" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"iO" = (
+/obj/machinery/holopad,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"iW" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8
+	},
+/obj/machinery/airalarm/directional/east,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"iZ" = (
+/obj/structure/chair/stool,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"ja" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"jw" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"jz" = (
+/obj/item/bedsheet/orange,
+/turf/open/floor/plasteel/dark,
+/area/ruin/unpowered)
+"jK" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"ki" = (
+/obj/machinery/washing_machine,
+/obj/effect/turf_decal/lumos/tile/blue/checker,
+/turf/open/floor/plasteel/cafeteria,
+/area/ruin/unpowered)
+"kk" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/obj/machinery/airalarm/directional/east,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"ks" = (
+/obj/structure/bookcase/random/fiction,
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#cee5d2"
+	},
+/turf/open/floor/wood,
+/area/ruin/unpowered)
+"kz" = (
+/obj/structure/sign/warning/electricshock,
+/turf/closed/wall/r_wall,
+/area/ruin/unpowered)
+"kE" = (
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"kR" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/barricade/wooden,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"kT" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"kV" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"kY" = (
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#cee5d2"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/structure/sign/nanotrasen{
+	icon = 'modular_skyrat/icons/obj/contraband.dmi';
+	icon_state = "poster2_legit";
+	pixel_y = 32
+	},
+/turf/open/floor/wood,
+/area/ruin/unpowered)
+"lg" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#c1caff"
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"lq" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/toilet{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"lu" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass{
+	name = "Brig Kitchen"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/unpowered)
+"lH" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"lQ" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Showers"
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/ruin/unpowered)
+"lT" = (
+/turf/open/floor/wood,
+/area/ruin/unpowered)
+"lW" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"md" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"me" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"mo" = (
+/obj/effect/mob_spawn/human/corpse/nanotrasensoldier,
+/turf/open/floor/plasteel/dark,
+/area/ruin/unpowered)
+"mq" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "Laundry"
+	},
+/obj/effect/turf_decal/lumos/tile/blue/checker,
+/turf/open/floor/plasteel/cafeteria,
+/area/ruin/unpowered)
+"mt" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/ruin/unpowered)
+"mC" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/obj/effect/turf_decal/sand,
+/turf/open/floor/plasteel/checker,
+/area/ruin/unpowered)
+"nf" = (
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#cee5d2"
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/unpowered)
+"nB" = (
+/obj/structure/holohoop{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/ruin/unpowered)
+"nL" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"nQ" = (
+/obj/machinery/requests_console{
+	department = "Prison";
+	departmentType = 1;
+	pixel_y = -30
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/unpowered)
+"nZ" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/obj/item/caution,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"ol" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/turf/open/floor/plasteel/checker,
+/area/ruin/unpowered)
+"om" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/bonfire,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/ruin/unpowered)
+"or" = (
+/obj/structure/toilet{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/unpowered)
+"ow" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/closed,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"oB" = (
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#cee5d2"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/structure/sign/nanotrasen{
+	icon = 'modular_skyrat/icons/obj/contraband.dmi';
+	icon_state = "poster2_legit";
+	pixel_y = 32
+	},
+/turf/open/floor/wood,
+/area/ruin/unpowered)
+"oC" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 5
+	},
+/obj/machinery/door/firedoor/closed,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"oG" = (
+/obj/structure/mopbucket,
+/turf/open/floor/plasteel/dark,
+/area/ruin/unpowered)
+"oM" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "License Workshop"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/open/floor/plasteel/checker,
+/area/ruin/unpowered)
+"pa" = (
+/obj/structure/chair/stool,
+/turf/open/floor/plasteel/cafeteria,
+/area/ruin/unpowered)
+"pq" = (
+/obj/structure/closet/secure_closet/freezer/meat,
+/turf/open/floor/plasteel/freezer,
+/area/ruin/unpowered)
+"pT" = (
+/obj/structure/rack,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"pZ" = (
+/obj/structure/table,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/glass/bucket,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"qo" = (
+/obj/item/storage/pill_bottle/dice,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"qv" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"qD" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Brig Mess"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/open/floor/plasteel/cafeteria,
+/area/ruin/unpowered)
+"qE" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass{
+	name = "Brig Hydroponics"
+	},
+/obj/effect/turf_decal/lumos/tile/green/half{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white/side,
+/area/ruin/unpowered)
+"qM" = (
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#cee5d2"
+	},
+/obj/structure/closet/crate/bin,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"qR" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"qZ" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/unpowered)
+"rh" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
+	},
+/obj/machinery/hydroponics/constructable,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"rs" = (
+/turf/open/floor/plasteel/freezer,
+/area/ruin/unpowered)
+"rw" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"rC" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"rQ" = (
+/obj/structure/fluff/broken_flooring,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"rT" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
+	},
+/obj/item/hatchet,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"sa" = (
+/obj/item/radio/intercom{
+	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_y = 24;
+	prison_radio = 1
+	},
+/obj/structure/bed{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/unpowered)
+"tk" = (
+/obj/structure/girder/reinforced,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"tz" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 10
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"tH" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"tW" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"ug" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"uq" = (
+/obj/item/radio/intercom{
+	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_y = 24;
+	prison_radio = 1
+	},
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"uT" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"vd" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#c1caff"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"vk" = (
+/obj/item/radio/intercom{
+	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_y = 24;
+	prison_radio = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/unpowered)
+"vn" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/preopen{
+	id = "permalock2"
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"vr" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"vI" = (
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/glass/bowl,
+/obj/machinery/door/firedoor/closed,
+/turf/open/floor/plasteel/white,
+/area/ruin/unpowered)
+"ww" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/chair/stool,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"wE" = (
+/obj/machinery/light{
+	light_color = "#cee5d2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/unpowered)
+"wI" = (
+/obj/structure/table,
+/obj/machinery/newscaster{
+	pixel_y = 32
+	},
+/turf/open/floor/wood,
+/area/ruin/unpowered)
+"wV" = (
+/obj/machinery/hydroponics/constructable,
+/obj/machinery/light,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 10
+	},
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"wW" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 4
+	},
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"xh" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/unpowered)
+"xD" = (
+/obj/machinery/airalarm/directional/west,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"xE" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"xN" = (
+/turf/closed/wall/r_wall,
+/area/ruin/unpowered)
+"xY" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/item/soap/homemade,
+/turf/open/floor/plasteel/showroomfloor,
+/area/ruin/unpowered)
+"ya" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"yd" = (
+/obj/machinery/shower{
+	dir = 4
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/ruin/unpowered)
+"yl" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"yH" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/barricade/wooden,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"yM" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor/closed,
+/turf/open/floor/plasteel/white,
+/area/ruin/unpowered)
+"yR" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/obj/item/weldingtool/mini,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"zj" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"zr" = (
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/unpowered)
+"zC" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"zZ" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"Ao" = (
+/obj/item/radio/intercom{
+	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_y = 24;
+	prison_radio = 1
+	},
+/obj/item/bedsheet/orange{
+	icon_state = "sheetorange_flip"
+	},
+/obj/structure/bed{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/unpowered)
+"Aq" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"At" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/components/binary/valve{
+	dir = 4
+	},
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"AC" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/drinks/drinkingglass{
+	pixel_x = -8;
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass{
+	pixel_x = -8;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass{
+	pixel_x = -8
+	},
+/obj/machinery/reagentgrinder,
+/obj/item/reagent_containers/dropper,
+/obj/machinery/light,
+/turf/open/floor/plasteel/white,
+/area/ruin/unpowered)
+"AZ" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/ruin/unpowered)
+"Ba" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"Bs" = (
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/ruin/unpowered)
+"Bt" = (
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#cee5d2"
+	},
+/obj/item/radio/off,
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/mob_spawn/human/corpse/assistant,
+/turf/open/floor/plasteel/showroomfloor,
+/area/ruin/unpowered)
+"Bv" = (
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"Cz" = (
+/obj/structure/closet/secure_closet/freezer/gulag_fridge,
+/turf/open/floor/plasteel/white,
+/area/ruin/unpowered)
+"CM" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"Dl" = (
+/obj/machinery/light,
+/obj/structure/table,
+/obj/structure/bedsheetbin,
+/obj/structure/sign/poster/official/work_for_a_future{
+	pixel_x = -32
+	},
+/obj/effect/turf_decal/lumos/tile/blue/checker,
+/turf/open/floor/plasteel/cafeteria,
+/area/ruin/unpowered)
+"Dm" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"Ds" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass{
+	name = "Brig Hydroponics"
+	},
+/obj/effect/turf_decal/lumos/tile/green/half{
+	dir = 4
+	},
+/obj/effect/turf_decal/lumos/tile/red/half{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"DR" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"En" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"Ep" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"Et" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -24;
+	pixel_y = 28
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"Eu" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"EB" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#c1caff"
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"Fe" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"Fv" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
+/obj/machinery/airalarm/directional/north,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"FC" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"FT" = (
+/obj/structure/grille/broken,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"Ga" = (
+/obj/structure/table,
+/obj/item/toy/cards/deck,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"Go" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"Gq" = (
+/obj/structure/rack,
+/obj/effect/turf_decal/sand,
+/turf/open/floor/plasteel/checker,
+/area/ruin/unpowered)
+"Gw" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"GG" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"GT" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/lumos/tile/blue/checker,
+/obj/item/reagent_containers/glass/bucket,
+/turf/open/floor/plasteel/cafeteria,
+/area/ruin/unpowered)
+"Hp" = (
+/obj/machinery/light,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"HA" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/lattice,
+/turf/template_noop,
+/area/template_noop)
+"It" = (
+/obj/machinery/camera{
+	c_tag = "Permabrig Kitchen";
+	network = list("ss13","prison")
+	},
+/obj/structure/table_frame,
+/obj/item/reagent_containers/food/condiment/flour{
+	list_reagents = list(/datum/reagent/consumable/flour = 90);
+	name = "large flour sack";
+	possible_transfer_amounts = list(1,5,10,15,30,60,90);
+	volume = 90
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/unpowered)
+"Iy" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"IB" = (
+/obj/structure/table,
+/turf/open/floor/plasteel/cafeteria,
+/area/ruin/unpowered)
+"IM" = (
+/obj/structure/closet/crate/bin,
+/turf/open/floor/plasteel/cafeteria,
+/area/ruin/unpowered)
+"Jc" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"Jr" = (
+/obj/effect/spawner/structure/window,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"JO" = (
+/obj/structure/bed,
+/obj/item/radio/intercom{
+	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_y = 24;
+	prison_radio = 1
+	},
+/obj/item/bedsheet/orange,
+/turf/open/floor/plasteel/dark,
+/area/ruin/unpowered)
+"Ke" = (
+/turf/closed/wall,
+/area/ruin/unpowered)
+"KA" = (
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"KC" = (
+/obj/structure/table,
+/obj/machinery/computer/libraryconsole{
+	pixel_y = 8
+	},
+/turf/open/floor/wood,
+/area/ruin/unpowered)
+"KK" = (
+/obj/machinery/light,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/ruin/unpowered)
+"KX" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/machinery/atmospherics/components/unary/tank/air{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"KY" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"Li" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"Lu" = (
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"LO" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"LP" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
+/turf/open/floor/wood,
+/area/ruin/unpowered)
+"LT" = (
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/ruin/unpowered)
+"Md" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Permabrig West Hallway 2";
+	dir = 4;
+	network = list("ss13","prison")
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"Me" = (
+/obj/structure/closet/crate/trashcart,
+/obj/effect/turf_decal/sand,
+/turf/open/floor/plasteel/checker,
+/area/ruin/unpowered)
+"Mj" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"Ms" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/chair/stool,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"MB" = (
+/turf/open/floor/plasteel/cafeteria,
+/area/ruin/unpowered)
+"MF" = (
+/obj/item/storage/bag/trash,
+/turf/open/floor/plasteel/checker,
+/area/ruin/unpowered)
+"MR" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/item/flashlight,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"Nl" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"Nm" = (
+/obj/item/reagent_containers/glass/bucket,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"NR" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/wood{
+	icon_state = "wood-broken7"
+	},
+/area/ruin/unpowered)
+"NW" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"NX" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"Op" = (
+/turf/open/floor/plasteel/showroomfloor,
+/area/ruin/unpowered)
+"OH" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/closed,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"OK" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/toilet{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"OL" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Brig Cell"
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/open/floor/plasteel/dark,
+/area/ruin/unpowered)
+"OQ" = (
+/obj/effect/turf_decal/trimline/green/filled/line,
+/obj/machinery/requests_console{
+	department = "Prison";
+	departmentType = 1;
+	pixel_y = -30
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"Pu" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Brig Cell"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/unpowered)
+"PC" = (
+/obj/item/radio/intercom{
+	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_y = 24;
+	prison_radio = 1
+	},
+/obj/structure/bed,
+/obj/item/bedsheet/orange,
+/turf/open/floor/plasteel/dark,
+/area/ruin/unpowered)
+"PN" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/obj/effect/decal/remains/human,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"Qc" = (
+/obj/item/radio/intercom{
+	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_y = 24;
+	prison_radio = 1
+	},
+/turf/closed/wall,
+/area/ruin/unpowered)
+"Qj" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/ruin/unpowered)
+"Qv" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"Qw" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/binary/valve/on{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"QU" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/obj/structure/barricade/wooden,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"QV" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/turf/open/floor/plasteel/checker,
+/area/ruin/unpowered)
+"QX" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 6
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"Rd" = (
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/checker,
+/area/ruin/unpowered)
+"Rs" = (
+/obj/item/mop,
+/turf/open/floor/plasteel/dark,
+/area/ruin/unpowered)
+"RB" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"Sy" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/toilet{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/unpowered)
+"SB" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/obj/structure/sign/nanotrasen{
+	icon = 'modular_skyrat/icons/obj/contraband.dmi';
+	icon_state = "poster2_legit";
+	pixel_y = 32
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"SE" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"SN" = (
+/obj/machinery/camera{
+	c_tag = "Permabrig Sleepers";
+	network = list("ss13","prison")
+	},
+/obj/structure/fluff/empty_sleeper,
+/turf/open/floor/circuit,
+/area/ruin/unpowered)
+"SR" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"Tg" = (
+/obj/machinery/door/firedoor/closed,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"TA" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"TG" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"TZ" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"Ud" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -24;
+	pixel_y = 28
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/obj/structure/barricade/wooden,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"Un" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"UG" = (
+/turf/open/floor/plasteel/dark,
+/area/ruin/unpowered)
+"UI" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/machinery/vending/dinnerware/prisoner,
+/turf/open/floor/plasteel/white,
+/area/ruin/unpowered)
+"Vz" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/ruin/unpowered)
+"VQ" = (
+/obj/structure/lattice,
+/obj/structure/grille,
+/turf/template_noop,
+/area/template_noop)
+"VS" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"Wb" = (
+/obj/structure/grille,
+/turf/template_noop,
+/area/template_noop)
+"Wl" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"Wp" = (
+/turf/open/floor/plasteel/white,
+/area/ruin/unpowered)
+"Ww" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
+	},
+/turf/open/floor/plasteel/checker,
+/area/ruin/unpowered)
+"WS" = (
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"WU" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/obj/item/caution,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"WY" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"WZ" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"Xc" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/closed,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"Xg" = (
+/obj/structure/holohoop{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/ruin/unpowered)
+"XD" = (
+/obj/machinery/door/airlock/public/glass,
+/turf/open/floor/plasteel/dark,
+/area/ruin/unpowered)
+"XJ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/unpowered)
+"XS" = (
+/obj/structure/chair/stool,
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#cee5d2"
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/ruin/unpowered)
+"XW" = (
+/obj/structure/table,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"Ym" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"Yo" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"Yr" = (
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
+	},
+/obj/machinery/door/airlock/glass{
+	name = "Storage"
+	},
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"YE" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"YI" = (
+/obj/effect/decal/cleanable/blood/hitsplatter,
+/turf/open/floor/plasteel/showroomfloor/shower,
+/area/ruin/unpowered)
+"YM" = (
+/obj/structure/bookcase/random/nonfiction,
+/turf/open/floor/wood,
+/area/ruin/unpowered)
+"YR" = (
+/obj/machinery/door/airlock/freezer{
+	desc = "Consult with the Warden for access.";
+	name = "prison freezer";
+	req_access_txt = "63;3"
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/open/floor/plasteel/freezer,
+/area/ruin/unpowered)
+"Zp" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"Zx" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"ZW" = (
+/obj/machinery/washing_machine,
+/obj/machinery/camera{
+	c_tag = "Permabrig Laundry";
+	dir = 4;
+	network = list("ss13","prison")
+	},
+/obj/effect/turf_decal/lumos/tile/blue/checker,
+/turf/open/floor/plasteel/cafeteria,
+/area/ruin/unpowered)
+"ZZ" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/item/storage/toolbox/mechanical,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+
+(1,1,1) = {"
+fn
+fn
+fn
+fn
+fn
+fn
+fn
+fn
+fn
+fn
+fn
+fn
+fn
+fn
+fn
+gw
+gw
+gw
+gw
+gw
+hq
+hq
+hq
+fn
+fn
+"}
+(2,1,1) = {"
+fn
+fn
+fn
+fn
+gk
+gk
+fn
+VQ
+VQ
+VQ
+VQ
+VQ
+fn
+gw
+xN
+xN
+xN
+xN
+xN
+gw
+gw
+gw
+gw
+fn
+fn
+"}
+(3,1,1) = {"
+fn
+fn
+gk
+gk
+gk
+gk
+gk
+fn
+gw
+fn
+gw
+fn
+fn
+gw
+xN
+cg
+KX
+Jc
+xN
+xN
+xN
+xN
+xN
+fn
+fn
+"}
+(4,1,1) = {"
+fn
+fn
+gk
+gk
+gk
+gk
+gk
+xN
+xN
+xN
+xN
+gw
+gw
+gw
+xN
+pT
+Qw
+At
+xN
+YM
+LP
+Lu
+WS
+fn
+fn
+"}
+(5,1,1) = {"
+fn
+fn
+gk
+gk
+gk
+gk
+gk
+gk
+MF
+Rd
+xN
+xN
+xN
+xN
+xN
+WS
+Iy
+me
+xN
+YM
+lT
+zZ
+fn
+fn
+fn
+"}
+(6,1,1) = {"
+fn
+fn
+fn
+gk
+gk
+gk
+gk
+gk
+mC
+Ww
+xN
+yd
+Op
+yd
+xN
+xN
+Yr
+xN
+xN
+ks
+WS
+En
+gw
+fn
+fn
+"}
+(7,1,1) = {"
+fn
+fn
+fn
+fn
+gk
+gk
+gk
+gk
+Me
+aT
+xN
+Bt
+YI
+KK
+Ke
+ZW
+GT
+Dl
+Ke
+wI
+WS
+HA
+gw
+fn
+fn
+"}
+(8,1,1) = {"
+fn
+fn
+hq
+hq
+gw
+gk
+gk
+Gq
+QV
+ol
+xN
+mt
+Op
+xY
+Ke
+ki
+hY
+gn
+Ke
+KC
+iZ
+En
+WS
+fn
+fn
+"}
+(9,1,1) = {"
+fn
+Wb
+gw
+gw
+xN
+xN
+xN
+xN
+xN
+oM
+xN
+Ke
+lQ
+Ke
+Ke
+Ke
+mq
+Ke
+Ke
+Ke
+fX
+eu
+FT
+fn
+fn
+"}
+(10,1,1) = {"
+fn
+gw
+gw
+kz
+xN
+qM
+KY
+KY
+Un
+jw
+xD
+yR
+Md
+WY
+Ud
+KY
+GG
+ow
+KY
+KY
+KY
+lH
+KY
+fn
+fn
+"}
+(11,1,1) = {"
+fn
+gw
+gw
+el
+zj
+Bv
+Go
+gx
+YE
+ZZ
+FC
+lg
+DR
+Li
+FC
+kR
+vd
+OH
+jK
+Wl
+FC
+iO
+Bv
+fn
+fn
+"}
+(12,1,1) = {"
+fn
+gw
+xN
+xN
+Ep
+Bv
+Zp
+hp
+Ke
+Ke
+Ke
+Ke
+Ke
+Ke
+Ke
+Ke
+Ke
+Ke
+Ke
+Ke
+Ke
+Fv
+Bv
+fn
+fn
+"}
+(13,1,1) = {"
+fn
+gw
+el
+ar
+nL
+Bv
+Ms
+Ga
+Ke
+vk
+Sy
+UG
+Ke
+sa
+lq
+aO
+Ke
+Ao
+Sy
+aO
+Ke
+cA
+Tg
+fn
+fn
+"}
+(14,1,1) = {"
+fn
+kz
+xN
+kY
+Xg
+bP
+aU
+XW
+Ke
+UG
+UG
+LT
+LT
+LT
+WS
+WS
+Ke
+UG
+UG
+UG
+Ke
+uT
+Bv
+gw
+fn
+"}
+(15,1,1) = {"
+fn
+md
+Bv
+AZ
+eU
+WS
+Zp
+hG
+Ke
+Ke
+UG
+ho
+Bs
+Ke
+Pu
+Ke
+Ke
+Ke
+Pu
+Ke
+Ke
+SB
+kE
+Bv
+gw
+"}
+(16,1,1) = {"
+fn
+hf
+Bv
+AZ
+iZ
+WS
+Zp
+KA
+ya
+WY
+nZ
+ef
+KY
+KY
+hE
+KY
+VS
+KY
+KY
+WY
+tz
+gb
+kE
+Bv
+Bv
+"}
+(17,1,1) = {"
+fn
+fU
+rw
+ja
+om
+Aq
+TZ
+Dm
+he
+Qv
+yl
+eN
+yl
+yl
+yl
+yl
+yl
+MR
+yl
+dO
+dM
+ug
+lW
+Bv
+WS
+"}
+(18,1,1) = {"
+fn
+hf
+Bv
+ww
+iZ
+WS
+Zp
+KA
+oC
+vr
+kV
+kV
+WU
+kk
+kV
+kV
+EB
+PN
+LO
+vr
+QX
+gb
+kE
+rQ
+WS
+"}
+(19,1,1) = {"
+gw
+TG
+Bv
+Nl
+WS
+NR
+Zp
+bT
+Ke
+Ke
+WS
+Ke
+Ke
+Ke
+Pu
+Ke
+Ke
+Ke
+OL
+Ke
+Ke
+SB
+kE
+Bv
+gw
+"}
+(20,1,1) = {"
+gw
+kz
+xN
+oB
+nB
+cT
+Zx
+KA
+Ke
+qo
+WS
+WS
+Ke
+Rs
+UG
+oG
+Ke
+mo
+UG
+jz
+Ke
+gb
+Bv
+Ke
+Ke
+"}
+(21,1,1) = {"
+gw
+gw
+el
+kT
+zj
+Bv
+qR
+KA
+Ke
+uq
+OK
+WS
+Ke
+JO
+or
+du
+Qc
+PC
+or
+ce
+Ke
+hr
+vn
+Ke
+fn
+"}
+(22,1,1) = {"
+fn
+fn
+xN
+xN
+NX
+Bv
+qR
+KA
+Ke
+Ke
+Ke
+Ke
+Ke
+Ke
+Ke
+Ke
+Ke
+Ke
+Ke
+Ke
+Ke
+Mj
+Hp
+Ke
+fn
+"}
+(23,1,1) = {"
+fn
+fn
+gw
+el
+nL
+Bv
+iF
+tW
+NW
+aI
+Et
+Fe
+qv
+hy
+Eu
+Yo
+yH
+ie
+Eu
+fR
+ca
+SR
+WS
+fn
+fn
+"}
+(24,1,1) = {"
+fn
+fn
+gw
+kz
+xN
+gV
+kV
+kV
+rC
+TA
+tH
+kV
+vr
+iW
+kV
+tH
+QU
+Xc
+kV
+kV
+zC
+WS
+fn
+fn
+fn
+"}
+(25,1,1) = {"
+fn
+fn
+gw
+gw
+xN
+xN
+XD
+xN
+Ke
+Jr
+Ds
+gz
+Ke
+Ke
+Ke
+lu
+Ke
+Ke
+Ke
+Ke
+qD
+Ke
+Ke
+fn
+fn
+"}
+(26,1,1) = {"
+fn
+VQ
+gw
+gw
+xN
+fJ
+UG
+xN
+hP
+Ba
+iE
+Ba
+wV
+Ke
+Wp
+XJ
+AC
+Ke
+IM
+pa
+Vz
+gw
+fn
+fn
+fn
+"}
+(27,1,1) = {"
+fn
+fn
+hq
+gw
+xN
+SN
+wE
+xN
+rh
+Bv
+RB
+Nm
+bi
+Ke
+It
+ex
+nQ
+gz
+pa
+MB
+Vz
+MB
+fn
+fn
+fn
+"}
+(28,1,1) = {"
+fn
+fn
+hq
+gw
+xN
+fJ
+zr
+xN
+rh
+xE
+cN
+rT
+OQ
+Ke
+bm
+xh
+Wp
+yM
+MB
+IB
+Vz
+MB
+fn
+fn
+fn
+"}
+(29,1,1) = {"
+fn
+fn
+hq
+gw
+xN
+xN
+xN
+xN
+pZ
+CM
+CM
+CM
+bi
+gz
+Cz
+qZ
+Wp
+yM
+MB
+MB
+Qj
+MB
+fn
+fn
+fn
+"}
+(30,1,1) = {"
+fn
+fn
+hq
+gw
+gw
+gw
+gw
+xN
+hh
+Ym
+wW
+Gw
+SE
+qE
+Wp
+Wp
+Wp
+vI
+MB
+MB
+ib
+WS
+WS
+fn
+fn
+"}
+(31,1,1) = {"
+fn
+fn
+fn
+VQ
+VQ
+gw
+gw
+xN
+xN
+xN
+xN
+xN
+xN
+xN
+nf
+cV
+UI
+xN
+pa
+pa
+bb
+WS
+WS
+fn
+fn
+"}
+(32,1,1) = {"
+fn
+fn
+fn
+fn
+fn
+VQ
+gw
+gw
+gw
+gw
+gw
+gw
+gw
+xN
+YR
+xN
+xN
+xN
+IB
+IB
+Nl
+WS
+fn
+fn
+fn
+"}
+(33,1,1) = {"
+fn
+fn
+fn
+fn
+fn
+fn
+VQ
+VQ
+VQ
+VQ
+VQ
+gw
+fn
+xN
+WS
+rs
+pq
+xN
+XS
+pa
+Nl
+WS
+fn
+fn
+fn
+"}
+(34,1,1) = {"
+fn
+fn
+fn
+fn
+fn
+fn
+fn
+fn
+fn
+fn
+fn
+fn
+fn
+fn
+fn
+WS
+WZ
+xN
+xN
+tk
+TG
+fn
+fn
+fn
+fn
+"}
+(35,1,1) = {"
+fn
+fn
+fn
+fn
+fn
+fn
+fn
+fn
+fn
+fn
+fn
+fn
+fn
+fn
+fn
+fn
+xN
+xN
+gw
+gw
+gw
+gw
+gw
+fn
+fn
+"}
+(36,1,1) = {"
+fn
+fn
+fn
+fn
+fn
+fn
+fn
+fn
+fn
+fn
+fn
+fn
+fn
+fn
+fn
+gw
+gw
+gw
+gw
+hq
+hq
+hq
+hq
+fn
+fn
+"}
+(37,1,1) = {"
+fn
+fn
+fn
+fn
+fn
+fn
+fn
+fn
+fn
+fn
+fn
+fn
+fn
+fn
+gw
+VQ
+hq
+hq
+VQ
+fn
+fn
+fn
+fn
+fn
+fn
+"}

--- a/_maps/map_files/BoxStation/BoxStation_Lumos.dmm
+++ b/_maps/map_files/BoxStation/BoxStation_Lumos.dmm
@@ -261,9 +261,6 @@
 /obj/structure/closet/secure_closet/freezer/gulag_fridge,
 /turf/open/floor/plasteel/white,
 /area/security/prison)
-"aaV" = (
-/turf/closed/wall/r_wall,
-/area/space)
 "aaW" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -87893,7 +87890,7 @@ gXs
 gXs
 aaa
 aoV
-aaa
+gXs
 aoV
 aai
 aai
@@ -88150,9 +88147,9 @@ aaa
 gXs
 gXs
 gXs
-ctv
+gXs
 aaf
-aaa
+eRz
 aaa
 gXs
 abG
@@ -88407,9 +88404,9 @@ aaa
 aaa
 aaa
 aaa
-ctv
+aaa
 aaf
-aaf
+aaT
 aaf
 gXs
 abG
@@ -88664,9 +88661,9 @@ aaa
 aaa
 aaa
 aaa
-aaV
+aaa
 aaf
-aaf
+aaT
 aoV
 gXs
 bdM
@@ -88921,9 +88918,9 @@ aaa
 aaa
 aaa
 aaa
-aaV
-aaT
-aaT
+aaa
+aaf
+aaf
 adR
 abo
 adR
@@ -89178,7 +89175,7 @@ aaa
 aaa
 aaa
 aaa
-aaf
+aaT
 aaf
 aaf
 adR
@@ -89692,7 +89689,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+eRz
 aaf
 aaa
 adR
@@ -89949,7 +89946,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+eRz
 aaf
 aaa
 abo
@@ -90206,7 +90203,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+eRz
 aaf
 aaa
 adR

--- a/_maps/map_files/BoxStation/BoxStation_Lumos.dmm
+++ b/_maps/map_files/BoxStation/BoxStation_Lumos.dmm
@@ -164,6 +164,9 @@
 /obj/item/kitchen/knife/combat/bone/plastic{
 	pixel_y = 4
 	},
+/obj/machinery/light/small{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/security/prison)
 "aaD" = (

--- a/_maps/map_files/BoxStation/BoxStation_Lumos.dmm
+++ b/_maps/map_files/BoxStation/BoxStation_Lumos.dmm
@@ -49,92 +49,92 @@
 /turf/closed/wall/r_wall,
 /area/security/prison)
 "aaj" = (
-/obj/structure/grille,
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/circuit/green,
+/area/security/prison)
 "aak" = (
-/obj/structure/lattice,
-/obj/machinery/camera{
-	c_tag = "Permabrig Space North";
-	dir = 1;
-	name = "aft camera"
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
-"aam" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plating,
-/area/security/prison)
-"aan" = (
-/obj/structure/punching_bag,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"aap" = (
-/obj/structure/weightmachine/weightlifter,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"aaq" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"aar" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"aas" = (
+/obj/machinery/biogenerator,
+/obj/effect/turf_decal/lumos/tile/green/fulltile,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"aam" = (
+/obj/machinery/camera{
+	c_tag = "Prison Common Room";
+	network = list("ss13","prison")
+	},
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/lumos/tile/green/half{
+	dir = 1
+	},
+/obj/item/seeds/cabbage,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"aan" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/lumos/tile/green/half{
+	dir = 1
+	},
+/obj/item/seeds/tower,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"aap" = (
+/obj/structure/sign/warning/electricshock{
+	pixel_y = 32
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/mopbucket,
+/obj/item/mop,
+/obj/item/caution,
+/obj/item/caution,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"aaq" = (
+/obj/effect/turf_decal/lumos/tile/green/fulltile,
+/obj/item/plant_analyzer,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"aar" = (
+/obj/structure/window/reinforced,
+/turf/open/floor/circuit/green,
+/area/security/prison)
+"aas" = (
+/obj/effect/turf_decal/lumos/tile/green/fulltile,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aat" = (
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aau" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"aav" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"aaw" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plating,
-/area/security/prison)
-"aax" = (
-/obj/item/toy/beach_ball/holoball{
-	desc = "Come on, getcha head in the game (gotta gotta getcha getcha getcha getcha head in the game)."
-	},
+/obj/item/cultivator,
+/obj/effect/turf_decal/lumos/tile/green/fulltile,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/wood,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"aav" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/lumos/tile/green/half,
+/obj/item/seeds/corn,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"aaw" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/lumos/tile/green/half,
+/obj/item/seeds/cotton,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"aax" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
 /area/security/prison)
 "aaz" = (
 /obj/machinery/disposal/bin,
@@ -160,36 +160,30 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "aaB" = (
-/obj/structure/cable{
-	icon_state = "2-4"
+/obj/structure/table,
+/obj/item/kitchen/knife/combat/bone/plastic{
+	pixel_y = 4
 	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/white,
 /area/security/prison)
 "aaD" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-4"
+/obj/machinery/light{
+	dir = 1
 	},
-/turf/open/floor/plating,
-/area/security/prison)
-"aaE" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating,
-/area/security/prison)
-"aaF" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/sign/poster/official/spiderlings{
+	pixel_y = 32
 	},
 /turf/open/floor/plasteel,
+/area/security/prison)
+"aaE" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"aaF" = (
+/obj/machinery/holopad,
+/turf/open/floor/plasteel/white,
 /area/security/prison)
 "aaH" = (
 /turf/open/floor/plating/airless,
@@ -249,19 +243,9 @@
 /turf/closed/wall,
 /area/security/warden)
 "aaR" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/wood,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/turf/open/floor/plasteel/white,
 /area/security/prison)
 "aaS" = (
 /obj/structure/grille,
@@ -274,21 +258,18 @@
 /turf/open/space,
 /area/space/nearstation)
 "aaU" = (
-/turf/open/floor/wood,
+/obj/structure/closet/secure_closet/freezer/gulag_fridge,
+/turf/open/floor/plasteel/white,
 /area/security/prison)
 "aaV" = (
-/obj/machinery/requests_console{
-	department = "Prison";
-	departmentType = 1
-	},
 /turf/closed/wall/r_wall,
-/area/security/prison)
+/area/space)
 "aaW" = (
-/obj/machinery/cryopod,
-/obj/machinery/computer/cryopod{
-	pixel_y = 26
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-4"
 	},
-/turf/open/floor/circuit/green,
+/turf/open/floor/plating,
 /area/security/prison)
 "aaY" = (
 /obj/effect/turf_decal/bot,
@@ -329,20 +310,8 @@
 /turf/open/space,
 /area/space/nearstation)
 "abb" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#cee5d2"
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/obj/structure/sign/nanotrasen{
-	icon = 'modular_skyrat/icons/obj/contraband.dmi';
-	icon_state = "poster2_legit";
-	pixel_y = 32
 	},
 /turf/open/floor/wood,
 /area/security/prison)
@@ -350,57 +319,66 @@
 /turf/closed/wall,
 /area/security/execution/transfer)
 "abd" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#cee5d2"
+/mob/living/simple_animal/chicken{
+	desc = "A dumb hen, kept in the Brig to boost Prisoner morale... For more mushroom wine.";
+	name = "Broiler"
 	},
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
-/obj/structure/sign/nanotrasen{
-	icon = 'modular_skyrat/icons/obj/contraband.dmi';
-	icon_state = "poster2_legit";
-	pixel_y = 32
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
 	},
-/turf/open/floor/wood,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
 /area/security/prison)
 "abe" = (
-/obj/structure/holohoop{
+/obj/machinery/door/airlock/public/glass{
+	name = "Brig Kitchen"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
-/turf/open/floor/wood,
+/turf/open/floor/plasteel/white,
 /area/security/prison)
 "abg" = (
-/obj/structure/holohoop{
-	dir = 8
+/obj/structure/sign/warning/securearea{
+	pixel_y = -32
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
 	},
-/turf/open/floor/wood,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/turf/open/floor/plasteel/white,
 /area/security/prison)
 "abh" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/bookcase/random/religion,
+/turf/open/floor/wood,
+/area/security/prison)
+"abi" = (
+/obj/effect/landmark/event_spawn,
 /obj/machinery/holopad,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"abi" = (
-/obj/machinery/cryopod,
-/obj/machinery/camera{
-	c_tag = "Permabrig Sleepers";
-	network = list("ss13","prison")
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
 	},
-/turf/open/floor/circuit/green,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/security/prison)
 "abk" = (
 /obj/effect/turf_decal/lumos/tile/red/half{
@@ -484,20 +462,15 @@
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
 "abx" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/wood,
+/turf/open/floor/plasteel,
 /area/security/prison)
 "aby" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
-/turf/open/floor/wood,
+/obj/item/storage/pill_bottle/dice,
+/obj/structure/table,
+/turf/open/floor/plasteel,
 /area/security/prison)
 "abz" = (
 /obj/machinery/camera{
@@ -512,36 +485,30 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "abA" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/wood,
+/obj/item/toy/cards/deck,
+/obj/structure/table,
+/turf/open/floor/plasteel,
 /area/security/prison)
 "abB" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-2"
+/obj/machinery/door/airlock/freezer{
+	desc = "Consult with the Warden for access.";
+	name = "prison freezer";
+	req_access_txt = "63;3"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/freezer,
 /area/security/prison)
 "abD" = (
-/obj/machinery/cryopod,
-/turf/open/floor/circuit/green,
+/obj/machinery/washing_machine,
+/turf/open/floor/plasteel,
 /area/security/prison)
 "abE" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 6
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
+/obj/machinery/shower{
+	pixel_y = 20
 	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/showroomfloor/shower,
 /area/security/prison)
 "abF" = (
 /obj/structure/trash_pile,
@@ -589,23 +556,14 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "abL" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
+/obj/item/soap/nanotrasen,
+/obj/machinery/shower{
+	pixel_y = 20
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
-/turf/open/floor/wood,
+/turf/open/floor/plasteel/showroomfloor/shower,
 /area/security/prison)
 "abM" = (
-/obj/machinery/camera{
-	c_tag = "Permabrig Lounge East";
-	dir = 8;
-	network = list("ss13","prison");
-	start_active = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/freezer,
 /area/security/prison)
 "abN" = (
 /obj/effect/landmark/secequipment,
@@ -644,8 +602,11 @@
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "abS" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
-/turf/open/floor/plasteel,
+/obj/structure/table/reinforced,
+/obj/item/storage/box/monkeycubes{
+	pixel_y = 6
+	},
+/turf/open/floor/plasteel/freezer,
 /area/security/prison)
 "abT" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -942,13 +903,11 @@
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
 "acE" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#cee5d2"
-	},
-/obj/structure/closet/crate/bin,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
+/obj/machinery/light,
+/obj/structure/sign/nanotrasen{
+	icon = 'modular_skyrat/icons/obj/contraband.dmi';
+	icon_state = "poster2_legit";
+	pixel_y = -32
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -966,13 +925,10 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "acG" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+/obj/machinery/light/small{
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/freezer,
 /area/security/prison)
 "acI" = (
 /obj/machinery/door/poddoor/preopen{
@@ -998,11 +954,10 @@
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
 "acJ" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/flasher{
+	id = "PCell 2";
+	pixel_x = -28
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "acL" = (
@@ -1110,70 +1065,68 @@
 /turf/open/floor/plating,
 /area/security/execution/transfer)
 "ada" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/door/poddoor/preopen{
+	id = "permacell1";
+	name = "cell blast door"
 	},
-/turf/open/floor/wood,
-/area/security/prison)
-"adb" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/wood,
-/area/security/prison)
-"adc" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
+/obj/machinery/door/airlock/public/glass{
+	id_tag = "permabolt1";
+	name = "Cell 1"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plasteel,
 /area/security/prison)
+"adb" = (
+/obj/machinery/door/airlock{
+	name = "Unisex Restroom"
+	},
+/turf/open/floor/plasteel/freezer,
+/area/security/prison)
+"adc" = (
+/obj/structure/closet/secure_closet/freezer/meat,
+/turf/open/floor/plasteel/freezer,
+/area/security/prison)
 "add" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
-	icon_state = "2-8"
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "2-4"
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "ade" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#cee5d2"
+/obj/machinery/camera{
+	c_tag = "Prison Cell 1";
+	network = list("ss13","prison")
 	},
-/obj/structure/closet/crate/bin,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
+/obj/item/radio/intercom{
+	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_y = 24;
+	prison_radio = 1
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "adf" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
+/obj/machinery/door/airlock/security/glass{
+	name = "Long-Term Cell 3";
+	req_access_txt = "2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
-/obj/structure/chair/stool,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "adg" = (
@@ -1400,38 +1353,50 @@
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
 "adG" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
+/obj/machinery/door/airlock/security/glass{
+	name = "Long-Term Cell 2";
+	req_access_txt = "2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
 	},
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "adI" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
+/obj/machinery/door/airlock/security/glass{
+	name = "Long-Term Cell 1";
+	req_access_txt = "2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "adJ" = (
-/obj/machinery/camera{
-	c_tag = "Permabrig Space East";
-	dir = 4;
-	name = "aft camera"
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
 	},
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/machinery/button/door{
+	id = "permacell2";
+	name = "Cell 2 Lockdown";
+	pixel_x = -4;
+	pixel_y = 25;
+	req_access_txt = "2"
+	},
+/obj/machinery/button/flasher{
+	id = "PCell 2";
+	pixel_x = 6;
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "adK" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -1636,87 +1601,91 @@
 /area/security/execution/transfer)
 "aef" = (
 /obj/structure/table,
-/obj/item/restraints/handcuffs,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 9
+	},
+/obj/item/stack/license_plates/empty/fifty{
+	pixel_y = -4
+	},
+/obj/item/stack/license_plates/empty/fifty,
+/obj/item/stack/license_plates/empty/fifty{
+	pixel_y = 4
+	},
+/obj/item/stack/license_plates/empty/fifty{
+	pixel_y = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aeg" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/door/firedoor,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/sign/poster/official/safety_report{
+	pixel_y = 32
 	},
 /turf/open/floor/plasteel,
-/area/security/prison)
+/area/security/brig)
 "aeh" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /turf/open/floor/plasteel,
-/area/security/prison)
+/area/security/brig)
 "aej" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 4
-	},
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
-/area/security/prison)
+/area/security/brig)
 "aek" = (
-/obj/machinery/camera{
-	c_tag = "Permabrig Space Northwest";
-	dir = 1;
-	name = "aft camera"
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/structure/rack,
+/obj/item/tank/internals/plasmaman/belt,
+/obj/item/tank/internals/plasmaman/belt{
+	pixel_x = -6
 	},
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/item/tank/internals/nitrogen/belt/full{
+	pixel_x = 6
+	},
+/obj/item/tank/internals/nitrogen/belt/full,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "ael" = (
-/obj/structure/toilet{
-	contents = newlist(/obj/item/toy/snappop/phoenix);
-	dir = 4
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
-"aem" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/effect/landmark/start/prisoner,
-/obj/structure/toilet{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
-"aep" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore)
+"aem" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
+/area/maintenance/fore)
+"aep" = (
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/security/prison)
 "aer" = (
 /obj/machinery/firealarm{
@@ -1811,16 +1780,16 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "aex" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
-/obj/structure/chair/stool,
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel,
-/area/security/prison)
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "aey" = (
 /obj/machinery/keycard_auth{
 	pixel_x = 24;
@@ -2035,19 +2004,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"aeR" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 8
-	},
-/obj/machinery/holopad,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aeS" = (
 /obj/structure/closet/secure_closet/brig,
 /obj/item/radio/headset{
@@ -2066,12 +2022,8 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/trimline/red/filled/corner,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aeU" = (
@@ -2091,12 +2043,8 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aeW" = (
@@ -2190,16 +2138,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
-"afh" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/vending/hydroseeds,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "afi" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
@@ -2323,10 +2261,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
-"afy" = (
-/obj/machinery/vending/hydronutrients/prisoner,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "afz" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -2423,13 +2357,6 @@
 /obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/brig)
-"afK" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "afL" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -2481,13 +2408,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/main)
-"afR" = (
-/obj/structure/closet/crate/bin,
-/obj/structure/sign/poster/official/random{
-	pixel_y = -32
-	},
-/turf/open/floor/wood,
-/area/security/prison)
 "afS" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Brig EVA Storage";
@@ -2650,19 +2570,6 @@
 /obj/effect/turf_decal/lumos/tile/red/fulltile,
 /turf/open/floor/plasteel,
 /area/security/brig)
-"agl" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/chair/stool,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "agm" = (
 /obj/machinery/light{
 	dir = 8
@@ -2713,19 +2620,6 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
-"agt" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/structure/chair/stool,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "agu" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -2819,14 +2713,8 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "agD" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -2842,18 +2730,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/security/main)
-"agF" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "agG" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -2922,15 +2798,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"agN" = (
-/obj/structure/lattice,
-/obj/machinery/camera{
-	c_tag = "Permabrig Space West";
-	dir = 8;
-	name = "aft camera"
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "agO" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Brig Infirmary";
@@ -2950,12 +2817,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"agQ" = (
-/obj/machinery/light{
-	light_color = "#cee5d2"
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "agR" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 4;
@@ -3023,13 +2884,6 @@
 /obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
-"agZ" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#cee5d2"
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/prison)
 "aha" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -3204,25 +3058,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
-"ahs" = (
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
-"aht" = (
-/obj/structure/bed,
-/obj/effect/landmark/start/prisoner,
-/obj/item/radio/intercom{
-	desc = "Talk through this. It looks like it has been modified to not broadcast.";
-	name = "Prison Intercom (General)";
-	pixel_y = 24;
-	prison_radio = 1
-	},
-/obj/item/bedsheet/orange,
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "ahu" = (
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
@@ -3231,16 +3066,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
-"ahv" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Brig Hydroponics"
-	},
-/obj/effect/turf_decal/lumos/tile/green/half{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white/side,
-/area/security/prison)
 "ahx" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -3375,20 +3200,9 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "ahP" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"ahQ" = (
 /obj/structure/chair/stool,
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/structure/sign/nanotrasen{
-	icon = 'modular_skyrat/icons/obj/contraband.dmi';
-	icon_state = "poster2_legit";
-	pixel_y = -32
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -3859,14 +3673,6 @@
 /mob/living/simple_animal/pet/dog/cheems,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"aiK" = (
-/obj/machinery/camera{
-	c_tag = "Permabrig Pressing Room";
-	dir = 4;
-	network = list("ss13","prison")
-	},
-/turf/open/floor/plasteel/checker,
-/area/security/prison)
 "aiL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -3903,16 +3709,6 @@
 /obj/effect/turf_decal/lumos/shower,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
-"aiQ" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/toilet{
-	contents = newlist(/obj/item/toy/snappop/phoenix);
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "aiR" = (
 /obj/structure/closet/secure_closet/brig{
 	id = "Cell 2";
@@ -4115,10 +3911,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
-"ajv" = (
-/obj/machinery/plate_press,
-/turf/open/floor/plasteel/checker,
-/area/security/prison)
 "ajw" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -4161,19 +3953,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"ajz" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "ajA" = (
 /obj/effect/landmark/start/security_officer,
 /obj/structure/chair{
@@ -4184,10 +3963,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
-"ajB" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
-/turf/open/floor/plasteel/checker,
-/area/security/prison)
 "ajE" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -4212,16 +3987,6 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/security/brig)
-"ajG" = (
-/obj/machinery/holopad,
-/obj/effect/turf_decal/trimline/red/filled/corner,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "ajH" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -4465,19 +4230,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"akf" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "akh" = (
 /obj/structure/table,
 /obj/item/storage/fancy/donut_box,
@@ -4625,19 +4377,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/security/main)
-"akt" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aku" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -4722,21 +4461,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
-"akC" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "akD" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -4777,12 +4501,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
-"akH" = (
-/obj/structure/table,
-/obj/item/toy/cards/deck,
-/obj/effect/turf_decal/trimline/red/filled/line,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "akI" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -4805,20 +4523,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"akK" = (
-/obj/structure/table,
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/item/storage/pill_bottle/dice,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "akL" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 10
+/obj/machinery/newscaster{
+	pixel_y = 32
 	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/preopen{
-	id = "permalock2"
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/lumos/tile/green/half{
+	dir = 1
 	},
+/obj/item/seeds/plump,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "akM" = (
@@ -4826,14 +4539,6 @@
 /obj/effect/turf_decal/trimline/green/filled/line,
 /turf/open/floor/plasteel,
 /area/security/brig)
-"akN" = (
-/obj/machinery/airalarm/directional/east,
-/obj/structure/sink/kitchen{
-	dir = 8;
-	pixel_x = 11
-	},
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "akO" = (
 /obj/structure/table,
 /obj/machinery/microwave{
@@ -4848,10 +4553,6 @@
 /obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/main)
-"akP" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "akQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -4895,31 +4596,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
-"akT" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "akU" = (
 /obj/machinery/holopad,
 /turf/open/floor/plasteel,
 /area/security/brig)
-"akW" = (
-/obj/machinery/holopad,
-/turf/open/floor/plasteel/checker,
-/area/security/prison)
 "akY" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -5000,11 +4680,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/courtroom)
-"alf" = (
-/obj/structure/chair/stool,
-/obj/effect/turf_decal/trimline/red/filled/line,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "alh" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -5058,19 +4733,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"alm" = (
-/obj/item/camera,
-/obj/item/camera_film,
-/obj/item/storage/photo_album,
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/structure/table,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"aln" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/structure/table,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "alo" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -5091,18 +4753,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel/dark,
 /area/security/warden)
-"alr" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/holopad,
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "als" = (
 /obj/machinery/door_timer{
 	id = "Cell 3";
@@ -5196,10 +4846,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"alD" = (
-/obj/structure/sign/warning/electricshock,
-/turf/closed/wall/r_wall,
-/area/security/prison)
 "alE" = (
 /obj/machinery/requests_console{
 	department = "Security";
@@ -5326,12 +4972,6 @@
 "alU" = (
 /turf/closed/wall,
 /area/maintenance/port/fore)
-"alV" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "alX" = (
 /obj/machinery/button/door{
 	id = "atmos";
@@ -5346,21 +4986,6 @@
 /obj/machinery/computer/secure_data,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
-"alZ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "ama" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -5368,27 +4993,6 @@
 /mob/living/simple_animal/slime,
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"amb" = (
-/obj/structure/bed{
-	dir = 4
-	},
-/obj/item/bedsheet/orange{
-	icon_state = "sheetorange_flip"
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
-"amc" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
 "amd" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
@@ -5432,40 +5036,8 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "amk" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
+/obj/item/reagent_containers/glass/bucket,
 /turf/open/floor/plasteel,
-/area/security/prison)
-"aml" = (
-/obj/structure/rack,
-/obj/item/tank/internals/emergency_oxygen,
-/obj/item/tank/internals/emergency_oxygen,
-/obj/item/tank/internals/nitrogen/belt/full,
-/obj/item/tank/internals/nitrogen/belt/full,
-/obj/item/tank/internals/plasmaman/belt,
-/obj/item/tank/internals/plasmaman/belt,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plating,
 /area/security/prison)
 "amm" = (
 /obj/effect/turf_decal/stripes/line{
@@ -5491,13 +5063,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/brig)
-"amo" = (
-/obj/structure/rack,
-/obj/item/storage/bag/trash,
-/obj/item/flashlight,
-/obj/item/radio/off,
-/turf/open/floor/plating,
-/area/security/prison)
 "amp" = (
 /obj/effect/turf_decal/lumos/tile/red/fullcorner{
 	dir = 4
@@ -5508,15 +5073,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/courtroom)
-"ams" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 5
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "amt" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Courtroom";
@@ -5527,20 +5083,8 @@
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
 "amu" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 5
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/effect/turf_decal/bot_red,
-/obj/machinery/holopad,
+/obj/structure/table,
+/obj/item/flashlight,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "amv" = (
@@ -5616,20 +5160,6 @@
 /obj/item/coin/diamond,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"amG" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"amH" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "amI" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -5720,41 +5250,12 @@
 /obj/machinery/holopad,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
-"amP" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"amQ" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "amS" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"amT" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 9
-	},
-/obj/structure/sign/poster/official/random{
-	pixel_x = -32
-	},
-/obj/machinery/hydroponics/constructable,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "amU" = (
 /obj/structure/chair/office/dark{
 	dir = 8
@@ -5814,16 +5315,6 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
-"ana" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "anb" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -5913,23 +5404,6 @@
 /obj/structure/table,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"ano" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 1
-	},
-/obj/machinery/hydroponics/constructable,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"anp" = (
-/obj/structure/table,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/hatchet,
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "anq" = (
 /obj/structure/chair{
 	dir = 8
@@ -5980,17 +5454,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"anx" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#cee5d2"
-	},
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 5
-	},
-/obj/machinery/biogenerator/prisoner,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "any" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -6166,11 +5629,19 @@
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
 "anW" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
+/obj/machinery/light/small{
+	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/button/door{
+	id = "permabolt3";
+	name = "Cell Bolt Control";
+	normaldoorcontrol = 1;
+	pixel_y = 25;
+	specialfunctions = 4
+	},
+/obj/structure/bed,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -6321,14 +5792,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
-"aos" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
-/turf/open/floor/plasteel/checker,
-/area/security/prison)
 "aot" = (
 /obj/effect/turf_decal/lumos/tile/red/fullcorner{
 	dir = 1
@@ -6356,13 +5819,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"aow" = (
-/obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aox" = (
 /obj/machinery/camera{
 	c_tag = "Fore Primary Hallway West";
@@ -6662,7 +6118,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
@@ -7261,16 +6716,6 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"aqB" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 5
-	},
-/obj/machinery/plate_chute/inputchute{
-	pixel_y = -25
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel/checker,
-/area/security/prison)
 "aqC" = (
 /obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 1
@@ -7300,18 +6745,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"aqG" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/light,
-/obj/machinery/requests_console{
-	department = "Prison";
-	departmentType = 1;
-	pixel_y = -30
-	},
-/turf/open/floor/plasteel/checker,
-/area/security/prison)
 "aqH" = (
 /obj/machinery/light{
 	dir = 1;
@@ -7420,10 +6853,6 @@
 /obj/item/paper/fluff/jobs/security/beepsky_mom,
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"aqV" = (
-/mob/living/simple_animal/sloth/paperwork,
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
 "aqW" = (
 /turf/open/floor/carpet,
 /area/security/detectives_office)
@@ -8166,17 +7595,6 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"asV" = (
-/obj/structure/bed,
-/obj/item/bedsheet/orange,
-/obj/item/radio/intercom{
-	desc = "Talk through this. It looks like it has been modified to not broadcast.";
-	name = "Prison Intercom (General)";
-	pixel_y = 24;
-	prison_radio = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "asW" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -8186,20 +7604,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
-"asX" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "asZ" = (
 /obj/structure/sign/poster/contraband/lizard{
 	pixel_x = -32
@@ -8263,13 +7667,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"atl" = (
-/obj/structure/mopbucket,
-/obj/item/mop,
-/obj/item/caution,
-/obj/item/caution,
-/turf/open/floor/plating,
-/area/security/prison)
 "atm" = (
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
@@ -8279,16 +7676,6 @@
 /obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/brig)
-"ato" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "atp" = (
 /obj/machinery/door/airlock/external{
 	name = "Construction Zone"
@@ -8301,20 +7688,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
-"ats" = (
-/obj/structure/table/reinforced,
-/obj/item/stack/license_plates/empty/fifty{
-	pixel_y = 8
-	},
-/obj/item/stack/license_plates/empty/fifty{
-	pixel_y = 4
-	},
-/obj/item/stack/license_plates/empty/fifty,
-/obj/item/stack/license_plates/empty/fifty{
-	pixel_y = -4
-	},
-/turf/open/floor/plasteel/checker,
-/area/security/prison)
 "att" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 6
@@ -8435,19 +7808,6 @@
 "atS" = (
 /turf/closed/wall,
 /area/space/nearstation)
-"atT" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/door/airlock/public/glass{
-	name = "License Workshop"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/checker,
-/area/security/prison)
 "atU" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -8457,15 +7817,6 @@
 /obj/structure/chair/stool,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"atX" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 5
-	},
-/turf/open/floor/plasteel/checker,
-/area/security/prison)
 "atZ" = (
 /obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 8
@@ -8494,13 +7845,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
-"aud" = (
-/obj/machinery/airalarm/directional/west,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aue" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
@@ -8544,17 +7888,6 @@
 /obj/effect/turf_decal/lumos/tile/blue/checker,
 /turf/open/floor/plasteel/dark,
 /area/blueshield)
-"auj" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "auk" = (
 /obj/effect/turf_decal/trimline/green/filled/line,
 /turf/open/floor/plasteel,
@@ -8582,15 +7915,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"aup" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/toilet{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "auq" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -8619,11 +7943,11 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
 "auu" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Brig Cell"
+/obj/structure/sign/warning/securearea{
+	pixel_y = -32
 	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
+/turf/open/space,
+/area/space)
 "auv" = (
 /obj/structure/chair/comfy/black{
 	dir = 8
@@ -8657,15 +7981,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/fitness)
-"auA" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "auB" = (
 /obj/effect/turf_decal/lumos/tile/red/fullcorner{
 	dir = 4
@@ -8673,7 +7988,10 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "auC" = (
-/turf/open/floor/plasteel/dark,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/closed/wall/r_wall,
 /area/security/prison)
 "auD" = (
 /obj/structure/reagent_dispensers/fueltank,
@@ -8736,15 +8054,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/department/electrical)
-"auN" = (
-/obj/structure/toilet{
-	dir = 8
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "auO" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
@@ -8771,66 +8080,17 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"auS" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24;
-	pixel_y = 28
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "auT" = (
 /obj/structure/table/glass,
 /obj/item/hemostat,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"auU" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Brig Hydroponics"
-	},
-/obj/effect/turf_decal/lumos/tile/green/half{
-	dir = 4
-	},
-/obj/effect/turf_decal/lumos/tile/red/half{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "auV" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"auW" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 9
-	},
-/obj/machinery/seed_extractor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "auX" = (
 /obj/machinery/iv_drip,
 /obj/structure/mirror{
@@ -8868,21 +8128,6 @@
 /obj/structure/closet,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"avd" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 4
-	},
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 11
-	},
-/obj/machinery/camera{
-	c_tag = "Permabrig Garden";
-	dir = 8;
-	network = list("ss13","prison")
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "avg" = (
 /obj/machinery/door/airlock{
 	id_tag = "Dorm5";
@@ -8948,15 +8193,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"avr" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "avt" = (
 /obj/machinery/button/door{
 	id = "PoolShut";
@@ -8969,13 +8205,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/pool)
-"avu" = (
-/obj/machinery/shower{
-	dir = 4
-	},
-/obj/item/soap/homemade,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/prison)
 "avv" = (
 /obj/machinery/camera{
 	c_tag = "Dorms West"
@@ -9012,13 +8241,6 @@
 /obj/structure/bedsheetbin/towel,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"avB" = (
-/obj/effect/spawner/structure/window,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plating,
-/area/security/prison)
 "avC" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -9224,21 +8446,16 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "awe" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/security/brig)
-"awf" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "awg" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -9369,18 +8586,6 @@
 "awr" = (
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"aws" = (
-/obj/machinery/camera{
-	c_tag = "Permabrig Cell Hallway 2";
-	dir = 8;
-	network = list("ss13","prison");
-	start_active = 1
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "awt" = (
 /obj/structure/sign/warning/fire{
 	desc = "A sign that states the labeled room's number.";
@@ -9401,20 +8606,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"aww" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "awy" = (
 /obj/machinery/pool/filter{
 	pixel_y = 24
@@ -9708,16 +8899,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
-"axd" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/trimline/green/filled/line,
-/obj/machinery/requests_console{
-	department = "Prison";
-	departmentType = 1;
-	pixel_y = -30
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "axe" = (
 /obj/machinery/sleeper{
 	dir = 4
@@ -9729,15 +8910,11 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "axg" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
-	},
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "0-8"
 	},
-/turf/open/floor/plasteel,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/security/prison)
 "axh" = (
 /obj/effect/turf_decal/lumos/tile/red/half{
@@ -9772,12 +8949,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"axm" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "axn" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -9806,6 +8977,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "axr" = (
@@ -9823,12 +8997,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"axs" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "axt" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -10003,25 +9171,13 @@
 /obj/structure/chair/comfy/brown,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"axS" = (
-/obj/effect/spawner/structure/window,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plating,
-/area/security/prison)
 "axT" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+/obj/structure/table,
+/obj/structure/bedsheetbin/color,
+/obj/machinery/light/small{
 	dir = 4
 	},
-/obj/machinery/holopad,
 /turf/open/floor/plasteel,
-/area/security/prison)
-"axU" = (
-/turf/open/floor/plasteel/showroomfloor/shower,
-/area/security/prison)
-"axV" = (
-/turf/open/floor/plasteel/showroomfloor,
 /area/security/prison)
 "axW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -10049,33 +9205,6 @@
 /obj/effect/turf_decal/trimline/green/filled/line,
 /turf/open/floor/plasteel,
 /area/security/brig)
-"axY" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Permabrig West Hallway 2";
-	dir = 4;
-	network = list("ss13","prison")
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"axZ" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aya" = (
 /obj/machinery/airalarm/directional/east,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
@@ -10097,21 +9226,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"ayd" = (
-/obj/item/radio/intercom{
-	desc = "Talk through this. It looks like it has been modified to not broadcast.";
-	name = "Prison Intercom (General)";
-	pixel_y = 24;
-	prison_radio = 1
-	},
-/obj/item/bedsheet/orange{
-	icon_state = "sheetorange_flip"
-	},
-/obj/structure/bed{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "aye" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 6
@@ -10221,22 +9335,8 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "ayt" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel,
+/obj/machinery/cryopod,
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "ayu" = (
 /obj/item/shard,
@@ -10265,35 +9365,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"ayz" = (
-/turf/closed/wall/r_wall,
-/area/maintenance/port/fore)
-"ayA" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plating,
-/area/maintenance/fore)
-"ayB" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8
-	},
-/obj/machinery/camera{
-	c_tag = "Permabrig East Hallway 2";
-	dir = 8;
-	network = list("ss13","prison");
-	start_active = 1
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "ayC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -10303,14 +9374,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
-"ayE" = (
-/turf/closed/wall/r_wall,
-/area/crew_quarters/theatre)
-"ayF" = (
-/obj/structure/closet/crate/bin,
-/obj/effect/turf_decal/trimline/green/filled/line,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "ayG" = (
 /turf/closed/wall/r_wall,
 /area/gateway)
@@ -10523,16 +9586,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"azd" = (
-/obj/machinery/washing_machine,
-/obj/machinery/camera{
-	c_tag = "Permabrig Laundry";
-	dir = 4;
-	network = list("ss13","prison")
-	},
-/obj/effect/turf_decal/lumos/tile/blue/checker,
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
 "aze" = (
 /obj/structure/chair/comfy/brown{
 	dir = 8
@@ -10585,12 +9638,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
-"azh" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "azi" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Garden Maintenance";
@@ -10624,8 +9671,12 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/trimline/red/filled/line,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "azn" = (
@@ -10845,15 +9896,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"azP" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/obj/machinery/atmospherics/components/unary/tank/air{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/security/prison)
 "azQ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -10939,13 +9981,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
-"azV" = (
-/obj/machinery/shower{
-	dir = 4
-	},
-/obj/item/soap,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/prison)
 "azW" = (
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
@@ -11021,23 +10056,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"aAf" = (
-/obj/machinery/light,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/prison)
-"aAg" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aAh" = (
 /turf/closed/wall,
 /area/crew_quarters/toilet)
@@ -11072,16 +10090,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/security/brig)
-"aAm" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8
-	},
-/obj/machinery/airalarm/directional/east,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aAn" = (
 /obj/machinery/light{
 	dir = 1
@@ -11255,15 +10263,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"aAM" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/binary/valve/on{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/security/prison)
 "aAN" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -11437,19 +10436,15 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "aBl" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
+/obj/machinery/cryopod,
+/obj/machinery/computer/cryopod{
+	dir = 8;
+	pixel_x = 26
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "aBm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -11620,19 +10615,6 @@
 /obj/effect/turf_decal/lumos/tile/red/fulltile,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"aBD" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/condiment/flour,
-/obj/item/reagent_containers/food/condiment/flour,
-/obj/item/reagent_containers/food/condiment/flour,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
-"aBE" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aBF" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
@@ -11655,27 +10637,6 @@
 "aBI" = (
 /turf/closed/wall,
 /area/security/checkpoint/auxiliary)
-"aBJ" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
-"aBK" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aBL" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Tool Storage Maintenance";
@@ -11688,15 +10649,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"aBM" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aBN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -11726,17 +10678,15 @@
 "aBQ" = (
 /turf/closed/wall,
 /area/storage/primary)
-"aBR" = (
-/turf/closed/wall/r_wall,
-/area/storage/primary)
 "aBS" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 6
+/obj/structure/sign/warning/electricshock{
+	pixel_y = 32
 	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/preopen{
-	id = "permalock2"
+/obj/machinery/light{
+	dir = 1
 	},
+/obj/machinery/seed_extractor,
+/obj/effect/turf_decal/lumos/tile/green/fulltile,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aBT" = (
@@ -11810,10 +10760,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"aCf" = (
-/obj/structure/closet/secure_closet/freezer/gulag_fridge,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "aCg" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -11832,6 +10778,9 @@
 /obj/effect/turf_decal/lumos/tile/red/checker,
 /obj/structure/closet/crate/wooden/toy,
 /obj/item/megaphone/clown,
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
 "aCi" = (
@@ -11856,12 +10805,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
-"aCm" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/security/prison)
 "aCn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -11874,14 +10817,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/pool)
-"aCo" = (
-/obj/machinery/door/airlock/freezer{
-	desc = "Consult with the Warden for access.";
-	name = "prison freezer";
-	req_access_txt = "63;3"
-	},
-/turf/open/floor/plasteel/freezer,
-/area/security/prison)
 "aCp" = (
 /obj/machinery/camera{
 	c_tag = "Arrivals North";
@@ -11926,13 +10861,6 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
-"aCx" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/box/monkeycubes{
-	pixel_y = 6
-	},
-/turf/open/floor/plasteel/freezer,
-/area/security/prison)
 "aCy" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 6
@@ -12083,15 +11011,6 @@
 "aCR" = (
 /turf/closed/wall,
 /area/chapel/main)
-"aCS" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aCT" = (
 /obj/structure/table,
 /obj/item/stack/sheet/metal/fifty,
@@ -12102,22 +11021,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
-"aCU" = (
-/obj/machinery/washing_machine,
-/obj/effect/turf_decal/lumos/tile/blue/checker,
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
-"aCV" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24;
-	pixel_y = 28
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aCW" = (
 /obj/effect/spawner/blocker,
 /turf/open/floor/plating,
@@ -12338,31 +11241,12 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/circuit,
 /area/ai_monitored/nuke_storage)
-"aDu" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Brig Kitchen"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "aDv" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
+/obj/effect/landmark/start/prisoner/prilate,
+/turf/open/floor/plasteel/elevatorshaft{
+	desc = "A simple teleportation pad designed for one-way personnel transfer.";
+	name = "Brig Tele-Reception Pad"
 	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/preopen{
-	id = "permalock2"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
 /area/security/prison)
 "aDw" = (
 /obj/structure/window/reinforced,
@@ -12505,15 +11389,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"aDO" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "aDP" = (
 /obj/effect/landmark/start/assistant,
 /obj/structure/toilet{
@@ -12548,15 +11423,6 @@
 	},
 /turf/open/floor/carpet,
 /area/library)
-"aDS" = (
-/obj/item/radio/intercom{
-	desc = "Talk through this. It looks like it has been modified to not broadcast.";
-	name = "Prison Intercom (General)";
-	pixel_y = 24;
-	prison_radio = 1
-	},
-/turf/closed/wall,
-/area/security/prison)
 "aDT" = (
 /obj/machinery/door/airlock{
 	desc = "A small bathroom with a sink, toilet and shower.";
@@ -12573,12 +11439,6 @@
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/crew_quarters/toilet)
-"aDV" = (
-/turf/open/floor/plasteel/white,
-/area/security/prison)
-"aDW" = (
-/turf/open/floor/plasteel/freezer,
-/area/security/prison)
 "aDY" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -12613,15 +11473,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"aEb" = (
-/obj/machinery/atmospherics/pipe/layer_manifold{
-	dir = 4
-	},
-/obj/machinery/door/airlock/glass{
-	name = "Storage"
-	},
-/turf/open/floor/plating,
-/area/security/prison)
 "aEe" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -12740,23 +11591,6 @@
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/chapel/main)
-"aEp" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/turf_decal/lumos/tile/blue/checker,
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
-"aEq" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/door/airlock/public/glass{
-	name = "Laundry"
-	},
-/obj/effect/turf_decal/lumos/tile/blue/checker,
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
 "aEr" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -12772,85 +11606,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
-"aEs" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/drinks/drinkingglass{
-	pixel_x = -8;
-	pixel_y = 8
-	},
-/obj/item/reagent_containers/food/drinks/drinkingglass{
-	pixel_x = -8;
-	pixel_y = 4
-	},
-/obj/item/reagent_containers/food/drinks/drinkingglass{
-	pixel_x = -8
-	},
-/obj/machinery/reagentgrinder,
-/obj/item/reagent_containers/dropper,
-/obj/machinery/light,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
-"aEt" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/condiment/rice,
-/obj/item/reagent_containers/food/condiment/rice,
-/obj/item/reagent_containers/food/condiment/rice,
-/obj/machinery/requests_console{
-	department = "Prison";
-	departmentType = 1;
-	pixel_y = -30
-	},
-/obj/item/reagent_containers/food/condiment/sugar{
-	pixel_x = -9;
-	pixel_y = 8
-	},
-/obj/item/reagent_containers/food/condiment/enzyme{
-	layer = 5;
-	pixel_x = -5;
-	pixel_y = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/security/prison)
-"aEu" = (
-/obj/structure/closet/crate/bin,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
-"aEv" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/open/floor/plating,
-/area/security/prison)
-"aEw" = (
-/obj/structure/closet/secure_closet/freezer/meat,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/freezer,
-/area/security/prison)
-"aEx" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/components/binary/valve{
-	dir = 4
-	},
-/obj/machinery/airalarm/directional/south,
-/obj/item/reagent_containers/glass/bucket,
-/turf/open/floor/plating,
-/area/security/prison)
-"aEy" = (
-/obj/machinery/light,
-/obj/structure/table,
-/obj/structure/bedsheetbin,
-/obj/structure/sign/poster/official/work_for_a_future{
-	pixel_x = -32
-	},
-/obj/effect/turf_decal/lumos/tile/blue/checker,
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
 "aEz" = (
 /obj/machinery/power/apc{
 	areastring = "/area/hallway/secondary/entry";
@@ -13128,51 +11883,6 @@
 	dir = 8
 	},
 /area/crew_quarters/dorms)
-"aFf" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/effect/turf_decal/lumos/tile/blue/checker,
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 12;
-	pixel_y = 4
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
-"aFg" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"aFh" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
-/obj/structure/closet/crate/trashcart,
-/turf/open/floor/plating,
-/area/security/prison)
-"aFi" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"aFj" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aFk" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -13222,12 +11932,6 @@
 /obj/structure/falsewall,
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"aFt" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/item/reagent_containers/glass/bowl,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "aFu" = (
 /turf/closed/wall,
 /area/library)
@@ -13267,29 +11971,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
-"aFD" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"aFF" = (
-/obj/machinery/camera{
-	c_tag = "Permabrig West Hallway 1";
-	dir = 4;
-	network = list("ss13","prison")
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aFG" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -13425,8 +12106,10 @@
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "aFS" = (
-/obj/structure/chair/stool,
-/turf/open/floor/plasteel/cafeteria,
+/obj/structure/sink/kitchen{
+	pixel_y = 28
+	},
+/turf/open/floor/plasteel/white,
 /area/security/prison)
 "aFT" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
@@ -13585,12 +12268,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"aGn" = (
-/obj/machinery/shower{
-	dir = 8
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/prison)
 "aGo" = (
 /obj/structure/table,
 /obj/item/stack/sheet/rglass{
@@ -13610,7 +12287,8 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "aGp" = (
-/turf/open/floor/plasteel/cafeteria,
+/obj/machinery/vending/sustenance,
+/turf/open/floor/plasteel/white,
 /area/security/prison)
 "aGq" = (
 /obj/item/stack/sheet/plasteel{
@@ -13791,14 +12469,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"aGK" = (
-/obj/structure/chair/stool,
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#cee5d2"
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
 "aGL" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -13866,10 +12536,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"aGR" = (
-/obj/structure/bookcase/random/nonfiction,
-/turf/open/floor/wood,
-/area/security/prison)
 "aGS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -14006,14 +12672,6 @@
 	},
 /turf/open/floor/wood,
 /area/library)
-"aHc" = (
-/obj/structure/bookcase/random/fiction,
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#cee5d2"
-	},
-/turf/open/floor/wood,
-/area/security/prison)
 "aHd" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -14106,33 +12764,10 @@
 	dir = 4
 	},
 /area/chapel/main)
-"aHp" = (
-/obj/machinery/camera{
-	c_tag = "Permabrig Library";
-	network = list("ss13","prison")
-	},
-/obj/structure/table,
-/obj/item/paper_bin{
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/obj/item/pen,
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
-/turf/open/floor/wood,
-/area/security/prison)
 "aHq" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/chapel/main)
-"aHr" = (
-/obj/structure/table,
-/obj/machinery/computer/libraryconsole{
-	pixel_y = 8
-	},
-/turf/open/floor/wood,
-/area/security/prison)
 "aHs" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
@@ -14240,9 +12875,6 @@
 "aHI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
@@ -14260,21 +12892,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/gateway)
-"aHK" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aHL" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -14357,43 +12974,12 @@
 /obj/machinery/door/airlock/glass_large,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"aHU" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
 "aHW" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
 /turf/open/floor/wood,
 /area/bridge/meeting_room)
-"aHX" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/door/airlock/public/glass{
-	name = "Library"
-	},
-/turf/open/floor/wood,
-/area/security/prison)
 "aHY" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -14471,11 +13057,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"aIi" = (
-/obj/structure/bed,
-/obj/item/bedsheet/orange,
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "aIj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -14613,17 +13194,6 @@
 /obj/structure/table/glass,
 /turf/open/floor/plasteel/chapel,
 /area/chapel/main)
-"aIF" = (
-/obj/structure/chair/stool,
-/turf/open/floor/wood,
-/area/security/prison)
-"aIG" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aIH" = (
 /obj/structure/table,
 /obj/item/storage/box/lights/mixed,
@@ -14803,24 +13373,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
-"aJd" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aJe" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -15104,22 +13661,6 @@
 /obj/item/nullrod,
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
-"aJN" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Brig Mess"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
 "aJO" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
@@ -15220,16 +13761,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
-"aKb" = (
-/obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
 "aKc" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
@@ -15279,32 +13810,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"aKg" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -26
-	},
-/turf/open/floor/wood,
-/area/security/prison)
 "aKh" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/preopen{
-	id = "permalock2"
+/obj/item/seeds/carrot,
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/lumos/tile/green/half{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/security/prison)
-"aKi" = (
-/obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/wood,
 /area/security/prison)
 "aKj" = (
 /obj/machinery/door/firedoor,
@@ -15377,46 +13889,6 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/crew_quarters/theatre)
-"aKv" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/security/prison)
-"aKw" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
-/obj/machinery/requests_console{
-	department = "Prison";
-	departmentType = 1;
-	pixel_y = 32
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"aKx" = (
-/obj/machinery/holopad,
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aKy" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -15699,10 +14171,6 @@
 /obj/structure/table/wood,
 /turf/open/floor/wood,
 /area/library)
-"aLh" = (
-/obj/machinery/smartfridge/food,
-/turf/closed/wall,
-/area/security/prison)
 "aLj" = (
 /obj/structure/chair/comfy/beige,
 /turf/open/floor/plasteel/grimy,
@@ -15885,8 +14353,12 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aLJ" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
+/obj/structure/chair/stool,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -15895,9 +14367,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "aLL" = (
-/obj/effect/spawner/structure/window,
-/obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/space/basic,
 /area/security/prison)
 "aLN" = (
 /obj/effect/turf_decal/stripes/line{
@@ -15939,14 +14409,6 @@
 	dir = 8
 	},
 /area/crew_quarters/dorms)
-"aLS" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aLT" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/corner{
@@ -16092,12 +14554,6 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/plasteel/showroomfloor/shower,
 /area/crew_quarters/toilet)
-"aMp" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aMq" = (
 /obj/structure/sign/poster/contraband/space_cola{
 	pixel_x = -32
@@ -16106,9 +14562,6 @@
 /area/crew_quarters/bar)
 "aMr" = (
 /obj/structure/musician/piano,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
 "aMs" = (
@@ -16147,18 +14600,9 @@
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
 "aMv" = (
-/obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/turf/open/floor/plasteel/dark/side{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel,
 /area/security/prison)
 "aMw" = (
 /obj/machinery/vending/dinnerware{
@@ -16278,15 +14722,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
-"aMK" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
 "aML" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -16340,7 +14775,9 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "aMR" = (
-/obj/effect/turf_decal/bot,
+/obj/item/seeds/potato,
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/lumos/tile/green/half,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aMS" = (
@@ -16442,12 +14879,8 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "aNi" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/bot,
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/lumos/tile/green/half,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aNj" = (
@@ -16478,10 +14911,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"aNn" = (
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/wood,
-/area/security/prison)
 "aNo" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -16522,12 +14951,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"aNt" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/security/prison)
 "aNu" = (
 /obj/structure/table/wood,
 /obj/item/paper/fluff{
@@ -16623,15 +15046,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/misc_lab)
-"aNH" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/security/prison)
 "aNI" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/food/condiment/pack/ketchup{
@@ -16673,19 +15087,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"aNJ" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8
-	},
-/obj/machinery/airalarm/directional/north,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aNK" = (
 /mob/living/simple_animal/hostile/retaliate/goat{
 	name = "Pete"
@@ -16939,10 +15340,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"aOu" = (
-/obj/machinery/door/airlock/public/glass,
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "aOv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 9
@@ -17028,15 +15425,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"aOH" = (
-/obj/machinery/button/door{
-	id = "permalock2";
-	name = "Perma Secure Airlock";
-	pixel_x = -26;
-	req_access_txt = "3"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aOI" = (
 /obj/structure/kitchenspike,
 /turf/open/floor/plasteel/showroomfloor,
@@ -17057,16 +15445,9 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "aOK" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
-/obj/structure/sign/nanotrasen{
-	icon = 'modular_skyrat/icons/obj/contraband.dmi';
-	icon_state = "poster2_legit";
-	pixel_y = 32
-	},
+/obj/effect/turf_decal/lumos/tile/green/fulltile,
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -17166,15 +15547,6 @@
 /obj/structure/bookcase/random/religion,
 /turf/open/floor/wood,
 /area/library)
-"aPc" = (
-/obj/machinery/button/door{
-	id = "permalock2";
-	name = "Perma Secure Airlock";
-	pixel_x = 26;
-	req_access_txt = "3"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aPd" = (
 /obj/structure/bookcase/random/reference,
 /turf/open/floor/wood,
@@ -17190,15 +15562,6 @@
 /obj/structure/chair/comfy/brown,
 /turf/open/floor/carpet,
 /area/library)
-"aPh" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"aPj" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aPk" = (
 /turf/open/floor/plasteel/chapel{
 	dir = 4
@@ -17256,10 +15619,13 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "aPw" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
 /area/security/prison)
 "aPx" = (
 /obj/structure/chair/comfy/beige{
@@ -17354,8 +15720,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "aPP" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel/cafeteria,
+/turf/open/floor/plasteel/white,
 /area/security/prison)
 "aPQ" = (
 /turf/closed/wall,
@@ -17728,13 +16093,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
-"aQQ" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
 "aQR" = (
 /obj/machinery/vending/cola/pwr_game,
 /obj/structure/sign/poster/contraband/pwr_game{
@@ -17975,11 +16333,8 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "aRv" = (
-/obj/structure/sign/poster/official/random{
-	pixel_y = -32
-	},
-/obj/structure/chair/stool,
-/turf/open/floor/plasteel/cafeteria,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/turf/open/floor/plasteel/white,
 /area/security/prison)
 "aRx" = (
 /obj/structure/chair/sofa,
@@ -18259,17 +16614,8 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "aSj" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/window/reinforced{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -18307,21 +16653,6 @@
 /obj/item/extinguisher,
 /turf/open/floor/plating,
 /area/storage/emergency/port)
-"aSo" = (
-/obj/structure/bookcase/random/religion,
-/turf/open/floor/wood,
-/area/security/prison)
-"aSp" = (
-/obj/machinery/camera{
-	c_tag = "Permabrig Showers";
-	dir = 4;
-	network = list("ss13","prison")
-	},
-/obj/structure/sign/poster/official/random{
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/prison)
 "aSq" = (
 /obj/structure/chair/comfy/brown{
 	dir = 8
@@ -18466,7 +16797,10 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/crew_quarters/toilet)
 "aSG" = (
-/obj/effect/turf_decal/delivery,
+/obj/machinery/plate_chute/inputchute{
+	pixel_x = -26
+	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aSH" = (
@@ -18515,13 +16849,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/kitchen)
-"aSR" = (
-/obj/structure/lattice,
-/obj/machinery/camera{
-	dir = 4
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "aSS" = (
 /obj/machinery/vending/hydroseeds{
 	slogan_delay = 700
@@ -18656,12 +16983,6 @@
 	icon_state = "wood-broken6"
 	},
 /area/crew_quarters/dorms)
-"aTq" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Showers"
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/prison)
 "aTr" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/status_display/evac{
@@ -18696,28 +17017,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
-"aTx" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Visitation - Prisoners"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/preopen{
-	id = "visitexit"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aTy" = (
 /obj/machinery/door/airlock/titanium,
 /turf/open/floor/plating,
 /area/space/nearstation)
 "aTA" = (
-/obj/structure/sign/poster/official/random{
-	pixel_x = -32
-	},
-/obj/machinery/light{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -18994,7 +17300,20 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aUr" = (
-/obj/machinery/airalarm/directional/north,
+/obj/machinery/door/poddoor/preopen{
+	id = "permacell2";
+	name = "cell blast door"
+	},
+/obj/machinery/door/airlock/public/glass{
+	id_tag = "permabolt2";
+	name = "Cell 2"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aUs" = (
@@ -19072,18 +17391,6 @@
 /obj/structure/bookcase/random/adult,
 /turf/open/floor/wood,
 /area/library)
-"aUC" = (
-/obj/machinery/camera{
-	c_tag = "Permabrig Entrance";
-	dir = 8;
-	network = list("ss13","prison");
-	start_active = 1
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aUD" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green{
@@ -19141,12 +17448,11 @@
 /turf/open/floor/wood,
 /area/security/vacantoffice)
 "aUP" = (
-/obj/machinery/flasher{
-	id = "visitflash";
-	pixel_y = 25
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -19183,14 +17489,17 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "aUV" = (
-/obj/machinery/light{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/firealarm{
 	dir = 1;
-	light_color = "#cee5d2"
+	pixel_y = -24
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/white,
 /area/security/prison)
 "aUW" = (
 /obj/structure/table/wood,
@@ -19505,12 +17814,21 @@
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "aVx" = (
-/obj/structure/window/reinforced{
-	dir = 4;
-	layer = 2.9
+/obj/machinery/camera{
+	c_tag = "Prison Cell 3";
+	network = list("ss13","prison")
 	},
-/obj/machinery/conveyor/auto{
-	dir = 1
+/obj/item/radio/intercom{
+	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_y = 24;
+	prison_radio = 1
+	},
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -19601,12 +17919,6 @@
 /obj/structure/table/wood,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"aVG" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aVH" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/biogenerator,
@@ -20292,22 +18604,25 @@
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "aXx" = (
-/obj/machinery/conveyor/auto{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4;
-	layer = 2.9
+/obj/machinery/plate_press,
+/obj/item/stack/license_plates/empty/fifty,
+/obj/machinery/requests_console{
+	department = "Prison";
+	departmentType = 1;
+	pixel_x = -30
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aXA" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/machinery/door/poddoor/preopen{
+	id = "permacell3";
+	name = "cell blast door"
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4
+/obj/machinery/door/airlock/public/glass{
+	id_tag = "permabolt3";
+	name = "Cell 3"
 	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aXD" = (
@@ -20334,16 +18649,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"aXH" = (
-/obj/machinery/button/door{
-	id = "permalock2";
-	name = "Perma Secure Airlock";
-	pixel_y = -26;
-	req_access_txt = "3"
-	},
-/obj/machinery/light,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aXI" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -20386,7 +18691,11 @@
 /turf/open/floor/wood,
 /area/security/vacantoffice)
 "aXO" = (
-/obj/structure/table,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aXP" = (
@@ -20456,26 +18765,6 @@
 	},
 /turf/open/floor/wood,
 /area/security/vacantoffice)
-"aYa" = (
-/obj/structure/table,
-/obj/item/storage/box/hug,
-/obj/item/razor{
-	pixel_x = -6
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"aYc" = (
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "outerbrig";
-	name = "Visitation - Visitors";
-	req_access_txt = "3"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/lumos/tile/red/fulltile,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aYd" = (
 /obj/structure/chair/office/dark,
 /turf/open/floor/wood,
@@ -20503,17 +18792,22 @@
 /obj/structure/chair/sofa/left,
 /turf/open/floor/plating,
 /area/construction)
-"aYh" = (
-/obj/structure/bookcase/random/reference,
-/obj/machinery/light,
-/turf/open/floor/wood,
-/area/security/prison)
 "aYi" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/button/door{
+	id = "permacell1";
+	name = "Cell 1 Lockdown";
+	pixel_x = -4;
+	pixel_y = 25;
+	req_access_txt = "2"
+	},
+/obj/machinery/button/flasher{
+	id = "PCell 1";
+	pixel_x = 6;
+	pixel_y = 24
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aYj" = (
@@ -20714,13 +19008,11 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aYI" = (
-/obj/machinery/conveyor/auto{
-	dir = 1
+/obj/machinery/plate_press,
+/obj/structure/sign/poster/official/work_for_a_future{
+	pixel_x = -32
 	},
-/obj/structure/plasticflaps/opaque,
-/obj/machinery/door/poddoor/preopen{
-	id = "locklock"
-	},
+/obj/item/stack/license_plates/empty/fifty,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aYJ" = (
@@ -20813,22 +19105,6 @@
 "aYW" = (
 /turf/open/floor/carpet,
 /area/library)
-"aYX" = (
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "outerbrig";
-	name = "Perma Wing";
-	req_access_txt = "63"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/preopen{
-	id = "locklock"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aZa" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/flora/ausbushes/stalkybush,
@@ -21217,24 +19493,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
-"bae" = (
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "outerbrig";
-	name = "Perma Wing";
-	req_access_txt = "63"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/preopen{
-	id = "locklock"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "baf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -21628,12 +19886,7 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/locker)
 "bbr" = (
-/obj/structure/table/reinforced,
-/obj/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters{
-	id = "visit"
-	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/showroomfloor,
 /area/security/prison)
 "bbs" = (
 /obj/structure/window/reinforced{
@@ -21761,12 +20014,12 @@
 /turf/open/floor/carpet/blue,
 /area/bridge/meeting_room)
 "bbN" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/shutters{
-	id = "visit"
+/obj/machinery/door/window/westleft{
+	base_state = "right";
+	icon_state = "right";
+	name = "Unisex Showers"
 	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/showroomfloor,
 /area/security/prison)
 "bbO" = (
 /obj/machinery/washing_machine,
@@ -21845,15 +20098,6 @@
 /obj/structure/table/wood,
 /turf/open/floor/wood,
 /area/bridge/meeting_room)
-"bbZ" = (
-/obj/machinery/hydroponics/constructable,
-/obj/machinery/light,
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 10
-	},
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "bca" = (
 /turf/open/floor/carpet/blue,
 /area/bridge/meeting_room)
@@ -22117,16 +20361,6 @@
 /obj/item/hand_labeler,
 /turf/open/floor/carpet/blue,
 /area/bridge/meeting_room)
-"bcO" = (
-/obj/machinery/flasher{
-	id = "permalock";
-	pixel_y = 25
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "bcP" = (
 /obj/structure/table,
 /turf/open/floor/wood,
@@ -22145,32 +20379,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"bcT" = (
-/obj/structure/table/reinforced,
-/obj/item/clothing/head/helmet/space/plasmaman/prisoner,
-/obj/item/clothing/head/helmet/space/plasmaman/prisoner,
-/obj/item/clothing/under/plasmaman/prisoner,
-/obj/item/clothing/under/plasmaman/prisoner,
-/obj/item/clothing/shoes/sneakers/orange,
-/obj/item/clothing/shoes/sneakers/orange,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/item/radio/headset{
-	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
-	name = "prisoner headset";
-	prison_radio = 1
-	},
-/obj/item/radio/headset{
-	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
-	name = "prisoner headset";
-	prison_radio = 1
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "bcU" = (
 /obj/effect/turf_decal/box,
 /obj/effect/turf_decal/vg_decals/numbers/three,
@@ -22608,21 +20816,21 @@
 /obj/item/reagent_containers/glass/bottle/vial/small,
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
-"bdV" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+"bdW" = (
+/obj/machinery/camera{
+	c_tag = "Prison Cell 2";
+	network = list("ss13","prison")
+	},
+/obj/item/radio/intercom{
+	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_y = 24;
+	prison_radio = 1
+	},
+/obj/structure/bed{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"bdW" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -23162,18 +21370,20 @@
 /turf/open/floor/plating,
 /area/quartermaster/sorting)
 "bfk" = (
-/obj/structure/table/reinforced,
-/obj/machinery/camera{
-	c_tag = "Permabrig Prisoner Processing";
-	dir = 8;
-	network = list("ss13","prison");
-	start_active = 1
+/obj/machinery/light/small{
+	dir = 1
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
+/obj/machinery/button/door{
+	id = "permabolt2";
+	name = "Cell Bolt Control";
+	normaldoorcontrol = 1;
+	pixel_y = 25;
+	specialfunctions = 4
 	},
-/obj/item/clothing/suit/straight_jacket,
-/obj/item/clothing/suit/straight_jacket,
+/obj/structure/bed,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "bfl" = (
@@ -23497,8 +21707,11 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "bgl" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -23565,12 +21778,19 @@
 /turf/closed/wall,
 /area/quartermaster/office)
 "bgx" = (
-/obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
+/obj/machinery/light/small{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 6
+/obj/machinery/button/door{
+	id = "permabolt1";
+	name = "Cell Bolt Control";
+	normaldoorcontrol = 1;
+	pixel_y = 25;
+	specialfunctions = 4
+	},
+/obj/structure/bed,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -23705,13 +21925,17 @@
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "bgR" = (
-/obj/machinery/camera{
-	c_tag = "Permabrig Visitations Visitor-side";
-	dir = 8;
-	network = list("ss13","prison");
-	start_active = 1
+/obj/structure/mirror{
+	pixel_x = 25
 	},
-/turf/open/floor/plasteel,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
+	},
+/turf/open/floor/plasteel/freezer,
 /area/security/prison)
 "bgS" = (
 /obj/structure/cable{
@@ -23990,13 +22214,9 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "bhK" = (
-/obj/machinery/light,
-/obj/structure/sign/poster/official/random{
-	pixel_x = -32
-	},
-/obj/structure/plasticflaps,
-/obj/machinery/conveyor/auto{
-	dir = 1
+/obj/machinery/flasher{
+	id = "PCell 3";
+	pixel_x = -28
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -24032,13 +22252,8 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "bhP" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
-	},
-/obj/machinery/conveyor/auto{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "bhQ" = (
@@ -24242,15 +22457,6 @@
 "biL" = (
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
-"biM" = (
-/obj/effect/turf_decal/loading_area{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "biN" = (
 /obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 1
@@ -24365,28 +22571,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"biZ" = (
-/obj/structure/table/reinforced,
-/obj/item/radio/headset{
-	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
-	name = "prisoner headset";
-	prison_radio = 1
-	},
-/obj/item/radio/headset{
-	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
-	name = "prisoner headset";
-	prison_radio = 1
-	},
-/obj/item/radio/headset{
-	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
-	name = "prisoner headset";
-	prison_radio = 1
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "bja" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -24633,8 +22817,10 @@
 /turf/open/floor/plating,
 /area/maintenance/central)
 "bjD" = (
-/obj/machinery/light,
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/machinery/flasher{
+	id = "PCell 1";
+	pixel_x = -28
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "bjE" = (
@@ -24769,9 +22955,9 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "bke" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/toilet{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "bkg" = (
@@ -24810,29 +22996,10 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "bkl" = (
-/obj/machinery/button/flasher{
-	id = "visitflash";
-	pixel_x = 22;
-	pixel_y = 3;
-	req_access_txt = "3"
+/obj/structure/toilet{
+	dir = 1
 	},
-/obj/machinery/button/door{
-	id = "visit";
-	name = "Visitation Shutters";
-	pixel_x = 23;
-	pixel_y = 10;
-	req_access_txt = "3"
-	},
-/obj/structure/chair/stool,
-/obj/machinery/button/door{
-	id = "visitexit";
-	name = "Visitation Prisoner Lockdown";
-	pixel_x = 33;
-	pixel_y = 10;
-	req_access_txt = "3"
-	},
-/obj/effect/turf_decal/trimline/red/filled/line,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/freezer,
 /area/security/prison)
 "bkm" = (
 /obj/effect/turf_decal/stripes/line{
@@ -24951,21 +23118,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
-"bkA" = (
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "outerbrig";
-	name = "Prisoner Processing";
-	req_access_txt = "63"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "bkB" = (
 /obj/machinery/button/door{
 	id = "Disposal Exit";
@@ -25012,23 +23164,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
 /area/maintenance/port)
-"bkI" = (
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "outerbrig";
-	name = "Prisoner Processing";
-	req_access_txt = "63"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "bkJ" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -25474,18 +23609,14 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "blT" = (
-/obj/machinery/button/flasher{
-	id = "permalock";
-	pixel_x = 6;
-	pixel_y = 36;
-	req_access_txt = "3"
-	},
 /obj/machinery/light{
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "blU" = (
@@ -25675,26 +23806,13 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "bmu" = (
-/obj/machinery/button/door{
-	id = "locklock";
-	name = "Perma Airlock Lockdown";
-	pixel_y = 26;
-	req_access_txt = "3"
-	},
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"bmv" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/computer/security/telescreen/prison{
+	pixel_y = 30
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "bmx" = (
@@ -25857,6 +23975,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
+	},
+/obj/machinery/computer/security/telescreen/prison{
+	pixel_y = 30
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -26247,17 +24368,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/front_office)
-"bop" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
-/turf/open/floor/plasteel,
-/area/security/brig)
 "bor" = (
 /obj/item/clothing/gloves/color/latex,
 /obj/item/surgical_drapes,
@@ -35110,9 +33220,6 @@
 /area/crew_quarters/dorms)
 "bMa" = (
 /obj/structure/chair/stool,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8
-	},
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
 "bMc" = (
@@ -38382,10 +36489,6 @@
 /obj/item/integrated_electronics/detailer,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
-"bVk" = (
-/obj/structure/closet/secure_closet/freezer/meat,
-/turf/open/floor/plasteel/freezer,
-/area/security/prison)
 "bVl" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
@@ -49814,11 +47917,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
-"dgc" = (
-/obj/structure/chair/stool,
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
 "dgv" = (
 /obj/structure/table/wood,
 /obj/item/folder/yellow,
@@ -49838,13 +47936,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"dlx" = (
-/obj/structure/table,
-/obj/machinery/microwave{
-	pixel_y = 6
-	},
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "dly" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -50478,9 +48569,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/effect/turf_decal/lumos/tile/blue/checker{
 	dir = 4
 	},
@@ -50643,11 +48731,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/entry)
-"faw" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "fcn" = (
 /obj/structure/lattice,
 /turf/closed/wall/r_wall,
@@ -50766,22 +48849,19 @@
 /turf/open/floor/wood,
 /area/maintenance/bar)
 "fne" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
 /turf/open/floor/plasteel/white/side{
 	dir = 8
 	},
@@ -51083,10 +49163,12 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/holopad,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "fMN" = (
@@ -51096,9 +49178,6 @@
 "fOA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
@@ -51166,23 +49245,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/teleporter)
-"fUD" = (
-/obj/item/radio/intercom{
-	desc = "Talk through this. It looks like it has been modified to not broadcast.";
-	name = "Prison Intercom (General)";
-	pixel_y = 24;
-	prison_radio = 1
-	},
-/obj/structure/bed,
-/obj/item/bedsheet/orange,
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
-"fYb" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "fYr" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -51772,15 +49834,6 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/theatre)
-"gVw" = (
-/obj/structure/lattice,
-/obj/machinery/camera{
-	c_tag = "Permabrig Space southwest";
-	dir = 8;
-	name = "aft camera"
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "gVQ" = (
 /obj/effect/turf_decal/lumos/tile/blue/fullcorner,
 /turf/open/floor/plasteel/white,
@@ -52062,11 +50115,23 @@
 /turf/open/floor/plating,
 /area/space/nearstation)
 "hsU" = (
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/item/paper_bin{
+	pixel_x = -10;
+	pixel_y = 6
 	},
-/obj/effect/landmark/start/prisoner/prilate,
-/turf/open/floor/circuit/green,
+/obj/structure/table,
+/obj/item/pen{
+	pixel_x = 4
+	},
+/obj/item/pen{
+	pixel_x = 7;
+	pixel_y = 3
+	},
+/obj/item/pen{
+	pixel_x = 3;
+	pixel_y = 4
+	},
+/turf/open/floor/wood,
 /area/security/prison)
 "htK" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
@@ -52225,23 +50290,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"hKQ" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/machinery/vending/dinnerware/prisoner,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
-"hLb" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "hLo" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -52552,7 +50600,11 @@
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "ixS" = (
-/turf/open/floor/circuit/green,
+/obj/structure/table,
+/obj/machinery/computer/libraryconsole/bookmanagement{
+	pixel_y = 8
+	},
+/turf/open/floor/wood,
 /area/security/prison)
 "iyz" = (
 /obj/machinery/light/small{
@@ -52884,15 +50936,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
-"jdL" = (
-/obj/machinery/camera{
-	c_tag = "Permabrig Visitations Prisoner-side";
-	dir = 8;
-	network = list("ss13","prison");
-	start_active = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "jex" = (
 /obj/machinery/smartfridge/organ/preloaded,
 /turf/closed/wall,
@@ -52902,11 +50945,11 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "jfp" = (
-/obj/effect/landmark/start/prisoner/prilate,
-/turf/open/floor/plasteel/elevatorshaft{
-	desc = "A simple teleportation pad designed for one-way personnel transfer.";
-	name = "Brig Tele-Reception Pad"
+/obj/structure/chair/stool,
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
+/turf/open/floor/wood,
 /area/security/prison)
 "jgm" = (
 /obj/machinery/button/door{
@@ -53019,17 +51062,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/front_office)
-"jmH" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24;
-	pixel_y = 28
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "jmV" = (
 /obj/structure/table/wood/fancy,
 /obj/item/reagent_containers/food/drinks/britcup{
@@ -53118,11 +51150,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "jxW" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/preopen{
-	id = "permalock2"
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/circuit/green,
 /area/security/prison)
 "jyt" = (
 /obj/structure/disposalpipe/segment{
@@ -53190,7 +51218,10 @@
 /area/maintenance/aft)
 "jDN" = (
 /obj/structure/table,
-/turf/open/floor/plasteel/cafeteria,
+/obj/machinery/microwave{
+	pixel_y = 6
+	},
+/turf/open/floor/plasteel/white,
 /area/security/prison)
 "jEc" = (
 /obj/machinery/vr_sleeper{
@@ -53391,10 +51422,6 @@
 	},
 /turf/open/floor/wood,
 /area/maintenance/bar)
-"jNy" = (
-/obj/structure/lattice,
-/turf/closed/wall/r_wall,
-/area/security/prison)
 "jOY" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -53866,8 +51893,8 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "kze" = (
-/obj/effect/landmark/start/prisoner/prilate,
-/turf/open/floor/circuit/green,
+/obj/structure/bookcase/random/nonfiction,
+/turf/open/floor/wood,
 /area/security/prison)
 "kzT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -53958,12 +51985,6 @@
 /obj/structure/closet,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
-"kLD" = (
-/obj/structure/bed,
-/obj/item/bedsheet/orange,
-/obj/effect/landmark/start/prisoner,
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "kMt" = (
 /obj/machinery/computer/prisoner/gulag_teleporter_computer,
 /turf/open/floor/plasteel,
@@ -54313,13 +52334,6 @@
 	},
 /turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/captain)
-"lEt" = (
-/obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "lEG" = (
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/white,
@@ -54340,17 +52354,6 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/abandoned_gambling_den)
-"lGW" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
-	},
-/obj/machinery/camera{
-	c_tag = "Permabrig Cell Hallway 1";
-	dir = 4;
-	network = list("ss13","prison")
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "lID" = (
 /obj/machinery/suit_storage_unit/cmo,
 /obj/effect/turf_decal/lumos/tile/blue/checker{
@@ -54369,15 +52372,6 @@
 /obj/machinery/door/poddoor/incinerator_atmos_main,
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
-"lKA" = (
-/obj/structure/lattice,
-/obj/machinery/camera{
-	c_tag = "Permabrig Space Northeast";
-	dir = 1;
-	name = "aft camera"
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "lKL" = (
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall,
@@ -54908,20 +52902,6 @@
 /obj/effect/turf_decal/lumos/tile/blue/checker,
 /turf/open/floor/plasteel/dark,
 /area/blueshield)
-"mYU" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "nac" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
@@ -55020,10 +53000,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/front_office)
-"njP" = (
-/obj/effect/landmark/start/prisoner,
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "nlz" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -55445,13 +53421,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"nSN" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#cee5d2"
-	},
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "nTb" = (
 /turf/closed/wall/r_wall,
 /area/crew_quarters/heads/cmo)
@@ -56032,9 +54001,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "oWn" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
+/obj/structure/table,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "oZc" = (
@@ -56273,16 +54240,6 @@
 /obj/effect/turf_decal/lumos/tile/green/fulltile,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"pvX" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "pwd" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder{
@@ -56405,9 +54362,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/lumos/tile/blue/checker{
 	dir = 4
@@ -56693,11 +54647,20 @@
 /turf/closed/wall,
 /area/quartermaster/miningdock)
 "qkG" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
+	},
+/obj/machinery/button/flasher{
+	id = "PCell 3";
+	pixel_x = 6;
+	pixel_y = 24
+	},
+/obj/machinery/button/door{
+	id = "permacell3";
+	name = "Cell 3 Lockdown";
+	pixel_x = -4;
+	pixel_y = 25;
+	req_access_txt = "2"
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -56796,10 +54759,6 @@
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"qzq" = (
-/obj/structure/closet/crate/bin,
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
 "qBa" = (
 /turf/closed/wall,
 /area/medical/medbay/lobby)
@@ -56888,15 +54847,6 @@
 /obj/item/pizzabox,
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
-"qKw" = (
-/obj/structure/chair/stool,
-/obj/machinery/camera{
-	c_tag = "Permabrig Cafeteria";
-	dir = 1;
-	network = list("ss13","prison")
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
 "qLc" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/preopen{
@@ -57089,15 +55039,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/bridge)
-"rjQ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/theatre)
 "rkg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -57273,13 +55214,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"rDu" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "rEQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
@@ -57396,14 +55330,16 @@
 /turf/open/space,
 /area/space/nearstation)
 "rPU" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
 /obj/structure/chair/stool,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/white/side{
 	dir = 8
 	},
@@ -57925,14 +55861,6 @@
 /obj/structure/barricade/wooden/crude,
 /turf/open/floor/plating,
 /area/maintenance/bar)
-"sNK" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/wood,
-/area/crew_quarters/theatre)
 "sOn" = (
 /obj/machinery/camera{
 	c_tag = "Departures Security Holding Area";
@@ -58031,13 +55959,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/maintenance/disposal/incinerator)
-"sWj" = (
-/obj/machinery/shower{
-	dir = 8
-	},
-/obj/item/soap/homemade,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/prison)
 "sWR" = (
 /obj/machinery/mineral/ore_redemption{
 	input_dir = 8;
@@ -58311,21 +56232,6 @@
 /obj/item/crowbar/red,
 /turf/open/floor/plating,
 /area/maintenance/port)
-"txx" = (
-/obj/item/radio/intercom{
-	desc = "Talk through this. It looks like it has been modified to not broadcast.";
-	name = "Prison Intercom (General)";
-	pixel_y = 24;
-	prison_radio = 1
-	},
-/obj/structure/bed{
-	dir = 4
-	},
-/obj/item/bedsheet/orange{
-	icon_state = "sheetorange_flip"
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "tyO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/structure/disposalpipe/broken{
@@ -58444,14 +56350,6 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/theatre)
-"tIF" = (
-/obj/structure/lattice,
-/obj/machinery/camera{
-	c_tag = "Permabrig Space Southeast";
-	dir = 4
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "tJi" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -59943,11 +57841,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
-"wgd" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/trimline/green/filled/line,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "wgq" = (
 /obj/machinery/newscaster{
 	pixel_y = 32
@@ -60496,18 +58389,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/front_office)
-"xez" = (
-/obj/machinery/camera{
-	c_tag = "Permabrig East";
-	dir = 8;
-	network = list("ss13","prison");
-	start_active = 1
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "xfE" = (
 /obj/machinery/light{
 	light_color = "#c9d3e8"
@@ -60623,14 +58504,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
-"xkD" = (
-/obj/machinery/camera{
-	c_tag = "Permabrig Kitchen";
-	network = list("ss13","prison")
-	},
-/obj/machinery/processor,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "xkL" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -60651,11 +58524,12 @@
 /turf/open/floor/plasteel/dark,
 /area/hydroponics)
 "xmo" = (
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 10
+	},
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
 "xmS" = (
@@ -60714,13 +58588,13 @@
 /area/medical/psych)
 "xtP" = (
 /obj/structure/cable{
-	icon_state = "2-4"
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
@@ -60808,9 +58682,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -61110,10 +58981,14 @@
 /turf/open/floor/plasteel/white,
 /area/science/explab)
 "ycV" = (
-/obj/structure/bed,
-/obj/effect/landmark/start/prisoner,
-/obj/item/bedsheet/orange,
-/turf/open/floor/plasteel/dark,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/security/prison)
 "ydD" = (
 /obj/effect/turf_decal/bot,
@@ -80803,16 +78678,16 @@ ali
 ali
 alU
 axo
-ayz
-ayz
-ayz
-aBR
-aBR
-aBR
-aBR
-aBR
-aBR
-aBR
+alU
+alU
+alU
+aBQ
+aBQ
+aBQ
+aBQ
+aBQ
+aBQ
+aBQ
 pNr
 aLF
 flh
@@ -81316,8 +79191,8 @@ aqQ
 aqQ
 aqQ
 arP
-axo
-aCr
+ael
+aex
 rPU
 fne
 fOA
@@ -81573,7 +79448,7 @@ aqR
 aGh
 aqR
 avW
-axo
+aem
 aCr
 aCh
 pIf
@@ -82088,8 +79963,8 @@ pEL
 lXX
 arP
 xtP
-ayA
-sNK
+aCr
+viF
 xmo
 aBV
 szG
@@ -82297,14 +80172,14 @@ aaa
 aaa
 aaa
 aaa
-eRz
-eRz
-eRz
-eRz
-eRz
-eRz
-eRz
-eRz
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -82347,7 +80222,7 @@ arP
 xxi
 aCr
 viF
-rjQ
+viF
 xZD
 hcb
 uRS
@@ -82552,22 +80427,22 @@ aaa
 aaa
 aaa
 aaa
-iDo
-iDo
-gXs
-gXs
-agN
-gXs
-gXs
-gXs
-gXs
-gXs
-aaj
-aaj
-aaj
-aaj
-aaj
-aaj
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -82804,27 +80679,27 @@ aaa
 aaa
 aaa
 aaa
-aaj
-aaj
-aaj
-aaj
-aaj
-gXs
-gXs
-gXs
-gXs
-aai
-aai
-aai
-aai
-aai
-gXs
-gXs
-gXs
-gXs
-gVw
-gXs
-aaj
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -83060,28 +80935,28 @@ aaa
 aaa
 aaa
 aaa
-eRz
-gXs
-gXs
-gXs
-gXs
-gXs
-gXs
-gXs
-gXs
-gXs
-aai
-aml
-azP
-aEv
-aai
-aai
-aai
-aai
-aai
-aai
-gXs
-aaj
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -83149,7 +81024,7 @@ biT
 bbR
 bmP
 bbR
-aqV
+bbR
 bbR
 bbR
 bbR
@@ -83317,28 +81192,28 @@ aaa
 aaa
 aaa
 aaa
-eRz
-gXs
-aai
-aai
-aai
-aai
-aai
-gXs
-gXs
-gXs
-aai
-amo
-aAM
-aEx
-aai
-aGR
-aKg
-aNn
-aSo
-aai
-gXs
-aaj
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -83373,16 +81248,16 @@ asQ
 aqR
 aFs
 axr
-ayE
-ayE
-ayE
-ayE
-ayE
-ayE
-ayE
-ayE
-ayE
-ayE
+aCr
+aCr
+aCr
+aCr
+aCr
+aCr
+aCr
+aCr
+aCr
+aCr
 aLE
 aMT
 aOi
@@ -83574,28 +81449,28 @@ aaa
 aaa
 aaa
 aaa
-eRz
-aek
-aai
-ajv
-aiK
-ats
-aai
-aai
-aai
-aai
-aai
-atl
-aCm
-aFh
-aai
-aGR
-aaU
-aNt
-aSo
-aai
-gXs
-aaj
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -83831,28 +81706,28 @@ aaa
 aaa
 aaa
 aaa
-eRz
-gXs
-aai
-ajv
-ajB
-aqB
-aai
-avu
-aSp
-azV
-aai
-aai
-aEb
-aai
-aai
-aHc
-aaU
-aKi
-aYh
-aai
-gXs
-aaj
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -84086,30 +81961,30 @@ aaa
 aaa
 aaa
 aaa
-aaj
-eRz
-eRz
-gXs
-aai
-ajv
-akW
-aqG
-aai
-agZ
-axU
-aAf
-acd
-azd
-aEp
-aEy
-acd
-aHp
-aaU
-aNH
-afR
-aai
-gXs
-aaj
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -84342,31 +82217,31 @@ aaa
 aaa
 aaa
 aaa
-aaj
-aaj
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 gXs
 gXs
 gXs
-aai
-ajv
-aos
-atX
-aai
-aGn
-axV
-sWj
-acd
-aCU
-aEp
-aFf
-acd
-aHr
-aIF
-aKv
-aaU
-aai
 gXs
-eRz
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -84598,32 +82473,32 @@ aaa
 aaa
 aaa
 aaa
-aaj
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 gXs
 gXs
 gXs
-aai
-aai
-aai
-aai
-aai
-atT
-aai
-acd
-aTq
-acd
-acd
-acd
-aEq
-acd
-acd
-acd
-axS
-aHX
 aLL
-aai
-aai
-jNy
+aLL
+gXs
+xhY
+xhY
 afA
 abu
 abu
@@ -84634,7 +82509,7 @@ aec
 aeJ
 afw
 abc
-abc
+afA
 dly
 lAa
 mcp
@@ -84855,32 +82730,32 @@ aaa
 aaa
 aaa
 aaa
-aaj
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 gXs
+aaa
+aaa
 gXs
-alD
+aLL
 aai
-acE
-aFg
-aFg
-aIG
-adI
-aud
-aFg
-axY
-aAg
-aCV
-aFg
-aCS
-aFi
-aFF
-aFg
-aFg
-aBK
-aFg
-hsU
-ixS
-kze
+aai
+aaW
+aai
 afA
 abt
 aca
@@ -84891,7 +82766,7 @@ aeb
 aeI
 afv
 agf
-abc
+afA
 dly
 lAa
 mcp
@@ -85112,32 +82987,32 @@ aaa
 aaa
 aaa
 aaa
-eRz
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 gXs
 gXs
-abB
-aar
-aat
-abE
-ajG
-aJd
-aej
-auj
-alZ
-ajz
-akf
-auj
-auj
-akT
-aFD
-auj
-auj
-auj
-aKx
-aat
+gXs
+gXs
+gXs
+gXs
+aai
+aai
+aai
+aai
 ixS
 jfp
-ixS
+abh
 afA
 abw
 acc
@@ -85148,7 +83023,7 @@ aee
 aeL
 afv
 agh
-abc
+afA
 qCC
 hnU
 vda
@@ -85369,31 +83244,31 @@ aaa
 aaa
 aaa
 aaa
-aaj
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 gXs
+aaa
 aai
-aai
-aau
-aat
-adc
-alf
-acd
-acd
-acd
-acd
-acd
-acd
-acd
-acd
-acd
-acd
-acd
-acd
-acd
-aNJ
-aat
+jxW
+jxW
+aar
 hsU
-ixS
+abb
 kze
 afA
 abv
@@ -85405,7 +83280,7 @@ aed
 aeK
 afx
 agg
-abc
+afA
 dWM
 dCV
 idK
@@ -85625,32 +83500,32 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+gXs
+gXs
+gXs
+aaa
+aai
 aaj
-gXs
-gXs
-abB
-aaB
-aav
-aat
-agl
-akH
-acd
-asV
-ael
-aIi
-acd
-txx
-aiQ
-amb
-acd
-ayd
-aup
-amb
-acd
 aDv
 jxW
-aai
-aai
+aat
+aTA
 aai
 afA
 afA
@@ -85662,7 +83537,7 @@ afA
 aeN
 afA
 afA
-abc
+afA
 wVh
 laq
 kdP
@@ -85882,36 +83757,36 @@ aaa
 aaa
 aaa
 aaa
-aaj
-aak
-alD
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+gXs
+aaa
 aai
-abb
-abe
-aby
-aex
-akK
-acd
-auC
-auC
-auC
-acd
-auC
-auC
-auC
-acd
-auC
-auC
-auC
-acd
-aHK
+jxW
+jxW
+aar
 aat
-aOH
 aTA
 aSG
 aXx
 aYI
-aXx
+acd
 aVx
 bhK
 acd
@@ -85923,7 +83798,7 @@ ail
 wPh
 vIi
 fsj
-dXP
+qxq
 alz
 atf
 jhb
@@ -86139,48 +84014,48 @@ aaa
 aaa
 aaa
 aaa
-aaj
-gXs
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+gJi
+auu
+aai
+aai
+aai
+aai
 aaD
-aan
-abx
-aaU
-adb
-adc
-ahQ
-acd
-acd
-auu
-acd
-acd
-acd
-auu
-acd
-acd
-acd
-auu
-acd
-acd
-aOK
-aMR
+aTA
 aat
 aat
-aVG
-rDu
-acd
+aat
 aXA
-bdV
+bgl
 bhP
-acd
+adf
 blT
 aeV
 afJ
-dXP
-dXP
-dXP
-dXP
-dXP
-dXP
+qxq
+qxq
+qxq
+qxq
+qxq
+qxq
 gjc
 ajX
 agj
@@ -86396,39 +84271,39 @@ aaa
 aaa
 aaa
 aaa
-aaj
-gXs
-aaE
-aap
-abx
-aaU
-adb
-adc
-akP
-amG
-aAg
-aFg
-awf
-aFg
-aFg
-jmH
-aFg
-lGW
-aFg
-aFg
-aAg
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+gJi
+aaf
+aai
 akL
 aJe
 aMR
 aat
-aat
+ahP
 oWn
-aas
-aYX
-acG
+aaJ
+aat
+acd
 anW
-biM
-bkA
+bke
+acd
 qkG
 xDo
 azG
@@ -86653,41 +84528,41 @@ aaa
 aaa
 aaa
 aaa
-aaj
-gXs
-aaw
-aas
-aaR
-aax
-ada
-add
-aBM
-aeg
-aep
-ahP
-aeh
-ahP
-ahP
-abh
-ahP
-ahP
-ahP
-ahP
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+gJi
+aaa
 aep
 aKh
 amk
 aNi
-ahP
+aat
 ahP
 amu
-aXH
+aaJ
+acE
 acd
-bcO
-aow
-aat
+acd
+acd
 acd
 bmu
-aeV
+aej
 azG
 agO
 afI
@@ -86910,42 +84785,42 @@ aaa
 aaa
 aaa
 aaa
-aaj
-gXs
-aaE
-aap
-abA
-aaU
-adb
-adc
-akP
-amH
-auA
-aPw
-aws
-aPw
-afK
-aPw
-aPw
-pvX
-aPw
-aPw
-auA
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+gJi
+aaf
+auC
 aBS
-aJe
-aMR
+aaq
+aas
 aat
-aat
+aTA
 agD
-acJ
-bae
-ana
+aat
+aat
+acd
 bdW
 acJ
-bkI
-bmv
-bop
-azG
+acd
+oMZ
+xDo
+aek
 agj
 bot
 bpg
@@ -87167,39 +85042,39 @@ aaa
 aaa
 aaa
 aaa
-aaj
-gXs
-aam
-aan
-abx
-aaU
-adb
-adc
-ahQ
-acd
-acd
-auu
-acd
-acd
-acd
-auu
-acd
-acd
-acd
-auu
-acd
-acd
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+gJi
+aaa
+ycV
+aak
 aOK
-aMR
-aat
-aat
-aat
+aau
+aaE
+abd
+abi
 aXO
-acd
+aXO
 aUr
-aat
-aat
-acd
+add
+aXO
+adG
 awe
 fLS
 ahE
@@ -87424,40 +85299,40 @@ aaa
 aaa
 aaa
 aaa
-aaj
-gXs
-alD
-aai
-abd
-abg
-abL
-adf
-alm
-acd
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+gJi
+aaf
 auC
-auC
-auC
-acd
-auC
-auC
-auC
-acd
-njP
-auC
-auC
-acd
-aKw
+aam
 aat
-aPc
-aUC
-aaJ
-aYa
+aav
+aat
+aUP
+abx
+aat
+aat
 acd
-bcT
 bfk
-biZ
+bke
 acd
-oMZ
+adJ
 apn
 ahE
 agj
@@ -87681,38 +85556,38 @@ aaa
 aaa
 aaa
 aaa
-aaj
-gXs
-gXs
-abB
-aaq
-aar
-aat
-agt
-aln
-acd
-asV
-aem
-aIi
-acd
-aht
-auN
-kLD
-aDS
-fUD
-auN
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+gJi
+aaa
 ycV
+aan
+aat
+aaw
+aat
+aLJ
+aby
+aaJ
+acE
 acd
-aDv
-jxW
-aai
-aai
-aai
-aai
-aai
-aai
-aai
-aai
+acd
+acd
 acd
 bnd
 apo
@@ -87939,39 +85814,39 @@ aaa
 aaa
 aaa
 aaa
-eRz
-gXs
-aai
-aaV
-aaF
-aat
-adG
-alf
-acd
-acd
-acd
-acd
-acd
-acd
-acd
-acd
-acd
-acd
-acd
-acd
-acd
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+gJi
+aaf
+auC
+aap
 aSj
-aPh
-aai
+aSj
+aat
 aLJ
-aat
-aaJ
-bbr
+abA
 aaJ
 aat
+acd
+ade
 bjD
 acd
-oMZ
+aeg
 aev
 aeS
 agj
@@ -88196,39 +86071,39 @@ aaa
 aaa
 aaa
 aaa
-eRz
-gXs
-gXs
-abB
-abM
-aat
-agD
-alr
-amP
-asX
-auS
-aww
-axZ
-akt
-axg
-akC
-mYU
-aFj
-axg
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+gJi
+aaa
 axg
 ayt
 aMv
-aPj
-aTx
-aLS
-ams
-aaJ
-bbN
-aaJ
+aat
+aat
+aUP
+aat
+aat
+aat
+ada
 bgl
-akP
-acd
-oMZ
+bhP
+adI
+aeh
 aeT
 aAd
 agj
@@ -88453,43 +86328,43 @@ aaa
 aaa
 aaa
 aaa
-eRz
-gXs
-gXs
-alD
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+gJi
+aaf
 aai
-ade
-aPw
-aPw
-amQ
-avr
-agF
-aPw
-ayB
-aAm
-aPw
-agF
-aPw
-amQ
-xez
-aPw
 aBl
 aPw
-aPw
-aai
+aat
+aat
 aUP
 axT
+abD
 aat
 acd
-aat
 bgx
 bke
-aYc
+acd
 aYi
 azm
-agj
-agj
-agj
+aiX
+aiX
+aiX
 gCm
 ahG
 ajY
@@ -88710,37 +86585,37 @@ aaa
 aaa
 aaa
 aaa
-eRz
-gXs
-gXs
-gXs
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+gJi
+aaa
 aai
 aai
-aOu
 aai
-acd
-avB
-auU
-aLh
-acd
-acd
-acd
-aDu
-acd
-acd
-acd
-acd
-aJN
-acd
-acd
+aax
+aax
+abe
 aai
-aLJ
-azh
-aaJ
+abE
 bbN
-aaJ
-aBE
-akP
+acd
+acd
+acd
 acd
 aeP
 afC
@@ -88968,34 +86843,34 @@ aaa
 aaa
 aaa
 aaa
-eRz
-eRz
-gXs
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aai
-aaW
-auC
-aai
-amT
-axm
-aeR
-axm
-bbZ
-acd
-aBD
-aDO
-aEs
-acd
-qzq
-aGp
-amc
 aGp
 aPP
-aai
+aaF
 aUV
-jdL
-aaJ
+aai
+abL
 bbr
-aaJ
+adb
 bgR
 bkl
 acd
@@ -89226,29 +87101,29 @@ aaa
 aaa
 aaa
 aaa
-aaj
-gXs
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaf
+aaf
 aai
-abi
-agQ
-aai
-ano
-aat
-afh
-aat
-wgd
-acd
-xkD
-hLb
-aEt
-aLh
-aGp
-aGp
-amc
 aFS
 aRv
-aai
-aai
+aaR
+abg
 aai
 aai
 aai
@@ -89483,33 +87358,33 @@ aaa
 aaa
 aaa
 aaa
-aaj
-lKA
-aai
-abD
-ahs
-aai
-ano
-abS
-auW
-aMp
-axd
-acd
-dlx
-lEt
-aEu
-faw
-aGp
-aGp
-amc
-jDN
-jDN
-aai
-gXs
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 gXs
+gXs
+gXs
+gXs
+gXs
 aaa
+aai
+jDN
+aaB
+aaU
+aPP
+abB
+abM
+abM
+adc
 aaZ
 aeF
 ack
@@ -89740,33 +87615,33 @@ aaa
 aaa
 aaa
 aaa
-aaj
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 gXs
+aaa
 aai
 aai
 aai
 aai
-anp
-aat
-afy
-aat
-ayF
-aLh
-aCf
-alV
-aDV
-faw
-aGp
-aGp
-aHU
-aFS
-qKw
 aai
-gXs
-gXs
-gXs
-gXs
-gXs
+aai
+abS
+acG
+adc
 aaZ
 aeW
 acl
@@ -89997,33 +87872,33 @@ aaa
 aaa
 aaa
 aaa
-aaj
-gXs
-gXs
-gXs
-gXs
-aai
-anx
-ato
-avd
-axs
-fYb
-ahv
-aDV
-aDV
-aDV
-aFt
-aGp
-aGp
-aKb
-aGp
-aQQ
-aai
-aaf
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 gXs
-abG
+gXs
+gXs
+gXs
+gXs
+aaa
+aoV
+aaa
+aoV
+aai
+aai
+aai
+aai
 aaZ
 aeX
 acm
@@ -90255,27 +88130,27 @@ aaa
 aaa
 aaa
 aaa
-eRz
-eRz
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 gXs
 gXs
-aai
-aai
-aai
-aai
-aai
-aai
-aai
-nSN
-akN
-hKQ
-aai
-aFS
-aFS
-aMK
-aFS
-dgc
-aai
+gXs
+ctv
 aaf
 aaa
 aaa
@@ -90514,25 +88389,25 @@ aaa
 aaa
 aaa
 aaa
-eRz
-gXs
-adJ
-gXs
-gXs
-gXs
-gXs
-gXs
-aai
-aCo
-aai
-aai
-aai
-jDN
-jDN
-aBJ
-jDN
-jDN
-aai
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+ctv
 aaf
 aaf
 aaf
@@ -90772,24 +88647,24 @@ aaa
 aaa
 aaa
 aaa
-eRz
-eRz
-eRz
-eRz
-eRz
-gXs
-gXs
-aai
-aDW
-aDW
-bVk
-aai
-aGK
-aFS
-aBJ
-aFS
-aRv
-aai
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaV
 aaf
 aaf
 aoV
@@ -91034,19 +88909,19 @@ aaa
 aaa
 aaa
 aaa
-eRz
-gXs
-aai
-aCx
-aDW
-aEw
-aai
-aai
-aai
-aam
-aai
-aai
-aai
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaV
 aaT
 aaT
 adR
@@ -91291,18 +89166,18 @@ aaa
 aaa
 aaa
 aaa
-eRz
-gXs
-aai
-aai
-aai
-aai
-aai
-gXs
-gXs
-gXs
-gXs
-aSR
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaf
 aaf
 aaf
@@ -91548,18 +89423,18 @@ aaa
 aaa
 aaa
 aaa
-eRz
-gXs
-tIF
-gXs
-gXs
-gXs
-gXs
-gXs
-aaj
-aaj
-aaj
-aaj
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaT
 aaf
 aaa
@@ -91806,13 +89681,13 @@ aaa
 aaa
 aaa
 aaa
-eRz
-eRz
-eRz
-eRz
-aaj
-aaj
-eRz
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa

--- a/modular_lumos/code/datums/ruins/lumos_space.dm
+++ b/modular_lumos/code/datums/ruins/lumos_space.dm
@@ -19,6 +19,12 @@
 	name = "The Gold Nugget"
 	description = "Not to be confused with the 21st century casino."
 
+/datum/map_template/ruin/space/lostbrig
+	id = "lostboxbrig"
+	suffix = "lostbrig_box.dmm"
+	name = "Ejected Brig"
+	description = "Sometimes to save money and time, stations will simply slice off outdated sections. This one appears to have not been properly evacuated beforehand."
+
 /datum/map_template/ruin/spacenearstation/gone_fishin
 	id = "fishinstroid"
 	suffix = "gone_fishin.dmm"


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/26664829/112063829-009e5680-8b30-11eb-9ba8-a58cfc64e095.png)

## About The Pull Request

Reverts Boxstation's Permabrig to an editted version of the old TG version.

Current perma now turned into a space ruin, for interesting exploration.

## Why It's Good For The Game

Even though my pervious edits of the perma were not the "Skyrat Sex Hotels" (See: https://github.com/Skyrat-SS13/Skyrat13/pull/3558 for what I mean), it was entirely too large for what is supposed to be more or less a holding facility on a backwater mining/research installation. Instead, the old version is now alot more compatible with the 4 prisoner slots change I've done previously. Prisoner job is literally a net-negative on station work, daresay worse than assistants. It should not be incentivized outside of roleplaying to play Prisoner.

## Changelog
:cl:
Revert: Boxstation Perma
Add: Lumos-made Perma space ruin
/:cl: