### PR TITLE
exp_requirements changes

### DIFF
--- a/code/modules/jobs/job_types/captain.dm
+++ b/code/modules/jobs/job_types/captain.dm
@@ -11,7 +11,7 @@
 	selection_color = "#aac1ee"
 	req_admin_notify = 1
 	minimal_player_age = 20
-	exp_requirements = 180
+	exp_requirements = 540 // Lumos change - Upping head requirements to 9 hours in their respective departments
 	exp_type = EXP_TYPE_COMMAND
 	exp_type_department = EXP_TYPE_COMMAND
 

--- a/code/modules/jobs/job_types/chief_engineer.dm
+++ b/code/modules/jobs/job_types/chief_engineer.dm
@@ -12,7 +12,7 @@
 	selection_color = "#ee7400"
 	req_admin_notify = 1
 	minimal_player_age = 10
-	exp_requirements = 180
+	exp_requirements = 540 // Lumos change - Upping head requirements to 9 hours in their respective departments
 	exp_type = EXP_TYPE_CREW
 	exp_type_department = EXP_TYPE_ENGINEERING
 

--- a/code/modules/jobs/job_types/chief_medical_officer.dm
+++ b/code/modules/jobs/job_types/chief_medical_officer.dm
@@ -12,7 +12,7 @@
 	selection_color = "#509ed1"
 	req_admin_notify = 1
 	minimal_player_age = 10
-	exp_requirements = 180
+	exp_requirements = 540 // Lumos change - Upping head requirements to 9 hours in their respective departments
 	exp_type = EXP_TYPE_CREW
 	exp_type_department = EXP_TYPE_MEDICAL
 

--- a/code/modules/jobs/job_types/clown.dm
+++ b/code/modules/jobs/job_types/clown.dm
@@ -9,7 +9,7 @@
 	supervisors = "the head of personnel"
 	selection_color = "#dddddd"
 	//SKYRAT CHANGES - adds job exp to clown, requires 100 hours.
-	exp_requirements = 6000
+	exp_requirements = 600 //Lumos change - 10 hours. We aren't as cruel as "Some people". But we don't trust new players either.
 	exp_type = EXP_TYPE_CREW
 	//END OF SKYRAT CHANGES
 

--- a/code/modules/jobs/job_types/head_of_personnel.dm
+++ b/code/modules/jobs/job_types/head_of_personnel.dm
@@ -12,7 +12,7 @@
 	selection_color = "#3a8529"
 	req_admin_notify = 1
 	minimal_player_age = 20
-	exp_requirements = 180
+	exp_requirements = 540 // Lumos change - Upping head requirements to 9 hours in their respective departments
 	exp_type = EXP_TYPE_CREW
 	exp_type_department = EXP_TYPE_SERVICE
 

--- a/code/modules/jobs/job_types/head_of_security.dm
+++ b/code/modules/jobs/job_types/head_of_security.dm
@@ -12,7 +12,7 @@
 	selection_color = "#b90000"
 	req_admin_notify = 1
 	minimal_player_age = 10
-	exp_requirements = 300
+	exp_requirements = 540 // Lumos change - Upping head requirements to 9 hours in their respective departments
 	exp_type = EXP_TYPE_CREW
 	exp_type_department = EXP_TYPE_SECURITY
 

--- a/code/modules/jobs/job_types/research_director.dm
+++ b/code/modules/jobs/job_types/research_director.dm
@@ -13,7 +13,7 @@
 	req_admin_notify = 1
 	minimal_player_age = 10
 	exp_type_department = EXP_TYPE_SCIENCE
-	exp_requirements = 180
+	exp_requirements = 540 // Lumos change - Upping head requirements to 9 hours in their respective departments
 	exp_type = EXP_TYPE_CREW
 
 	outfit = /datum/outfit/job/rd

--- a/modular_skyrat/code/modules/jobs/job_types/blueshield.dm
+++ b/modular_skyrat/code/modules/jobs/job_types/blueshield.dm
@@ -9,7 +9,7 @@
 	supervisors = "the Captain"
 	selection_color = "#ddddff"
 	minimal_player_age = 7
-	exp_requirements = 2400
+	exp_requirements = 360 // Lumos change - Lowering blueshield requirement to 6 hours
 	exp_type = EXP_TYPE_SECURITY
 
 	paycheck = PAYCHECK_HARD


### PR DESCRIPTION
## About The Pull Request

Changes the amount of time required to play in each department before head positions are unlocked (raised). Also changes the time required for clown and blueshield (lowered).

## Why It's Good For The Game

Should avoid the large amount of players playing as heads without any knowledge to some degree. Alongside lowering the limits for blueshield and clown.

## Changelog
:cl:
tweak: exp requirements for head positions and both clown and blueshield
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
