### PR TITLE
Updates the deleted discord link with the new one.

### DIFF
--- a/modular_skyrat/code/game/world.dm
+++ b/modular_skyrat/code/game/world.dm
@@ -22,7 +22,7 @@
 		hostedby = CONFIG_GET(string/hostedby)*/
 
 	s += " ("
-	s += "<a href=\"https://discord.gg/2KghZZg\">" //Change this to wherever you want the hub to link to. wzds change - links to the discord // lumos change
+	s += "<a href=\"https://discord.gg/3ezfTxXwaR\">" //Change this to wherever you want the hub to link to. wzds change - links to the discord // lumos change
 	s += "Discord"  //Replace this with something else. Or ever better, delete it and uncomment the game version. wzds change - modifies hub entry link
 	// s += "</a>|<a href=\"https://shadow-station.com\">"
 	// s += "Website"


### PR DESCRIPTION
A certain based individual deleted the previous discord, so we have to update the info on the hub with the new discord.

