### PR TITLE
Missing spawns for mining technician and foreman

### DIFF
--- a/_maps/map_files/OmegaStation/OmegaStation_Lumos.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation_Lumos.dmm
@@ -5967,6 +5967,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/effect/landmark/start/mining_foreman,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "ang" = (
@@ -6940,6 +6941,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/effect/landmark/start/shaft_miner,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "aoX" = (
@@ -28813,6 +28815,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/effect/landmark/start/mining_engineer,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "gti" = (
@@ -35301,7 +35304,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line,
-/obj/effect/landmark/start/shaft_miner,
+/obj/effect/landmark/start/mining_engineer,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "llP" = (


### PR DESCRIPTION
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Missing job spawns.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

People no longer spawn in the Captains office due to the lack of spawns for those roles.

## Changelog
:cl:
add: Added mining technician spawn
add: Added mining foreman spawn
/:cl:
