### PR TITLE
Makes standard EVA suit containers use the EVA suit again

### DIFF
--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -29,7 +29,12 @@
 	var/breakout_time = 300
 
 /obj/machinery/suit_storage_unit/standard_unit
-	suit_type = /obj/item/clothing/suit/space/commando // LUMOS CHANGE: Replaces the default EVA suit with a new one
+	suit_type = /obj/item/clothing/suit/space/eva
+	helmet_type = /obj/item/clothing/head/helmet/space/eva
+	mask_type = /obj/item/clothing/mask/breath
+
+/obj/machinery/suit_storage_unit/commando
+	suit_type = /obj/item/clothing/suit/space/commando // Fajetti - Think it'd be better to just split it to a separate obj
 	helmet_type = /obj/item/clothing/head/helmet/space/commando
 	mask_type = /obj/item/clothing/mask/breath
 

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -670,3 +670,15 @@
 	name ="Cydonian Knight Captain"
 	l_pocket = /obj/item/dualsaber/hypereutactic
 	id = /obj/item/card/id/knight/captain
+
+/obj/effect/mob_spawn/human/corpse/commando
+	name = "Obliterated Commando"
+	outfit = /datum/outfit/ror_commando
+
+/datum/outfit/ror_commando
+	name = "Commando"
+	uniform = /obj/item/clothing/under/color/black
+	back = /obj/item/tank/internals/oxygen/yellow
+	shoes = /obj/item/clothing/shoes/jackboots/fast
+	suit = /obj/item/clothing/suit/space/commando
+	head = /obj/item/clothing/head/helmet/space/commando


### PR DESCRIPTION
## About The Pull Request

Technically a revert, I guess? Makes suit storage units in EVA use the proper suits.

I actually like the Command suit, so I decided to move it into a separate storage unit. For extra points, I made a corpse spawner (used in ruins and away missions) use the suit and made a new datum for the commando suit.

## Why It's Good For The Game

Keeps the theme I'm going for abit more consistent while expanding more outer station content potentially.

## Changelog
:cl:
add: Commando suit datum
add: "Obliterated Commando" corpse
add: Commando suit storage unit (possibly for ruins?)
revert: EVA suit storage units to use eva suit items again
/:cl: