### PR TITLE
MetaHaul (patched (hopefully))

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation_Lumos.dmm
+++ b/_maps/map_files/MetaStation/MetaStation_Lumos.dmm
@@ -1067,11 +1067,11 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
 /obj/effect/turf_decal/lumos/tile/red/checker{
 	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -1974,7 +1974,6 @@
 /turf/open/floor/grass,
 /area/hydroponics/garden)
 "aie" = (
-/obj/effect/turf_decal/stripes/line,
 /obj/machinery/button/door{
 	id = "armouryshutters";
 	name = "Armoury Access";
@@ -1991,6 +1990,9 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/effect/turf_decal/delivery/red,
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/flasher/portable,
 /turf/open/floor/plasteel/dark/side{
 	dir = 10
 	},
@@ -2777,24 +2779,6 @@
 	id = "PRelease";
 	pixel_x = 24;
 	pixel_y = 20
-	},
-/obj/item/clothing/suit/armor/vest{
-	pixel_x = 8;
-	pixel_y = -2
-	},
-/obj/item/clothing/suit/armor/vest{
-	pixel_x = -8;
-	pixel_y = -2
-	},
-/obj/item/clothing/head/helmet{
-	layer = 3.00001;
-	pixel_x = -8;
-	pixel_y = 7
-	},
-/obj/item/clothing/head/helmet{
-	layer = 3.00001;
-	pixel_x = 8;
-	pixel_y = 7
 	},
 /obj/machinery/camera{
 	c_tag = "Security - Armoury";
@@ -4037,6 +4021,8 @@
 /turf/open/floor/wood,
 /area/maintenance/bar)
 "aoR" = (
+/obj/structure/closet/secure_closet/armory1,
+/obj/item/storage/box/rubbershot,
 /turf/open/floor/plasteel/dark/side{
 	dir = 5
 	},
@@ -4558,7 +4544,7 @@
 "aqh" = (
 /obj/machinery/power/apc/highcap/five_k{
 	areastring = "/area/security/main";
-	dir = 4;
+	dir = 1;
 	name = "Security Office APC";
 	pixel_y = 24
 	},
@@ -4844,6 +4830,8 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aqM" = (
+/obj/structure/closet/secure_closet/armory1,
+/obj/item/storage/box/rubbershot,
 /turf/open/floor/plasteel/dark/side{
 	dir = 4
 	},
@@ -6740,6 +6728,7 @@
 	},
 /obj/machinery/power/apc{
 	areastring = "/area/security/warden";
+	dir = 1;
 	name = "Brig Control APC";
 	pixel_y = 26
 	},
@@ -7501,11 +7490,11 @@
 /turf/open/floor/carpet,
 /area/security/warden)
 "awZ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)
@@ -8240,13 +8229,13 @@
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "azh" = (
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/red,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
+	},
 /turf/open/floor/plasteel/dark/side{
 	dir = 8
 	},
@@ -8449,7 +8438,7 @@
 	req_access_txt = "1";
 	specialfunctions = 4
 	},
-/obj/effect/turf_decal/lumos/tile/red/checker{
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -8508,9 +8497,11 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "azJ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
 	},
 /turf/open/floor/wood,
 /area/security/brig)
@@ -8561,6 +8552,9 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "azP" = (
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark/side,
 /area/security/main)
 "azQ" = (
@@ -8901,13 +8895,13 @@
 /turf/closed/wall/r_wall,
 /area/engine/engineering)
 "aAy" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 1
+/obj/effect/turf_decal/lumos/tile/red/checker{
+	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/light{
+	dir = 8
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "aAz" = (
 /obj/machinery/computer/security/telescreen/entertainment{
@@ -9138,6 +9132,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -9998,12 +9995,9 @@
 /turf/open/floor/plasteel/dark/side,
 /area/security/prison)
 "aDf" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/carpet,
-/area/security/brig)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/crew_quarters/locker)
 "aDg" = (
 /obj/effect/turf_decal/lumos/tile/blue/half,
 /turf/open/floor/plasteel/dark/side{
@@ -10280,10 +10274,10 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aDG" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/wood,
 /area/security/brig)
 "aDH" = (
@@ -10461,9 +10455,6 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "aEc" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
 	},
@@ -11386,18 +11377,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"aGm" = (
-/obj/item/gun/ballistic/shotgun/riot{
-	pixel_y = -3
-	},
-/obj/item/storage/box/rubbershot,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/effect/turf_decal/lumos/tile/red/fulltile,
-/obj/structure/rack,
-/turf/open/floor/plasteel,
-/area/ai_monitored/security/armory)
 "aGn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -11447,12 +11426,12 @@
 /area/security/detectives_office)
 "aGq" = (
 /obj/machinery/suit_storage_unit/security,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /obj/effect/turf_decal/lumos/tile/red/fulltile,
 /obj/machinery/light/small{
 	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)
@@ -11914,9 +11893,6 @@
 	weaponscheck = 1
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -12065,9 +12041,6 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/locker)
 "aHP" = (
-/obj/effect/turf_decal/lumos/tile/red/checker{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/red/filled/corner,
 /turf/open/floor/plasteel/dark/corner,
 /area/security/brig)
@@ -13053,6 +13026,10 @@
 	dir = 8;
 	name = "Station Intercom (General)";
 	pixel_x = -28
+	},
+/obj/machinery/camera{
+	c_tag = "Security - Detective Office";
+	dir = 4
 	},
 /turf/open/floor/wood,
 /area/security/detectives_office)
@@ -14097,16 +14074,15 @@
 /turf/open/floor/plasteel/dark,
 /area/blueshield)
 "aMR" = (
-/obj/machinery/camera{
-	c_tag = "Security - Detective Office";
-	dir = 4
-	},
 /obj/machinery/button/door{
 	id = "DetectiveShutters";
 	name = "Detective Office Shutters";
 	pixel_x = -24;
 	pixel_y = -7;
 	req_access_txt = "4"
+	},
+/obj/machinery/light{
+	dir = 8
 	},
 /turf/open/floor/wood,
 /area/security/detectives_office)
@@ -14537,9 +14513,6 @@
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "aNU" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
@@ -14865,13 +14838,6 @@
 	},
 /area/crew_quarters/locker)
 "aOB" = (
-/obj/structure/window/reinforced,
-/obj/effect/turf_decal/lumos/tile/red/fulltile,
-/obj/item/gun/ballistic/shotgun/riot{
-	pixel_y = -3
-	},
-/obj/item/storage/box/rubbershot,
-/obj/structure/rack,
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "aOC" = (
@@ -14887,9 +14853,6 @@
 /turf/open/floor/grass,
 /area/hydroponics/garden)
 "aOF" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
-	},
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
@@ -15898,6 +15861,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "aQP" = (
@@ -15954,16 +15920,16 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "aQU" = (
-/obj/item/gun/energy/disabler{
-	pixel_x = 2
-	},
-/obj/item/gun/energy/disabler{
-	pixel_x = -2;
-	pixel_y = 4
-	},
 /obj/structure/window/reinforced,
 /obj/effect/turf_decal/lumos/tile/red/fulltile,
 /obj/structure/rack,
+/obj/item/gun/ballistic/shotgun/riot{
+	pixel_y = -3
+	},
+/obj/item/gun/ballistic/shotgun/riot{
+	pixel_x = -3;
+	pixel_y = 3
+	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "aQV" = (
@@ -16481,7 +16447,7 @@
 "aSn" = (
 /obj/machinery/power/apc{
 	areastring = "/area/crew_quarters/dorms";
-	dir = 1;
+	dir = 8;
 	name = "Dormitories APC";
 	pixel_x = -26
 	},
@@ -16638,6 +16604,8 @@
 /area/engine/engineering)
 "aSC" = (
 /obj/machinery/light,
+/obj/structure/closet/secure_closet/armory1,
+/obj/item/storage/box/rubbershot,
 /turf/open/floor/plasteel/dark/side{
 	dir = 6
 	},
@@ -18644,9 +18612,7 @@
 	pixel_y = -32
 	},
 /obj/structure/lattice,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light,
 /turf/open/space/basic,
 /area/crew_quarters/locker)
 "aWK" = (
@@ -19712,6 +19678,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/plaque{
+	icon_state = "L6"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -20969,9 +20938,6 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
 "bbE" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
@@ -21504,7 +21470,6 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "bcU" = (
-/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 6
 	},
@@ -21514,6 +21479,8 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
+/obj/effect/turf_decal/delivery/red,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/dark/side,
 /area/ai_monitored/security/armory)
 "bcV" = (
@@ -21770,7 +21737,7 @@
 /obj/structure/closet/wardrobe/grey,
 /obj/machinery/power/apc{
 	areastring = "/area/vacant_room/commissary";
-	dir = 8;
+	dir = 4;
 	name = "Commissary APC";
 	pixel_x = 26;
 	pixel_y = -6
@@ -22265,10 +22232,11 @@
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "beH" = (
-/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
+/obj/effect/turf_decal/delivery/red,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/dark/side,
 /area/ai_monitored/security/armory)
 "beI" = (
@@ -22419,6 +22387,9 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark/side,
 /area/ai_monitored/security/armory)
@@ -25685,11 +25656,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -28265,7 +28236,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/dark,
 /area/blueshield)
 "brb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -28939,9 +28910,6 @@
 /turf/open/space/basic,
 /area/space)
 "bsw" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 4
 	},
@@ -38682,12 +38650,6 @@
 /obj/machinery/camera{
 	c_tag = "Club - Fore"
 	},
-/obj/machinery/power/apc/highcap/five_k{
-	areastring = "/area/crew_quarters/bar";
-	dir = 1;
-	name = "Bar APC";
-	pixel_y = 25
-	},
 /obj/machinery/requests_console{
 	department = "Bar";
 	departmentType = 2;
@@ -39445,6 +39407,7 @@
 "bRT" = (
 /obj/machinery/power/apc/highcap/five_k{
 	areastring = "/area/crew_quarters/toilet/auxiliary";
+	dir = 4;
 	name = "Auxiliary Restrooms APC";
 	pixel_x = 26
 	},
@@ -40128,7 +40091,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bTk" = (
@@ -53636,7 +53599,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "ctN" = (
@@ -56392,7 +56355,7 @@
 "cAo" = (
 /obj/machinery/power/apc{
 	areastring = "/area/science/robotics/lab";
-	dir = 1;
+	dir = 8;
 	name = "Robotics Lab APC";
 	pixel_x = -28
 	},
@@ -69952,7 +69915,6 @@
 	},
 /obj/machinery/power/apc{
 	areastring = "/area/security/checkpoint/customs";
-	dir = 1;
 	name = "Customs APC";
 	pixel_y = -26
 	},
@@ -70446,6 +70408,7 @@
 /turf/open/floor/plasteel/dark/side,
 /area/hallway/secondary/command)
 "gbI" = (
+/obj/machinery/light,
 /turf/open/floor/plasteel/dark/corner,
 /area/hallway/secondary/command)
 "gca" = (
@@ -70864,6 +70827,11 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
+"gRb" = (
+/obj/structure/lattice,
+/obj/machinery/light,
+/turf/open/space/basic,
+/area/crew_quarters/locker)
 "gSz" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -71407,6 +71375,18 @@
 	},
 /turf/open/floor/wood,
 /area/bridge/showroom/corporate)
+"iin" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "iky" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin{
@@ -72157,13 +72137,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
-"kcV" = (
-/obj/structure/lattice,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/space/basic,
-/area/crew_quarters/locker)
 "keX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -73900,6 +73873,9 @@
 /obj/structure/chair{
 	dir = 1
 	},
+/obj/machinery/light/small{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "nXA" = (
@@ -74019,7 +73995,6 @@
 "oha" = (
 /obj/machinery/power/apc{
 	areastring = "/area/security/nuke_storage";
-	dir = 1;
 	name = "Vault APC";
 	pixel_y = -26
 	},
@@ -74541,6 +74516,18 @@
 "prl" = (
 /turf/open/floor/plasteel,
 /area/space/nearstation)
+"prO" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/command)
 "pvX" = (
 /obj/structure/table/wood,
 /obj/machinery/reagentgrinder{
@@ -74878,7 +74865,7 @@
 "qfk" = (
 /obj/structure/lattice,
 /obj/machinery/light{
-	dir = 4
+	dir = 1
 	},
 /turf/open/space/basic,
 /area/crew_quarters/locker)
@@ -75355,6 +75342,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)
+"ran" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/locker)
 "rbE" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -76331,9 +76324,6 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "tFR" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
@@ -77198,9 +77188,6 @@
 /area/maintenance/fore)
 "vUT" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
-/obj/effect/turf_decal/lumos/tile/red/checker{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 1
 	},
@@ -77694,10 +77681,10 @@
 /turf/open/floor/plasteel/dark/corner,
 /area/hydroponics/garden)
 "xoG" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
-	},
 /obj/effect/turf_decal/tile/red,
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark/side{
 	dir = 8
 	},
@@ -77710,6 +77697,7 @@
 	},
 /area/hallway/secondary/command)
 "xpM" = (
+/obj/machinery/light,
 /turf/open/floor/plasteel/dark/corner{
 	dir = 8
 	},
@@ -78007,6 +77995,13 @@
 	},
 /turf/open/floor/plasteel/cult,
 /area/library)
+"ycK" = (
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#c1caff"
+	},
+/turf/open/floor/wood,
+/area/security/detectives_office)
 "ydn" = (
 /obj/machinery/door/airlock/security{
 	name = "Customs Desk";
@@ -78025,6 +78020,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"yge" = (
+/obj/machinery/light,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/command)
 "ygA" = (
 /obj/structure/chair/sofa{
 	dir = 1
@@ -90806,7 +90805,7 @@ bGs
 bMz
 bOe
 bvY
-cAi
+iin
 aqK
 alK
 aaf
@@ -102838,9 +102837,9 @@ wIs
 aLB
 kmD
 azJ
-aAy
 aBP
-aDf
+aBP
+aBP
 aDG
 aEQ
 aEY
@@ -103088,7 +103087,7 @@ xHb
 aDV
 xHb
 aDV
-xHb
+xoG
 aDV
 ajm
 lwd
@@ -104161,7 +104160,7 @@ bfv
 byl
 oVP
 bfv
-bDr
+prO
 bES
 tEy
 prl
@@ -104421,7 +104420,7 @@ byl
 bDv
 xLV
 heK
-tEy
+yge
 bzR
 fAg
 bNb
@@ -104637,7 +104636,7 @@ tFR
 aPa
 azq
 azO
-rLG
+aAy
 rLG
 rLG
 fVo
@@ -104872,7 +104871,7 @@ bvS
 bvS
 auo
 aoC
-aGm
+aOB
 aOB
 bcU
 bPS
@@ -106477,7 +106476,7 @@ byl
 bDo
 ddX
 kwX
-tEy
+yge
 bzR
 qGz
 bNj
@@ -106731,7 +106730,7 @@ bfv
 byl
 dLM
 bfv
-bDr
+prO
 bES
 tEy
 prl
@@ -108767,7 +108766,7 @@ ayJ
 alb
 aOu
 dCv
-aOu
+ran
 aSe
 wqs
 aZp
@@ -109787,7 +109786,7 @@ ayJ
 aHC
 ayJ
 aIY
-aMV
+ycK
 aLG
 xyr
 aOr
@@ -110808,7 +110807,7 @@ aiQ
 aDQ
 aje
 aUM
-kcV
+qfk
 lMJ
 lMJ
 lMJ
@@ -112613,7 +112612,7 @@ lMJ
 kwN
 aVI
 kwN
-qfk
+gRb
 aUM
 hSj
 aOu
@@ -112864,7 +112863,7 @@ axC
 agq
 agq
 aUM
-aUM
+aDf
 aUM
 aUM
 aUM
@@ -115933,16 +115932,16 @@ acP
 acP
 acQ
 acP
-acQ
-acQ
-acQ
-aIA
+acP
 acQ
 acQ
 aIA
 acQ
 acQ
+aIA
 acQ
+acQ
+acP
 arB
 kOh
 doV

--- a/_maps/map_files/MetaStation/MetaStation_Lumos.dmm
+++ b/_maps/map_files/MetaStation/MetaStation_Lumos.dmm
@@ -1793,8 +1793,8 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/effect/landmark/xeno_spawn,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
 "aht" = (
@@ -2049,7 +2049,6 @@
 	},
 /area/maintenance/solars/port/fore)
 "aim" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -2057,6 +2056,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
 "ain" = (
@@ -2338,7 +2338,6 @@
 	},
 /area/maintenance/disposal)
 "ajh" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/airlock/engineering{
 	name = "Port Bow Solar Access";
 	req_access_txt = "10"
@@ -2346,6 +2345,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
 "aji" = (
@@ -3343,37 +3343,40 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "amI" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 6
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
 "amJ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
 	},
-/obj/effect/turf_decal/bot_white/left,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
-/area/engine/gravity_generator)
+/area/engine/engineering)
 "amK" = (
 /obj/machinery/gravity_generator/main/station,
 /obj/effect/turf_decal/bot_white,
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
 "amL" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
-/obj/effect/turf_decal/bot_white/right,
 /turf/open/floor/plasteel/dark,
-/area/engine/gravity_generator)
+/area/engine/engineering)
 "amM" = (
 /obj/machinery/camera{
 	c_tag = "Gravity Generator Room";
 	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
@@ -3699,22 +3702,26 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "anO" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
 "anP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
 "anQ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
 "anR" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
@@ -4161,31 +4168,38 @@
 /turf/open/floor/plating,
 /area/engine/gravity_generator)
 "api" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
-	icon_state = "0-2"
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
 	},
 /obj/structure/cable{
-	icon_state = "0-8"
+	icon_state = "2-4"
 	},
-/turf/open/floor/plating,
-/area/engine/gravity_generator)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "apj" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Gravity Generator Area";
 	req_access_txt = "19; 61"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
 "apk" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
-	icon_state = "0-4"
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
 	},
-/turf/open/floor/plating,
-/area/engine/gravity_generator)
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "apl" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -4609,18 +4623,6 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
-"aqp" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/layer_manifold{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "aqq" = (
 /obj/item/cigbutt,
 /turf/open/floor/plating,
@@ -4639,9 +4641,6 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aqt" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
@@ -4655,12 +4654,15 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
+	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "aqu" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -4670,26 +4672,32 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "aqv" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "aqw" = (
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -4722,8 +4730,8 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/effect/landmark/xeno_spawn,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
 "aqA" = (
@@ -5168,8 +5176,8 @@
 	},
 /area/maintenance/starboard/fore)
 "arL" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/effect/landmark/xeno_spawn,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "arM" = (
@@ -5183,29 +5191,28 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "arN" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
+/obj/structure/cable/white{
+	icon_state = "4-8"
 	},
-/turf/closed/wall/r_wall,
-/area/engine/gravity_generator)
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/turf/open/floor/engine,
+/area/engine/engineering)
 "arO" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "arP" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "arQ" = (
@@ -5213,19 +5220,22 @@
 	dir = 1;
 	pixel_y = -22
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
 /obj/machinery/holopad,
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
+	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "arR" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
 /obj/machinery/power/terminal,
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "arS" = (
@@ -5258,7 +5268,6 @@
 	},
 /area/maintenance/solars/starboard/fore)
 "arU" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -5266,6 +5275,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
 "arV" = (
@@ -5556,10 +5566,6 @@
 /turf/open/space/basic,
 /area/solar/port/fore)
 "asI" = (
-/obj/machinery/camera{
-	c_tag = "Security - Detective Office";
-	dir = 4
-	},
 /obj/structure/table/wood,
 /obj/item/folder/red{
 	pixel_x = -7;
@@ -5788,22 +5794,28 @@
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "ate" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "atf" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall/r_wall,
-/area/engine/gravity_generator)
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "atg" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Gravity Generator Room";
 	req_access_txt = "19;23"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/delivery,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "ath" = (
@@ -5834,7 +5846,6 @@
 	},
 /area/maintenance/starboard)
 "atk" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/airlock/engineering{
 	name = "Starboard Bow Solar Access";
 	req_access_txt = "10"
@@ -5842,6 +5853,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
 "atl" = (
@@ -6420,19 +6432,17 @@
 	dir = 1;
 	pixel_y = 32
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "auv" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "auw" = (
@@ -6448,22 +6458,19 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "aux" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "auy" = (
@@ -6838,9 +6845,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/sign/warning/radiation/rad_area{
 	dir = 1;
 	pixel_y = 32
@@ -6851,13 +6855,13 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "avv" = (
 /obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /obj/machinery/door/airlock/maintenance{
@@ -6869,31 +6873,30 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "avw" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/light/small,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "avx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable{
@@ -6902,22 +6905,23 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "avy" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "avz" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
 	},
@@ -6927,12 +6931,12 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "avA" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/sign/warning/radiation/rad_area{
 	dir = 1;
 	pixel_y = 32
@@ -6943,56 +6947,59 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "avB" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "avC" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/starboard/fore)
 "avD" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg2"
 	},
 /area/maintenance/starboard/fore)
 "avE" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
 /area/maintenance/starboard/fore)
 "avF" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
 /obj/structure/cable{
 	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
@@ -7399,7 +7406,6 @@
 /area/maintenance/starboard/fore)
 "awK" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/airlock/highsecurity{
 	name = "Gravity Generator Foyer";
 	req_access_txt = "10"
@@ -7411,6 +7417,8 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "awL" = (
@@ -7752,11 +7760,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
@@ -7764,13 +7772,13 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "axQ" = (
@@ -7854,23 +7862,19 @@
 /area/maintenance/starboard/fore)
 "axW" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "axX" = (
 /obj/machinery/light_switch{
 	pixel_x = 23
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
 	},
 /obj/machinery/shower{
 	dir = 8;
@@ -8129,18 +8133,22 @@
 /obj/structure/sign/warning/securearea{
 	pixel_y = 32
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "ayT" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/structure/cable/white{
+	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
+/obj/structure/cable/white{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 10
+	},
+/turf/open/floor/plating,
 /area/engine/engineering)
 "ayU" = (
 /obj/structure/disposalpipe/segment{
@@ -8161,25 +8169,34 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "ayW" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Supermatter Engine";
 	req_access_txt = "10"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/engine/engineering)
 "ayX" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
@@ -8195,8 +8212,8 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "aza" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
@@ -8851,6 +8868,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aAs" = (
@@ -8868,7 +8888,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aAu" = (
@@ -8879,16 +8904,17 @@
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/start/station_engineer,
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aAv" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aAw" = (
@@ -8898,8 +8924,10 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "aAx" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall/r_wall,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "aAy" = (
 /obj/effect/turf_decal/lumos/tile/red/checker{
@@ -9406,21 +9434,13 @@
 	dir = 4;
 	pixel_x = -22
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aBK" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aBL" = (
@@ -9467,9 +9487,8 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aBO" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "aBP" = (
 /obj/structure/cable{
@@ -9911,59 +9930,54 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aCS" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"aCT" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aCU" = (
-/obj/structure/disposalpipe/segment{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aCV" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Supermatter Engine";
+	req_access_txt = "10"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/effect/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating,
 /area/engine/engineering)
 "aCW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
+/obj/machinery/door/firedoor,
+/obj/structure/cable/white{
+	icon_state = "4-8"
 	},
-/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Laser Room";
+	req_access_txt = "10"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/engine/engineering)
 "aCX" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
+/obj/structure/cable/white{
+	icon_state = "4-8"
 	},
-/turf/closed/wall/r_wall,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plating,
 /area/engine/engineering)
 "aCY" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Supermatter Engine";
 	req_access_txt = "10"
@@ -10515,22 +10529,21 @@
 /area/engine/engineering)
 "aEj" = (
 /obj/effect/landmark/start/station_engineer,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aEk" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aEl" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -10540,6 +10553,12 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aEm" = (
@@ -10548,47 +10567,39 @@
 	name = "Engineering Storage";
 	req_access_txt = "32"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/bot{
 	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel{
 	dir = 1
 	},
 /area/engine/engineering)
 "aEn" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"aEo" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aEp" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
 /obj/structure/cable/white{
 	icon_state = "1-4"
 	},
@@ -10598,14 +10609,17 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aEq" = (
 /obj/structure/cable/white{
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -11006,16 +11020,18 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aFs" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
+/obj/structure/cable/white{
+	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
+/obj/structure/cable/white{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/turf/open/floor/plating,
 /area/engine/engineering)
 "aFt" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/item/clothing/head/cone{
 	pixel_x = -4;
 	pixel_y = 4
@@ -11042,39 +11058,36 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aFu" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engine/engineering)
 "aFv" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
+/turf/closed/wall/r_wall,
+/area/maintenance/central)
 "aFw" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aFx" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aFy" = (
@@ -11089,6 +11102,9 @@
 	name = "Supermatter Engine";
 	req_access_txt = "10"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/engine/engineering)
 "aFA" = (
@@ -11097,6 +11113,9 @@
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -11108,6 +11127,7 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 6
 	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "aFC" = (
@@ -11116,6 +11136,9 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/engine,
@@ -11128,6 +11151,9 @@
 /obj/machinery/meter,
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/engine,
 /area/engine/engineering)
 "aFE" = (
@@ -11454,14 +11480,14 @@
 /area/security/main)
 "aGs" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
-	},
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
@@ -11763,15 +11789,16 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/station_engineer,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aGX" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/effect/landmark/start/station_engineer,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aGY" = (
@@ -11793,6 +11820,7 @@
 /area/engine/engineering)
 "aHa" = (
 /obj/structure/cable/white,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
 /area/engine/engineering)
 "aHb" = (
@@ -12115,7 +12143,9 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aHY" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aHZ" = (
@@ -12137,9 +12167,6 @@
 /turf/closed/wall/r_wall,
 /area/construction/storage/wing)
 "aIc" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plating,
@@ -12154,9 +12181,12 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "aIe" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/turf/closed/wall/r_wall,
-/area/engine/engineering)
+/obj/machinery/camera{
+	c_tag = "Captain's Quarters";
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/heads/captain/private)
 "aIf" = (
 /obj/machinery/camera{
 	c_tag = "Auxillary Base Construction";
@@ -13139,15 +13169,15 @@
 /area/engine/engineering)
 "aKB" = (
 /obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aKC" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aKD" = (
@@ -13219,6 +13249,9 @@
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8;
 	name = "Mix Bypass"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -13740,22 +13773,21 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aMd" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aMe" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aMf" = (
@@ -14259,10 +14291,10 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aNr" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aNu" = (
@@ -14894,7 +14926,6 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aOP" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -14904,7 +14935,6 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aOQ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -14912,6 +14942,8 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aOR" = (
@@ -14959,8 +14991,8 @@
 /turf/open/space,
 /area/space/nearstation)
 "aOW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/space,
 /area/aisat)
 "aOX" = (
@@ -16084,41 +16116,28 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aRp" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aRq" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aRr" = (
-/obj/structure/disposalpipe/sorting/mail{
-	sortType = 5
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aRs" = (
@@ -16141,7 +16160,7 @@
 /turf/closed/wall/r_wall,
 /area/aisat)
 "aRz" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/closed/wall/r_wall,
 /area/aisat)
 "aRA" = (
@@ -16543,44 +16562,53 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aSu" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aSv" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aSw" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aSx" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -16597,6 +16625,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/engine,
 /area/engine/engineering)
 "aSA" = (
@@ -16608,6 +16639,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -16636,13 +16670,13 @@
 /turf/open/space,
 /area/space/nearstation)
 "aSE" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
 	},
 /turf/closed/wall/r_wall,
 /area/aisat)
 "aSF" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
 	},
 /turf/closed/wall/r_wall,
@@ -17148,43 +17182,34 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"aTH" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aTI" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aTJ" = (
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
 /obj/structure/cable/white{
 	icon_state = "1-4"
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/sorting/mail{
+	sortType = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aTK" = (
@@ -17271,13 +17296,13 @@
 /turf/open/floor/plasteel/dark,
 /area/aisat)
 "aTS" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/lattice/catwalk,
 /obj/machinery/camera{
 	c_tag = "MiniSat Exterior - Fore";
 	dir = 1;
 	network = list("minisat")
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/space,
 /area/aisat)
 "aTT" = (
@@ -17312,7 +17337,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/ai)
 "aTY" = (
@@ -17847,23 +17872,9 @@
 /turf/closed/wall,
 /area/engine/engineering)
 "aVb" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/delivery,
 /obj/structure/closet/secure_closet/engineering_welding,
 /turf/open/floor/plasteel,
-/area/engine/engineering)
-"aVc" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/bot{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel{
-	dir = 1
-	},
 /area/engine/engineering)
 "aVd" = (
 /obj/structure/table,
@@ -17885,16 +17896,24 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aVe" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8
 	},
-/turf/closed/wall/r_wall,
-/area/engine/engineering)
+/obj/machinery/keycard_auth{
+	pixel_x = 24;
+	pixel_y = 24
+	},
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Captain's Desk";
+	departmentType = 5;
+	name = "Captain RC";
+	pixel_x = 32
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/heads/captain/private)
 "aVf" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/door/airlock/engineering{
 	name = "Supermatter Engine";
 	req_access_txt = "10"
@@ -17920,12 +17939,16 @@
 /turf/open/floor/wood,
 /area/security/detectives_office)
 "aVh" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 4
 	},
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/turf/open/floor/plating,
-/area/engine/engineering)
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "aVi" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel,
@@ -17987,14 +18010,14 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
 "aVq" = (
 /obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
 "aVr" = (
@@ -18573,7 +18596,6 @@
 "aWB" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/airlock/command{
 	name = "Chief Engineer's Office";
 	req_access_txt = "56"
@@ -18584,14 +18606,19 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel{
 	dir = 1
 	},
 /area/crew_quarters/heads/chief)
 "aWC" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall,
-/area/engine/engineering)
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/lumos/tile/red/half{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
 "aWD" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
@@ -18599,7 +18626,6 @@
 	name = "Engine Room";
 	req_access_txt = "10"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/bot{
 	dir = 1
 	},
@@ -18607,6 +18633,8 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel{
 	dir = 1
 	},
@@ -18665,7 +18693,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
 	},
 /turf/open/floor/circuit,
@@ -18674,7 +18702,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
 	},
 /turf/open/floor/circuit,
@@ -18722,7 +18750,7 @@
 "aWZ" = (
 /obj/structure/lattice,
 /turf/closed/wall/r_wall,
-/area/space/nearstation)
+/area/crew_quarters/heads/captain/private)
 "aXa" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -19280,9 +19308,15 @@
 	name = "Station Intercom (General)";
 	pixel_x = -29
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
 "aYp" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
 "aYq" = (
@@ -19292,6 +19326,9 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Chief Engineer's Office"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
@@ -19303,9 +19340,6 @@
 	name = "CE Office APC";
 	pixel_x = 28
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
 /obj/machinery/light_switch{
 	pixel_x = 26;
 	pixel_y = 26
@@ -19314,6 +19348,10 @@
 	icon_state = "1-2"
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
 "aYs" = (
@@ -19321,7 +19359,6 @@
 	pixel_y = 32
 	},
 /obj/structure/closet/radiation,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/delivery,
 /obj/item/clothing/glasses/meson/engine,
 /turf/open/floor/plasteel,
@@ -19386,7 +19423,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "aYB" = (
@@ -19874,6 +19911,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
 "aZD" = (
@@ -19908,13 +19946,10 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
 "aZI" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/shower{
 	dir = 4
 	},
@@ -19924,23 +19959,26 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aZJ" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aZK" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/machinery/shower{
 	dir = 8
 	},
@@ -20123,7 +20161,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "aZX" = (
@@ -20817,6 +20855,7 @@
 	pixel_y = 5;
 	req_access_txt = "11"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
 "bbt" = (
@@ -20873,12 +20912,10 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
 "bby" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
 /obj/machinery/light/small{
 	dir = 8
 	},
@@ -20889,19 +20926,17 @@
 /area/engine/engineering)
 "bbz" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "bbA" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
 /obj/machinery/light/small{
 	dir = 4
 	},
@@ -20911,6 +20946,9 @@
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -21343,26 +21381,14 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/chief)
-"bcG" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
 "bcH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
@@ -21376,25 +21402,15 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
 "bcJ" = (
 /obj/structure/closet/toolcloset,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
-/area/engine/engineering)
-"bcK" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/bot{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel{
-	dir = 1
-	},
 /area/engine/engineering)
 "bcL" = (
 /obj/machinery/power/apc{
@@ -21838,9 +21854,6 @@
 /area/hallway/primary/central)
 "bdR" = (
 /obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/closet/secure_closet/engineering_electrical,
 /obj/item/storage/toolbox/artistic{
 	icon_state = "yellow";
@@ -22009,7 +22022,6 @@
 /area/crew_quarters/heads/chief)
 "bej" = (
 /obj/structure/filingcabinet/chestdrawer,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /mob/living/simple_animal/parrot/Poly,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
@@ -22031,7 +22043,6 @@
 	name = "Engine Room";
 	req_access_txt = "10"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/bot{
 	dir = 1
 	},
@@ -22041,12 +22052,13 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel{
 	dir = 1
 	},
 /area/engine/engineering)
 "bem" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/machinery/camera/autoname{
 	dir = 4
 	},
@@ -22075,10 +22087,12 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
 "ben" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -22092,6 +22106,10 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
 "beo" = (
@@ -22123,18 +22141,18 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
 	},
 /turf/open/floor/plasteel/dark,
 /area/aisat)
 "bet" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/aisat)
@@ -22160,7 +22178,7 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "bey" = (
@@ -22493,6 +22511,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bfq" = (
@@ -22699,8 +22718,6 @@
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "bfQ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/poddoor/preopen{
 	id = "ceprivacy";
 	name = "privacy shutter"
@@ -22708,6 +22725,7 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/crew_quarters/heads/chief)
 "bfR" = (
@@ -22723,7 +22741,7 @@
 /turf/open/floor/plating,
 /area/crew_quarters/heads/chief)
 "bfS" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/plasteel/dark,
 /area/aisat)
 "bfT" = (
@@ -22732,29 +22750,31 @@
 	name = "Engineering Security Doors"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/delivery,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bfV" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/security/checkpoint/engineering)
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
 "bfW" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security/glass{
 	name = "Engineering Security Post";
 	req_access_txt = "63"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
 "bfX" = (
@@ -22798,17 +22818,17 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
 /obj/machinery/camera{
 	c_tag = "MiniSat Exterior - Space Access";
 	network = list("minisat")
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/aisat)
 "bgf" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -22823,7 +22843,7 @@
 	icon_state = "right";
 	name = "MiniSat Airlock Access"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -22845,22 +22865,22 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
 "bgj" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
 /obj/machinery/ai_slipper{
 	uses = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "bgk" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "bgl" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
@@ -23720,7 +23740,6 @@
 	dir = 4;
 	pixel_x = -23
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/table/glass,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -23781,7 +23800,6 @@
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bhY" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/junction/flip{
 	dir = 2
 	},
@@ -23794,6 +23812,8 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bhZ" = (
@@ -23825,20 +23845,15 @@
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bib" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
+/turf/open/floor/goonplaque{
+	desc = "\"This is a plaque in honour of our comrades on the G4407 Stations. Hopefully TG4407 model can live up to your fame and fortune.\" Scratched in beneath that is a crude image of sentient postcards in a realm of darkness. The station model number is MSv42A-160516"
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/break_room)
+/area/hallway/primary/port)
 "bic" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -23851,6 +23866,8 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bid" = (
@@ -23913,7 +23930,7 @@
 	dir = 8;
 	name = "MiniSat Airlock Access"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel/dark,
 /area/aisat)
 "bim" = (
@@ -23948,7 +23965,7 @@
 /area/ai_monitored/turret_protected/ai)
 "bip" = (
 /obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
 "bir" = (
@@ -24588,18 +24605,12 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bjF" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
 /obj/machinery/light_switch{
 	pixel_x = -22
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bjG" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
@@ -24615,7 +24626,6 @@
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "bjI" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -24623,28 +24633,19 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/turf/open/floor/plasteel,
-/area/engine/break_room)
-"bjJ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bjK" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bjL" = (
@@ -24672,7 +24673,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel/dark,
 /area/aisat)
 "bjP" = (
@@ -25374,14 +25375,13 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "blk" = (
-/obj/machinery/atmospherics/pipe/layer_manifold,
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bll" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "blm" = (
@@ -25408,15 +25408,15 @@
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "blp" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "blq" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "blr" = (
@@ -25516,7 +25516,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "blE" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -25535,8 +25535,8 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "blG" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/landmark/start/cyborg,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "blH" = (
@@ -25554,7 +25554,6 @@
 	name = "AI Chamber";
 	req_access_txt = "16"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "AI Chamber entrance shutters";
 	name = "AI Chamber entrance shutters"
@@ -25572,6 +25571,7 @@
 	pixel_x = 28
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "blJ" = (
@@ -25594,10 +25594,8 @@
 /obj/machinery/airalarm{
 	pixel_y = 26
 	},
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	name = "Auxiliary MiniSat Distribution Port"
-	},
 /obj/machinery/portable_atmospherics/canister/air,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer1,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/satellite)
 "blM" = (
@@ -26203,9 +26201,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 9
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
@@ -26218,18 +26213,22 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bna" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/layer_manifold{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bnb" = (
@@ -26237,14 +26236,20 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bnc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -26255,6 +26260,12 @@
 	pixel_y = 7
 	},
 /obj/item/storage/belt/utility,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bne" = (
@@ -26262,13 +26273,24 @@
 	pixel_y = 4
 	},
 /obj/structure/table/glass,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bnf" = (
 /obj/structure/chair/stool{
 	pixel_y = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bng" = (
@@ -26362,6 +26384,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/plasteel/dark,
 /area/aisat)
 "bns" = (
@@ -26369,10 +26392,10 @@
 	dir = 1;
 	name = "MiniSat Walkway Access"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel/dark,
 /area/aisat)
 "bnt" = (
@@ -26401,6 +26424,11 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
+	},
+/obj/machinery/camera{
+	c_tag = "MiniSat Exterior - Port Aft";
+	dir = 9;
+	network = list("minisat")
 	},
 /turf/open/floor/plasteel/dark,
 /area/aisat)
@@ -26492,7 +26520,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/cyborg,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "bnD" = (
@@ -26557,6 +26585,7 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/satellite)
 "bnH" = (
@@ -26566,12 +26595,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/satellite)
 "bnI" = (
@@ -26579,9 +26606,6 @@
 	dir = 8;
 	pixel_x = 9;
 	pixel_y = 2
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
 	},
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -26692,7 +26716,6 @@
 /obj/machinery/camera{
 	c_tag = "Port Primary Hallway - Port"
 	},
-/obj/machinery/vending/pdavendor,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "bnV" = (
@@ -27007,11 +27030,11 @@
 	icon_state = "map-right-MS";
 	pixel_y = 32
 	},
-/obj/machinery/camera{
-	c_tag = "Captain's Quarters";
-	dir = 8
-	},
 /obj/structure/chair/comfy/brown,
+/obj/machinery/light_switch{
+	pixel_x = 11;
+	pixel_y = 23
+	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain/private)
 "boG" = (
@@ -27027,25 +27050,22 @@
 /obj/machinery/status_display/ai{
 	pixel_y = 32
 	},
-/obj/machinery/keycard_auth{
-	pixel_x = 24;
-	pixel_y = 24
-	},
 /obj/structure/filingcabinet,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain/private)
 "boI" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk,
+/obj/machinery/vending/boozeomat,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain/private)
 "boJ" = (
 /obj/machinery/camera{
 	c_tag = "Central Primary Hallway - Starboard - Art Storage";
 	dir = 4
+	},
+/obj/item/radio/intercom{
+	dir = 8;
+	name = "Station Intercom (General)";
+	pixel_x = -28
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -27252,34 +27272,48 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bpj" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/engine/break_room)
-"bpk" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"bpk" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bpl" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
@@ -27292,6 +27326,12 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bpn" = (
@@ -27316,6 +27356,12 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/engine/break_room)
 "bpq" = (
@@ -27330,7 +27376,7 @@
 /area/aisat)
 "bps" = (
 /obj/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel/dark,
 /area/aisat)
 "bpt" = (
@@ -27355,43 +27401,18 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/break_room)
-"bpw" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
+"bpy" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/transit_tube/horizontal,
-/turf/open/space,
-/area/space/nearstation)
-"bpx" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
-	},
-/obj/structure/lattice/catwalk,
-/obj/structure/cable{
-	icon_state = "4-8"
 	},
 /obj/structure/transit_tube/crossing/horizontal,
 /turf/open/space,
 /area/space/nearstation)
-"bpy" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/transit_tube/horizontal,
-/turf/open/space,
-/area/space/nearstation)
 "bpz" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -27399,15 +27420,18 @@
 /obj/structure/transit_tube/junction/flipped{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /turf/open/space,
 /area/space/nearstation)
 "bpA" = (
 /obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
 /turf/open/space,
 /area/space/nearstation)
@@ -27416,11 +27440,11 @@
 	dir = 4
 	},
 /obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
 /turf/open/space,
 /area/space/nearstation)
@@ -27428,42 +27452,42 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/structure/transit_tube/station{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/aisat)
 "bpD" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/aisat)
 "bpE" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /turf/open/floor/plasteel/dark,
 /area/aisat)
 "bpF" = (
 /obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
 /turf/open/floor/plasteel/dark,
 /area/aisat)
 "bpG" = (
@@ -27473,6 +27497,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/aisat)
 "bpH" = (
@@ -27481,6 +27508,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/aisat)
@@ -27496,12 +27526,17 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "bpJ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
@@ -27510,6 +27545,9 @@
 /obj/item/beacon,
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
@@ -27522,6 +27560,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
@@ -27537,6 +27578,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "bpN" = (
@@ -27545,6 +27589,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
@@ -27558,10 +27605,12 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "bpP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/ai_slipper{
 	uses = 10
 	},
@@ -27575,12 +27624,15 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "bpQ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
@@ -27590,6 +27642,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
@@ -27605,6 +27660,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "bpT" = (
@@ -27614,24 +27672,28 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/satellite)
 "bpU" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/satellite)
 "bpV" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/satellite)
 "bpW" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/satellite)
@@ -27641,11 +27703,11 @@
 	name = "MiniSat Maintenance";
 	req_access_txt = "32"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/satellite)
@@ -27654,11 +27716,11 @@
 	dir = 1
 	},
 /obj/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/ai_slipper{
 	uses = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/aisat)
@@ -27667,7 +27729,7 @@
 	dir = 1
 	},
 /obj/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -27676,7 +27738,7 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -28214,8 +28276,6 @@
 /area/crew_quarters/heads/captain/private)
 "bqX" = (
 /obj/structure/table/wood,
-/obj/item/storage/photo_album,
-/obj/item/camera,
 /obj/item/razor{
 	pixel_x = -17;
 	pixel_y = 2
@@ -28223,14 +28283,12 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain/private)
 "bqY" = (
-/obj/structure/disposalpipe/junction/flip{
-	dir = 2
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain/private)
 "bqZ" = (
@@ -28365,14 +28423,14 @@
 /area/hallway/primary/starboard)
 "brs" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
@@ -28477,18 +28535,14 @@
 	},
 /area/engine/break_room)
 "brE" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "brF" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/power/apc{
 	areastring = "/area/engine/break_room";
 	name = "Engineering Foyer APC";
@@ -28502,9 +28556,6 @@
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "brG" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -24
@@ -28515,23 +28566,26 @@
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "brH" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "brI" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
@@ -28559,21 +28613,27 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/engine/break_room)
 "brL" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/break_room)
 "brM" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -28582,6 +28642,9 @@
 	dir = 8
 	},
 /obj/structure/transit_tube/curved{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /turf/open/space,
@@ -28602,7 +28665,7 @@
 	pixel_x = 5;
 	pixel_y = -1
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -28626,9 +28689,6 @@
 /area/aisat)
 "brQ" = (
 /obj/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
 /obj/machinery/light/small,
 /obj/machinery/camera{
 	c_tag = "MiniSat Exterior Access";
@@ -28646,29 +28706,18 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/dark,
 /area/aisat)
-"brR" = (
-/obj/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
 "brS" = (
 /obj/machinery/door/window{
 	name = "MiniSat Walkway Access"
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel/dark,
 /area/aisat)
 "brT" = (
 /obj/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
@@ -28681,9 +28730,6 @@
 	pixel_x = 9;
 	pixel_y = 2
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = 24
@@ -28694,13 +28740,10 @@
 /turf/open/floor/plasteel/dark,
 /area/aisat)
 "brV" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/aisat)
-"brW" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/closed/wall/r_wall,
+/area/engine/atmos)
+"brW" = (
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_y = -28
@@ -28728,9 +28771,6 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "brY" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/power/apc/highcap/five_k{
 	areastring = "/area/ai_monitored/turret_protected/aisat/foyer";
 	name = "MiniSat Foyer APC";
@@ -28748,17 +28788,15 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "brZ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/turf/closed/wall/r_wall,
-/area/ai_monitored/turret_protected/aisat_interior)
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
 "bsa" = (
 /obj/machinery/light/small{
 	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
 	},
 /obj/machinery/airalarm{
 	dir = 4;
@@ -28771,9 +28809,6 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "bsb" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -28781,15 +28816,17 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "bsc" = (
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "bsd" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/effect/turf_decal/tile/blue,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "bse" = (
@@ -28804,11 +28841,11 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "bsf" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
@@ -28817,7 +28854,6 @@
 	dir = 1
 	},
 /obj/machinery/light,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/machinery/computer/security/telescreen/minisat{
 	dir = 1;
 	pixel_y = -29
@@ -28830,9 +28866,6 @@
 	name = "Station Intercom (General)";
 	pixel_y = -28
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/computer/monitor{
 	dir = 1
 	},
@@ -28843,9 +28876,6 @@
 	c_tag = "MiniSat Maintenance";
 	dir = 8;
 	network = list("minisat")
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
 	},
 /obj/structure/rack,
 /obj/item/storage/toolbox/electrical{
@@ -29170,6 +29200,9 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -24
+	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain/private)
 "btd" = (
@@ -29325,12 +29358,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"btv" = (
-/obj/machinery/atmospherics/pipe/layer_manifold{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "btw" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 4
@@ -29381,28 +29408,18 @@
 	name = "Engineering Foyer Maintenance";
 	req_one_access_txt = "32;19"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"btA" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark/corner,
-/area/engine/break_room)
 "btB" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel/dark/corner,
 /area/engine/break_room)
 "btC" = (
@@ -29419,9 +29436,11 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
 "btD" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/sign/warning/securearea{
 	pixel_x = 32
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
@@ -29444,6 +29463,8 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel/dark,
 /area/engine/break_room)
 "btG" = (
@@ -29454,13 +29475,13 @@
 /obj/item/folder/blue{
 	pixel_y = 3
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/item/pen,
 /obj/machinery/computer/security/telescreen/minisat{
 	dir = 1;
 	pixel_y = -28
 	},
 /obj/effect/turf_decal/tile/blue,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel/dark,
 /area/engine/break_room)
 "btH" = (
@@ -29511,13 +29532,13 @@
 	name = "Telecomms Control Room";
 	req_one_access_txt = "19; 61"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/computer)
 "btO" = (
@@ -29901,15 +29922,20 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/captain/private)
 "buF" = (
-/obj/machinery/vending/boozeomat,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain/private)
 "buG" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 2
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain/private)
@@ -30046,6 +30072,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark/corner,
 /area/hallway/primary/starboard)
 "bvc" = (
@@ -30055,16 +30084,25 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "bvd" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "bve" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plating{
@@ -30109,14 +30147,20 @@
 /turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/ai)
 "bvg" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/effect/landmark/blobstart,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/effect/landmark/blobstart,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "bvh" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 9
 	},
 /turf/open/floor/plating{
@@ -30140,35 +30184,27 @@
 	id = "atmos";
 	name = "Atmospherics Blast Door"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
 /obj/effect/turf_decal/delivery,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bvl" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "atmos";
-	name = "Atmospherics Blast Door"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/delivery,
+/obj/machinery/vending/pdavendor,
 /turf/open/floor/plasteel,
-/area/engine/break_room)
+/area/hallway/primary/port)
 "bvm" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/closed/wall/r_wall,
-/area/engine/break_room)
+/turf/open/floor/plasteel/grimy,
+/area/tcommsat/computer)
 "bvn" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
@@ -30185,23 +30221,25 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/break_room)
 "bvp" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/machinery/camera{
 	c_tag = "Engineering - Transit Tube Access";
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/corner,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/engine/break_room)
 "bvq" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 1
+	},
 /turf/closed/wall/r_wall,
 /area/engine/break_room)
 "bvr" = (
 /obj/structure/table/glass,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/item/tank/internals/emergency_oxygen{
 	pixel_x = -8
 	},
@@ -30218,9 +30256,6 @@
 /obj/machinery/door/airlock/hatch{
 	name = "MiniSat Space Access Airlock";
 	req_one_access_txt = "32;19"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -30247,12 +30282,11 @@
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
 "bvv" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/break_room)
@@ -30390,6 +30424,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/turf_decal/lumos/tile/red/half{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "bvN" = (
@@ -30406,9 +30443,6 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/dark,
 /area/blueshield)
-"bvO" = (
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "bvP" = (
 /obj/structure/chair{
 	dir = 1
@@ -30451,7 +30485,7 @@
 /area/ai_monitored/security/armory)
 "bvU" = (
 /obj/machinery/camera{
-	c_tag = "Security - Holding Cell";
+	c_tag = "Security - Holding Cell A";
 	dir = 4;
 	network = list("ss13","prison")
 	},
@@ -30674,26 +30708,23 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "bwA" = (
-/obj/machinery/vending/cigarette,
+/obj/structure/bed/dogbed/renault,
+/mob/living/simple_animal/pet/fox/Renault,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain/private)
 "bwB" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain/private)
 "bwC" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/heads/captain/private)
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/command)
 "bwD" = (
 /obj/machinery/holopad{
 	pixel_x = -9;
@@ -30815,11 +30846,11 @@
 	},
 /area/construction/storage/wing)
 "bwR" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain/private)
@@ -30915,7 +30946,6 @@
 /turf/closed/wall,
 /area/engine/atmos)
 "bxe" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/atmos{
 	name = "Atmospherics";
@@ -30924,14 +30954,19 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bxf" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/turf/closed/wall,
-/area/engine/atmos)
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/plasteel/dark,
+/area/aisat)
 "bxg" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -30939,8 +30974,8 @@
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
 "bxh" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
 	},
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
@@ -30951,8 +30986,8 @@
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
 "bxj" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
 	},
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
@@ -30969,9 +31004,6 @@
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
 "bxm" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
 /obj/structure/sign/warning/vacuum/external{
 	pixel_y = -32
 	},
@@ -30981,27 +31013,28 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/dark,
 /area/engine/break_room)
 "bxn" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
 "bxo" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
 "bxp" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
 	},
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
@@ -31112,11 +31145,32 @@
 /area/maintenance/bar)
 "bxJ" = (
 /obj/effect/landmark/event_spawn,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "bxK" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -31152,17 +31206,9 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "bxR" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
+/obj/effect/turf_decal/lumos/tile/blue/half,
 /turf/open/floor/plasteel,
-/area/engine/engineering)
+/area/hallway/secondary/command)
 "bxS" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -31226,15 +31272,9 @@
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hop)
 "bya" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -31488,9 +31528,6 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = 24
@@ -31517,9 +31554,6 @@
 	areastring = "/area/ai_monitored/storage/satellite";
 	name = "MiniSat Maint APC";
 	pixel_y = -26
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
 	},
 /obj/item/stack/sheet/mineral/plasma{
 	amount = 35
@@ -31792,19 +31826,19 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
 /area/aisat)
 "bzl" = (
 /obj/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/window/reinforced{
 	dir = 1;
 	layer = 2.9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/aisat)
@@ -31813,8 +31847,8 @@
 	dir = 1;
 	layer = 2.9
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/aisat)
@@ -31846,7 +31880,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -31913,34 +31946,25 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "bzx" = (
 /turf/closed/wall,
 /area/security/vacantoffice)
 "bzy" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
 /obj/machinery/rnd/production/circuit_imprinter,
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "bzz" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/rnd/production/protolathe/department/engineering,
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -32154,6 +32178,9 @@
 	dir = 4;
 	pixel_x = -24
 	},
+/obj/structure/table/wood,
+/obj/item/storage/photo_album,
+/obj/item/camera,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain/private)
 "bAd" = (
@@ -32166,10 +32193,6 @@
 /turf/open/floor/plasteel/dark,
 /area/security/execution/education)
 "bAe" = (
-/obj/machinery/computer/security/telescreen/minisat{
-	dir = 1;
-	pixel_y = -29
-	},
 /obj/structure/flora/ausbushes/pointybush{
 	pixel_x = -3;
 	pixel_y = 3
@@ -32316,7 +32339,6 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/bar)
 "bAw" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/computer/rdconsole/production{
 	dir = 1
 	},
@@ -32436,10 +32458,10 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bAI" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bAJ" = (
@@ -32535,10 +32557,10 @@
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
 "bAX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
 "bAY" = (
@@ -32678,6 +32700,9 @@
 "bBm" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
+	},
+/obj/structure/chair{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
@@ -32842,22 +32867,9 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "bBG" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/goonplaque{
-	desc = "\"This is a plaque in honour of our comrades on the G4407 Stations. Hopefully TG4407 model can live up to your fame and fortune.\" Scratched in beneath that is a crude image of sentient postcards in a realm of darkness. The station model number is MSv42A-160516"
-	},
-/area/hallway/primary/port)
+/obj/effect/turf_decal/lumos/tile/blue/fullcorner,
+/turf/open/floor/plasteel,
+/area/space/nearstation)
 "bBL" = (
 /obj/effect/turf_decal/bot_white/right,
 /obj/machinery/ore_silo,
@@ -33089,10 +33101,10 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bCp" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bCq" = (
@@ -33207,7 +33219,6 @@
 /obj/machinery/door/airlock/hatch{
 	name = "Telecomms Server Room"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -33436,9 +33447,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
 	},
-/obj/effect/turf_decal/lumos/tile/blue/half{
-	dir = 4
-	},
 /turf/open/floor/plasteel/dark/side{
 	dir = 8
 	},
@@ -33515,9 +33523,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
-	},
-/obj/effect/turf_decal/lumos/tile/blue/half{
-	dir = 8
 	},
 /turf/open/floor/plasteel/dark/side{
 	dir = 4
@@ -33736,7 +33741,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bDU" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bDV" = (
@@ -33823,7 +33828,6 @@
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "bEi" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -34406,7 +34410,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bFO" = (
@@ -34697,7 +34701,6 @@
 /area/ai_monitored/storage/eva)
 "bGB" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -34742,7 +34745,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/effect/turf_decal/lumos/tile/blue/half,
 /turf/open/floor/plasteel/dark/side{
 	dir = 1
 	},
@@ -35051,18 +35053,12 @@
 /area/tcommsat/server)
 "bHE" = (
 /obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
 "bHF" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -35265,7 +35261,6 @@
 	name = "Station Intercom (General)";
 	pixel_y = 21
 	},
-/obj/effect/turf_decal/lumos/tile/blue/half,
 /turf/open/floor/plasteel/dark/side{
 	dir = 1
 	},
@@ -35736,7 +35731,6 @@
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
 "bJk" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -36944,15 +36938,17 @@
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
 "bMp" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
+/obj/structure/window/reinforced{
+	dir = 1;
+	layer = 2.9
 	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/tcommsat/server)
+/obj/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
 "bMq" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
@@ -37714,6 +37710,7 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel/dark,
 /area/aisat)
 "bNX" = (
@@ -37731,7 +37728,6 @@
 	dir = 1;
 	network = list("ss13","tcomms")
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/ntnet_relay,
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
@@ -38673,9 +38669,6 @@
 /turf/open/floor/carpet,
 /area/bridge/showroom/corporate)
 "bQm" = (
-/obj/machinery/camera{
-	c_tag = "Club - Fore"
-	},
 /obj/machinery/requests_console{
 	department = "Bar";
 	departmentType = 2;
@@ -38986,9 +38979,8 @@
 	dir = 1
 	},
 /obj/structure/window/reinforced,
-/obj/machinery/camera{
-	c_tag = "MiniSat Exterior - Port Aft";
-	network = list("minisat")
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/aisat)
@@ -39295,6 +39287,10 @@
 /obj/structure/table/wood,
 /obj/item/melee/chainofcommand,
 /obj/item/storage/lockbox/loyalty,
+/obj/machinery/computer/security/telescreen/minisat{
+	dir = 1;
+	pixel_y = -29
+	},
 /turf/open/floor/carpet/purple,
 /area/crew_quarters/heads/captain/private)
 "bRF" = (
@@ -39904,13 +39900,11 @@
 /obj/effect/turf_decal/bot{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/obj/effect/landmark/start/station_engineer,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel{
 	dir = 1
 	},
@@ -40140,7 +40134,6 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bTm" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/lattice/catwalk,
 /obj/structure/window/reinforced,
 /turf/open/space,
@@ -40164,16 +40157,21 @@
 /turf/closed/wall,
 /area/maintenance/solars/port/aft)
 "bTq" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
+/obj/structure/window/reinforced{
+	dir = 1;
+	layer = 2.9
 	},
-/turf/closed/wall/r_wall,
-/area/engine/engineering)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
 "bTr" = (
 /obj/machinery/door/airlock/maintenance/abandoned{
 	name = "Storage Room";
 	req_access_txt = "12"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "bTs" = (
@@ -41493,9 +41491,6 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "bWd" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -41619,6 +41614,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bWq" = (
@@ -43353,12 +43349,7 @@
 /turf/open/floor/circuit,
 /area/maintenance/port/aft)
 "bZR" = (
-/obj/machinery/light_switch{
-	pixel_x = 11;
-	pixel_y = 23
-	},
-/obj/structure/bed/dogbed/renault,
-/mob/living/simple_animal/pet/fox/Renault,
+/obj/machinery/vending/cigarette,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain/private)
 "bZS" = (
@@ -44971,9 +44962,6 @@
 	pixel_y = 5
 	},
 /obj/item/watertank,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
 /obj/item/grenade/chem_grenade/antiweed,
 /obj/structure/table/glass,
 /obj/effect/turf_decal/stripes/line{
@@ -46333,9 +46321,11 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /obj/structure/cable{
 	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
@@ -47704,7 +47694,9 @@
 	dir = 1;
 	layer = 2.9
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
 /turf/open/floor/plasteel/dark,
 /area/aisat)
 "chN" = (
@@ -49131,7 +49123,7 @@
 	},
 /area/maintenance/port/aft)
 "ckT" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -51438,14 +51430,14 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/science/explab)
@@ -52233,6 +52225,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/white,
 /area/science/explab)
 "cqU" = (
@@ -52715,7 +52708,6 @@
 /turf/closed/wall/r_wall,
 /area/science/storage)
 "crU" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/research{
@@ -54219,8 +54211,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 10
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/science/storage)
@@ -54881,6 +54873,9 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
+	},
 /turf/open/floor/plasteel,
 /area/science/storage)
 "cwP" = (
@@ -54892,6 +54887,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/science/storage)
@@ -55649,7 +55647,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "cyC" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "cyE" = (
@@ -56425,6 +56423,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/effect/landmark/blobstart,
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "cAr" = (
@@ -58186,12 +58185,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
-"cEr" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/maintenance/starboard/aft)
 "cEs" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -60099,8 +60092,8 @@
 /area/science/research)
 "cIa" = (
 /obj/structure/sign/warning/securearea,
-/obj/machinery/atmospherics/pipe/layer_manifold{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
 /turf/closed/wall/r_wall,
 /area/science/mixing)
@@ -60209,7 +60202,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
 	},
 /turf/open/floor/plating,
@@ -61718,7 +61711,6 @@
 /area/maintenance/disposal/incinerator)
 "cLE" = (
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_toxmix,
-/obj/effect/landmark/blobstart,
 /turf/open/floor/engine,
 /area/science/mixing)
 "cLF" = (
@@ -63193,9 +63185,6 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/ausbushes/sunnybush,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/grass,
 /area/hallway/secondary/exit/departure_lounge)
@@ -63811,7 +63800,6 @@
 	name = "Xenobiology Lab";
 	req_access_txt = "47"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -63892,8 +63880,8 @@
 	},
 /area/crew_quarters/bar)
 "cRf" = (
-/obj/machinery/atmospherics/pipe/layer_manifold{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
 /turf/closed/wall/r_wall,
 /area/maintenance/starboard/aft)
@@ -65255,6 +65243,9 @@
 /obj/machinery/atmospherics/pipe/manifold/green/visible{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/engine,
 /area/engine/engineering)
 "dbh" = (
@@ -65265,6 +65256,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /turf/open/floor/engine,
@@ -65380,7 +65374,6 @@
 /turf/open/floor/plasteel,
 /area/science/research)
 "dbI" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -66242,12 +66235,17 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "ddQ" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
 	},
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -66268,6 +66266,7 @@
 /area/engine/engineering)
 "ddT" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "ddU" = (
@@ -66280,15 +66279,15 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "ddW" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/cable{
-	icon_state = "2-4"
+	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "ddX" = (
@@ -66300,9 +66299,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/lumos/tile/blue/half{
-	dir = 4
-	},
 /turf/open/floor/plasteel/dark/side{
 	dir = 8
 	},
@@ -66313,35 +66309,6 @@
 "dea" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/engine_waste,
 /turf/open/floor/plating/airless,
-/area/engine/engineering)
-"deb" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/engine/engineering)
-"ded" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/turf/open/floor/plating,
-/area/engine/engineering)
-"dee" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/turf/open/floor/plating,
-/area/engine/engineering)
-"def" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
 /area/engine/engineering)
 "deh" = (
 /obj/structure/cable/white{
@@ -66383,18 +66350,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"del" = (
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "dem" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1;
@@ -66420,9 +66375,6 @@
 /obj/machinery/firealarm{
 	pixel_y = 32
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "deq" = (
@@ -66439,6 +66391,9 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/engine,
 /area/engine/engineering)
 "des" = (
@@ -66450,6 +66405,9 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/engine,
@@ -66464,6 +66422,9 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 10
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/engine,
 /area/engine/engineering)
 "dev" = (
@@ -66474,6 +66435,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/engine,
 /area/engine/engineering)
 "dew" = (
@@ -66485,11 +66449,17 @@
 	name = "Laser Room";
 	req_access_txt = "10"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/engine/engineering)
 "dex" = (
 /obj/structure/cable/white{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
@@ -66776,6 +66746,7 @@
 /obj/structure/cable/white{
 	icon_state = "0-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/engine/engineering)
 "dfB" = (
@@ -66811,6 +66782,9 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/engine,
 /area/engine/engineering)
 "dfE" = (
@@ -66822,6 +66796,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/green/visible{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -66839,6 +66816,9 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/engine,
 /area/engine/engineering)
 "dfG" = (
@@ -66852,6 +66832,9 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /turf/open/floor/engine,
@@ -66870,6 +66853,9 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/engine,
 /area/engine/engineering)
 "dfJ" = (
@@ -66880,6 +66866,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/orange/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /turf/open/floor/engine,
@@ -66958,7 +66947,6 @@
 	dir = 1;
 	pixel_y = -22
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "dfW" = (
@@ -66967,26 +66955,10 @@
 /area/engine/engineering)
 "dfY" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/engine/engineering)
-"dfZ" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/closed/wall/r_wall,
 /area/engine/engineering)
 "dga" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/engine/engineering)
-"dgb" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
 /turf/closed/wall/r_wall,
 /area/engine/engineering)
 "dgc" = (
@@ -67174,15 +67146,15 @@
 /turf/open/floor/plasteel/dark,
 /area/science/research)
 "dgS" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/transit_tube/horizontal,
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/transit_tube/crossing/horizontal,
 /turf/open/space,
 /area/space/nearstation)
 "dha" = (
@@ -68170,19 +68142,6 @@
 	dir = 9
 	},
 /area/security/brig)
-"dmD" = (
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Captain's Desk";
-	departmentType = 5;
-	name = "Captain RC";
-	pixel_x = 32
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/heads/captain/private)
 "dmF" = (
 /turf/closed/wall,
 /area/quartermaster/sorting)
@@ -68291,6 +68250,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "doR" = (
@@ -68671,6 +68631,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/science/storage)
 "dyc" = (
@@ -68737,7 +68698,7 @@
 	dir = 4;
 	name = "manual inlet valve"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "dzK" = (
@@ -68922,6 +68883,7 @@
 	dir = 1
 	},
 /obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "dCl" = (
@@ -68983,11 +68945,12 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "dCw" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "dCx" = (
@@ -69426,8 +69389,8 @@
 	name = "Storage Room";
 	req_access_txt = "12"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/barricade/wooden/crude,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "dGF" = (
@@ -69587,7 +69550,6 @@
 	id = "kitchen";
 	name = "Serving Hatch"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/item/reagent_containers/food/snacks/pie/cream,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/kitchen)
@@ -71003,9 +70965,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
 	},
-/obj/effect/turf_decal/lumos/tile/blue/fullcorner{
-	dir = 1
-	},
 /turf/open/floor/plasteel/dark/corner{
 	dir = 4
 	},
@@ -71182,6 +71141,9 @@
 	req_access_txt = "3"
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/education)
 "hAE" = (
@@ -71427,7 +71389,7 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/light/small{
-	dir = 1
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
@@ -72389,7 +72351,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
 	},
-/obj/effect/turf_decal/lumos/tile/blue/fullcorner,
 /turf/open/floor/plasteel/dark/corner{
 	dir = 1
 	},
@@ -73030,7 +72991,6 @@
 /obj/machinery/door/airlock/hatch{
 	name = "Telecomms Server Room"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
@@ -73070,10 +73030,6 @@
 /area/science/robotics/mechbay)
 "may" = (
 /obj/structure/table/wood,
-/obj/machinery/camera{
-	c_tag = "Security - Detective Office";
-	dir = 4
-	},
 /obj/machinery/photocopier/faxmachine/longrange,
 /turf/open/floor/wood,
 /area/lawoffice)
@@ -73743,10 +73699,15 @@
 /turf/open/floor/plasteel/dark/side,
 /area/science/robotics/mechbay)
 "nDM" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /mob/living/simple_animal/opossum/poppy,
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
@@ -74535,6 +74496,9 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "prl" = (
+/obj/effect/turf_decal/lumos/tile/blue/fullcorner{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/space/nearstation)
 "prO" = (
@@ -75689,6 +75653,8 @@
 /area/chapel/main)
 "skb" = (
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "ske" = (
@@ -76069,7 +76035,7 @@
 /area/security/brig)
 "tap" = (
 /obj/machinery/camera{
-	c_tag = "Security - Holding Cell";
+	c_tag = "Security - Holding Cell B";
 	dir = 8;
 	network = list("ss13","prison")
 	},
@@ -76327,6 +76293,9 @@
 /turf/open/floor/engine,
 /area/engine/supermatter)
 "tEy" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
 "tFJ" = (
@@ -76707,8 +76676,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
@@ -76877,7 +76846,6 @@
 /turf/open/floor/carpet,
 /area/library)
 "uVQ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/lattice/catwalk,
 /obj/machinery/camera{
 	c_tag = "MiniSat Exterior - Aft";
@@ -77846,9 +77814,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/lumos/tile/blue/half{
-	dir = 8
-	},
 /turf/open/floor/plasteel/dark/side{
 	dir = 4
 	},
@@ -78006,6 +77971,7 @@
 /area/hallway/primary/central)
 "yge" = (
 /obj/machinery/light,
+/obj/effect/turf_decal/lumos/tile/blue/half,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
 "ygA" = (
@@ -78048,9 +78014,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "ykE" = (
@@ -91806,9 +91771,9 @@ blT
 bnL
 bqc
 bzw
-bzw
+aVh
 bvL
-bzw
+aVh
 fOL
 tre
 rbE
@@ -94119,10 +94084,10 @@ dne
 bNh
 lSe
 boc
-boc
-boc
-boc
-boc
+aWC
+aWC
+aWC
+brZ
 gHz
 bNh
 bNK
@@ -94634,7 +94599,7 @@ bbY
 bqk
 bGn
 bGn
-bGn
+bib
 bGn
 bGn
 dhZ
@@ -95145,12 +95110,12 @@ biD
 bkg
 bme
 bbY
-bBG
+bql
 bbY
-bbY
+bfV
 bBm
 bBm
-bBm
+bvl
 jCq
 bCR
 bKg
@@ -103361,10 +103326,10 @@ aVY
 aXG
 aZe
 bDB
-bSS
-bpu
-bpu
-bpu
+bcg
+aFv
+aFv
+aFv
 bfv
 bfv
 bmv
@@ -104664,7 +104629,7 @@ njL
 njL
 njL
 bGL
-tEy
+bxR
 kWC
 dKm
 bNc
@@ -106206,7 +106171,7 @@ njL
 njL
 njL
 bGL
-tEy
+bxR
 kWC
 xKk
 bNi
@@ -106719,8 +106684,8 @@ dLM
 bfv
 prO
 bES
-tEy
-prl
+bwC
+bBG
 dIb
 fdd
 bNk
@@ -107473,10 +107438,10 @@ aRX
 wqs
 lPz
 bEw
-aUv
+bcj
 aWZ
-bpu
-bpu
+bcj
+bcj
 bfv
 bfv
 bfv
@@ -107733,7 +107698,7 @@ oZt
 bcj
 aYH
 bNl
-bcj
+bjg
 bmJ
 bkJ
 bcj
@@ -107990,7 +107955,7 @@ bzK
 bcj
 bdH
 bfy
-bcj
+bjg
 bOJ
 bkK
 bjg
@@ -108245,9 +108210,9 @@ wqs
 sgn
 baW
 bcj
-bcj
+bjg
 bOk
-bcj
+bjg
 bqn
 bkL
 bjg
@@ -108255,7 +108220,7 @@ boE
 bqW
 btd
 buH
-bwC
+dCP
 dCP
 bQE
 bcj
@@ -109023,7 +108988,7 @@ bji
 bqZ
 bjg
 boH
-bqZ
+dCP
 btg
 buJ
 bwF
@@ -109278,9 +109243,9 @@ bhz
 bji
 bji
 bqZ
-bcj
+bjg
 bZR
-bqZ
+dCP
 bwR
 bwV
 bwG
@@ -109533,12 +109498,12 @@ bcj
 bdN
 bOw
 dCP
-dCP
+aIe
 bkP
-bcj
+bjg
 boI
-dmD
 dCP
+aVe
 buK
 bwH
 byu
@@ -109793,7 +109758,7 @@ bcj
 bcj
 bcj
 bcj
-bjg
+bcj
 bcj
 bcj
 bcj
@@ -110052,7 +110017,7 @@ bro
 bRF
 boJ
 bka
-bNt
+wqs
 buL
 bID
 wqs
@@ -112673,7 +112638,7 @@ uun
 rSL
 cAq
 bSJ
-cEr
+cRf
 dkq
 cTc
 cRi
@@ -117239,7 +117204,7 @@ aWy
 aYp
 aZD
 bbt
-bcG
+bcH
 beg
 aWw
 bli
@@ -117250,7 +117215,7 @@ bpe
 bry
 bIC
 brs
-bxa
+bpj
 bxa
 bAy
 bAy
@@ -117496,7 +117461,7 @@ aWz
 aYp
 aZE
 bbu
-bcG
+bcH
 beh
 aWw
 bhS
@@ -117736,7 +117701,7 @@ axY
 aBG
 dCk
 aEk
-aFs
+aFr
 aGT
 axY
 aJm
@@ -117753,7 +117718,7 @@ aWw
 aYq
 aZF
 bbv
-bcG
+bcH
 bei
 aWw
 bhT
@@ -118020,7 +117985,7 @@ bmZ
 cqi
 brA
 bep
-btv
+bvd
 bxd
 byR
 bAB
@@ -118242,7 +118207,7 @@ acP
 acP
 dnh
 dnh
-aqp
+axO
 doh
 dnS
 axY
@@ -118262,7 +118227,7 @@ aPZ
 aRo
 aSu
 aTG
-aVc
+bSN
 aWB
 aYr
 aZH
@@ -118505,9 +118470,9 @@ axT
 axY
 aBN
 aBJ
-ayT
+aEi
 aEn
-aFv
+aEi
 aGV
 aHX
 aEi
@@ -118518,7 +118483,7 @@ aOO
 aEi
 aRp
 aSv
-aTH
+aTI
 aVa
 aWw
 aWw
@@ -118761,13 +118726,13 @@ dqT
 axU
 aAo
 bgp
-aBK
+aCP
 aCS
-aEo
+aSw
 aFw
 aHY
-aHY
-aHY
+aCS
+aBK
 aKB
 aMd
 aNr
@@ -118777,7 +118742,7 @@ aRq
 aSw
 aTI
 aVb
-aWC
+aBI
 aYs
 aZI
 bby
@@ -119017,28 +118982,28 @@ axP
 dqT
 axV
 aAp
-aEi
+api
 ddW
-aCT
+aRr
 aEp
 aKC
 aFx
-aKC
-aKC
-aKC
+aAv
+aAv
+aAv
 aMe
-aKC
+aAv
 aOQ
-aKC
+aFx
 aRr
 aSx
 aTJ
 bSN
 aWD
-aVc
+bSN
 aZJ
 bbz
-bcK
+bSN
 bel
 bfT
 bhY
@@ -119274,12 +119239,12 @@ avu
 axY
 aCP
 aGW
-bvO
-bxR
-aCU
-aEq
+bxK
 aTO
-aGX
+aTO
+aEq
+atf
+aTO
 aHZ
 aJp
 aTO
@@ -119288,7 +119253,7 @@ aTO
 aOR
 aVd
 aGX
-aTO
+aCU
 aTK
 bdR
 baV
@@ -119533,7 +119498,7 @@ aCP
 aAr
 bxJ
 bya
-deb
+axY
 deh
 aFz
 aCZ
@@ -119545,9 +119510,9 @@ aCZ
 baN
 deM
 aCZ
-aFz
+aCV
 deh
-aVe
+axY
 axY
 aYu
 aYu
@@ -119781,16 +119746,16 @@ ajb
 ajb
 ajb
 ajb
-arN
-atf
+ajb
+ajb
 auu
 avw
-atf
+ajb
 ayS
 aAt
 bxK
 bzy
-deb
+axY
 dei
 aFA
 deB
@@ -119804,21 +119769,21 @@ deB
 deB
 aSz
 aTM
-aVe
+axY
 apc
 aYu
 aZL
 bbB
 bcL
 bem
-bfV
-bib
-bjJ
+bfX
+bhZ
+bWd
 blp
 bnf
-bpj
+bjL
 brH
-btA
+bvn
 bvj
 bxd
 byX
@@ -120034,7 +119999,7 @@ aaf
 ajb
 ajZ
 als
-amI
+ajZ
 anO
 aph
 aqt
@@ -120047,8 +120012,8 @@ axW
 aAu
 ddQ
 bzz
-aCV
-aEr
+aCZ
+arN
 aFB
 aGY
 daW
@@ -120083,7 +120048,7 @@ bDU
 bCp
 bDU
 bFN
-bAO
+bTS
 bIQ
 bKx
 bMd
@@ -120291,9 +120256,9 @@ aag
 ajb
 aka
 alt
-amJ
+akc
 anP
-api
+apl
 aqu
 arP
 ajb
@@ -120302,9 +120267,9 @@ avy
 ajb
 axX
 ayV
-aAv
+aTO
 bAw
-aCW
+aCZ
 aEr
 aFC
 aGZ
@@ -120318,7 +120283,7 @@ aQe
 aRv
 dfD
 aTN
-aVe
+axY
 apc
 aYu
 aZN
@@ -120333,8 +120298,8 @@ bng
 bpl
 btD
 bvn
-bvl
-bxf
+bvj
+bxd
 byZ
 bAJ
 bCq
@@ -120549,7 +120514,7 @@ ajb
 akb
 ajZ
 amK
-ajZ
+amI
 apj
 aqv
 arQ
@@ -120559,9 +120524,9 @@ avz
 axY
 axY
 ayW
-bTq
-aBO
-aCX
+axY
+aCZ
+axY
 dej
 aFC
 deC
@@ -120590,8 +120555,8 @@ bhT
 bpm
 bhT
 bhT
-bvm
-bxg
+bhT
+bxc
 bza
 bza
 bza
@@ -120805,9 +120770,9 @@ aaf
 ajb
 akc
 alt
-amL
+aka
 anQ
-apk
+aph
 aqw
 arR
 ath
@@ -120832,7 +120797,7 @@ dlI
 deD
 dfF
 aTN
-aVe
+axY
 aWH
 dgi
 dgc
@@ -121072,11 +121037,11 @@ ajb
 avB
 axY
 ddO
-bUw
+amJ
 ddT
-ddZ
-ded
-del
+apk
+aCZ
+aEr
 des
 djt
 daY
@@ -121089,7 +121054,7 @@ dfq
 djt
 dfG
 dfQ
-dfZ
+axY
 apc
 apc
 dgo
@@ -121329,10 +121294,10 @@ ajb
 avC
 axY
 aya
-bUw
+amL
 ddU
 aBQ
-dee
+aCZ
 aEr
 des
 bBW
@@ -121346,7 +121311,7 @@ daY
 bCs
 dfG
 cXz
-aVe
+axY
 atm
 alr
 dgp
@@ -121586,10 +121551,10 @@ dpL
 avD
 axY
 ddO
-bUw
+amL
 ddV
 aBQ
-dee
+aCZ
 aEr
 aKL
 djt
@@ -121619,7 +121584,7 @@ brN
 btG
 bvq
 bxm
-bxk
+brV
 bze
 bAN
 bCu
@@ -121860,7 +121825,7 @@ dlI
 deD
 dfI
 dfS
-aVh
+aCZ
 aaf
 aYx
 dgr
@@ -122100,10 +122065,10 @@ fHf
 avB
 axY
 axY
-bTq
-aAx
-aBO
-aIe
+axY
+axY
+aCZ
+axY
 aOS
 deu
 deI
@@ -122117,7 +122082,7 @@ dft
 dBB
 dbh
 dfT
-aVh
+aCZ
 aaa
 aYx
 dgf
@@ -122129,7 +122094,7 @@ aaa
 aaa
 aaa
 aaf
-bpw
+bpy
 aaf
 aaf
 ack
@@ -122386,7 +122351,7 @@ cUL
 aaa
 aaf
 aaf
-bpw
+bpy
 aaa
 aaf
 aaf
@@ -122617,21 +122582,21 @@ dqT
 aaf
 ack
 ack
-def
-aCZ
-dew
-aCZ
-axY
-axY
-aCZ
-aCZ
-aCZ
-axY
 axY
 aCZ
 dew
 aCZ
-aVe
+axY
+axY
+aCZ
+aCZ
+aCZ
+axY
+axY
+aCZ
+aCW
+aCZ
+axY
 dgf
 dgk
 dgt
@@ -122643,7 +122608,7 @@ aaf
 aaf
 aaf
 aaa
-bpw
+bpy
 aaa
 aaa
 aaf
@@ -122874,7 +122839,7 @@ dqT
 aaf
 aaf
 aaf
-def
+axY
 ddZ
 dex
 aJu
@@ -122886,9 +122851,9 @@ dff
 ddZ
 ddZ
 aJu
-dex
+aCX
 ddZ
-aVe
+axY
 aWK
 dgk
 dgt
@@ -123131,21 +123096,21 @@ dqT
 aaa
 aaa
 aaa
-bTq
+axY
 dep
-dey
+ayT
 aHa
+aAx
 ddZ
 ddZ
 ddZ
 ddZ
 ddZ
-ddZ
-ddZ
+aBO
 dfA
-dfM
+aFs
 dfV
-dgb
+axY
 dgg
 azd
 azd
@@ -123157,7 +123122,7 @@ aaa
 aaa
 aaf
 aaf
-bpx
+bpy
 aaf
 aaf
 aaf
@@ -123414,7 +123379,7 @@ aaa
 aaa
 aaf
 aaa
-bpw
+bpy
 aaa
 aaa
 aaf
@@ -123671,7 +123636,7 @@ aaa
 aaa
 aaf
 aaa
-bpw
+bpy
 aaa
 aaa
 aaf
@@ -123928,7 +123893,7 @@ aaa
 aaa
 aaf
 aaf
-bpx
+bpy
 aaf
 aaf
 aaf
@@ -124185,7 +124150,7 @@ aaf
 aaf
 aaf
 aaa
-bpw
+bpy
 aaa
 aaf
 aaa
@@ -124442,7 +124407,7 @@ aaa
 aaa
 aaf
 aaa
-bpw
+bpy
 aaa
 aaf
 aaf
@@ -124699,7 +124664,7 @@ aaa
 aaa
 aaf
 aaa
-bpw
+bpy
 aaa
 aaf
 aaa
@@ -124956,7 +124921,7 @@ aaa
 aaa
 aaf
 aaa
-bpw
+bpy
 aaa
 aaf
 aaf
@@ -125213,7 +125178,7 @@ aaa
 aaa
 aaf
 aaa
-bpw
+bpy
 aaa
 aaf
 aaa
@@ -125470,7 +125435,7 @@ aaa
 aaa
 aaf
 aaa
-bpw
+bpy
 aaa
 aaf
 aaf
@@ -125727,7 +125692,7 @@ aaa
 aaa
 aaf
 aaf
-bpx
+bpy
 aaf
 aaf
 aaa
@@ -125984,7 +125949,7 @@ aaa
 aaa
 aaf
 aaa
-bpw
+bpy
 aaa
 aaf
 aaf
@@ -126241,7 +126206,7 @@ aaa
 aaa
 aaf
 aaa
-bpw
+bpy
 aaa
 aaf
 aaa
@@ -126498,7 +126463,7 @@ aaa
 aaa
 aaf
 aaa
-bpw
+bpy
 aaa
 aaf
 aaa
@@ -126755,7 +126720,7 @@ aaa
 aaa
 aaf
 aaa
-bpw
+bpy
 aaa
 aaf
 aaa
@@ -127012,7 +126977,7 @@ aaa
 aaa
 aaf
 aaa
-bpw
+bpy
 aaa
 aaf
 aaa
@@ -127269,7 +127234,7 @@ aaa
 aaa
 aaf
 aaa
-bpw
+bpy
 aaa
 aaf
 aaa
@@ -127526,7 +127491,7 @@ aaa
 aaa
 aaf
 aaf
-bpx
+bpy
 aaf
 aaf
 aaa
@@ -130097,7 +130062,7 @@ aOX
 bly
 bnr
 bpE
-brR
+brT
 aOX
 aNw
 aNw
@@ -130873,20 +130838,20 @@ aOV
 aaa
 aMq
 bzm
-aOT
-aOT
-aOT
-aOT
-bMt
-bMt
+bjO
+bjO
+bjO
+bjO
+bxf
+bxf
 bNW
-bMt
-bMt
-bMt
-bMt
-aOT
-aOT
-bUK
+bxf
+bxf
+bxf
+bxf
+bjO
+bjO
+bzk
 bBb
 anT
 aaa
@@ -131125,7 +131090,7 @@ aRy
 aRy
 bnv
 bpI
-brV
+aRy
 aRy
 aaa
 bGh
@@ -131143,7 +131108,7 @@ aOY
 aOY
 aOY
 bcQ
-aNy
+bzl
 bgn
 anT
 aaa
@@ -131400,7 +131365,7 @@ aaa
 aaa
 aaa
 aMq
-aNy
+bzl
 bgn
 anT
 aaa
@@ -131657,7 +131622,7 @@ aaa
 aaa
 aaa
 aMq
-aNy
+bzl
 bgn
 anT
 aaa
@@ -131914,7 +131879,7 @@ aRy
 aaa
 aaa
 aMq
-bez
+bMp
 bBb
 anT
 anT
@@ -132153,7 +132118,7 @@ bjQ
 bjQ
 bnz
 bpM
-brZ
+bjQ
 btL
 bvu
 bxq
@@ -132171,7 +132136,7 @@ aRy
 aaa
 aaa
 aMq
-bez
+bMp
 bAT
 aNw
 aaa
@@ -132428,7 +132393,7 @@ aRy
 aRy
 aaa
 aMq
-chz
+bTq
 bpn
 cpO
 bgn
@@ -132685,7 +132650,7 @@ aRy
 aRy
 aaa
 aMq
-chz
+bTq
 cmK
 bpr
 bgn
@@ -132929,17 +132894,17 @@ btN
 bAX
 bxp
 bzq
-bAX
+bvm
 bCF
 bEi
 lWY
 bHE
 bKM
 bKO
-bMp
+bGd
 bNZ
-aRz
-aRz
+aRy
+aRy
 uVQ
 bTm
 chM
@@ -133695,7 +133660,7 @@ bjQ
 bjQ
 bnz
 bpS
-brZ
+bjQ
 btL
 bvA
 bxs

--- a/_maps/map_files/MetaStation/MetaStation_Lumos.dmm
+++ b/_maps/map_files/MetaStation/MetaStation_Lumos.dmm
@@ -2854,13 +2854,10 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "ali" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness/recreation)
 "alj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
@@ -3309,9 +3306,6 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "amD" = (
-/obj/structure/chair{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/airalarm{
 	dir = 8;
@@ -3322,7 +3316,7 @@
 "amE" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/light/small{
+/obj/machinery/light{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -12582,9 +12576,6 @@
 /area/hallway/primary/fore)
 "aII" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
-/obj/machinery/light/small{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "aIK" = (
@@ -20270,6 +20261,7 @@
 /obj/machinery/computer/holodeck{
 	dir = 4
 	},
+/obj/item/paper/fluff/holodeck/disclaimer,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "baj" = (
@@ -21535,7 +21527,16 @@
 /turf/closed/wall,
 /area/vacant_room/commissary)
 "bdc" = (
-/turf/open/floor/plating,
+/obj/structure/table/wood,
+/obj/item/paper_bin{
+	pixel_x = 2;
+	pixel_y = 4
+	},
+/obj/item/pen{
+	pixel_x = 2;
+	pixel_y = 4
+	},
+/turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "bdd" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -24048,11 +24049,8 @@
 	},
 /area/maintenance/port/fore)
 "biB" = (
-/obj/structure/table,
-/obj/item/paper/fluff/holodeck/disclaimer,
-/obj/item/storage/firstaid/regular{
-	pixel_x = 3;
-	pixel_y = -3
+/obj/structure/chair{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
@@ -67263,13 +67261,10 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "dht" = (
-/obj/machinery/camera{
-	c_tag = "Holodeck";
-	dir = 1
-	},
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = -28
+/obj/structure/table/wood,
+/obj/item/storage/firstaid/regular{
+	pixel_x = 3;
+	pixel_y = -3
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
@@ -68874,6 +68869,9 @@
 "dCi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg2"
 	},
@@ -69731,6 +69729,9 @@
 "erw" = (
 /obj/structure/chair{
 	dir = 1
+	},
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/fitness/recreation)
@@ -73129,6 +73130,17 @@
 /obj/effect/landmark/start/roboticist,
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
+"mjv" = (
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = -28
+	},
+/obj/machinery/camera{
+	c_tag = "Holodeck";
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness/recreation)
 "mjJ" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -73675,11 +73687,11 @@
 	},
 /area/library)
 "nAn" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "nAG" = (
@@ -74962,6 +74974,15 @@
 /obj/item/reagent_containers/glass/bucket,
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
+"qrm" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness/recreation)
 "qrQ" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -75839,7 +75860,6 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "sBD" = (
-/obj/machinery/light,
 /obj/structure/chair{
 	dir = 1
 	},
@@ -77010,6 +77030,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/starboard/aft)
+"vrS" = (
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "vsy" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -115882,7 +115909,7 @@ acP
 auq
 acP
 acP
-bdc
+acQ
 acP
 acP
 acQ
@@ -117425,15 +117452,15 @@ avo
 aaa
 aaa
 aaa
-alp
-alp
-alp
 acP
+acP
+acQ
+acQ
 aIB
 acQ
 acQ
 aIB
-acP
+acQ
 acP
 acP
 dnh
@@ -117683,17 +117710,17 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 alp
+bdc
+dht
 ahg
 bai
-biB
-dht
+ahg
+ahg
+mjv
 acP
 dnz
-dnR
-dnS
+vrS
 jQg
 axQ
 ayR
@@ -117940,9 +117967,9 @@ aaa
 aaa
 aaa
 akT
-akT
-lMJ
-alp
+azf
+biB
+qrm
 aII
 amC
 amD
@@ -118197,8 +118224,8 @@ aaf
 aaa
 aaa
 aaa
-lMJ
-aaa
+acP
+alp
 acP
 acP
 acP

--- a/_maps/map_files/MetaStation/MetaStation_Lumos.dmm
+++ b/_maps/map_files/MetaStation/MetaStation_Lumos.dmm
@@ -1840,7 +1840,7 @@
 /obj/item/instrument/recorder,
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/carpet,
-/area/maintenance/bar)
+/area/maintenance/fore)
 "ahx" = (
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
@@ -8193,8 +8193,8 @@
 /turf/closed/wall/r_wall,
 /area/lawoffice)
 "ayZ" = (
-/turf/open/floor/plating,
-/area/maintenance/bar)
+/turf/open/floor/wood,
+/area/maintenance/fore)
 "aza" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -8206,7 +8206,7 @@
 	pixel_y = 32
 	},
 /turf/open/floor/wood,
-/area/maintenance/bar)
+/area/maintenance/fore)
 "azd" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -10409,7 +10409,7 @@
 /obj/structure/closet/firecloset,
 /obj/item/tank/internals/oxygen/red,
 /turf/open/floor/plating,
-/area/maintenance/bar)
+/area/maintenance/fore)
 "aDX" = (
 /obj/machinery/power/apc{
 	areastring = "/area/maintenance/fore";
@@ -10421,7 +10421,7 @@
 	icon_state = "0-4"
 	},
 /turf/open/floor/plating,
-/area/maintenance/bar)
+/area/maintenance/fore)
 "aDY" = (
 /obj/machinery/light/small{
 	brightness = 3;
@@ -10742,7 +10742,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
-/area/maintenance/bar)
+/area/maintenance/fore)
 "aEI" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -10916,10 +10916,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"aFd" = (
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
-/area/maintenance/bar)
 "aFi" = (
 /turf/open/floor/carpet/orange,
 /area/crew_quarters/dorms)
@@ -26221,10 +26217,10 @@
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bnc" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -27225,20 +27221,11 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
-"bph" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/engine/break_room)
 "bpi" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bpj" = (
@@ -29210,9 +29197,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain/private)
-"bth" = (
-/turf/open/floor/wood,
-/area/maintenance/central)
 "bti" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -29934,7 +29918,7 @@
 	dir = 4
 	},
 /turf/open/floor/carpet/purple,
-/area/maintenance/central)
+/area/crew_quarters/heads/captain/private)
 "buL" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -30705,7 +30689,7 @@
 	dir = 9
 	},
 /turf/open/floor/carpet/purple,
-/area/maintenance/central)
+/area/crew_quarters/heads/captain/private)
 "bwH" = (
 /obj/item/radio/intercom{
 	dir = 8;
@@ -30717,7 +30701,7 @@
 	dir = 8
 	},
 /turf/open/floor/carpet/purple,
-/area/maintenance/central)
+/area/crew_quarters/heads/captain/private)
 "bwI" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -31364,7 +31348,7 @@
 	pixel_y = 5
 	},
 /turf/open/floor/carpet/purple,
-/area/maintenance/central)
+/area/crew_quarters/heads/captain/private)
 "byw" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
@@ -32205,7 +32189,7 @@
 	pixel_y = 5
 	},
 /turf/open/floor/carpet/purple,
-/area/maintenance/central)
+/area/crew_quarters/heads/captain/private)
 "bAi" = (
 /obj/machinery/light{
 	dir = 8
@@ -32867,9 +32851,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/crew_quarters/heads/captain/private)
-"bBO" = (
-/turf/closed/wall/r_wall,
-/area/maintenance/central)
 "bBP" = (
 /obj/structure/sign/directions/engineering{
 	dir = 4
@@ -32883,7 +32864,7 @@
 	pixel_y = -8
 	},
 /turf/closed/wall/r_wall,
-/area/maintenance/central)
+/area/crew_quarters/heads/captain/private)
 "bBR" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=12-Central-Starboard";
@@ -43847,7 +43828,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
-/area/maintenance/bar)
+/area/maintenance/fore)
 "caG" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -69893,7 +69874,7 @@
 /area/library)
 "ePc" = (
 /turf/open/floor/carpet,
-/area/maintenance/bar)
+/area/maintenance/fore)
 "eQc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -69984,7 +69965,7 @@
 	light_color = "#ffc1c1"
 	},
 /turf/open/floor/carpet,
-/area/maintenance/bar)
+/area/maintenance/fore)
 "eYw" = (
 /obj/structure/table/wood,
 /obj/item/folder/blue,
@@ -72711,13 +72692,13 @@
 /obj/item/instrument/guitar,
 /obj/item/instrument/eguitar,
 /turf/open/floor/carpet,
-/area/maintenance/bar)
+/area/maintenance/fore)
 "lgs" = (
 /obj/structure/musician/piano{
 	icon_state = "piano"
 	},
 /turf/open/floor/wood,
-/area/maintenance/bar)
+/area/maintenance/fore)
 "lgC" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
@@ -78063,6 +78044,9 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
@@ -109551,12 +109535,12 @@ bkP
 bcj
 boI
 dmD
-bth
+dCP
 buK
 bwH
 byu
 bAh
-bBO
+bcj
 bDx
 dHR
 bGT
@@ -109772,9 +109756,9 @@ arW
 aiQ
 aiQ
 aiQ
-ayZ
+aje
 caF
-aiQ
+agq
 aDW
 aCE
 aDY
@@ -109808,11 +109792,11 @@ bcj
 bcj
 bjg
 bcj
-bBO
-bBO
-bBO
-bBO
-bBO
+bcj
+bcj
+bcj
+bcj
+bcj
 bBP
 bDy
 bED
@@ -110031,8 +110015,8 @@ ala
 aiQ
 ayK
 caI
-aiQ
-aiQ
+agq
+agq
 agq
 agq
 agq
@@ -110288,7 +110272,7 @@ hRE
 aiQ
 ayL
 aDq
-aiQ
+agq
 aDX
 aCF
 bLj
@@ -110802,8 +110786,8 @@ ala
 aiQ
 aiQ
 aiQ
-aiQ
-aiQ
+agq
+agq
 aDQ
 aje
 aUM
@@ -111060,7 +111044,7 @@ aiQ
 ahw
 lfK
 lgs
-aFd
+btV
 aGl
 aje
 aUM
@@ -111316,7 +111300,7 @@ ala
 avl
 eYv
 ePc
-ala
+ayZ
 qLR
 aDQ
 azX
@@ -111572,8 +111556,8 @@ ary
 ala
 aiQ
 azb
-ala
-ala
+ayZ
+ayZ
 btV
 aoP
 und
@@ -111828,9 +111812,9 @@ fpY
 bXy
 aiQ
 aiQ
-aiQ
-aiQ
-aiQ
+agq
+agq
+agq
 agq
 aIO
 agq
@@ -118801,7 +118785,7 @@ bhX
 bWd
 cik
 bnc
-bph
+bpg
 brD
 bep
 bvg

--- a/_maps/map_files/MetaStation/MetaStation_Lumos.dmm
+++ b/_maps/map_files/MetaStation/MetaStation_Lumos.dmm
@@ -217,14 +217,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"aaU" = (
-/obj/effect/turf_decal/lumos/tile/yellow/half{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark/side{
-	dir = 4
-	},
-/area/security/prison)
 "aaV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -653,6 +645,10 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/delivery,
+/obj/machinery/door/poddoor/preopen{
+	id = "Prison Gate";
+	name = "Security Blast Door"
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "abY" = (
@@ -708,12 +704,12 @@
 /area/security/prison)
 "acd" = (
 /obj/machinery/suit_storage_unit/security,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /obj/effect/turf_decal/lumos/tile/red/fulltile,
 /obj/machinery/light/small{
 	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)
@@ -1990,9 +1986,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/effect/turf_decal/delivery/red,
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/flasher/portable,
 /turf/open/floor/plasteel/dark/side{
 	dir = 10
 	},
@@ -3077,6 +3071,7 @@
 	},
 /obj/item/bikehorn/rubberducky,
 /obj/effect/turf_decal/lumos/shower,
+/obj/machinery/light/small,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/prison)
 "alM" = (
@@ -3822,7 +3817,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/showroomfloor,
-/area/maintenance/port)
+/area/crew_quarters/toilet/auxiliary)
 "aoe" = (
 /obj/structure/closet/firecloset,
 /obj/item/reagent_containers/hypospray/medipen/firelocker,
@@ -4751,10 +4746,10 @@
 /turf/open/space,
 /area/space/nearstation)
 "aqC" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/lumos/tile/red/checker{
 	dir = 4
 	},
-/obj/effect/turf_decal/lumos/tile/red/checker{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -5064,7 +5059,9 @@
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
+	},
 /area/security/prison)
 "arv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -5594,12 +5591,8 @@
 /turf/open/floor/plating,
 /area/security/brig)
 "asK" = (
-/obj/effect/turf_decal/lumos/tile/yellow/half{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark/side{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/yellow/fulltile,
+/turf/open/floor/plasteel,
 /area/security/prison)
 "asL" = (
 /obj/effect/turf_decal/lumos/tile/yellow/fulltile,
@@ -5620,13 +5613,9 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "asO" = (
-/obj/effect/turf_decal/lumos/tile/yellow/half{
-	dir = 8
-	},
 /obj/structure/closet/secure_closet/brig,
-/turf/open/floor/plasteel/dark/side{
-	dir = 4
-	},
+/obj/effect/turf_decal/lumos/tile/yellow/fulltile,
+/turf/open/floor/plasteel,
 /area/security/prison)
 "asP" = (
 /obj/machinery/door/poddoor/shutters/window{
@@ -5790,6 +5779,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/security/glass{
+	desc = "The red door means be scared that you're here. Unless you're the person in red.";
+	name = "Armoury Primary Entrance";
+	req_access_txt = "63"
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)
@@ -6056,7 +6050,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
+	},
 /area/security/prison)
 "atI" = (
 /obj/structure/disposalpipe/segment{
@@ -6070,6 +6066,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "1-8"
+	},
+/obj/machinery/light/small{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
@@ -6098,12 +6097,8 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/lumos/tile/yellow/half{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark/side{
-	dir = 8
-	},
+/obj/effect/turf_decal/lumos/tile/yellow/fulltile,
+/turf/open/floor/plasteel,
 /area/security/prison)
 "atL" = (
 /obj/effect/turf_decal/lumos/tile/neutral/fulltile,
@@ -6329,9 +6324,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark/corner{
-	dir = 4
-	},
+/turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "auh" = (
 /obj/effect/turf_decal/stripes/corner{
@@ -6592,10 +6585,7 @@
 /turf/open/floor/plasteel/dark,
 /area/security/execution/education)
 "auQ" = (
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = -30
-	},
+/obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "auR" = (
@@ -7582,6 +7572,10 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
+/obj/machinery/door/poddoor/preopen{
+	id = "Prison Gate";
+	name = "Security Blast Door"
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "axq" = (
@@ -7722,9 +7716,6 @@
 /obj/item/paper,
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
-"axL" = (
-/turf/closed/wall,
-/area/holodeck/rec_center)
 "axM" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -8100,6 +8091,9 @@
 "ayO" = (
 /obj/structure/bed,
 /obj/effect/spawner/lootdrop/bedsheet,
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
 "ayP" = (
@@ -8193,8 +8187,13 @@
 /turf/closed/wall/r_wall,
 /area/lawoffice)
 "ayZ" = (
-/turf/open/floor/wood,
-/area/maintenance/fore)
+/obj/effect/turf_decal/delivery/red,
+/obj/machinery/flasher/portable,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/ai_monitored/security/armory)
 "aza" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -8220,10 +8219,10 @@
 /turf/open/floor/wood,
 /area/library)
 "azf" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/firedoor,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/holodeck/rec_center)
+/area/crew_quarters/fitness/recreation)
 "azg" = (
 /obj/item/stack/cable_coil,
 /turf/open/floor/plating/airless,
@@ -8250,6 +8249,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel/dark/side,
 /area/security/brig)
 "azj" = (
@@ -8371,6 +8371,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/dark/side,
 /area/security/brig)
 "azr" = (
@@ -8416,6 +8417,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
 "azy" = (
@@ -8433,8 +8437,8 @@
 	id = "innerbrig";
 	name = "Brig Interior Bolt Control";
 	normaldoorcontrol = 1;
-	pixel_x = -9;
-	pixel_y = 20;
+	pixel_x = 8;
+	pixel_y = 24;
 	req_access_txt = "1";
 	specialfunctions = 4
 	},
@@ -8451,6 +8455,9 @@
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark/side,
@@ -9108,9 +9115,7 @@
 /obj/effect/turf_decal/lumos/tile/yellow/fullcorner{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark/side{
-	dir = 5
-	},
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "aAZ" = (
 /obj/machinery/holopad,
@@ -9145,9 +9150,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/dark/side{
-	dir = 9
-	},
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "aBe" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
@@ -9157,7 +9160,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "aBf" = (
 /obj/structure/closet/secure_closet/brig{
@@ -9170,9 +9173,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/dark/side{
-	dir = 5
-	},
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "aBg" = (
 /obj/effect/turf_decal/lumos/tile/red/checker{
@@ -9189,7 +9190,8 @@
 	name = "Interrogation Lock";
 	pixel_x = 7;
 	pixel_y = 24;
-	req_access_txt = "63"
+	req_access_txt = "63";
+	specialfunctions = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -9642,7 +9644,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "aCk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
@@ -9657,7 +9659,7 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "aCl" = (
 /obj/structure/bed,
@@ -9668,7 +9670,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "aCm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -9736,7 +9738,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "aCt" = (
 /obj/structure/bed,
@@ -9744,7 +9746,7 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "aCv" = (
 /turf/open/floor/plasteel/dark/corner,
@@ -10195,9 +10197,7 @@
 /obj/effect/turf_decal/lumos/tile/yellow/fullcorner{
 	dir = 1
 	},
-/turf/open/floor/plasteel/dark/side{
-	dir = 10
-	},
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "aDw" = (
 /obj/effect/turf_decal/tile/red{
@@ -10214,21 +10214,17 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "aDy" = (
 /obj/effect/turf_decal/lumos/tile/yellow/fullcorner,
-/turf/open/floor/plasteel/dark/side{
-	dir = 6
-	},
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "aDz" = (
 /obj/effect/turf_decal/lumos/tile/blue/fullcorner{
 	dir = 1
 	},
-/turf/open/floor/plasteel/dark/side{
-	dir = 10
-	},
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "aDA" = (
 /obj/effect/turf_decal/lumos/tile/green/half{
@@ -10348,17 +10344,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/brig)
-"aDP" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark/side{
-	dir = 8
-	},
-/area/security/prison)
 "aDQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -10457,6 +10442,11 @@
 "aEc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
+	},
+/obj/effect/turf_decal/delivery/red,
+/obj/machinery/flasher/portable,
+/obj/structure/window/reinforced{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
@@ -10649,6 +10639,9 @@
 /obj/machinery/light_switch{
 	pixel_y = 28
 	},
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
 "aEu" = (
@@ -10705,6 +10698,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
 "aEB" = (
@@ -10728,6 +10724,9 @@
 "aEE" = (
 /obj/effect/landmark/blobstart,
 /obj/structure/light_construct/small{
+	dir = 4
+	},
+/obj/machinery/light{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -10848,6 +10847,12 @@
 /obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 1
 	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aEU" = (
@@ -10916,6 +10921,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"aFd" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/lumos/tile/red/checker{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/chair/office/dark{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "aFi" = (
 /turf/open/floor/carpet/orange,
 /area/crew_quarters/dorms)
@@ -10927,6 +10945,9 @@
 /area/crew_quarters/dorms)
 "aFl" = (
 /obj/effect/turf_decal/lumos/tile/red/half{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -11574,6 +11595,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aGH" = (
@@ -11624,7 +11648,7 @@
 "aGN" = (
 /obj/item/soap/nanotrasen,
 /turf/open/floor/plasteel/showroomfloor,
-/area/maintenance/port)
+/area/crew_quarters/toilet/auxiliary)
 "aGO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/item/cigbutt,
@@ -12578,7 +12602,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "aIO" = (
 /obj/machinery/door/airlock/maintenance{
@@ -13571,7 +13595,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/dark/corner,
+/turf/open/floor/plasteel,
 /area/security/main)
 "aLD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -13622,6 +13646,10 @@
 "aLI" = (
 /obj/effect/turf_decal/caution/stand_clear,
 /obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark/side,
@@ -14014,12 +14042,6 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching Prison Wing holding areas.";
-	name = "Prison Monitor";
-	network = list("prison");
-	pixel_y = 30
-	},
 /turf/open/floor/carpet,
 /area/lawoffice)
 "aMM" = (
@@ -14135,7 +14157,6 @@
 /obj/structure/chair{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel/dark/side{
 	dir = 8
 	},
@@ -14351,11 +14372,11 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "aNG" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4
-	},
 /obj/structure/sign/poster/official/high_class_martini{
 	pixel_x = -32
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
@@ -15835,7 +15856,7 @@
 "aQM" = (
 /obj/machinery/power/apc{
 	areastring = "/area/janitor";
-	dir = 8;
+	dir = 1;
 	name = "Custodial Closet APC";
 	pixel_y = 22
 	},
@@ -16392,6 +16413,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/light,
 /turf/open/floor/plasteel/dark,
 /area/security/detectives_office)
 "aSd" = (
@@ -21475,7 +21497,6 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/effect/turf_decal/delivery/red,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/dark/side,
 /area/ai_monitored/security/armory)
@@ -21498,10 +21519,8 @@
 /turf/closed/wall,
 /area/vacant_room/commissary)
 "bdc" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
-/area/security/checkpoint/customs)
+/area/crew_quarters/fitness/recreation)
 "bdd" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -22231,7 +22250,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/obj/effect/turf_decal/delivery/red,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/dark/side,
 /area/ai_monitored/security/armory)
@@ -22264,7 +22282,7 @@
 	pixel_y = 28
 	},
 /turf/open/floor/plating,
-/area/security/checkpoint/customs)
+/area/maintenance/port/fore)
 "beR" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/flasher/portable,
@@ -22956,7 +22974,7 @@
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
-/area/security/checkpoint/customs)
+/area/maintenance/port/fore)
 "bgB" = (
 /obj/structure/toilet{
 	dir = 4
@@ -24002,13 +24020,16 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "biy" = (
-/turf/open/floor/plating,
-/area/security/checkpoint/customs)
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness/recreation)
 "biz" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
-/area/security/checkpoint/customs)
+/area/maintenance/port/fore)
 "biB" = (
 /obj/structure/table,
 /obj/item/paper/fluff/holodeck/disclaimer,
@@ -24692,8 +24713,12 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "bjY" = (
-/turf/open/floor/plating,
-/area/hallway/primary/port)
+/obj/effect/turf_decal/lumos/tile/red/half{
+	dir = 1
+	},
+/obj/structure/table,
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "bka" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
@@ -24731,15 +24756,15 @@
 /turf/open/space/basic,
 /area/space)
 "bke" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/hallway/primary/port)
+/obj/machinery/light,
+/turf/open/floor/wood,
+/area/maintenance/bar)
 "bkf" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 30
 	},
 /turf/open/floor/plating,
-/area/hallway/primary/port)
+/area/quartermaster/sorting)
 "bkg" = (
 /obj/machinery/conveyor{
 	dir = 1;
@@ -25645,9 +25670,8 @@
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/entry)
 "blU" = (
-/obj/structure/sign/warning/pods,
-/turf/closed/wall,
-/area/hallway/primary/port)
+/turf/open/floor/wood,
+/area/maintenance/fore)
 "blY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -25655,13 +25679,13 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /obj/effect/turf_decal/lumos/tile/red/checker{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -25673,7 +25697,7 @@
 	id = "rundown_room"
 	},
 /turf/open/floor/plating,
-/area/hallway/primary/port)
+/area/maintenance/port/fore)
 "bmb" = (
 /obj/machinery/door/airlock/security/glass{
 	desc = "The red door means be scared that you're here. Unless you're the person in red.";
@@ -26602,17 +26626,14 @@
 	},
 /area/security/prison)
 "bnP" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
+/obj/machinery/computer/security/telescreen{
+	desc = "Used for watching Prison Wing holding areas.";
+	name = "Prison Monitor";
+	network = list("prison");
+	pixel_y = 30
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/customs)
+/turf/open/floor/carpet,
+/area/lawoffice)
 "bnR" = (
 /obj/machinery/door/airlock/security/glass{
 	desc = "The red door means be scared that you're here. Unless you're the person in red.";
@@ -27179,13 +27200,13 @@
 /area/maintenance/starboard)
 "bpc" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "bpd" = (
@@ -27221,6 +27242,12 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
+"bph" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "bpi" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -27710,7 +27737,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
-/area/security/checkpoint/customs)
+/area/hallway/primary/port)
 "bqg" = (
 /obj/machinery/computer/card,
 /obj/machinery/requests_console{
@@ -28122,6 +28149,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/structure/table,
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "bqR" = (
@@ -28350,9 +28378,6 @@
 /area/hallway/primary/starboard)
 "brt" = (
 /obj/item/storage/box/lights/mixed,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 8
 	},
@@ -29197,6 +29222,17 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain/private)
+"bth" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "bti" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -30425,9 +30461,7 @@
 /obj/effect/turf_decal/lumos/tile/yellow/fullcorner{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark/side{
-	dir = 9
-	},
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "bvW" = (
 /turf/closed/wall,
@@ -31418,7 +31452,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
-/area/crew_quarters/toilet/auxiliary)
+/area/hallway/primary/port)
 "byH" = (
 /obj/structure/chair/sofa/corp/left{
 	dir = 8
@@ -32222,7 +32256,7 @@
 	map_pad_link_id = "tostation"
 	},
 /turf/open/floor/plating,
-/area/crew_quarters/toilet/auxiliary)
+/area/hallway/primary/port)
 "bAo" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/bar,
@@ -32259,9 +32293,6 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "bAu" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -32272,6 +32303,9 @@
 /obj/effect/landmark/start/assistant,
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
@@ -32646,7 +32680,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/crew_quarters/toilet/auxiliary)
+/area/hallway/primary/port)
 "bBn" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -32851,6 +32885,11 @@
 	},
 /turf/closed/wall/r_wall,
 /area/crew_quarters/heads/captain/private)
+"bBO" = (
+/obj/structure/table/wood/poker,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "bBP" = (
 /obj/structure/sign/directions/engineering{
 	dir = 4
@@ -33535,7 +33574,6 @@
 	c_tag = "Bar - Seating Area";
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "bDA" = (
@@ -33611,6 +33649,7 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/assistant,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "bDL" = (
@@ -33832,7 +33871,7 @@
 	dir = 4
 	},
 /turf/open/floor/wood,
-/area/security/vacantoffice)
+/area/crew_quarters/theatre)
 "bEp" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -34198,11 +34237,11 @@
 /obj/structure/disposalpipe/junction/flip{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
@@ -34222,18 +34261,12 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/bar)
 "bFy" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
+/turf/closed/wall,
+/area/crew_quarters/theatre)
 "bFz" = (
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = 24
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
@@ -34624,7 +34657,7 @@
 	dir = 1
 	},
 /turf/open/floor/wood,
-/area/security/vacantoffice)
+/area/crew_quarters/theatre)
 "bGv" = (
 /obj/structure/bookcase/random/religion,
 /turf/open/floor/wood,
@@ -34730,6 +34763,9 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/gateway)
 "bGP" = (
@@ -35064,7 +35100,7 @@
 	dir = 10
 	},
 /turf/open/floor/wood,
-/area/security/vacantoffice)
+/area/crew_quarters/theatre)
 "bHK" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
@@ -35080,7 +35116,7 @@
 /obj/item/lipstick/random,
 /obj/item/lipstick/random,
 /turf/open/floor/wood,
-/area/security/vacantoffice)
+/area/crew_quarters/theatre)
 "bHM" = (
 /obj/structure/table/wood,
 /turf/open/floor/wood,
@@ -35090,6 +35126,7 @@
 /obj/structure/chair/comfy/brown{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "bHP" = (
@@ -35697,7 +35734,7 @@
 "bJj" = (
 /obj/structure/closet/secure_closet/freezer/cream_pie,
 /turf/open/floor/wood,
-/area/security/vacantoffice)
+/area/crew_quarters/theatre)
 "bJk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
@@ -35745,7 +35782,7 @@
 	dir = 8
 	},
 /turf/open/floor/wood,
-/area/security/vacantoffice)
+/area/crew_quarters/theatre)
 "bJr" = (
 /turf/open/floor/plating,
 /area/maintenance/aft)
@@ -36059,11 +36096,14 @@
 	},
 /area/crew_quarters/kitchen)
 "bKk" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/command)
 "bKl" = (
 /obj/structure/closet/secure_closet/freezer/kitchen,
 /turf/open/floor/plasteel/showroomfloor,
@@ -36348,7 +36388,7 @@
 	pixel_x = -32
 	},
 /turf/open/floor/wood,
-/area/security/vacantoffice)
+/area/crew_quarters/theatre)
 "bKY" = (
 /obj/machinery/power/apc{
 	areastring = "/area/security/vacantoffice";
@@ -37882,7 +37922,7 @@
 "bOw" = (
 /obj/machinery/power/apc{
 	areastring = "/area/crew_quarters/heads/captain/private";
-	dir = 8;
+	dir = 4;
 	name = "Captain's Quarters APC";
 	pixel_x = 28
 	},
@@ -38337,6 +38377,11 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
 	},
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_x = 29;
+	pixel_y = -8
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "bPD" = (
@@ -38402,7 +38447,7 @@
 	},
 /obj/effect/turf_decal/lumos/shower,
 /turf/open/floor/plasteel/showroomfloor,
-/area/maintenance/port)
+/area/crew_quarters/toilet/auxiliary)
 "bPK" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
@@ -42341,9 +42386,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
 	},
-/turf/open/floor/plasteel/white/side{
-	dir = 9
-	},
+/turf/open/floor/plasteel/white,
 /area/science/research)
 "bXY" = (
 /obj/structure/disposalpipe/segment,
@@ -42472,9 +42515,8 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
 	},
-/turf/open/floor/plasteel/white/side{
-	dir = 5
-	},
+/obj/effect/turf_decal/lumos/tile/purple/half,
+/turf/open/floor/plasteel/white,
 /area/science/research)
 "bYj" = (
 /obj/machinery/holopad,
@@ -44652,11 +44694,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
@@ -44743,7 +44785,7 @@
 /obj/machinery/recharge_station,
 /obj/effect/landmark/start/cyborg,
 /turf/open/floor/circuit,
-/area/science/robotics/lab)
+/area/science/robotics/mechbay)
 "ccl" = (
 /obj/item/screwdriver{
 	pixel_y = 10
@@ -45682,7 +45724,7 @@
 	pixel_y = 32
 	},
 /turf/open/floor/wood,
-/area/security/vacantoffice)
+/area/crew_quarters/theatre)
 "cem" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Entertainer Closet";
@@ -45692,13 +45734,13 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/security/vacantoffice)
+/area/crew_quarters/theatre)
 "cen" = (
 /obj/structure/chair/wood/wings{
 	dir = 4
 	},
 /turf/open/floor/wood,
-/area/security/vacantoffice)
+/area/crew_quarters/theatre)
 "ceo" = (
 /obj/item/toy/dummy,
 /obj/item/toy/prize/honk{
@@ -45707,7 +45749,7 @@
 /obj/structure/table/wood,
 /obj/structure/table/wood,
 /turf/open/floor/wood,
-/area/security/vacantoffice)
+/area/crew_quarters/theatre)
 "cep" = (
 /obj/structure/rack,
 /obj/item/screwdriver{
@@ -47492,7 +47534,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "chs" = (
-/turf/open/space/basic,
+/turf/open/floor/wood,
 /area/crew_quarters/theatre)
 "cht" = (
 /obj/machinery/portable_atmospherics/canister/air,
@@ -47527,8 +47569,20 @@
 /turf/open/floor/engine,
 /area/science/explab)
 "chy" = (
-/turf/open/space/basic,
-/area/maintenance/starboard)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "chz" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -47867,6 +47921,9 @@
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -49831,14 +49888,14 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
@@ -50503,7 +50560,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/white/side,
+/turf/open/floor/plasteel/white,
 /area/science/research)
 "cnR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -52105,7 +52162,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/circuit,
-/area/science/robotics/lab)
+/area/science/robotics/mechbay)
 "cqI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -52134,6 +52191,9 @@
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -24
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
@@ -52249,7 +52309,7 @@
 	},
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
-/area/science/robotics/lab)
+/area/science/robotics/mechbay)
 "cqZ" = (
 /obj/effect/spawner/blocker,
 /turf/open/floor/plating,
@@ -52265,7 +52325,7 @@
 	dir = 4
 	},
 /turf/open/floor/circuit,
-/area/science/robotics/lab)
+/area/science/robotics/mechbay)
 "crb" = (
 /obj/structure/bed,
 /obj/effect/decal/cleanable/blood/old,
@@ -52685,9 +52745,7 @@
 "crW" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/white/side{
-	dir = 5
-	},
+/turf/open/floor/plasteel/white,
 /area/science/research)
 "crX" = (
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -53269,9 +53327,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/turf/open/floor/plasteel/white/side{
-	dir = 9
+/obj/effect/turf_decal/lumos/tile/purple/half{
+	dir = 4
 	},
+/turf/open/floor/plasteel/white,
 /area/science/research)
 "cte" = (
 /obj/structure/flora/ausbushes/pointybush{
@@ -53636,9 +53695,7 @@
 /obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white/side{
-	dir = 4
-	},
+/turf/open/floor/plasteel/white,
 /area/science/research)
 "ctS" = (
 /obj/structure/disposalpipe/segment,
@@ -53989,7 +54046,7 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
-/area/science/robotics/mechbay)
+/area/science/robotics/lab)
 "cuG" = (
 /obj/machinery/requests_console{
 	department = "Robotics";
@@ -54001,7 +54058,7 @@
 /obj/machinery/mecha_part_fabricator,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
-/area/science/robotics/mechbay)
+/area/science/robotics/lab)
 "cuH" = (
 /obj/machinery/posialert{
 	pixel_y = 28
@@ -54009,7 +54066,7 @@
 /obj/machinery/autolathe,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
-/area/science/robotics/mechbay)
+/area/science/robotics/lab)
 "cuI" = (
 /obj/machinery/rnd/server,
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
@@ -54024,6 +54081,9 @@
 /turf/open/floor/plating,
 /area/space)
 "cuK" = (
+/obj/structure/chair/office/light{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/science/server)
 "cuL" = (
@@ -54032,7 +54092,7 @@
 	pixel_y = -28
 	},
 /obj/machinery/computer/rdservercontrol{
-	dir = 1
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/server)
@@ -54040,17 +54100,13 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/camera{
-	c_tag = "Research Division Hallway - Server Room";
-	dir = 4;
-	network = list("ss13","rd")
-	},
 /obj/structure/disposalpipe/junction{
 	dir = 1
 	},
-/turf/open/floor/plasteel/white/side{
-	dir = 5
+/obj/machinery/light{
+	dir = 8
 	},
+/turf/open/floor/plasteel/white,
 /area/science/research)
 "cuO" = (
 /obj/structure/disposalpipe/segment,
@@ -54064,9 +54120,10 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "cuP" = (
-/turf/open/floor/plasteel/white/side{
-	dir = 10
+/obj/effect/turf_decal/lumos/tile/purple/half{
+	dir = 4
 	},
+/turf/open/floor/plasteel/white,
 /area/science/research)
 "cuQ" = (
 /obj/structure/chair/office/light{
@@ -54482,7 +54539,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/science/robotics/mechbay)
+/area/science/robotics/lab)
 "cvR" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "Prison Gate";
@@ -54511,9 +54568,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/turf/open/floor/plasteel/white/side{
-	dir = 1
-	},
+/turf/open/floor/plasteel/white,
 /area/science/research)
 "cvT" = (
 /obj/structure/disposalpipe/segment{
@@ -54783,13 +54838,13 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/science/robotics/mechbay)
+/area/science/robotics/lab)
 "cwJ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/white,
-/area/science/robotics/mechbay)
+/area/science/circuit)
 "cwK" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -54845,7 +54900,10 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
 /area/science/research)
 "cwT" = (
 /obj/machinery/power/apc/highcap/five_k{
@@ -55173,21 +55231,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"cxC" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "robotics_shutters";
-	name = "robotics shutters"
-	},
-/turf/open/floor/plating,
-/area/science/robotics/mechbay)
 "cxD" = (
 /obj/structure/chair/office/light{
 	dir = 8
 	},
 /obj/effect/landmark/start/roboticist,
 /turf/open/floor/plasteel/dark,
-/area/science/robotics/mechbay)
+/area/science/robotics/lab)
 "cxE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/stripes/line{
@@ -55195,12 +55245,13 @@
 	},
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/dark,
-/area/science/robotics/mechbay)
+/area/science/robotics/lab)
 "cxF" = (
-/obj/effect/turf_decal/box,
-/obj/effect/landmark/start/cyborg,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
 /turf/open/floor/plasteel/white,
-/area/science/robotics/mechbay)
+/area/science/circuit)
 "cxI" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -55216,7 +55267,6 @@
 /turf/open/floor/engine,
 /area/science/storage)
 "cxK" = (
-/obj/structure/chair/office/light,
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
@@ -55487,7 +55537,7 @@
 	pixel_y = 31
 	},
 /turf/open/floor/mech_bay_recharge_floor,
-/area/science/robotics/lab)
+/area/science/robotics/mechbay)
 "cyq" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -55502,7 +55552,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/dark,
-/area/science/robotics/mechbay)
+/area/science/robotics/lab)
 "cyr" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -55515,10 +55565,11 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/science/robotics/mechbay)
+/area/science/robotics/lab)
 "cys" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel/white,
-/area/science/robotics/mechbay)
+/area/science/robotics/lab)
 "cyu" = (
 /obj/structure/table/reinforced,
 /obj/item/transfer_valve{
@@ -55567,9 +55618,12 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white/side{
-	dir = 6
+/obj/machinery/camera{
+	c_tag = "Research Division Hallway - Server Room";
+	dir = 4;
+	network = list("ss13","rd")
 	},
+/turf/open/floor/plasteel/white,
 /area/science/research)
 "cyz" = (
 /obj/machinery/light/small{
@@ -55841,7 +55895,7 @@
 	pixel_y = 12
 	},
 /turf/open/floor/plasteel/dark,
-/area/science/robotics/mechbay)
+/area/science/robotics/lab)
 "czj" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -55852,11 +55906,14 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
-/area/science/robotics/mechbay)
+/area/science/robotics/lab)
 "czk" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_x = 29
+	},
 /turf/open/floor/plasteel/white,
-/area/science/robotics/mechbay)
+/area/science/research)
 "czl" = (
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
@@ -55885,7 +55942,7 @@
 	dir = 4
 	},
 /turf/open/floor/circuit,
-/area/science/robotics/lab)
+/area/science/robotics/mechbay)
 "czn" = (
 /obj/machinery/light{
 	dir = 4
@@ -55941,7 +55998,7 @@
 /area/science/research)
 "czv" = (
 /obj/effect/turf_decal/tile/purple,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/white,
 /area/science/research)
 "czx" = (
 /obj/structure/closet/l3closet/scientist{
@@ -56045,9 +56102,10 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/white/side{
-	dir = 1
+/obj/effect/turf_decal/lumos/tile/purple/half{
+	dir = 4
 	},
+/turf/open/floor/plasteel/white,
 /area/science/research)
 "czJ" = (
 /turf/closed/wall,
@@ -56332,7 +56390,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/dark,
-/area/science/robotics/mechbay)
+/area/science/robotics/lab)
 "cAo" = (
 /obj/machinery/power/apc{
 	areastring = "/area/science/robotics/lab";
@@ -56358,7 +56416,7 @@
 /obj/item/healthanalyzer,
 /obj/item/healthanalyzer,
 /turf/open/floor/plasteel/dark,
-/area/science/robotics/mechbay)
+/area/science/robotics/lab)
 "cAp" = (
 /obj/machinery/vending/wardrobe/robo_wardrobe,
 /turf/open/floor/plasteel/dark,
@@ -56425,7 +56483,9 @@
 /area/science/storage)
 "cAy" = (
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
 /area/science/research)
 "cAz" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
@@ -56437,7 +56497,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/white,
 /area/science/research)
 "cAA" = (
 /obj/machinery/door/firedoor,
@@ -56809,7 +56869,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white/side,
+/turf/open/floor/plasteel/white,
 /area/science/research)
 "cBv" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -57171,7 +57231,7 @@
 	icon_state = "0-2"
 	},
 /turf/open/floor/plating,
-/area/science/robotics/lab)
+/area/science/robotics/mechbay)
 "cCo" = (
 /obj/effect/turf_decal/lumos/tile/purple/checker,
 /obj/structure/table,
@@ -57182,7 +57242,7 @@
 	pixel_y = -11
 	},
 /turf/open/floor/plasteel,
-/area/science/robotics/lab)
+/area/science/robotics/mechbay)
 "cCp" = (
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
@@ -57233,7 +57293,7 @@
 	pixel_y = 24
 	},
 /turf/open/floor/plasteel/dark,
-/area/science/robotics/mechbay)
+/area/science/robotics/lab)
 "cCw" = (
 /obj/structure/sign/warning/biohazard,
 /turf/closed/wall,
@@ -57475,7 +57535,7 @@
 /obj/structure/table,
 /obj/item/crowbar/large,
 /turf/open/floor/plasteel,
-/area/science/robotics/lab)
+/area/science/robotics/mechbay)
 "cDc" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -57486,7 +57546,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
-/area/science/robotics/lab)
+/area/science/robotics/mechbay)
 "cDd" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xeno_blastdoor";
@@ -58052,7 +58112,7 @@
 /area/science/xenobiology)
 "cEj" = (
 /turf/closed/wall,
-/area/science/robotics/lab)
+/area/science/robotics/mechbay)
 "cEl" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 8
@@ -58064,7 +58124,7 @@
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel,
-/area/science/robotics/lab)
+/area/science/robotics/mechbay)
 "cEn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -58079,7 +58139,7 @@
 	icon_state = "2-4"
 	},
 /turf/open/floor/circuit,
-/area/science/robotics/lab)
+/area/science/robotics/mechbay)
 "cEo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -58097,7 +58157,7 @@
 	icon_state = "1-4"
 	},
 /turf/open/floor/circuit,
-/area/science/robotics/lab)
+/area/science/robotics/mechbay)
 "cEp" = (
 /obj/item/radio/intercom{
 	pixel_y = -30
@@ -58139,7 +58199,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/white,
 /area/science/research)
 "cEt" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
@@ -58439,18 +58499,15 @@
 	pixel_y = 23;
 	req_one_access_txt = "29"
 	},
-/obj/effect/turf_decal/lumos/tile/purple/half{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "cFf" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel,
-/area/science/robotics/lab)
+/area/science/robotics/mechbay)
 "cFg" = (
 /turf/open/floor/circuit,
-/area/science/robotics/lab)
+/area/science/robotics/mechbay)
 "cFh" = (
 /obj/machinery/firealarm{
 	pixel_y = 26
@@ -58469,7 +58526,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plasteel,
-/area/science/robotics/lab)
+/area/science/robotics/mechbay)
 "cFk" = (
 /obj/structure/table/reinforced,
 /obj/item/stack/sheet/glass/fifty{
@@ -58872,7 +58929,7 @@
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/dark,
-/area/science/robotics/lab)
+/area/science/robotics/mechbay)
 "cGg" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -61296,7 +61353,7 @@
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/plasteel/dark,
-/area/science/research)
+/area/science/robotics/lab)
 "cKS" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/dropper,
@@ -61682,20 +61739,20 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/components/binary/pump/layer1{
+/obj/machinery/atmospherics/components/binary/pump/on/layer1{
 	dir = 1
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "cLM" = (
-/obj/structure/bodycontainer/morgue{
-	dir = 1
-	},
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/structure/bodycontainer/morgue{
+	dir = 2
+	},
 /turf/open/floor/plasteel/dark,
-/area/science/research)
+/area/science/robotics/lab)
 "cLN" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
@@ -61923,7 +61980,7 @@
 	pixel_y = -2
 	},
 /turf/open/floor/plasteel/dark,
-/area/science/research)
+/area/science/robotics/lab)
 "cMm" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -63679,7 +63736,7 @@
 /turf/open/floor/plasteel/dark/corner{
 	dir = 8
 	},
-/area/science/robotics/lab)
+/area/science/robotics/mechbay)
 "cQE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel/chapel{
@@ -64561,6 +64618,7 @@
 "cTA" = (
 /obj/machinery/power/apc/highcap/five_k{
 	areastring = "/area/maintenance/starboard/aft";
+	dir = 8;
 	name = "Starboard Quarter Maintenance APC";
 	pixel_x = -29
 	},
@@ -64776,7 +64834,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/security/checkpoint/customs)
+/area/maintenance/port/fore)
 "cXZ" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/structure/window/reinforced{
@@ -64971,7 +65029,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
-/area/security/checkpoint/customs)
+/area/hallway/primary/port)
 "daE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/cable{
@@ -67437,7 +67495,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
-/area/crew_quarters/toilet/auxiliary)
+/area/hallway/primary/port)
 "dhT" = (
 /obj/structure/chair/stool{
 	pixel_y = 8
@@ -67489,9 +67547,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "dib" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "dic" = (
 /obj/machinery/light{
 	dir = 4
@@ -68355,7 +68415,7 @@
 /area/maintenance/port/fore)
 "dta" = (
 /turf/open/floor/plasteel/showroomfloor,
-/area/maintenance/port)
+/area/crew_quarters/toilet/auxiliary)
 "dtl" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -68598,11 +68658,11 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
-/area/science/research)
+/area/science/robotics/lab)
 "dxP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel/dark/side,
-/area/science/robotics/lab)
+/area/science/robotics/mechbay)
 "dxQ" = (
 /obj/structure/chair/stool,
 /obj/structure/disposalpipe/segment{
@@ -69261,7 +69321,7 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
-/area/science/robotics/mechbay)
+/area/science/robotics/lab)
 "dDA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -69272,7 +69332,7 @@
 /obj/effect/turf_decal/lumos/tile/purple/half{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/white,
 /area/science/research)
 "dDB" = (
 /obj/structure/disposalpipe/segment{
@@ -69306,7 +69366,7 @@
 "dDF" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
-/area/science/research)
+/area/science/robotics/lab)
 "dDG" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
@@ -69492,7 +69552,7 @@
 	icon_state = "0-4"
 	},
 /turf/open/floor/plating,
-/area/science/robotics/lab)
+/area/science/robotics/mechbay)
 "dME" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible/layer1,
 /turf/open/floor/plating,
@@ -69579,9 +69639,11 @@
 /turf/open/floor/carpet,
 /area/library)
 "ehB" = (
-/obj/structure/trash_pile,
+/obj/machinery/light/small{
+	dir = 4
+	},
 /turf/open/floor/plating,
-/area/hallway/primary/port)
+/area/maintenance/aft)
 "eih" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -69604,9 +69666,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"eiS" = (
-/turf/open/floor/plasteel,
-/area/crew_quarters/toilet/auxiliary)
 "elg" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -69687,10 +69746,13 @@
 	loot = list(/obj/item/gun/ballistic/revolver/russian = 5, /obj/item/storage/box/syndie_kit/throwing_weapons, /obj/item/toy/cards/deck/syndicate = 2);
 	name = "gambling valuables spawner"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "eqq" = (
-/obj/structure/cable,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
 "eqG" = (
@@ -69723,6 +69785,9 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "evy" = (
@@ -69748,16 +69813,17 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "ezd" = (
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -23
-	},
 /obj/structure/closet/firecloset,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
-/area/science/research)
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
+	},
+/area/science/robotics/lab)
 "eCC" = (
 /obj/structure/sign/warning/biohazard,
 /turf/closed/wall/r_wall,
@@ -69898,10 +69964,6 @@
 	areastring = "/area/security/checkpoint/customs";
 	name = "Customs APC";
 	pixel_y = -26
-	},
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_x = -25
 	},
 /obj/machinery/airalarm{
 	dir = 4;
@@ -70083,7 +70145,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/security/checkpoint/customs)
+/area/maintenance/port/fore)
 "frH" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
@@ -70179,6 +70241,9 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/dark,
 /area/hydroponics/garden)
 "fAg" = (
@@ -70416,7 +70481,7 @@
 	pixel_y = 6
 	},
 /turf/open/floor/plating,
-/area/security/checkpoint/customs)
+/area/maintenance/port/fore)
 "geV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -70429,8 +70494,8 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/lumos/tile/purple/fulltile,
-/turf/open/floor/plasteel/dark,
-/area/science/robotics/lab)
+/turf/open/floor/plasteel,
+/area/science/robotics/mechbay)
 "gfD" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -70513,6 +70578,9 @@
 	name = "Command Hallway APC";
 	pixel_y = 25
 	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
 "giY" = (
@@ -70528,7 +70596,7 @@
 	},
 /obj/effect/turf_decal/lumos/shower,
 /turf/open/floor/plasteel/showroomfloor,
-/area/maintenance/port)
+/area/crew_quarters/toilet/auxiliary)
 "gkH" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -70703,7 +70771,9 @@
 	pixel_x = -27
 	},
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/white/side,
+/turf/open/floor/plasteel/white/side{
+	dir = 6
+	},
 /area/science/research)
 "gCh" = (
 /obj/effect/turf_decal/box,
@@ -70779,7 +70849,7 @@
 	name = "Robotics Operating Computer"
 	},
 /turf/open/floor/plasteel/dark,
-/area/science/research)
+/area/science/robotics/lab)
 "gLC" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/delivery,
@@ -70799,8 +70869,10 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
-/area/science/research)
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
+	},
+/area/science/robotics/lab)
 "gPA" = (
 /obj/machinery/computer/rdconsole/robotics{
 	dir = 1
@@ -70841,9 +70913,6 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "gUa" = (
-/obj/effect/turf_decal/lumos/tile/purple/half{
-	dir = 8
-	},
 /turf/open/floor/plasteel/dark/side{
 	dir = 4
 	},
@@ -70924,10 +70993,6 @@
 /obj/structure/table/wood,
 /turf/open/floor/plasteel/dark,
 /area/security/main)
-"heb" = (
-/obj/structure/trash_pile,
-/turf/open/floor/plating,
-/area/security/checkpoint/customs)
 "heK" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -71068,7 +71133,7 @@
 "hzJ" = (
 /obj/machinery/power/apc{
 	areastring = "/area/security/execution/education";
-	dir = 1;
+	dir = 4;
 	name = "Prisoner Education Chamber APC";
 	pixel_x = 26
 	},
@@ -71178,7 +71243,7 @@
 "hKh" = (
 /obj/structure/sign/directions/evac,
 /turf/closed/wall/r_wall,
-/area/hallway/primary/aft)
+/area/science/robotics/mechbay)
 "hLf" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -71213,7 +71278,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
-/area/crew_quarters/toilet/auxiliary)
+/area/hallway/primary/port)
 "hRE" = (
 /obj/structure/chair/comfy/brown{
 	color = "#66b266";
@@ -71245,13 +71310,13 @@
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/costume,
 /turf/open/floor/plating,
-/area/security/checkpoint/customs)
+/area/maintenance/port/fore)
 "hXb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
-/area/science/research)
+/area/science/robotics/lab)
 "icu" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -71271,7 +71336,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
-/area/crew_quarters/toilet/auxiliary)
+/area/hallway/primary/port)
 "idu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -71284,7 +71349,7 @@
 "idz" = (
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall,
-/area/hallway/primary/port)
+/area/maintenance/port/fore)
 "ies" = (
 /obj/machinery/light{
 	dir = 8
@@ -71324,14 +71389,12 @@
 	pixel_y = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/science/robotics/mechbay)
+/area/science/robotics/lab)
 "igx" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark/side{
-	dir = 4
-	},
+/turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "igP" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -71382,7 +71445,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/mech_bay_recharge_floor,
-/area/science/robotics/lab)
+/area/science/robotics/mechbay)
 "ioI" = (
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
@@ -71522,7 +71585,7 @@
 	pixel_y = 32
 	},
 /turf/open/floor/plating,
-/area/security/checkpoint/customs)
+/area/maintenance/port/fore)
 "iFA" = (
 /obj/structure/closet/firecloset/full,
 /obj/effect/spawner/lootdrop/space_cash/medium_chance,
@@ -71705,7 +71768,7 @@
 	pixel_y = -32
 	},
 /turf/open/floor/plasteel,
-/area/crew_quarters/toilet/auxiliary)
+/area/hallway/primary/port)
 "jdw" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible/layer1,
 /obj/effect/landmark/blobstart,
@@ -71915,7 +71978,7 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/turf/open/floor/plasteel/dark/side,
+/turf/open/floor/plasteel/dark/corner,
 /area/security/main)
 "jGL" = (
 /obj/structure/cable{
@@ -72085,16 +72148,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"kar" = (
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "kaP" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -72276,7 +72329,7 @@
 	},
 /obj/item/folder/red,
 /turf/open/floor/plating,
-/area/hallway/primary/port)
+/area/security/checkpoint/customs)
 "kux" = (
 /obj/structure/table,
 /obj/item/storage/backpack/duffelbag/med/surgery,
@@ -72286,7 +72339,7 @@
 	pixel_x = 24
 	},
 /turf/open/floor/plasteel/dark,
-/area/science/research)
+/area/science/robotics/lab)
 "kuP" = (
 /obj/structure/sign/directions/evac{
 	dir = 1
@@ -72771,7 +72824,7 @@
 	network = list("ss13","rd")
 	},
 /turf/open/floor/circuit,
-/area/science/robotics/lab)
+/area/science/robotics/mechbay)
 "lqN" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -72779,26 +72832,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/virology)
-"lsv" = (
-/obj/machinery/power/apc{
-	areastring = "/area/science/circuit";
-	dir = 1;
-	name = "Circuitry Lab APC";
-	pixel_y = 30
-	},
-/obj/structure/table/reinforced,
-/obj/item/integrated_circuit_printer,
-/obj/item/integrated_electronics/wirer{
-	pixel_x = 7
-	},
-/obj/item/integrated_electronics/debugger{
-	pixel_x = -5
-	},
-/obj/item/integrated_electronics/analyzer{
-	pixel_x = 2
-	},
-/turf/open/floor/plasteel/white,
-/area/science/circuit)
 "lte" = (
 /obj/machinery/shower{
 	dir = 8
@@ -72809,7 +72842,7 @@
 "ltu" = (
 /obj/item/weaponcrafting/improvised_parts/shotgun_receiver,
 /turf/open/floor/plating,
-/area/security/checkpoint/customs)
+/area/maintenance/port/fore)
 "ltz" = (
 /obj/structure/chair/wood/normal,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -72852,9 +72885,11 @@
 /turf/open/floor/plasteel/dark/side{
 	dir = 1
 	},
-/area/hallway/primary/port)
+/area/security/checkpoint/customs)
 "lzG" = (
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
 /area/security/main)
 "lCn" = (
 /obj/structure/table,
@@ -72926,7 +72961,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/science/robotics/lab)
+/area/science/robotics/mechbay)
 "lOV" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -72978,7 +73013,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
-/area/security/checkpoint/customs)
+/area/hallway/primary/port)
 "lSm" = (
 /obj/structure/chair/sofa/right{
 	dir = 1
@@ -73032,7 +73067,7 @@
 	pixel_y = -30
 	},
 /turf/open/floor/plasteel/dark/side,
-/area/science/robotics/lab)
+/area/science/robotics/mechbay)
 "may" = (
 /obj/structure/table/wood,
 /obj/machinery/camera{
@@ -73058,7 +73093,7 @@
 	dir = 4
 	},
 /turf/open/floor/wood,
-/area/security/vacantoffice)
+/area/crew_quarters/theatre)
 "mci" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/med_data/laptop{
@@ -73128,6 +73163,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/dark/side,
 /area/security/brig)
 "mjf" = (
@@ -73136,7 +73172,7 @@
 	},
 /obj/effect/landmark/start/roboticist,
 /turf/open/floor/plasteel/white,
-/area/science/research)
+/area/science/robotics/lab)
 "mjJ" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -73200,15 +73236,18 @@
 /area/science/mixing)
 "mmT" = (
 /obj/structure/disposalpipe/segment,
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -23
+	},
 /turf/open/floor/plasteel/white/side{
-	dir = 1
+	dir = 5
 	},
 /area/science/research)
 "mmZ" = (
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "mnl" = (
@@ -73227,16 +73266,15 @@
 /turf/open/floor/plasteel/dark/side{
 	dir = 8
 	},
-/area/science/robotics/lab)
-"mrr" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
-/area/security/checkpoint/customs)
+/area/science/robotics/mechbay)
 "mtD" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin{
 	pixel_x = 6;
 	pixel_y = 4
+	},
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
@@ -73311,7 +73349,7 @@
 	icon_state = "0-2"
 	},
 /turf/open/floor/plasteel,
-/area/science/robotics/lab)
+/area/science/robotics/mechbay)
 "mLd" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -73499,7 +73537,7 @@
 	pixel_y = 3
 	},
 /turf/open/floor/plasteel/dark,
-/area/science/robotics/mechbay)
+/area/science/robotics/lab)
 "nbi" = (
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
@@ -73531,7 +73569,7 @@
 	dir = 6
 	},
 /turf/open/floor/plating,
-/area/security/checkpoint/customs)
+/area/maintenance/port/fore)
 "ngO" = (
 /obj/structure/rack,
 /obj/item/electronics/electrochromatic_kit,
@@ -73617,7 +73655,7 @@
 /obj/machinery/recharge_station,
 /obj/effect/landmark/start/cyborg,
 /turf/open/floor/plasteel,
-/area/science/robotics/lab)
+/area/science/robotics/mechbay)
 "nsM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -73703,7 +73741,7 @@
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/dark/side,
-/area/science/robotics/lab)
+/area/science/robotics/mechbay)
 "nDM" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /mob/living/simple_animal/opossum/poppy,
@@ -73846,7 +73884,7 @@
 "nWx" = (
 /obj/structure/curtain,
 /turf/open/floor/plasteel/freezer,
-/area/maintenance/port)
+/area/crew_quarters/toilet/auxiliary)
 "nWX" = (
 /obj/effect/turf_decal/lumos/tile/blue/fullcorner{
 	dir = 8
@@ -73874,7 +73912,9 @@
 	name = "Interrogation";
 	req_access_txt = "63"
 	},
-/turf/open/floor/plasteel/dark/side,
+/turf/open/floor/plasteel/dark/side{
+	dir = 6
+	},
 /area/security/brig)
 "obX" = (
 /obj/docking_port/stationary{
@@ -73958,7 +73998,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
-/area/science/robotics/mechbay)
+/area/science/robotics/lab)
 "ogw" = (
 /obj/structure/table,
 /obj/item/folder{
@@ -74064,7 +74104,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/white,
 /area/science/research)
 "omz" = (
 /obj/machinery/status_display/supply,
@@ -74077,7 +74117,7 @@
 	name = "robotics shutters"
 	},
 /turf/open/floor/plating,
-/area/science/research)
+/area/science/robotics/lab)
 "oni" = (
 /obj/machinery/seed_extractor,
 /turf/open/floor/grass,
@@ -74106,7 +74146,7 @@
 	pixel_y = 7
 	},
 /turf/open/floor/plasteel/dark,
-/area/science/robotics/mechbay)
+/area/science/robotics/lab)
 "oou" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
@@ -74206,14 +74246,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"oBf" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/plasteel/white/side{
-	dir = 5
-	},
-/area/science/research)
 "oBR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/cable{
@@ -74261,7 +74293,7 @@
 "oFj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
-/area/science/robotics/lab)
+/area/science/robotics/mechbay)
 "oFq" = (
 /obj/effect/spawner/structure/window/reinforced/tinted/electrochromatic{
 	electrochromatic_id = "!interrogation_room"
@@ -74296,6 +74328,15 @@
 	},
 /obj/machinery/light{
 	dir = 1
+	},
+/obj/machinery/power/apc{
+	areastring = "/area/science/circuit";
+	dir = 1;
+	name = "Circuitry Lab APC";
+	pixel_y = 30
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
 	},
 /turf/open/floor/plasteel,
 /area/science/circuit)
@@ -74380,9 +74421,8 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "oXL" = (
-/turf/open/floor/plasteel/white/side{
-	dir = 1
-	},
+/obj/effect/turf_decal/lumos/tile/purple/half,
+/turf/open/floor/plasteel/white,
 /area/science/research)
 "oYC" = (
 /obj/structure/table/wood,
@@ -74479,7 +74519,7 @@
 	icon_state = "0-8"
 	},
 /turf/open/floor/plasteel/dark/side,
-/area/science/robotics/lab)
+/area/science/robotics/mechbay)
 "pmc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
@@ -74588,7 +74628,7 @@
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/dark,
-/area/science/robotics/lab)
+/area/science/robotics/mechbay)
 "pCk" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
@@ -74664,7 +74704,7 @@
 	dir = 1
 	},
 /turf/open/floor/wood,
-/area/security/vacantoffice)
+/area/crew_quarters/theatre)
 "pJY" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
@@ -74768,7 +74808,7 @@
 	pixel_y = -24
 	},
 /turf/open/floor/plasteel/dark/side,
-/area/science/robotics/lab)
+/area/science/robotics/mechbay)
 "pXu" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -74912,14 +74952,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"qmo" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white/side{
-	dir = 1
-	},
-/area/science/research)
 "qmp" = (
 /obj/structure/table,
 /obj/item/nanite_scanner{
@@ -75035,7 +75067,7 @@
 	pixel_y = -3
 	},
 /turf/open/floor/plating,
-/area/science/robotics/mechbay)
+/area/science/robotics/lab)
 "qDZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -75045,7 +75077,7 @@
 "qEC" = (
 /obj/structure/closet/secure_closet/security,
 /turf/open/floor/plasteel/dark,
-/area/hallway/primary/port)
+/area/security/checkpoint/customs)
 "qEW" = (
 /obj/structure/lattice,
 /obj/machinery/camera{
@@ -75075,7 +75107,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
 /area/science/research)
 "qFL" = (
 /obj/structure/disposalpipe/segment{
@@ -75102,7 +75136,7 @@
 	name = "Recreation Area"
 	},
 /obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/dark/corner,
+/turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "qHd" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -75301,15 +75335,15 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "qYs" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/structure/chair/stool/bar,
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
@@ -75396,7 +75430,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
-/area/crew_quarters/toilet/auxiliary)
+/area/hallway/primary/port)
 "rrK" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
@@ -75787,7 +75821,7 @@
 	},
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plating,
-/area/security/checkpoint/customs)
+/area/maintenance/port/fore)
 "svl" = (
 /obj/structure/closet,
 /obj/item/storage/box/lights/mixed,
@@ -75825,7 +75859,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/science/robotics/lab)
+/area/science/robotics/mechbay)
 "szY" = (
 /obj/structure/closet/wardrobe/black,
 /obj/item/clothing/under/misc/assistantformal,
@@ -75860,7 +75894,7 @@
 	},
 /obj/machinery/light/small,
 /turf/open/floor/plasteel/dark,
-/area/science/research)
+/area/science/robotics/lab)
 "sDJ" = (
 /obj/structure/chair/sofa/corp/corner,
 /turf/open/floor/plasteel,
@@ -75888,9 +75922,8 @@
 /area/maintenance/solars/starboard/fore)
 "sIn" = (
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/white/side{
-	dir = 9
-	},
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/plasteel/white,
 /area/science/research)
 "sIA" = (
 /obj/machinery/door/airlock/external{
@@ -75974,7 +76007,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
-/area/science/research)
+/area/science/robotics/lab)
 "sRy" = (
 /obj/structure/table,
 /turf/open/floor/plasteel/cafeteria{
@@ -76041,9 +76074,7 @@
 	network = list("ss13","prison")
 	},
 /obj/effect/turf_decal/lumos/tile/blue/fullcorner,
-/turf/open/floor/plasteel/dark/side{
-	dir = 6
-	},
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "taB" = (
 /obj/structure/extinguisher_cabinet{
@@ -76412,7 +76443,7 @@
 /obj/item/mmi,
 /obj/item/mmi,
 /turf/open/floor/plasteel/white,
-/area/science/research)
+/area/science/robotics/lab)
 "tOT" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating{
@@ -76454,7 +76485,7 @@
 	icon_state = "0-2"
 	},
 /turf/open/floor/plasteel,
-/area/science/robotics/lab)
+/area/science/robotics/mechbay)
 "tVY" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -76485,17 +76516,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"tYX" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "corporate_privacy";
-	name = "showroom shutters"
-	},
-/turf/open/floor/plating,
-/area/hallway/secondary/command)
 "udj" = (
 /obj/structure/table,
 /obj/item/storage/box/disks_nanite,
@@ -76874,7 +76894,7 @@
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
-/area/science/research)
+/area/science/robotics/lab)
 "uXu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -76886,14 +76906,14 @@
 /turf/open/floor/plasteel/dark/side{
 	dir = 10
 	},
-/area/science/robotics/lab)
+/area/science/robotics/mechbay)
 "vdn" = (
 /obj/machinery/computer/mech_bay_power_console{
 	dir = 1
 	},
 /obj/structure/cable,
 /turf/open/floor/plasteel,
-/area/science/robotics/lab)
+/area/science/robotics/mechbay)
 "vep" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -76961,7 +76981,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark/side,
-/area/science/robotics/lab)
+/area/science/robotics/mechbay)
 "vhG" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -76982,19 +77002,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"vlu" = (
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
-/area/security/checkpoint/customs)
 "vmL" = (
 /obj/machinery/button/electrochromatic{
 	id = "!interrogation_room";
 	pixel_y = -26
 	},
-/turf/open/floor/plasteel/dark/side{
-	dir = 4
-	},
+/turf/open/floor/plasteel,
 /area/security/main)
 "vpf" = (
 /obj/effect/turf_decal/tile/red{
@@ -77240,9 +77253,10 @@
 "wdE" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/white/side{
-	dir = 9
+/obj/effect/turf_decal/lumos/tile/purple/half{
+	dir = 4
 	},
+/turf/open/floor/plasteel/white,
 /area/science/research)
 "wdO" = (
 /obj/structure/chair/comfy/black{
@@ -77287,6 +77301,9 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "wkV" = (
@@ -77304,7 +77321,7 @@
 "wlH" = (
 /obj/machinery/vending/autodrobe,
 /turf/open/floor/wood,
-/area/security/vacantoffice)
+/area/crew_quarters/theatre)
 "wmt" = (
 /obj/effect/decal/cleanable/flour,
 /turf/open/floor/plating,
@@ -77390,21 +77407,21 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "wAN" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "wEt" = (
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
-/area/hallway/primary/port)
+/area/maintenance/port/fore)
 "wEQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -77476,12 +77493,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/circuit)
-"wPK" = (
-/obj/effect/turf_decal/lumos/tile/purple/half{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "wRy" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -77544,7 +77555,7 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/item/storage/box/lights/mixed,
 /turf/open/floor/plating,
-/area/security/checkpoint/customs)
+/area/maintenance/port/fore)
 "xdm" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -77600,7 +77611,7 @@
 	req_one_access_txt = null
 	},
 /turf/open/floor/plating,
-/area/hallway/primary/port)
+/area/maintenance/port/fore)
 "xhB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -77706,14 +77717,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"xuE" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/science/research)
 "xwG" = (
 /turf/closed/wall,
 /area/library/lounge)
@@ -89248,12 +89251,12 @@ aWU
 aVs
 aaa
 aaf
-chs
-chs
-chs
-chs
-chs
-chs
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -89505,12 +89508,12 @@ bMw
 aRA
 aaa
 aaf
-chs
-chs
-chs
-chs
-chs
-chs
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -89762,12 +89765,12 @@ aWU
 aVs
 aaf
 aaf
-chs
-chs
-chs
-chs
-chs
-chs
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -90019,12 +90022,12 @@ aWU
 aRA
 aaa
 aaf
-chs
-chs
-chs
-chs
-chs
-chs
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -90276,12 +90279,12 @@ aWW
 aRA
 aaa
 aaf
-chs
-chs
-chs
-chy
-chs
-chs
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -91552,12 +91555,12 @@ ntF
 bCQ
 bJp
 rbE
-bzx
-bzx
+bFy
+bFy
 cem
-bzx
-bzx
-bzx
+bFy
+bFy
+bFy
 alK
 alK
 cgG
@@ -91809,12 +91812,12 @@ bzw
 fOL
 tre
 rbE
-bzx
+bFy
 bJj
 bEo
 bJq
 bKX
-bBg
+chs
 cfB
 aob
 rxX
@@ -92050,26 +92053,26 @@ dne
 dne
 dne
 baf
-bbK
-bbK
-bbK
-bbK
-bbK
-baE
-blU
+dne
+dne
+dne
+dne
+dne
+dne
+cru
 fZI
 tnJ
-bnM
-bnM
+bpt
+bpt
 kuk
-baE
-baE
+bbK
+bbK
 jPu
 bCJ
-bzx
+bFy
 cel
 maP
-bBg
+chs
 cen
 bGu
 alK
@@ -92307,23 +92310,23 @@ aaa
 aaa
 dne
 elg
-bbK
-bdc
+dne
+awM
 xbX
 frk
-heb
-bjY
-baE
+gco
+aRG
+dne
 bqi
-bnP
+tnJ
 bpt
 qEC
 tch
 eQf
-baE
+bbK
 djW
 bNd
-bzx
+bFy
 wlH
 bHJ
 pHS
@@ -92564,20 +92567,20 @@ aaa
 aaa
 dne
 bym
-bbK
+dne
 beQ
-biy
-biy
-biy
-bjY
-baE
+aRG
+aRG
+aRG
+aRG
+dne
 pmU
 bqf
 ydn
 yaq
 tyK
 iky
-bnM
+bpt
 bBf
 bxv
 bzx
@@ -92821,20 +92824,20 @@ aaa
 aaf
 dne
 bdd
-bbK
+dne
 hTI
-vlu
-biy
+dnZ
+aRG
 biz
 wEt
-baE
+dne
 vkL
-bnP
+tnJ
 bbK
 acJ
 acO
 eSW
-baE
+bbK
 cVd
 bCL
 bzx
@@ -93078,20 +93081,20 @@ aaa
 aaf
 aip
 bym
-bbK
+dne
 iCR
-biy
+aRG
 ltu
-bjY
-bjY
+aRG
+aRG
 bma
 xIg
-bnP
+tnJ
 bbK
 bqg
 acO
 naY
-baE
+bbK
 rNX
 jBe
 bzx
@@ -93335,15 +93338,15 @@ aaa
 aaa
 aip
 bym
-bbK
+dne
 gdt
-biy
+aRG
 bgA
-biy
+aRG
 xgP
 bma
 bbY
-bnP
+tnJ
 bpt
 acK
 acO
@@ -93592,20 +93595,20 @@ aaa
 aaa
 aip
 bym
-bbK
-bdc
+dne
+awM
 ngg
 stx
-biy
-ehB
-baE
+aRG
+gco
+dne
 vQO
-bnP
+tnJ
 bbK
 emd
 pxl
 mlu
-bnM
+bpt
 cVd
 bCM
 bzx
@@ -93849,20 +93852,20 @@ aaa
 aaf
 dne
 daX
-bbK
-bbK
+dne
+dne
 tCp
 cXP
-biy
-bjY
-baE
+aRG
+aRG
+dne
 bCJ
 cZX
 bbK
 bbK
 ncw
 bpt
-bnM
+bpt
 cVd
 bbY
 xfI
@@ -94111,14 +94114,14 @@ dne
 vKJ
 dne
 dne
-baE
-baE
+dne
+dne
 bNh
 lSe
-mrr
 boc
-mrr
-mrr
+boc
+boc
+boc
 boc
 gHz
 bNh
@@ -94368,7 +94371,7 @@ bde
 beT
 gCC
 auL
-bke
+auL
 idz
 ruA
 bqj
@@ -94626,7 +94629,7 @@ beU
 bgE
 bxY
 bkf
-baE
+dmF
 bbY
 bqk
 bGn
@@ -94640,7 +94643,7 @@ bvW
 bGl
 bvW
 clO
-alK
+bvW
 bPJ
 bPJ
 bPJ
@@ -94888,8 +94891,8 @@ bnU
 tsk
 bbY
 bbY
-eiS
-eiS
+bbY
+bbY
 jcx
 bvW
 kWD
@@ -94897,7 +94900,7 @@ bvW
 bGm
 bvW
 coh
-alK
+bvW
 aod
 aGN
 dta
@@ -95402,16 +95405,16 @@ bbY
 bql
 kbt
 bub
-jCq
-jCq
-jCq
+bnM
+bnM
+bnM
 bvW
 bCS
 bxx
 bxA
 bvW
 bvW
-alK
+bvW
 gkD
 gkD
 gkD
@@ -95668,7 +95671,7 @@ cXh
 cXh
 vQt
 cHT
-alK
+bvW
 alK
 alK
 alK
@@ -95925,7 +95928,7 @@ bEv
 bLc
 bvW
 cJf
-alK
+bvW
 aob
 aob
 dIN
@@ -96175,14 +96178,14 @@ kQP
 alK
 alK
 alK
-bvW
-bvW
-bvW
-bvW
-bvW
-bvW
-bvW
 alK
+bvW
+bvW
+bvW
+bvW
+bvW
+bvW
+bvW
 rhE
 aob
 aob
@@ -101854,7 +101857,7 @@ cdw
 cdw
 cdw
 cip
-cjP
+chy
 clo
 cqk
 cnD
@@ -102799,7 +102802,7 @@ aak
 asK
 atK
 ahN
-aDP
+aMZ
 aMZ
 ahN
 amg
@@ -103568,7 +103571,7 @@ aaa
 aaa
 aak
 asO
-aaU
+asK
 abe
 ajH
 abg
@@ -104405,7 +104408,7 @@ bDv
 xLV
 heK
 yge
-bzR
+bLw
 fAg
 bNb
 dDg
@@ -104662,7 +104665,7 @@ njL
 njL
 bGL
 tEy
-tYX
+kWC
 dKm
 bNc
 bOz
@@ -104855,7 +104858,7 @@ bvS
 bvS
 auo
 aoC
-aOB
+ayZ
 aOB
 bcU
 bPS
@@ -104919,7 +104922,7 @@ njL
 njL
 bGL
 gbI
-bzR
+bLw
 bLw
 bTZ
 dDg
@@ -105637,7 +105640,7 @@ awh
 acj
 awZ
 aAh
-ast
+bjY
 asz
 asz
 bPO
@@ -105730,8 +105733,8 @@ chh
 chh
 mmZ
 cFc
-wPK
-kar
+chh
+cgc
 cHN
 cIG
 cJG
@@ -105947,7 +105950,7 @@ njL
 njL
 bGL
 xpM
-bzR
+bLw
 bLw
 bTZ
 dDg
@@ -105976,12 +105979,12 @@ cgd
 csM
 ctH
 clK
-cAk
-cxC
+cCq
+onf
 qCt
 ofS
-cAk
-cAk
+cCq
+cCq
 hKh
 cwL
 iNU
@@ -106204,7 +106207,7 @@ njL
 njL
 bGL
 tEy
-tYX
+kWC
 xKk
 bNi
 bOD
@@ -106239,7 +106242,7 @@ cxD
 cyq
 czi
 cAo
-cCq
+cAk
 cCn
 dMb
 cEj
@@ -106461,7 +106464,7 @@ bDo
 ddX
 kwX
 yge
-bzR
+bLw
 qGz
 bNj
 bOE
@@ -106496,7 +106499,7 @@ cxE
 cyr
 cvL
 ifq
-cCq
+cAk
 cCo
 cDb
 cQD
@@ -106748,8 +106751,8 @@ khe
 diL
 clK
 cuG
-cwJ
-cxF
+cBc
+gCh
 dDz
 czj
 cAn
@@ -106919,7 +106922,7 @@ apU
 auh
 aoA
 awi
-awI
+aFd
 awI
 aAX
 aBg
@@ -106936,7 +106939,7 @@ nVV
 aBi
 rtq
 ayY
-aEu
+bnP
 asI
 aFy
 aQH
@@ -107005,12 +107008,12 @@ csP
 bTs
 clK
 cuH
-cwJ
-cys
-cys
-czk
+cBc
+cCp
+cCp
+ghc
 nbf
-cCq
+cAk
 npy
 cFf
 cqY
@@ -107267,7 +107270,7 @@ cCp
 cCp
 ghc
 uAY
-cCq
+cAk
 cck
 cFg
 cra
@@ -107524,7 +107527,7 @@ gCh
 cCp
 ghc
 sUN
-cCq
+cAk
 tTS
 cqF
 czm
@@ -107743,7 +107746,7 @@ dCP
 bAc
 bcj
 giO
-bES
+bKk
 bGM
 bIo
 bJV
@@ -107781,7 +107784,7 @@ cxI
 snj
 ghq
 gPA
-cCq
+cAk
 cyp
 cFg
 cEn
@@ -108038,7 +108041,7 @@ enL
 enL
 enL
 jPj
-cCq
+cAk
 mIf
 lpW
 cEo
@@ -108295,12 +108298,12 @@ owm
 owm
 owm
 cCq
-cCq
-cCq
-cCq
+cAk
+cAk
+cAk
 pAP
-cCq
-cCq
+cAk
+cAk
 clK
 cHV
 bTs
@@ -108309,7 +108312,7 @@ bJr
 sLD
 bJr
 naU
-bJr
+dib
 bTs
 aaa
 aaa
@@ -108550,7 +108553,7 @@ ctL
 cKI
 dDF
 hXb
-ccd
+cCp
 gJV
 cgo
 jIZ
@@ -108805,7 +108808,7 @@ ctO
 crM
 ctL
 cLM
-ccd
+cCp
 uXd
 mjf
 sBT
@@ -109062,7 +109065,7 @@ ctP
 cuK
 ctL
 cMl
-cci
+cys
 dxL
 tOJ
 kux
@@ -109318,11 +109321,11 @@ csY
 cxK
 cuL
 ctL
-cgo
+cCq
 onf
 sNo
 onf
-cgo
+cCq
 cgo
 fQV
 qmp
@@ -109337,7 +109340,7 @@ fba
 dHi
 bJr
 mYl
-bJr
+ehB
 bTs
 akT
 aaa
@@ -109569,7 +109572,7 @@ dwL
 cgo
 cod
 bWO
-qmo
+cqI
 ctL
 ctL
 ctQ
@@ -109826,7 +109829,7 @@ clL
 cmM
 coe
 cpq
-oBf
+cqK
 crW
 cuN
 ctR
@@ -110090,9 +110093,9 @@ ctS
 cuO
 cvS
 cEs
-xuE
+cyB
 omf
-xuE
+cyB
 cAz
 cnQ
 cyB
@@ -110343,12 +110346,12 @@ crL
 sIn
 wdE
 ctc
-tXK
+cuP
 cuP
 czI
 cwS
-coi
-clQ
+czk
+ccd
 czv
 dDA
 cBu
@@ -110535,9 +110538,9 @@ aCG
 aje
 aUM
 aUM
-aUM
-aUM
-aUM
+aDf
+aDf
+aDf
 aUM
 aUM
 aUM
@@ -110782,7 +110785,7 @@ bDq
 bHg
 aoT
 bVW
-ala
+bke
 aiQ
 aiQ
 aiQ
@@ -111111,7 +111114,7 @@ cBB
 cgo
 ccd
 hLY
-ccd
+oXL
 cuD
 cwM
 cxN
@@ -111300,7 +111303,7 @@ ala
 avl
 eYv
 ePc
-ayZ
+blU
 qLR
 aDQ
 azX
@@ -111556,8 +111559,8 @@ ary
 ala
 aiQ
 azb
-ayZ
-ayZ
+blU
+blU
 btV
 aoP
 und
@@ -112113,7 +112116,7 @@ bAl
 dCU
 bDF
 utI
-byC
+bwO
 bIw
 bmP
 pla
@@ -112370,7 +112373,7 @@ byw
 bBV
 bFA
 utI
-byC
+bwO
 bSV
 bmP
 bLN
@@ -112884,7 +112887,7 @@ byE
 dhT
 bFi
 qYs
-bLg
+byC
 bUn
 bKe
 bLO
@@ -114160,7 +114163,7 @@ bjv
 bla
 bmQ
 byC
-byC
+bph
 aNG
 buR
 byC
@@ -114169,7 +114172,7 @@ bFA
 bFA
 byC
 wAN
-bHc
+byC
 byC
 deQ
 bKd
@@ -114417,7 +114420,7 @@ bjw
 btj
 bDC
 byD
-byD
+bth
 bpc
 bDd
 bFw
@@ -114938,8 +114941,8 @@ bFx
 bAv
 bAu
 epe
-gTu
-byC
+bBO
+bLg
 byC
 cjs
 bKe
@@ -115453,7 +115456,7 @@ dhV
 cbV
 bHN
 bDK
-bKk
+bHc
 bQG
 cbs
 bKe
@@ -115659,7 +115662,7 @@ afB
 ahg
 ahg
 axF
-ahg
+biy
 aiY
 aiY
 ahg
@@ -115708,9 +115711,9 @@ alq
 bzB
 dhV
 cmB
-bLg
 byC
-bFy
+byC
+byC
 bHj
 ygA
 bKe
@@ -115742,7 +115745,7 @@ bxF
 dwL
 lMz
 czr
-cxO
+cwJ
 cxO
 ckd
 cDl
@@ -115914,7 +115917,7 @@ acP
 auq
 acP
 acP
-acQ
+bdc
 acP
 acP
 acQ
@@ -115966,7 +115969,7 @@ bPf
 dhW
 bFu
 bDz
-dib
+byC
 bFz
 dif
 dij
@@ -115999,7 +116002,7 @@ csb
 dvY
 mjJ
 eqq
-cxO
+cxF
 cxO
 uTS
 cnP
@@ -116172,7 +116175,7 @@ aus
 avZ
 acQ
 aaa
-axL
+azf
 afD
 afD
 afD
@@ -116256,7 +116259,7 @@ cuW
 dvY
 evy
 krD
-lsv
+cEq
 txj
 cxO
 txj
@@ -116429,7 +116432,7 @@ avn
 wOY
 acP
 aaa
-axL
+azf
 afD
 afD
 afD
@@ -116686,7 +116689,7 @@ aaa
 aaa
 acP
 aaa
-axL
+azf
 afD
 afD
 afD
@@ -117200,7 +117203,7 @@ aaa
 aaa
 aaa
 aaa
-azf
+alp
 afD
 afD
 afD
@@ -117465,9 +117468,9 @@ aIB
 acQ
 acQ
 aIB
-dnh
-dnh
-dnh
+acP
+acP
+acP
 dnh
 dnh
 aAm
@@ -117722,7 +117725,7 @@ ahg
 bai
 biB
 dht
-dnh
+acP
 dnz
 dnR
 dnS
@@ -118233,10 +118236,10 @@ lMJ
 aaa
 acP
 acP
-dnh
-dnh
-dnh
-dnh
+acP
+acP
+acP
+acP
 dnh
 dnh
 aqp


### PR DESCRIPTION
## Overhauls the northern part of MetaStation to fit certain requests and also to make it generally nicer to be on.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

old meta cringe. (i made all of the bug-fixing changes while i was watching space jam 2, so i blame any mistakes on how bad the movie was)

## Changelog
:cl:
add: Items/Rooms that did not exist before and should have
del: Probably something stupid
tweak: Redid all of the atmospherics pipes EXCEPT in atmos, ironically. Moved some rooms around, got rid of some stuff that was genuinely bad ideas like Warden's bedroom, etc.
balance: balanced a pencil on my nose for 2 minutes while i was thinking of what to make for dinner
fix: Fixed bugs from the old map and most, if not hopefully all, bugs I made during my first touch with the map