### PR TITLE
Cholostomy bags

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -20,6 +20,8 @@
 	for(var/i in 1 to 3)
 		new /obj/item/reagent_containers/glass/bottle/charcoal(src)
 	new /obj/item/storage/box/rxglasses(src)
+	new /obj/item/reagent_containers/cholostomy_bag(src)
+	new /obj/item/reagent_containers/cholostomy_bag(src)
 
 /obj/structure/closet/secure_closet/medical2
 	name = "anesthetic closet"


### PR DESCRIPTION
## About The Pull Request

Adds cholostomy bags
Cholostomy bags can drain bloodstream reagents from the mob they are attached to.
Useful to treat poisoning or to steal rare weird reagents like determination.

## Why It's Good For The Game

i'm a medical main

## Changelog
:cl:
add: added cholostomy bags
/:cl: